### PR TITLE
Fix wrong error message when there is no scarb and path to scarb.toml is supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Cast
 
+#### Changed
+
+- fixed misleading error message when there was no scarb in PATH and `--path-to-scarb-toml` was passed
+
 ## [0.5.0] - 2023-08-30
 
 ### Forge

--- a/crates/cast/src/helpers/scarb_utils.rs
+++ b/crates/cast/src/helpers/scarb_utils.rs
@@ -67,6 +67,9 @@ pub fn get_scarb_manifest() -> Result<Utf8PathBuf> {
 }
 
 pub fn get_scarb_metadata(manifest_path: &Utf8PathBuf) -> Result<scarb_metadata::Metadata> {
+    which::which("scarb")
+        .context("Cannot find `scarb` binary in PATH. Make sure you have Scarb installed https://github.com/software-mansion/scarb")?;
+
     scarb_metadata::MetadataCommand::new()
         .inherit_stderr()
         .manifest_path(manifest_path)

--- a/crates/cast/src/starknet_commands/declare.rs
+++ b/crates/cast/src/starknet_commands/declare.rs
@@ -64,8 +64,7 @@ pub async fn declare(
         Some(path) => path,
         None => get_scarb_manifest().context("Failed to obtain manifest path from scarb")?,
     };
-    which::which("scarb")
-        .context("Cannot find `scarb` binary in PATH. Make sure you have Scarb installed https://github.com/software-mansion/scarb")?;
+
     let command_result = Command::new("scarb")
         .arg("--manifest-path")
         .arg(&manifest_path)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes https://github.com/foundry-rs/starknet-foundry/issues/545

## Introduced changes

When there was no scarb in PATH and a user passed the `--path-to-scarb-toml`, the error was that we couldn't find the file (even though it exists in the fs), where is should be that scarb was not found in PATH. This PR changes that behaviour. The issue did not persists, if user did not pass the `--path-to-scarb-toml` flag.

## Breaking changes

None

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
