### PR TITLE
Fix forge on windows

### DIFF
--- a/crates/cheatnet/src/cheatcodes/declare.rs
+++ b/crates/cheatnet/src/cheatcodes/declare.rs
@@ -128,7 +128,9 @@ mod test {
         let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
             .unwrap()
             .canonicalize_utf8()
-            .unwrap();
+            .unwrap()
+            .to_string()
+            .replace('\\', "/");
 
         let manifest_path = temp.child("Scarb.toml");
         manifest_path
@@ -150,11 +152,12 @@ mod test {
             ))
             .unwrap();
 
-        Command::new("scarb")
+        let output = Command::new("scarb")
             .current_dir(&temp)
             .arg("build")
             .output()
             .unwrap();
+        assert!(output.status.success());
 
         let temp_dir_path = temp.path();
 

--- a/crates/forge/src/scarb.rs
+++ b/crates/forge/src/scarb.rs
@@ -231,12 +231,12 @@ mod tests {
         )
         .unwrap();
 
-        let snforge_std_path = Utf8PathBuf::from_str("..")
+        let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
             .unwrap()
-            .join("..")
-            .join("snforge_std")
             .canonicalize_utf8()
-            .unwrap();
+            .unwrap()
+            .to_string()
+            .replace('\\', "/"); // to make tests on Windows pass - prevents incorrect toml format error
 
         let manifest_path = temp.child("Scarb.toml");
         manifest_path
