### PR TITLE
Added printing in contracts

### DIFF
--- a/crates/cheatnet/src/contract_print.rs
+++ b/crates/cheatnet/src/contract_print.rs
@@ -48,7 +48,7 @@ pub fn contract_print(
             "print" => {
                 for value in inputs {
                     if let Some(short_string) = as_cairo_short_string(&value) {
-                        println!("PRINT: {value} => {short_string}",);
+                        println!("PRINT: {value} => {short_string}");
                     } else {
                         println!("PRINT: {value}");
                     }

--- a/crates/cheatnet/src/contract_print.rs
+++ b/crates/cheatnet/src/contract_print.rs
@@ -1,0 +1,66 @@
+use cairo_felt::Felt252;
+use cairo_lang_casm::{
+    hints::{Hint, StarknetHint},
+    operand::ResOperand,
+};
+use cairo_lang_runner::{
+    casm_run::{extract_relocatable, vm_get_range},
+    short_string::as_cairo_short_string,
+};
+use cairo_vm::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
+
+pub enum PrintingResult {
+    Printed,
+    Passed,
+    Err(HintError),
+}
+
+fn extract_input(
+    vm: &mut VirtualMachine,
+    input_start: &ResOperand,
+    input_end: &ResOperand,
+) -> Result<Vec<Felt252>, HintError> {
+    let input_start = extract_relocatable(vm, input_start)?;
+    let input_end = extract_relocatable(vm, input_end)?;
+    vm_get_range(vm, input_start, input_end)
+        .map_err(|_| HintError::CustomHint("Failed to read input data".into()))
+}
+
+pub fn contract_print(
+    vm: &mut VirtualMachine,
+    maybe_extended_hint: Option<&Hint>,
+) -> PrintingResult {
+    if let Some(Hint::Starknet(StarknetHint::Cheatcode {
+        selector,
+        input_start,
+        input_end,
+        ..
+    })) = maybe_extended_hint
+    {
+        let selector = &selector.value.to_bytes_be().1;
+        let selector = std::str::from_utf8(selector).unwrap();
+        let inputs = match extract_input(vm, input_start, input_end) {
+            Ok(inputs) => inputs,
+            Err(err) => return PrintingResult::Err(err),
+        };
+
+        match selector {
+            "print" => {
+                for value in inputs {
+                    if let Some(short_string) = as_cairo_short_string(&value) {
+                        println!("PRINT: {value} => {short_string}",);
+                    } else {
+                        println!("PRINT: {value}");
+                    }
+                }
+                return PrintingResult::Printed;
+            }
+            _ => {
+                return PrintingResult::Err(HintError::CustomHint(
+                    "Only `print` cheatcode is available in contracts.".into(),
+                ))
+            }
+        }
+    };
+    PrintingResult::Passed
+}

--- a/crates/cheatnet/src/contract_print.rs
+++ b/crates/cheatnet/src/contract_print.rs
@@ -48,9 +48,11 @@ pub fn contract_print(
             "print" => {
                 for value in inputs {
                     if let Some(short_string) = as_cairo_short_string(&value) {
-                        println!("PRINT: {value} => {short_string}");
+                        println!(
+                            "original value: [{value}], converted to a string: [{short_string}]",
+                        );
                     } else {
-                        println!("PRINT: {value}");
+                        println!("original value: [{value}]");
                     }
                 }
                 return PrintingResult::Printed;

--- a/crates/cheatnet/src/lib.rs
+++ b/crates/cheatnet/src/lib.rs
@@ -7,6 +7,7 @@ use state::{CheatcodeState, DictStateReader};
 
 pub mod cheatcodes;
 pub mod constants;
+pub mod contract_print;
 pub mod conversions;
 pub mod panic_data;
 pub mod rpc;

--- a/crates/cheatnet/src/rpc.rs
+++ b/crates/cheatnet/src/rpc.rs
@@ -17,6 +17,7 @@ use std::{any::Any, collections::HashMap, sync::Arc};
 
 use crate::{
     constants::{build_block_context, build_transaction_context},
+    contract_print::{contract_print, PrintingResult},
     CheatnetState,
 };
 use blockifier::execution::entry_point::{handle_empty_constructor, Retdata};
@@ -369,6 +370,13 @@ impl HintProcessorLogic for CheatableSyscallHandler<'_> {
                 return self.execute_next_syscall_cheated(vm, hint);
             }
         }
+
+        match contract_print(vm, maybe_extended_hint) {
+            PrintingResult::Printed => return Ok(()),
+            PrintingResult::Passed => (),
+            PrintingResult::Err(err) => return Err(err),
+        }
+
         self.syscall_handler
             .execute_hint(vm, exec_scopes, hint_data, constants)
     }

--- a/crates/forge/tests/data/contract_printing/Scarb.toml
+++ b/crates/forge/tests/data/contract_printing/Scarb.toml
@@ -1,0 +1,17 @@
+[package]
+name = "contract_printing"
+version = "0.1.0"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
+
+[[target.starknet-contract]]
+sierra = true
+casm = true
+allowed-libfuncs-deny = false
+
+[dependencies]
+starknet = "2.2.0"
+snforge_std = { path = "../../../../../snforge_std" }
+
+[tool.snforge]
+# exit_first = true

--- a/crates/forge/tests/data/contract_printing/src/lib.cairo
+++ b/crates/forge/tests/data/contract_printing/src/lib.cairo
@@ -1,0 +1,28 @@
+#[starknet::interface]
+trait IHelloStarknet<TContractState> {
+    fn increase_balance(ref self: TContractState, amount: felt252);
+    fn get_balance(self: @TContractState) -> felt252;
+}
+
+#[starknet::contract]
+mod HelloStarknet {
+    use snforge_std::PrintTrait;
+
+    #[storage]
+    struct Storage {
+        balance: felt252, 
+    }
+
+    #[external(v0)]
+    impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
+        fn increase_balance(ref self: ContractState, amount: felt252) {
+            assert(amount != 0, 'Amount cannot be 0');
+            self.balance.write(self.balance.read() + amount);
+            'Hello world!'.print();
+        }
+
+        fn get_balance(self: @ContractState) -> felt252 {
+            self.balance.read()
+        }
+    }
+}

--- a/crates/forge/tests/data/contract_printing/tests/test_contract.cairo
+++ b/crates/forge/tests/data/contract_printing/tests/test_contract.cairo
@@ -1,0 +1,48 @@
+use array::ArrayTrait;
+use result::ResultTrait;
+use option::OptionTrait;
+use traits::TryInto;
+use starknet::ContractAddress;
+use starknet::Felt252TryIntoContractAddress;
+
+use snforge_std::{declare, ContractClass, ContractClassTrait};
+
+use contract_printing::IHelloStarknetSafeDispatcher;
+use contract_printing::IHelloStarknetSafeDispatcherTrait;
+
+fn deploy_contract(name: felt252) -> ContractAddress {
+    let contract = declare(name);
+    contract.deploy(@ArrayTrait::new()).unwrap()
+}
+
+#[test]
+fn test_increase_balance() {
+    let contract_address = deploy_contract('HelloStarknet');
+
+    let safe_dispatcher = IHelloStarknetSafeDispatcher { contract_address };
+
+    let balance_before = safe_dispatcher.get_balance().unwrap();
+    assert(balance_before == 0, 'Invalid balance');
+
+    safe_dispatcher.increase_balance(42).unwrap();
+
+    let balance_after = safe_dispatcher.get_balance().unwrap();
+    assert(balance_after == 42, 'Invalid balance');
+}
+
+#[test]
+fn test_cannot_increase_balance_with_zero_value() {
+    let contract_address = deploy_contract('HelloStarknet');
+
+    let safe_dispatcher = IHelloStarknetSafeDispatcher { contract_address };
+
+    let balance_before = safe_dispatcher.get_balance().unwrap();
+    assert(balance_before == 0, 'Invalid balance');
+
+    match safe_dispatcher.increase_balance(0) {
+        Result::Ok(_) => panic_with_felt252('Should have panicked'),
+        Result::Err(panic_data) => {
+            assert(*panic_data.at(0) == 'Amount cannot be 0', *panic_data.at(0));
+        }
+    };
+}

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -507,3 +507,32 @@ fn should_panic() {
         Tests: 3 passed, 3 failed, 0 skipped
         "#});
 }
+
+#[test]
+fn printing_in_contracts() {
+    let temp = setup_package("contract_printing");
+    let snapbox = runner();
+
+    snapbox
+        .current_dir(&temp)
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r#"
+        [..]Compiling[..]
+        warn: libfunc `cheatcode` is not allowed in the libfuncs list `Default libfunc list`
+         --> contract: HelloStarknet
+        help: try compiling with the `experimental` list
+         --> Scarb.toml
+            [[target.starknet-contract]]
+            allowed-libfuncs-list.name = "experimental"
+        
+        [..]Finished[..]
+        Collected 2 test(s) and 2 test file(s)
+        Running 0 test(s) from contract_printing package
+        Running 2 test(s) from tests/test_contract.cairo
+        PRINT: 22405534230753963835153736737 => Hello world!
+        [PASS] test_contract::test_increase_balance
+        [PASS] test_contract::test_cannot_increase_balance_with_zero_value
+        Tests: 2 passed, 0 failed, 0 skipped
+        "#});
+}

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -530,7 +530,7 @@ fn printing_in_contracts() {
         Collected 2 test(s) and 2 test file(s)
         Running 0 test(s) from contract_printing package
         Running 2 test(s) from tests/test_contract.cairo
-        PRINT: 22405534230753963835153736737 => Hello world!
+        original value: [22405534230753963835153736737], converted to a string: [Hello world!]
         [PASS] test_contract::test_increase_balance
         [PASS] test_contract::test_cannot_increase_balance_with_zero_value
         Tests: 2 passed, 0 failed, 0 skipped


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #481

## Introduced changes

<!-- A brief description of the changes -->

To use this functionality this has to be included in `Scarb.toml`:

```toml
[[target.starknet-contract]]
allowed-libfuncs-deny = false
```


Effect: 
<img width="512" alt="image" src="https://github.com/foundry-rs/starknet-foundry/assets/39826471/79810557-7338-4458-8518-08b2f443586f">

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
