### PR TITLE
Add 'v' to tag version in changelog example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```toml
 [dependencies]
 # ...
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "0.4.0" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.4.0" }
 ```
 
 - Moved `ForgeConfigFromScarb` to `scarb.rs` and renamed to `ForgeConfig`


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #494

## Introduced changes

<!-- A brief description of the changes -->

- CHANGELOG example update
  - add `v` to tag dependency documentation

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
