### PR TITLE
Update Scarb documentation links

### DIFF
--- a/benchmarks/data/project/Scarb.toml
+++ b/benchmarks/data/project/Scarb.toml
@@ -2,7 +2,7 @@
 name = "project"
 version = "0.1.0"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
 starknet = "2.1.0-rc2"

--- a/crates/forge/tests/data/complex_structure_test/Scarb.toml
+++ b/crates/forge/tests/data/complex_structure_test/Scarb.toml
@@ -2,7 +2,7 @@
 name = "test_multiple"
 version = "0.1.0"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
 # foo = { path = "vendor/foo" }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -26,11 +26,11 @@ pub fn setup_package(package_name: &str) -> TempDir {
                 [package]
                 name = "{}"
                 version = "0.1.0"
-        
+
                 [[target.starknet-contract]]
                 sierra = true
                 casm = true
-        
+
                 [dependencies]
                 starknet = "2.1.0-rc2"
                 cheatcodes = {{ path = "{}" }}
@@ -66,15 +66,15 @@ fn simple_package() {
         [PASS] test_simple::test_two
         [PASS] test_simple::test_two_and_two
         [FAIL] test_simple::test_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         [FAIL] test_simple::test_another_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         Running 1 test(s) from tests/without_prefix.cairo
         [PASS] without_prefix::five
         Tests: 9 passed, 2 failed, 0 skipped
@@ -95,11 +95,11 @@ fn simple_package_with_git_dependency() {
             [package]
             name = "simple_package"
             version = "0.1.0"
-    
+
             [[target.starknet-contract]]
             sierra = true
             casm = true
-    
+
             [dependencies]
             starknet = "2.1.0-rc2"
             cheatcodes = { git = "https://github.com/foundry-rs/starknet-foundry.git" }
@@ -127,12 +127,12 @@ fn simple_package_with_git_dependency() {
         [PASS] test_simple::test_two
         [PASS] test_simple::test_two_and_two
         [FAIL] test_simple::test_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         [FAIL] test_simple::test_another_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
 
@@ -265,7 +265,7 @@ fn with_panic_data_decoding() {
         Running 4 test(s) from tests/test_panic_decoding.cairo
         [PASS] test_panic_decoding::test_simple
         [FAIL] test_panic_decoding::test_panic_decoding
-        
+
         Failure data:
             original value: [123], converted to a string: [{]
             original value: [6381921], converted to a string: [aaa]
@@ -273,12 +273,12 @@ fn with_panic_data_decoding() {
             original value: [152]
             original value: [124], converted to a string: [|]
             original value: [149]
-        
+
         [FAIL] test_panic_decoding::test_panic_decoding2
-        
+
         Failure data:
             original value: [128]
-        
+
         [PASS] test_panic_decoding::test_simple2
         Tests: 2 passed, 2 failed, 0 skipped
         "#});
@@ -295,8 +295,6 @@ fn with_exit_first() {
             name = "simple_package"
             version = "0.1.0"
 
-            # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
-
             [dependencies]
             starknet = "2.1.0-rc2"
             cheatcodes = {{ path = "{}" }}
@@ -304,10 +302,10 @@ fn with_exit_first() {
             [[target.starknet-contract]]
             sierra = true
             casm = true
-            
+
             [tool.snforge]
             exit_first = true
-            "#, 
+            "#,
             Utf8PathBuf::from_str("../../cheatcodes")
                 .unwrap()
                 .canonicalize_utf8()
@@ -335,10 +333,10 @@ fn with_exit_first() {
         [PASS] test_simple::test_two
         [PASS] test_simple::test_two_and_two
         [FAIL] test_simple::test_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         [SKIP] test_simple::test_another_failing
         [SKIP] without_prefix::five
         Tests: 8 passed, 1 failed, 2 skipped
@@ -368,10 +366,10 @@ fn with_exit_first_flag() {
         [PASS] test_simple::test_two
         [PASS] test_simple::test_two_and_two
         [FAIL] test_simple::test_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         [SKIP] test_simple::test_another_failing
         [SKIP] without_prefix::five
         Tests: 8 passed, 1 failed, 2 skipped
@@ -388,8 +386,6 @@ fn exit_first_flag_takes_precedence() {
             [package]
             name = "simple_package"
             version = "0.1.0"
-
-            # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 
             [dependencies]
             starknet = "2.1.0-rc2"
@@ -425,10 +421,10 @@ fn exit_first_flag_takes_precedence() {
         [PASS] test_simple::test_two
         [PASS] test_simple::test_two_and_two
         [FAIL] test_simple::test_failing
-        
+
         Failure data:
             original value: [8111420071579136082810415440747], converted to a string: [failing check]
-        
+
         [SKIP] test_simple::test_another_failing
         [SKIP] without_prefix::five
         Tests: 8 passed, 1 failed, 2 skipped

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -5,8 +5,8 @@ In this section, we will walk through the process of installing Starknet Foundry
 
 ### Requirements
 
-To use Starknet Foundry, you need [Scarb](https://docs.swmansion.com/scarb/download) installed and added to
-your `PATH` environment variable.
+To use Starknet Foundry, you need [Scarb](https://docs.swmansion.com/scarb/download.html) installed
+and added to your `PATH` environment variable.
 You can find what version of Scarb is compatible with your version of Starknet Foundry
 in [release notes](https://github.com/foundry-rs/starknet-foundry/releases).
 

--- a/docs/src/getting-started/scarb.md
+++ b/docs/src/getting-started/scarb.md
@@ -4,11 +4,11 @@
 Those coming from Rust ecosystem will find Scarb very similar to [Cargo](https://doc.rust-lang.org/cargo/).
 
 Starknet Foundry uses [Scarb](https://docs.swmansion.com/scarb) to:
-- [manage dependencies](https://docs.swmansion.com/scarb/docs/reference/specifying-dependencies)
-- [build contracts](https://docs.swmansion.com/scarb/docs/starknet/contract-target)\
+- [manage dependencies](https://docs.swmansion.com/scarb/docs/reference/specifying-dependencies.html)
+- [build contracts](https://docs.swmansion.com/scarb/docs/starknet/contract-target.html)
 
-One of the core concepts of Scarb is its [manifest file](https://docs.swmansion.com/scarb/docs/reference/manifest) - `Scarb.toml`.
+One of the core concepts of Scarb is its [manifest file](https://docs.swmansion.com/scarb/docs/reference/manifest.html) - `Scarb.toml`.
 It can be also used to provide [configuration](../projects/configuration.md) for Starknet Foundry.
 
-Last but not least, remember that in order to use Starknet Foundry, you must have Scarb 
-[installed](https://docs.swmansion.com/scarb/download) and added to the `PATH` environment variable. 
+Last but not least, remember that in order to use Starknet Foundry, you must have Scarb
+[installed](https://docs.swmansion.com/scarb/download.html) and added to the `PATH` environment variable.


### PR DESCRIPTION
## Introduced changes

We've changed website generator for Scarb docs, and one of the changes it brings is that it emits `.html` files instead of doing `dir/index.html` hack.

## Breaking changes

None

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
