### PR TITLE
docs: revert runnable config

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,8 +5,9 @@ multilingual = false
 src = "src"
 title = "The Starknet Foundry Book"
 
-[output.html.playground]
 [output.html]
 git-repository-url = "https://github.com/foundry-rs/starknet-foundry/"
 edit-url-template = "https://github.com/foundry-rs/starknet-foundry/edit/master/docs/{path}"
+
+[output.html.playground]
 runnable = false


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

The changes introduced by #315 wrongfully enabled rust code to be runnable (it shouldn't). This PR fixes this small issue. Sorry!

## Introduced changes

<!-- A brief description of the changes -->

-
-

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
