### PR TITLE
Fix chaining `panic_data`

### DIFF
--- a/crates/cheatnet/src/cheatcodes/deploy.rs
+++ b/crates/cheatnet/src/cheatcodes/deploy.rs
@@ -16,7 +16,7 @@ use blockifier::state::state_api::StateReader;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transactions::{ExecutableTransaction, InvokeTransaction};
 use cairo_felt::Felt252;
-use regex::Regex;
+
 use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::transaction::{
@@ -24,6 +24,8 @@ use starknet_api::transaction::{
 };
 use starknet_api::{patricia_key, stark_felt};
 
+use crate::conversions::felt_from_short_string;
+use crate::panic_data::try_extract_panic_data;
 use cairo_lang_runner::casm_run::MemBuffer;
 
 impl CheatedState {
@@ -132,31 +134,6 @@ fn create_execute_calldata(
     Calldata(execute_calldata.into())
 }
 
-fn try_extract_panic_data(err: &str) -> Option<Vec<Felt252>> {
-    let re = Regex::new(r#"(?m)^Got an exception while executing a hint: Custom Hint Error: Execution failed\. Failure reason: "(.*)"\.$"#)
-        .expect("Could not create panic_data matching regex");
-
-    if let Some(captures) = re.captures(err) {
-        if let Some(panic_data_match) = captures.get(1) {
-            if panic_data_match.as_str().is_empty() {
-                return Some(vec![]);
-            }
-            let panic_data_felts: Vec<Felt252> = panic_data_match
-                .as_str()
-                .split(", ")
-                .map(felt_from_short_string)
-                .collect();
-
-            return Some(panic_data_felts);
-        }
-    }
-    None
-}
-
-fn felt_from_short_string(short_str: &str) -> Felt252 {
-    return Felt252::from_bytes_be(short_str.as_bytes());
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -206,42 +183,5 @@ mod test {
                 StarkFelt::from(0_u32),
             ]))
         );
-    }
-
-    #[test]
-    fn string_extracting_panic_data() {
-        let cases: [(&str, Option<Vec<Felt252>>); 4] = [
-            (
-                "Beginning of trace\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"PANIK, DAYTA\".\n
-                 End of trace",
-                Some(vec![Felt252::from(344_693_033_291_u64), Felt252::from(293_154_149_441_u64)])
-            ),
-            (
-                "Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"AYY, LMAO\".",
-                Some(vec![Felt252::from(4_282_713_u64), Felt252::from(1_280_131_407_u64)])
-            ),
-            (
-                "Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"\".",
-                Some(vec![])
-            ),
-            ("Custom Hint Error: Invalid trace: \"PANIC, DATA\"", None)
-        ];
-
-        for (str, expected) in cases {
-            assert_eq!(try_extract_panic_data(str), expected);
-        }
-    }
-
-    #[test]
-    fn parsing_felt_from_short_string() {
-        let cases = [
-            ("", Felt252::from(0)),
-            ("{", Felt252::from(123)),
-            ("PANIK", Felt252::from(344_693_033_291_u64)),
-        ];
-
-        for (str, felt_res) in cases {
-            assert_eq!(felt_from_short_string(str), felt_res);
-        }
     }
 }

--- a/crates/cheatnet/src/conversions.rs
+++ b/crates/cheatnet/src/conversions.rs
@@ -1,0 +1,24 @@
+use cairo_felt::Felt252;
+
+#[must_use]
+pub fn felt_from_short_string(short_str: &str) -> Felt252 {
+    return Felt252::from_bytes_be(short_str.as_bytes());
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn parsing_felt_from_short_string() {
+        let cases = [
+            ("", Felt252::from(0)),
+            ("{", Felt252::from(123)),
+            ("PANIK", Felt252::from(344_693_033_291_u64)),
+        ];
+
+        for (str, felt_res) in cases {
+            assert_eq!(felt_from_short_string(str), felt_res);
+        }
+    }
+}

--- a/crates/cheatnet/src/lib.rs
+++ b/crates/cheatnet/src/lib.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 pub mod cheatcodes;
 pub mod constants;
+pub mod conversions;
+pub mod panic_data;
 pub mod rpc;
 pub mod state;
 

