### PR TITLE
Fix events

### DIFF
--- a/crates/forge/tests/integration/spy_events.rs
+++ b/crates/forge/tests/integration/spy_events.rs
@@ -92,7 +92,16 @@ fn assert_emitted_fails() {
 
     assert_failed!(result);
     assert_case_output_contains!(result, "test_expect_events_simple", "FirstEvent");
-    assert_case_output_contains!(result, "test_expect_events_simple", "event was not emitted");
+    assert_case_output_contains!(
+        result,
+        "test_expect_events_simple",
+        "event with matching data and"
+    );
+    assert_case_output_contains!(
+        result,
+        "test_expect_events_simple",
+        "keys was not emitted from"
+    );
 }
 
 #[test]
@@ -148,7 +157,12 @@ fn expect_three_events_while_two_emitted() {
     assert_case_output_contains!(
         result,
         "test_expect_three_events_while_two_emitted",
-        "event was not emitted"
+        "event with matching data and"
+    );
+    assert_case_output_contains!(
+        result,
+        "test_expect_three_events_while_two_emitted",
+        "keys was not emitted from"
     );
 }
 
@@ -245,15 +259,19 @@ fn event_emitted_wrong_data_asserted() {
 
     assert_failed!(result);
     assert_case_output_contains!(result, "test_assert_wrong_data", "FirstEvent");
-    assert_case_output_contains!(result, "test_assert_wrong_data", "event was emitted from");
     assert_case_output_contains!(
         result,
         "test_assert_wrong_data",
-        "1123343347349132833855871321423793552243395519676903121856829201345276603084"
+        "event with matching data and"
     );
     assert_case_output_contains!(
         result,
         "test_assert_wrong_data",
-        "but keys or data are different"
+        "keys was not emitted from"
+    );
+    assert_case_output_contains!(
+        result,
+        "test_assert_wrong_data",
+        "1123343347349132833855871321423793552243395519676903121856829201345276603084"
     );
 }

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -26,7 +26,7 @@ enum SpyOn {
 
 > ⚠️ **Warning**
 >
-> Sharing contracts to spy on between spies can result in unexpected behavior — avoid it if possible.
+> Spying on the same contract with multiple spies can result in unexpected behavior — avoid it if possible.
 
 `EventSpy` implements `EventFetcher` and `EventAssertions` traits.
 

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -24,6 +24,10 @@ enum SpyOn {
 }
 ```
 
+> ⚠️ **Warning**
+>
+> Sharing contracts to spy on between spies can result in unexpected behavior — avoid it if possible.
+
 `EventSpy` implements `EventFetcher` and `EventAssertions` traits.
 
 ```rust

--- a/snforge_std/src/events.cairo
+++ b/snforge_std/src/events.cairo
@@ -82,7 +82,8 @@ impl EventAssertionsImpl of EventAssertions {
                 panic(
                     array![
                         *events.at(i).name,
-                        'event was not emitted from',
+                        'event with matching data and',
+                        'keys was not emitted from',
                         (*events.at(i).from).into()
                     ]
                 );
@@ -102,21 +103,10 @@ fn assert_if_emitted(ref self: EventSpy, event: Event) -> bool {
         }
 
         if event_name_hash(event.name) == *self.events.at(j).name
-            && event.from == *emitted_events.at(j).from {
-            if @event.keys != emitted_events.at(j).keys
-                || @event.data != emitted_events.at(j).data {
-                panic(
-                    array![
-                        event.name,
-                        'event was emitted from',
-                        event.from.into(),
-                        'but keys or data are different'
-                    ]
-                );
-            }
-
+          && event.from == *emitted_events.at(j).from
+          && @event.keys == emitted_events.at(j).keys
+          && @event.data == emitted_events.at(j).data {
             remove_event(ref self, j);
-
             break true;
         }
 

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -32,12 +32,13 @@ mod forge_print;
 
 use forge_print::PrintTrait;
 
-mod event;
 
-use event::SpyOn;
-use event::Event;
-use event::EventSpy;
-use event::EventFetcher;
-use event::EventAssertions;
-use event::spy_events;
-use event::event_name_hash;
+mod events;
+
+use events::SpyOn;
+use events::Event;
+use events::EventSpy;
+use events::EventFetcher;
+use events::EventAssertions;
+use events::spy_events;
+use events::event_name_hash;


### PR DESCRIPTION
## Breaking changes

Does not require to assert events in any specific order when looking for 2 events with same `from` and `name` but different `data` or `keys

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
