### PR TITLE
Declare signature fixed

### DIFF
--- a/corelib/src/cheatcodes.cairo
+++ b/corelib/src/cheatcodes.cairo
@@ -27,17 +27,13 @@ impl RevertedTransactionImpl of RevertedTransactionTrait {
     }
 }
 
-fn declare(contract: felt252) -> Result::<felt252, felt252> {
+fn declare(contract: felt252) -> felt252 {
     let span = cheatcode::<'declare'>(array![contract].span());
 
     let exit_code = *span[0];
     let result = *span[1];
-
-    if exit_code == 0 {
-        Result::<felt252, felt252>::Ok(result)
-    } else {
-        Result::<felt252, felt252>::Err(result)
-    }
+    assert(exit_code == 0, 'declare should never fail');
+    result
 }
 
 fn deploy(prepared_contract: PreparedContract) -> Result::<felt252, RevertedTransaction> {

--- a/docs/src/appendix/forge-library/declare.md
+++ b/docs/src/appendix/forge-library/declare.md
@@ -1,6 +1,6 @@
 # `declare`
 
-> `fn declare(contract: felt252) -> Result::<felt252, felt252>`
+> `fn declare(contract: felt252) -> felt252`
 
 Declares a contract and returns its class hash.
 
@@ -11,7 +11,7 @@ use result::ResultTrait;
 
 #[test]
 fn test_declare() {
-    let class_hash = declare('HelloStarknet').unwrap();
+    let class_hash = declare('HelloStarknet');
     // ...
 }
 ```

--- a/docs/src/appendix/forge-library/deploy.md
+++ b/docs/src/appendix/forge-library/deploy.md
@@ -15,7 +15,7 @@ use cheatcodes::PreparedContract;
 
 #[test]
 fn test_deploy() {
-    let class_hash = declare('HelloStarknet').unwrap();
+    let class_hash = declare('HelloStarknet');
     
     let mut constructor_calldata = ArrayTrait::new();
     constructor_calldata.append(42_u8.into());

--- a/docs/src/testing/contracts.md
+++ b/docs/src/testing/contracts.md
@@ -46,7 +46,7 @@ Let's write a test that will deploy the `HelloStarknet` contract and call some f
 #[test]
 fn call_and_invoke() {
     // First declare and deploy a contract
-    let class_hash = declare('HelloStarknet').unwrap();
+    let class_hash = declare('HelloStarknet');
     let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @ArrayTrait::new() };
     let contract_address = deploy(prepared).unwrap();
     let contract_address: ContractAddress = contract_address.try_into().unwrap();

--- a/starknet-foundry/crates/forge/tests/data/simple_package/tests/contract.cairo
+++ b/starknet-foundry/crates/forge/tests/data/simple_package/tests/contract.cairo
@@ -10,7 +10,7 @@ use simple_package::hello_starknet::IHelloStarknetDispatcherTrait;
 
 #[test]
 fn call_and_invoke() {
-    let class_hash = declare('HelloStarknet').unwrap();
+    let class_hash = declare('HelloStarknet');
     let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @ArrayTrait::new() };
     let contract_address = deploy(prepared).unwrap();
     let contract_address: ContractAddress = contract_address.try_into().unwrap();

--- a/starknet-foundry/crates/forge/tests/integration/declare.rs
+++ b/starknet-foundry/crates/forge/tests/integration/declare.rs
@@ -64,7 +64,7 @@ fn simple_declare() {
         #[test]
         fn test_declare_simple() {
             assert(1 == 1, 'simple check');
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             assert(class_hash != 0, 'proper class hash');
         }
         "#
@@ -120,10 +120,10 @@ fn multiple_declare() {
 
         #[test]
         fn multiple_contracts() {
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             assert(class_hash != 0, 'proper class hash');
         
-            let class_hash2 = declare('Contract1').unwrap();
+            let class_hash2 = declare('Contract1');
             assert(class_hash2 != 0, 'proper class hash');
         
             assert(class_hash != class_hash2, 'class hashes neq');
@@ -222,7 +222,7 @@ fn simple_declare_from_contract_code() {
         #[test]
         fn test_declare_simple() {
             assert(1 == 1, 'simple check');
-            let class_hash = declare('Contract1').unwrap();
+            let class_hash = declare('Contract1');
             assert(class_hash != 0, 'proper class hash');
         }
         "#
@@ -253,7 +253,7 @@ fn declare_unknown() {
         #[test]
         fn test_declare_simple() {
             assert(1 == 1, 'simple check');
-            let class_hash = declare('Unknown').unwrap();
+            let class_hash = declare('Unknown');
             assert(class_hash != 0, 'proper class hash');
         }
         "#

--- a/starknet-foundry/crates/forge/tests/integration/deploy.rs
+++ b/starknet-foundry/crates/forge/tests/integration/deploy.rs
@@ -18,7 +18,7 @@ fn error_handling() {
         
         #[test]
         fn test_deploy_error_handling() {
-            let class_hash = declare('PanickingConstructor').expect('Could not declare');
+            let class_hash = declare('PanickingConstructor');
             let prepared_contract = PreparedContract {
                 class_hash: class_hash,
                 constructor_calldata: @ArrayTrait::new()

--- a/starknet-foundry/crates/forge/tests/integration/deploy.rs
+++ b/starknet-foundry/crates/forge/tests/integration/deploy.rs
@@ -88,7 +88,7 @@ fn deploy_fails_on_calldata_when_contract_has_no_constructor() {
             calldata.append(1234);
             calldata.append(5678);
         
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @calldata };
             let contract_address = deploy(prepared).unwrap();
         
@@ -131,7 +131,7 @@ fn test_deploy_fails_on_missing_constructor_arguments() {
         fn deploy_invalid_calldata() {
             let mut calldata = ArrayTrait::new();
         
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @calldata };
             let contract_address = deploy(prepared).unwrap();
         
@@ -189,7 +189,7 @@ fn test_deploy_fails_on_too_many_constructor_arguments() {
             calldata.append(4);
             calldata.append(5);
 
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @calldata };
             let contract_address = deploy(prepared).unwrap();
 
@@ -300,7 +300,7 @@ fn test_deploy_invokes_the_constructor() {
             let mut calldata = ArrayTrait::new();
             calldata.append(420);
 
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @calldata };
             let contract_address = deploy(prepared).unwrap();
             let contract_address: ContractAddress = contract_address.try_into().unwrap();

--- a/starknet-foundry/crates/forge/tests/integration/dispatchers.rs
+++ b/starknet-foundry/crates/forge/tests/integration/dispatchers.rs
@@ -31,7 +31,7 @@ fn simple_call_and_invoke() {
 
         #[test]
         fn call_and_invoke() {
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @ArrayTrait::new() };
             let contract_address = deploy(prepared).unwrap();
             let contract_address: ContractAddress = contract_address.try_into().unwrap();
@@ -111,7 +111,7 @@ fn advanced_types() {
             calldata.append(0);         // initial supply high
             calldata.append(1234);      // recipient
         
-            let class_hash = declare('ERC20').unwrap();
+            let class_hash = declare('ERC20');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @calldata };
             let contract_address = deploy(prepared).unwrap();
             let contract_address: ContractAddress = contract_address.try_into().unwrap();
@@ -176,7 +176,7 @@ fn handling_errors() {
 
         #[test]
         fn handling_errors() {
-            let class_hash = declare('HelloStarknet').unwrap();
+            let class_hash = declare('HelloStarknet');
             let prepared = PreparedContract { class_hash: class_hash, constructor_calldata: @ArrayTrait::new() };
             let contract_address = deploy(prepared).unwrap();
             let contract_address: ContractAddress = contract_address.try_into().unwrap();


### PR DESCRIPTION
Closes #60 

## Introduced changes

- Updated declare signature as it should never fail

## Breaking changes

- declare signature does not return `Result` anymore, `felt252` instead

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