@@ -289,12 +289,12 @@ mod tests {
     fn get_starknet_artifacts_path_for_project_with_different_package_and_target_name() {
         let temp = setup_package("simple_package");
 
-        let snforge_std_path = Utf8PathBuf::from_str("..")
+        let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
             .unwrap()
-            .join("..")
-            .join("snforge_std")
             .canonicalize_utf8()
-            .unwrap();
+            .unwrap()
+            .to_string()
+            .replace('\\', "/"); // to make tests on Windows pass - prevents incorrect toml format error;
 
         let scarb_path = temp.child("Scarb.toml");
         scarb_path
@@ -331,10 +331,7 @@ mod tests {
         let path = result.unwrap().unwrap();
         assert_eq!(
             path,
-            temp.path()
-                .join("target")
-                .join("dev")
-                .join("essa.starknet_artifacts.json")
+            temp.path().join("target/dev/essa.starknet_artifacts.json")
         );
     }
 
@@ -393,9 +390,7 @@ mod tests {
 
         let artifacts_path = temp
             .path()
-            .join("target")
-            .join("dev")
-            .join("simple_package.starknet_artifacts.json");
+            .join("targe/dev/simple_package.starknet_artifacts.json");
         let artifacts_path = Utf8PathBuf::from_path_buf(artifacts_path).unwrap();
 
         let artifacts = artifacts_for_package(&artifacts_path).unwrap();
@@ -430,9 +425,7 @@ mod tests {
 
         let artifacts_path = temp
             .path()
-            .join("target")
-            .join("dev")
-            .join("simple_package.starknet_artifacts.json");
+            .join("target/dev/simple_package.starknet_artifacts.json");
         let artifacts_path = Utf8PathBuf::from_path_buf(artifacts_path).unwrap();
 
         let contracts = get_contracts_map(&artifacts_path).unwrap();
@@ -440,34 +433,20 @@ mod tests {
         assert!(contracts.contains_key("ERC20"));
         assert!(contracts.contains_key("HelloStarknet"));
 
-        let sierra_contents_erc20 = fs::read_to_string(
-            temp.join("target")
-                .join("dev")
-                .join("simple_package_ERC20.sierra.json"),
-        )
-        .unwrap();
-        let casm_contents_erc20 = fs::read_to_string(
-            temp.join("target")
-                .join("dev")
-                .join("simple_package_ERC20.casm.json"),
-        )
-        .unwrap();
+        let sierra_contents_erc20 =
+            fs::read_to_string(temp.join("target/dev/simple_package_ERC20.sierra.json")).unwrap();
+        let casm_contents_erc20 =
+            fs::read_to_string(temp.join("target/dev/simple_package_ERC20.casm.json")).unwrap();
         let contract = contracts.get("ERC20").unwrap();
         assert_eq!(&sierra_contents_erc20, &contract.sierra);
         assert_eq!(&casm_contents_erc20, &contract.casm);
 
-        let sierra_contents_erc20 = fs::read_to_string(
-            temp.join("target")
-                .join("dev")
-                .join("simple_package_HelloStarknet.sierra.json"),
-        )
-        .unwrap();
-        let casm_contents_erc20 = fs::read_to_string(
-            temp.join("target")
-                .join("dev")
-                .join("simple_package_HelloStarknet.casm.json"),
-        )
-        .unwrap();
+        let sierra_contents_erc20 =
+            fs::read_to_string(temp.join("target/dev/simple_package_HelloStarknet.sierra.json"))
+                .unwrap();
+        let casm_contents_erc20 =
+            fs::read_to_string(temp.join("target/dev/simple_package_HelloStarknet.casm.json"))
+                .unwrap();
         let contract = contracts.get("HelloStarknet").unwrap();
         assert_eq!(&sierra_contents_erc20, &contract.sierra);
         assert_eq!(&casm_contents_erc20, &contract.casm);
@@ -503,7 +482,7 @@ mod tests {
             paths_for_package(&scarb_metadata, &scarb_metadata.workspace.members[0]).unwrap();
 
         assert!(package_path.is_dir());
-        assert!(lib_path.ends_with(Utf8PathBuf::from("src").join("lib.cairo")));
+        assert!(lib_path.ends_with(Utf8PathBuf::from("src/lib.cairo")));
         assert!(lib_path.starts_with(package_path));
     }
 

--- a/crates/forge/src/scarb.rs
+++ b/crates/forge/src/scarb.rs
@@ -236,7 +236,7 @@ mod tests {
             .canonicalize_utf8()
             .unwrap()
             .to_string()
-            .replace('\\', "/"); // to make tests on Windows pass - prevents incorrect toml format error
+            .replace('\\', "/");
 
         let manifest_path = temp.child("Scarb.toml");
         manifest_path
@@ -294,7 +294,7 @@ mod tests {
             .canonicalize_utf8()
             .unwrap()
             .to_string()
-            .replace('\\', "/"); // to make tests on Windows pass - prevents incorrect toml format error;
+            .replace('\\', "/");
 
         let scarb_path = temp.child("Scarb.toml");
         scarb_path
@@ -390,7 +390,7 @@ mod tests {
 
         let artifacts_path = temp
             .path()
-            .join("targe/dev/simple_package.starknet_artifacts.json");
+            .join("target/dev/simple_package.starknet_artifacts.json");
         let artifacts_path = Utf8PathBuf::from_path_buf(artifacts_path).unwrap();
 
         let artifacts = artifacts_for_package(&artifacts_path).unwrap();

--- a/crates/forge/src/scarb.rs
+++ b/crates/forge/src/scarb.rs
@@ -162,7 +162,7 @@ pub fn corelib_for_package(metadata: &Metadata, package: &PackageId) -> Result<U
     let corelib = compilation_unit
         .components
         .iter()
-        .find(|du| du.source_path.to_string().contains("core/src"))
+        .find(|du| du.name == "core")
         .context("corelib could not be found")?;
     Ok(Utf8PathBuf::from(corelib.source_root()))
 }
@@ -231,8 +231,10 @@ mod tests {
         )
         .unwrap();
 
-        let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
+        let snforge_std_path = Utf8PathBuf::from_str("..")
             .unwrap()
+            .join("..")
+            .join("snforge_std")
             .canonicalize_utf8()
             .unwrap();
 
@@ -287,8 +289,10 @@ mod tests {
     fn get_starknet_artifacts_path_for_project_with_different_package_and_target_name() {
         let temp = setup_package("simple_package");
 
-        let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
+        let snforge_std_path = Utf8PathBuf::from_str("..")
             .unwrap()
+            .join("..")
+            .join("snforge_std")
             .canonicalize_utf8()
             .unwrap();
 
@@ -327,7 +331,10 @@ mod tests {
         let path = result.unwrap().unwrap();
         assert_eq!(
             path,
-            temp.path().join("target/dev/essa.starknet_artifacts.json")
+            temp.path()
+                .join("target")
+                .join("dev")
+                .join("essa.starknet_artifacts.json")
         );
     }
 
@@ -386,7 +393,9 @@ mod tests {
 
         let artifacts_path = temp
             .path()
-            .join("target/dev/simple_package.starknet_artifacts.json");
+            .join("target")
+            .join("dev")
+            .join("simple_package.starknet_artifacts.json");
         let artifacts_path = Utf8PathBuf::from_path_buf(artifacts_path).unwrap();
 
         let artifacts = artifacts_for_package(&artifacts_path).unwrap();
@@ -421,7 +430,9 @@ mod tests {
 
         let artifacts_path = temp
             .path()
-            .join("target/dev/simple_package.starknet_artifacts.json");
+            .join("target")
+            .join("dev")
+            .join("simple_package.starknet_artifacts.json");
         let artifacts_path = Utf8PathBuf::from_path_buf(artifacts_path).unwrap();
 
         let contracts = get_contracts_map(&artifacts_path).unwrap();
@@ -429,20 +440,34 @@ mod tests {
         assert!(contracts.contains_key("ERC20"));
         assert!(contracts.contains_key("HelloStarknet"));
 
-        let sierra_contents_erc20 =
-            fs::read_to_string(temp.join("target/dev/simple_package_ERC20.sierra.json")).unwrap();
-        let casm_contents_erc20 =
-            fs::read_to_string(temp.join("target/dev/simple_package_ERC20.casm.json")).unwrap();
+        let sierra_contents_erc20 = fs::read_to_string(
+            temp.join("target")
+                .join("dev")
+                .join("simple_package_ERC20.sierra.json"),
+        )
+        .unwrap();
+        let casm_contents_erc20 = fs::read_to_string(
+            temp.join("target")
+                .join("dev")
+                .join("simple_package_ERC20.casm.json"),
+        )
+        .unwrap();
         let contract = contracts.get("ERC20").unwrap();
         assert_eq!(&sierra_contents_erc20, &contract.sierra);
         assert_eq!(&casm_contents_erc20, &contract.casm);
 
-        let sierra_contents_erc20 =
-            fs::read_to_string(temp.join("target/dev/simple_package_HelloStarknet.sierra.json"))
-                .unwrap();
-        let casm_contents_erc20 =
-            fs::read_to_string(temp.join("target/dev/simple_package_HelloStarknet.casm.json"))
-                .unwrap();
+        let sierra_contents_erc20 = fs::read_to_string(
+            temp.join("target")
+                .join("dev")
+                .join("simple_package_HelloStarknet.sierra.json"),
+        )
+        .unwrap();
+        let casm_contents_erc20 = fs::read_to_string(
+            temp.join("target")
+                .join("dev")
+                .join("simple_package_HelloStarknet.casm.json"),
+        )
+        .unwrap();
         let contract = contracts.get("HelloStarknet").unwrap();
         assert_eq!(&sierra_contents_erc20, &contract.sierra);
         assert_eq!(&casm_contents_erc20, &contract.casm);
@@ -478,7 +503,7 @@ mod tests {
             paths_for_package(&scarb_metadata, &scarb_metadata.workspace.members[0]).unwrap();
 
         assert!(package_path.is_dir());
-        assert!(lib_path.ends_with(Utf8PathBuf::from("src/lib.cairo")));
+        assert!(lib_path.ends_with(Utf8PathBuf::from("src").join("lib.cairo")));
         assert!(lib_path.starts_with(package_path));
     }
 

--- a/crates/forge/tests/e2e/common/runner.rs
+++ b/crates/forge/tests/e2e/common/runner.rs
@@ -21,7 +21,9 @@ pub(crate) fn setup_package(package_name: &str) -> TempDir {
     let snforge_std_path = Utf8PathBuf::from_str("../../snforge_std")
         .unwrap()
         .canonicalize_utf8()
-        .unwrap();
+        .unwrap()
+        .to_string()
+        .replace('\\', "/");
 
     let manifest_path = temp.child("Scarb.toml");
     manifest_path

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -45,7 +45,6 @@ fn simple_package() {
 }
 
 #[test]
-#[ignore]
 fn simple_package_with_git_dependency() {
     let temp = TempDir::new().unwrap();
     temp.copy_from("tests/data/simple_package", &["**/*.cairo", "**/*.toml"])

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -285,6 +285,8 @@ fn with_exit_first() {
                 .unwrap()
                 .canonicalize_utf8()
                 .unwrap()
+                .to_string()
+                .replace('\\', "/")
         ))
         .unwrap();
 


### PR DESCRIPTION
Tested manually on windows, still need to fix some tests as "Windows bad" (absolute paths in toml issues), but in general it works with integration tests and with template

From now on we should use only `join` instead of slashes when creating new paths

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
