### PR TITLE
Handle unnecessary calldata in `deploy`

### DIFF
--- a/starknet-foundry/crates/forge/src/cheatcodes_hint_processor.rs
+++ b/starknet-foundry/crates/forge/src/cheatcodes_hint_processor.rs
@@ -602,7 +602,7 @@ fn create_execute_calldata(
 }
 
 fn read_data_from_range(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     mut start: Relocatable,
     end: Relocatable,
 ) -> Result<Vec<Felt252>> {

--- a/starknet-foundry/crates/forge/src/lib.rs
+++ b/starknet-foundry/crates/forge/src/lib.rs
@@ -259,7 +259,7 @@ fn run_tests_from_file(
     contracts: &HashMap<String, StarknetContractArtifacts>,
     predeployed_contracts: &Utf8PathBuf,
 ) -> Result<TestFileSummary> {
-    let mut runner = SierraCasmRunner::new(
+    let runner = SierraCasmRunner::new(
         tests.sierra_program,
         Some(MetadataComputationConfig::default()),
         OrderedHashMap::default(),
@@ -269,7 +269,7 @@ fn run_tests_from_file(
     pretty_printing::print_running_tests(&tests.relative_path, tests.test_cases.len());
     let mut results = vec![];
     for (i, case) in tests.test_cases.iter().enumerate() {
-        let result = run_from_test_case(&mut runner, case, contracts, predeployed_contracts)?;
+        let result = run_from_test_case(&runner, case, contracts, predeployed_contracts)?;
         results.push(result.clone());
 
         pretty_printing::print_test_result(&result);

--- a/starknet-foundry/crates/forge/src/running.rs
+++ b/starknet-foundry/crates/forge/src/running.rs
@@ -45,7 +45,7 @@ fn build_hints_dict<'b>(
 }
 
 pub(crate) fn run_from_test_case(
-    runner: &mut SierraCasmRunner,
+    runner: &SierraCasmRunner,
     case: &TestCase,
     contracts: &HashMap<String, StarknetContractArtifacts>,
     predeployed_contracts: &Utf8PathBuf,

--- a/starknet-foundry/crates/forge/src/scarb.rs
+++ b/starknet-foundry/crates/forge/src/scarb.rs
@@ -55,7 +55,9 @@ pub fn try_get_starknet_artifacts_path(
 ) -> Result<Option<Utf8PathBuf>> {
     let path = path.join("target/dev");
     let paths = fs::read_dir(path);
-    let Ok(mut paths) = paths else { return Ok(None) };
+    let Ok(mut paths) = paths else {
+        return Ok(None);
+    };
     let starknet_artifacts = paths.find_map(|path| match path {
         Ok(path) => {
             let name = path.file_name().into_string().ok()?;

--- a/starknet-foundry/crates/forge/src/vm_memory.rs
+++ b/starknet-foundry/crates/forge/src/vm_memory.rs
@@ -27,7 +27,7 @@ pub(crate) fn insert_at_pointer<T: Into<MaybeRelocatable>>(
     Ok(())
 }
 
-pub(crate) fn usize_from_pointer(vm: &mut VirtualMachine, ptr: &mut Relocatable) -> Result<usize> {
+pub(crate) fn usize_from_pointer(vm: &VirtualMachine, ptr: &mut Relocatable) -> Result<usize> {
     let gas_counter = vm
         .get_integer(*ptr)?
         .to_usize()
@@ -37,7 +37,7 @@ pub(crate) fn usize_from_pointer(vm: &mut VirtualMachine, ptr: &mut Relocatable)
 }
 
 pub(crate) fn relocatable_from_pointer(
-    vm: &mut VirtualMachine,
+    vm: &VirtualMachine,
     ptr: &mut Relocatable,
 ) -> Result<Relocatable> {
     let start = vm.get_relocatable(*ptr)?;
@@ -45,7 +45,7 @@ pub(crate) fn relocatable_from_pointer(
     Ok(start)
 }
 
-pub(crate) fn felt_from_pointer(vm: &mut VirtualMachine, ptr: &mut Relocatable) -> Result<Felt252> {
+pub(crate) fn felt_from_pointer(vm: &VirtualMachine, ptr: &mut Relocatable) -> Result<Felt252> {
     let entry_point_selector = vm.get_integer(*ptr)?.into_owned();
     *ptr += 1;
     Ok(entry_point_selector)

--- a/starknet-foundry/crates/forge/tests/integration/deploy.rs
+++ b/starknet-foundry/crates/forge/tests/integration/deploy.rs
@@ -104,7 +104,7 @@ fn deploy_fails_on_calldata_when_contract_has_no_constructor() {
 
     let result = run(
         &test.path().unwrap(),
-        Some(test.linked_libraries()),
+        &Some(test.linked_libraries()),
         &Default::default(),
         Some(&Utf8PathBuf::from_path_buf(corelib().to_path_buf()).unwrap()),
         &test.contracts(corelib().path()).unwrap(),
@@ -156,7 +156,7 @@ fn test_deploy_fails_on_missing_constructor_arguments() {
 
     let result = run(
         &test.path().unwrap(),
-        Some(test.linked_libraries()),
+        &Some(test.linked_libraries()),
         &Default::default(),
         Some(&Utf8PathBuf::from_path_buf(corelib().to_path_buf()).unwrap()),
         &test.contracts(corelib().path()).unwrap(),
@@ -213,7 +213,7 @@ fn test_deploy_fails_on_too_many_constructor_arguments() {
 
     let result = run(
         &test.path().unwrap(),
-        Some(test.linked_libraries()),
+        &Some(test.linked_libraries()),
         &Default::default(),
         Some(&Utf8PathBuf::from_path_buf(corelib().to_path_buf()).unwrap()),
         &test.contracts(corelib().path()).unwrap(),


### PR DESCRIPTION
Closes #166 

Also did a small refactor of cheatcodes_hint_processor - extracted memory related helpers to a separate file, didn't change any functionality. 