--- a/crates/cheatnet/src/panic_data.rs
+++ b/crates/cheatnet/src/panic_data.rs
@@ -1,0 +1,55 @@
+use super::conversions::felt_from_short_string;
+use cairo_felt::Felt252;
+use regex::Regex;
+
+#[allow(clippy::module_name_repetitions)]
+pub fn try_extract_panic_data(err: &str) -> Option<Vec<Felt252>> {
+    let re = Regex::new(r#"(?m)^Got an exception while executing a hint: Custom Hint Error: Execution failed\. Failure reason: "(.*)"\.$"#)
+        .expect("Could not create panic_data matching regex");
+
+    if let Some(captures) = re.captures(err) {
+        if let Some(panic_data_match) = captures.get(1) {
+            if panic_data_match.as_str().is_empty() {
+                return Some(vec![]);
+            }
+            let panic_data_felts: Vec<Felt252> = panic_data_match
+                .as_str()
+                .split(", ")
+                .map(felt_from_short_string)
+                .collect();
+
+            return Some(panic_data_felts);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cairo_felt::Felt252;
+
+    #[test]
+    fn string_extracting_panic_data() {
+        let cases: [(&str, Option<Vec<Felt252>>); 4] = [
+            (
+                "Beginning of trace\nGot an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"PANIK, DAYTA\".\n
+                 End of trace",
+                Some(vec![Felt252::from(344_693_033_291_u64), Felt252::from(293_154_149_441_u64)])
+            ),
+            (
+                "Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"AYY, LMAO\".",
+                Some(vec![Felt252::from(4_282_713_u64), Felt252::from(1_280_131_407_u64)])
+            ),
+            (
+                "Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: \"\".",
+                Some(vec![])
+            ),
+            ("Custom Hint Error: Invalid trace: \"PANIC, DATA\"", None)
+        ];
+
+        for (str, expected) in cases {
+            assert_eq!(try_extract_panic_data(str), expected);
+        }
+    }
+}

--- a/crates/forge/tests/integration/dispatchers.rs
+++ b/crates/forge/tests/integration/dispatchers.rs
@@ -478,3 +478,114 @@ fn proxy_storage() {
 
     assert_passed!(result);
 }
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn proxy_dispatcher_panic() {
+    let test = test_case!(
+        indoc!(
+            r#"
+        use array::ArrayTrait;
+        use result::ResultTrait;
+        use option::OptionTrait;
+        use traits::TryInto;
+        use traits::Into;
+        use starknet::ContractAddress;
+        use starknet::Felt252TryIntoContractAddress;
+        use cheatcodes::{ declare, PreparedContract, deploy };
+        
+
+        fn deploy_contract(name: felt252, constructor_calldata: @Array<felt252>) -> ContractAddress {
+            let class_hash = declare(name);
+            let prepared = PreparedContract { class_hash, constructor_calldata };
+            deploy(prepared).unwrap()
+        }
+        
+        #[starknet::interface]
+        trait ICaller<T> {
+            fn invoke_executor(ref self: T);
+        }
+        
+        #[test]
+        fn test_proxy_storage() {
+            let executor_address = deploy_contract('Executor', @ArrayTrait::new());
+            let caller_constructor_calldata: Array<felt252> = array![executor_address.into()]; 
+            let caller_address = deploy_contract('Caller', @caller_constructor_calldata);
+        
+            let caller_dispatcher = ICallerSafeDispatcher { contract_address: caller_address };
+        
+            match caller_dispatcher.invoke_executor() {
+                Result::Ok(_) => panic_with_felt252('should have panicked'),
+                Result::Err(x) => assert(*x.at(0) == 'panic_msg', 'wrong panic msg')
+            }
+        }
+    "#
+        ),
+        Contract::new(
+            "Caller",
+            indoc!(
+                r#"
+            #[starknet::contract]
+            mod Caller {
+                use result::ResultTrait;
+                use starknet::ContractAddress;
+            
+                #[starknet::interface]
+                trait IExecutor<T> {
+                    fn invoke_with_panic(self: @T);
+                }
+            
+                #[storage]
+                struct Storage {
+                    executor_address: ContractAddress
+                }
+            
+                #[constructor]
+                fn constructor(ref self: ContractState, executor_address: ContractAddress) {
+                    self.executor_address.write(executor_address);
+                }
+                
+                #[external(v0)]
+                fn invoke_executor(
+                    self: @ContractState,
+                ) {
+                    let dispatcher = IExecutorDispatcher { contract_address: self.executor_address.read() };
+                    dispatcher.invoke_with_panic()
+                }
+            }
+            "#
+            )
+        ),
+        Contract::new(
+            "Executor",
+            indoc!(
+                r#"
+            #[starknet::contract]
+            mod Executor {
+                #[storage]
+                struct Storage {}
+            
+                #[external(v0)]
+                fn invoke_with_panic(ref self: ContractState){
+                    panic_with_felt252('panic_msg');
+                }
+            }
+            "#
+            )
+        )
+    );
+
+    let result = run(
+        &test.path().unwrap(),
+        &String::from("src"),
+        &test.path().unwrap().join("src/lib.cairo"),
+        &Some(test.linked_libraries()),
+        &Default::default(),
+        &corelib_path(),
+        &test.contracts(&corelib_path()).unwrap(),
+        &Utf8PathBuf::from_path_buf(predeployed_contracts().to_path_buf()).unwrap(),
+    )
+    .unwrap();
+
+    assert_passed!(result);
+}

--- a/crates/forge/tests/integration/dispatchers.rs
+++ b/crates/forge/tests/integration/dispatchers.rs
@@ -492,7 +492,7 @@ fn proxy_dispatcher_panic() {
         use traits::Into;
         use starknet::ContractAddress;
         use starknet::Felt252TryIntoContractAddress;
-        use cheatcodes::{ declare, PreparedContract, deploy };
+        use snforge_std::{ declare, PreparedContract, deploy };
         
 
         fn deploy_contract(name: felt252, constructor_calldata: @Array<felt252>) -> ContractAddress {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #420

## Introduced changes

<!-- A brief description of the changes -->

- Added `panic_data` parsing (like in deploy) for syscall hint execution
- Moved a couple of functionalities to separate modules


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
