### PR TITLE
Catch scarb build errors

### DIFF
--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -69,7 +69,6 @@ fn main_execution() -> Result<()> {
         .arg("build")
         .output()
         .context("Failed to build contracts with Scarb")?;
-
     if !build_output.status.success() {
         bail!(
             "Scarb build didn't succeed:\n\n{}",

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -45,6 +45,29 @@ fn simple_package() {
 }
 
 #[test]
+fn with_failing_scarb_build() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    temp.copy_from("tests/data/simple_package", &["**/*.cairo", "**/*.toml"])
+        .unwrap();
+    let lib_file = temp.child("src/lib.cairo");
+    lib_file
+        .write_str(indoc!(
+            r#"
+        mod hello_starknet;
+        mods erc20;
+    "#
+        ))
+        .unwrap();
+
+    let snapbox = runner();
+
+    let result = snapbox.current_dir(&temp).assert().failure();
+
+    let stdout = String::from_utf8_lossy(&result.get_output().stdout);
+    assert!(stdout.contains("Scarb build didn't succeed:"));
+}
+
+#[test]
 fn with_filter() {
     let temp = assert_fs::TempDir::new().unwrap();
     temp.copy_from("tests/data/simple_package", &["**/*.cairo", "**/*.toml"])


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #359 

## Introduced changes

<!-- A brief description of the changes -->

- Added catching and printing of `scarb build` errors when running `snforge`.

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
