### PR TITLE
[tests] Use dynamically calculated hashes and addresses instead of hard-coded ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,6 +1080,7 @@ dependencies = [
  "clap",
  "console",
  "ctor",
+ "dotenv",
  "fs_extra",
  "indoc",
  "primitive-types",

--- a/crates/cast/.gitignore
+++ b/crates/cast/.gitignore
@@ -3,3 +3,4 @@ tests/utils/cairo
 tests/utils/scarb*
 /tests/data/contracts/**/*.tool-versions
 /tests/utils/compiler/
+.env*

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -32,6 +32,7 @@ tempfile = "3.8.0"
 test-case = "3.1.0"
 fs_extra = "1.3.0"
 sealed_test = "1.0.0"
+dotenv = "0.15.0"
 
 [[bin]]
 name = "sncast"

--- a/crates/cast/tests/e2e/call.rs
+++ b/crates/cast/tests/e2e/call.rs
@@ -1,11 +1,11 @@
-use crate::helpers::constants::{MAP_CONTRACT_ADDRESS_V1, MAP_CONTRACT_ADDRESS_V2};
 use crate::helpers::fixtures::{default_cli_args, invoke_map_contract};
 use crate::helpers::runner::runner;
 use indoc::indoc;
+use std::env;
 use test_case::test_case;
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1 ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2 ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_happy_case(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -31,8 +31,8 @@ fn test_happy_case(contract_address: &str) {
     "#});
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_call_after_storage_changed(contract_address: &str, account: &str) {
     invoke_map_contract("0x2", "0x3", account, contract_address).await;
@@ -75,8 +75,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1 ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2 ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -95,8 +95,8 @@ fn test_wrong_function_name(contract_address: &str) {
     "#});
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1 ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2 ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -119,11 +119,12 @@ fn test_wrong_calldata(contract_address: &str) {
 
 #[tokio::test]
 async fn test_invalid_selector() {
+    let address = &env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!");
     let mut args = default_cli_args();
     args.append(&mut vec![
         "call",
         "--contract-address",
-        MAP_CONTRACT_ADDRESS_V2,
+        address,
         "--function",
         "ą",
         "--calldata",

--- a/crates/cast/tests/e2e/call.rs
+++ b/crates/cast/tests/e2e/call.rs
@@ -1,11 +1,10 @@
-use crate::helpers::fixtures::{default_cli_args, invoke_map_contract};
+use crate::helpers::fixtures::{default_cli_args, from_env, invoke_map_contract};
 use crate::helpers::runner::runner;
 use indoc::indoc;
-use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str() ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str() ; "when cairo2 contract")]
 fn test_happy_case(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -31,8 +30,8 @@ fn test_happy_case(contract_address: &str) {
     "#});
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_call_after_storage_changed(contract_address: &str, account: &str) {
     invoke_map_contract("0x2", "0x3", account, contract_address).await;
@@ -75,8 +74,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str() ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str() ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -95,8 +94,8 @@ fn test_wrong_function_name(contract_address: &str) {
     "#});
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str() ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str() ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -119,12 +118,12 @@ fn test_wrong_calldata(contract_address: &str) {
 
 #[tokio::test]
 async fn test_invalid_selector() {
-    let address = &env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!");
+    let address = from_env("CAST_MAP_V2_ADDRESS").unwrap();
     let mut args = default_cli_args();
     args.append(&mut vec![
         "call",
         "--contract-address",
-        address,
+        &address,
         "--function",
         "ą",
         "--calldata",

--- a/crates/cast/tests/e2e/call.rs
+++ b/crates/cast/tests/e2e/call.rs
@@ -4,8 +4,8 @@ use indoc::indoc;
 use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_happy_case(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -31,8 +31,8 @@ fn test_happy_case(contract_address: &str) {
     "#});
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_call_after_storage_changed(contract_address: &str, account: &str) {
     invoke_map_contract("0x2", "0x3", account, contract_address).await;
@@ -75,8 +75,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -95,8 +95,8 @@ fn test_wrong_function_name(contract_address: &str) {
     "#});
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!") ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!") ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -119,7 +119,7 @@ fn test_wrong_calldata(contract_address: &str) {
 
 #[tokio::test]
 async fn test_invalid_selector() {
-    let address = &env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!");
+    let address = &env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!");
     let mut args = default_cli_args();
     args.append(&mut vec![
         "call",

--- a/crates/cast/tests/e2e/deploy.rs
+++ b/crates/cast/tests/e2e/deploy.rs
@@ -1,13 +1,14 @@
 use crate::helpers::constants::ACCOUNT;
-use crate::helpers::fixtures::{default_cli_args, get_transaction_hash, get_transaction_receipt};
+use crate::helpers::fixtures::{
+    default_cli_args, from_env, get_transaction_hash, get_transaction_receipt,
+};
 use crate::helpers::runner::runner;
 use indoc::indoc;
 use starknet::core::types::TransactionReceipt::Invoke;
-use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_CLASS_HASH").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_CLASS_HASH").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -35,8 +36,8 @@ async fn test_happy_case(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").unwrap().as_str(), "user3" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").unwrap().as_str(), "user4" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -61,8 +62,8 @@ async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").unwrap().as_str(), "user3" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").unwrap().as_str(), "user4" ; "when cairo2 contract")]
 fn test_wrong_calldata(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -99,8 +100,8 @@ async fn test_contract_not_declared() {
     assert!(output.contains("Class with hash 0x1 is not declared."));
 }
 
-#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_CLASS_HASH").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_CLASS_HASH").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 fn test_contract_already_deployed(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -120,8 +121,8 @@ fn test_contract_already_deployed(class_hash: &str, account: &str) {
     assert!(output.contains("StarknetErrorCode.CONTRACT_ADDRESS_UNAVAILABLE"));
 }
 
-#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_CLASS_HASH").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_CLASS_HASH").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/deploy.rs
+++ b/crates/cast/tests/e2e/deploy.rs
@@ -1,15 +1,13 @@
-use crate::helpers::constants::{
-    ACCOUNT, CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V1, CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V2,
-    MAP_CLASS_HASH_V1, MAP_CLASS_HASH_V2,
-};
+use crate::helpers::constants::ACCOUNT;
 use crate::helpers::fixtures::{default_cli_args, get_transaction_hash, get_transaction_receipt};
 use crate::helpers::runner::runner;
 use indoc::indoc;
 use starknet::core::types::TransactionReceipt::Invoke;
+use std::env;
 use test_case::test_case;
 
-#[test_case(MAP_CLASS_HASH_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CLASS_HASH_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -37,8 +35,8 @@ async fn test_happy_case(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V1, "user3" ; "when cairo1 contract")]
-#[test_case(CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V2, "user4" ; "when cairo2 contract")]
+#[test_case(&env::var("WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
+#[test_case(&env::var("WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -63,8 +61,8 @@ async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V1, "user3" ; "when cairo1 contract")]
-#[test_case(CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V2, "user4" ; "when cairo2 contract")]
+#[test_case(&env::var("WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
+#[test_case(&env::var("WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
 fn test_wrong_calldata(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -101,8 +99,8 @@ async fn test_contract_not_declared() {
     assert!(output.contains("Class with hash 0x1 is not declared."));
 }
 
-#[test_case(MAP_CLASS_HASH_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CLASS_HASH_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_contract_already_deployed(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -122,8 +120,8 @@ fn test_contract_already_deployed(class_hash: &str, account: &str) {
     assert!(output.contains("StarknetErrorCode.CONTRACT_ADDRESS_UNAVAILABLE"));
 }
 
-#[test_case(MAP_CLASS_HASH_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CLASS_HASH_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/deploy.rs
+++ b/crates/cast/tests/e2e/deploy.rs
@@ -6,8 +6,8 @@ use starknet::core::types::TransactionReceipt::Invoke;
 use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -35,8 +35,8 @@ async fn test_happy_case(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(&env::var("WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
-#[test_case(&env::var("WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
@@ -61,8 +61,8 @@ async fn test_happy_case_with_constructor(class_hash: &str, account: &str) {
     assert!(matches!(receipt, Invoke(_)));
 }
 
-#[test_case(&env::var("WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
-#[test_case(&env::var("WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V1_CLASS_HASH not available in env!"), "user3" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH").expect("CONTRACT_CAST_WITH_CONSTRUCTOR_V2_CLASS_HASH not available in env!"), "user4" ; "when cairo2 contract")]
 fn test_wrong_calldata(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -99,8 +99,8 @@ async fn test_contract_not_declared() {
     assert!(output.contains("Class with hash 0x1 is not declared."));
 }
 
-#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_contract_already_deployed(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -120,8 +120,8 @@ fn test_contract_already_deployed(class_hash: &str, account: &str) {
     assert!(output.contains("StarknetErrorCode.CONTRACT_ADDRESS_UNAVAILABLE"));
 }
 
-#[test_case(&env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_CLASS_HASH").expect("MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_CLASS_HASH").expect("CAST_MAP_V2_CLASS_HASH not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(class_hash: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/invoke.rs
+++ b/crates/cast/tests/e2e/invoke.rs
@@ -8,8 +8,8 @@ use starknet::core::types::TransactionReceipt::Invoke;
 use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
@@ -59,8 +59,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -81,8 +81,8 @@ fn test_wrong_function_name(contract_address: &str, account: &str) {
     "#});
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -108,8 +108,8 @@ fn test_wrong_calldata(contract_address: &str, account: &str) {
     assert!(stderr_str.contains(&convert_to_hex(contract_address)));
 }
 
-#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/invoke.rs
+++ b/crates/cast/tests/e2e/invoke.rs
@@ -1,12 +1,15 @@
-use crate::helpers::constants::{ACCOUNT, MAP_CONTRACT_ADDRESS_V1, MAP_CONTRACT_ADDRESS_V2};
-use crate::helpers::fixtures::{default_cli_args, get_transaction_hash, get_transaction_receipt};
+use crate::helpers::constants::ACCOUNT;
+use crate::helpers::fixtures::{
+    convert_to_hex, default_cli_args, get_transaction_hash, get_transaction_receipt,
+};
 use crate::helpers::runner::runner;
 use indoc::indoc;
 use starknet::core::types::TransactionReceipt::Invoke;
+use std::env;
 use test_case::test_case;
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
@@ -56,8 +59,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -78,8 +81,8 @@ fn test_wrong_function_name(contract_address: &str, account: &str) {
     "#});
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -102,11 +105,11 @@ fn test_wrong_calldata(contract_address: &str, account: &str) {
         std::str::from_utf8(&out.stderr).expect("failed to convert command output to string");
 
     assert!(stderr_str.contains("Error in the called contract"));
-    assert!(stderr_str.contains(contract_address));
+    assert!(stderr_str.contains(&convert_to_hex(contract_address)));
 }
 
-#[test_case(MAP_CONTRACT_ADDRESS_V1, "user1" ; "when cairo1 contract")]
-#[test_case(MAP_CONTRACT_ADDRESS_V2, "user2" ; "when cairo2 contract")]
+#[test_case(&env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
+#[test_case(&env::var("MAP_V2_ADDRESS").expect("MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/invoke.rs
+++ b/crates/cast/tests/e2e/invoke.rs
@@ -1,15 +1,14 @@
 use crate::helpers::constants::ACCOUNT;
 use crate::helpers::fixtures::{
-    convert_to_hex, default_cli_args, get_transaction_hash, get_transaction_receipt,
+    convert_to_hex, default_cli_args, from_env, get_transaction_hash, get_transaction_receipt,
 };
 use crate::helpers::runner::runner;
 use indoc::indoc;
 use starknet::core::types::TransactionReceipt::Invoke;
-use std::env;
 use test_case::test_case;
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 #[tokio::test]
 async fn test_happy_case(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
@@ -59,8 +58,8 @@ async fn test_contract_does_not_exist() {
     "#});
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 fn test_wrong_function_name(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -81,8 +80,8 @@ fn test_wrong_function_name(contract_address: &str, account: &str) {
     "#});
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 fn test_wrong_calldata(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![
@@ -108,8 +107,8 @@ fn test_wrong_calldata(contract_address: &str, account: &str) {
     assert!(stderr_str.contains(&convert_to_hex(contract_address)));
 }
 
-#[test_case(&env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!"), "user1" ; "when cairo1 contract")]
-#[test_case(&env::var("CAST_MAP_V2_ADDRESS").expect("CAST_MAP_V2_ADDRESS not available in env!"), "user2" ; "when cairo2 contract")]
+#[test_case(from_env("CAST_MAP_V1_ADDRESS").unwrap().as_str(), "user1" ; "when cairo1 contract")]
+#[test_case(from_env("CAST_MAP_V2_ADDRESS").unwrap().as_str(), "user2" ; "when cairo2 contract")]
 fn test_too_low_max_fee(contract_address: &str, account: &str) {
     let mut args = default_cli_args();
     args.append(&mut vec![

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -1,13 +1,10 @@
-use std::env;
-
-use crate::helpers::constants::{
-    ACCOUNT, ACCOUNT_FILE_PATH, CONTRACTS_DIR, MAP_CONTRACT_ADDRESS_V1, URL,
-};
+use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, URL};
 use crate::helpers::fixtures::duplicate_directory_with_salt;
 use crate::helpers::runner::runner;
 use cast::helpers::constants::KEYSTORE_PASSWORD_ENV_VAR;
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
+use std::env;
 use std::fs;
 
 #[tokio::test]
@@ -58,6 +55,7 @@ async fn test_happy_case_from_cli_no_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_from_cli_with_scarb() {
+    let address = env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!");
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,
@@ -72,7 +70,7 @@ async fn test_happy_case_from_cli_with_scarb() {
         ACCOUNT,
         "call",
         "--contract-address",
-        MAP_CONTRACT_ADDRESS_V1,
+        &address,
         "--function",
         "get",
         "--calldata",
@@ -93,6 +91,7 @@ async fn test_happy_case_from_cli_with_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_mixed() {
+    let address = env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!");
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,
@@ -105,7 +104,7 @@ async fn test_happy_case_mixed() {
         ACCOUNT,
         "call",
         "--contract-address",
-        MAP_CONTRACT_ADDRESS_V1,
+        &address,
         "--function",
         "get",
         "--calldata",

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -1,5 +1,5 @@
 use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, CONTRACTS_DIR, URL};
-use crate::helpers::fixtures::duplicate_directory_with_salt;
+use crate::helpers::fixtures::{duplicate_directory_with_salt, from_env};
 use crate::helpers::runner::runner;
 use cast::helpers::constants::KEYSTORE_PASSWORD_ENV_VAR;
 use indoc::indoc;
@@ -55,7 +55,7 @@ async fn test_happy_case_from_cli_no_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_from_cli_with_scarb() {
-    let address = env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!");
+    let address = from_env("CAST_MAP_V1_ADDRESS").unwrap();
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,
@@ -91,7 +91,7 @@ async fn test_happy_case_from_cli_with_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_mixed() {
-    let address = env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!");
+    let address = from_env("CAST_MAP_V1_ADDRESS").unwrap();
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -55,7 +55,7 @@ async fn test_happy_case_from_cli_no_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_from_cli_with_scarb() {
-    let address = env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!");
+    let address = env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!");
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,
@@ -91,7 +91,7 @@ async fn test_happy_case_from_cli_with_scarb() {
 
 #[tokio::test]
 async fn test_happy_case_mixed() {
-    let address = env::var("MAP_V1_ADDRESS").expect("MAP_V1_ADDRESS not available in env!");
+    let address = env::var("CAST_MAP_V1_ADDRESS").expect("CAST_MAP_V1_ADDRESS not available in env!");
     let args = vec![
         "--accounts-file",
         ACCOUNT_FILE_PATH,

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -1,4 +1,4 @@
-use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, URL};
+use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, CONTRACTS_DIR, URL};
 use crate::helpers::fixtures::duplicate_directory_with_salt;
 use crate::helpers::runner::runner;
 use cast::helpers::constants::KEYSTORE_PASSWORD_ENV_VAR;

--- a/crates/cast/tests/helpers/constants.rs
+++ b/crates/cast/tests/helpers/constants.rs
@@ -8,23 +8,10 @@ pub const NETWORK: &str = "testnet";
 pub const SEED: u32 = 1_053_545_548;
 
 pub const CONTRACTS_DIR: &str = "tests/data/contracts";
-pub const MAP_CONTRACT_ADDRESS_V1: &str =
-    "0x6a9b1c31fa25ca8f3cecb58142f3ec4d1f7611ed9520b4d3ae598d02d625e41";
-pub const MAP_CONTRACT_ADDRESS_V2: &str =
-    "0x3b96d821f8754564fd0b8a9ded6f549b675d7767bae1a5706f5095f81f5e357";
-pub const MAP_CLASS_HASH_V1: &str =
-    "0x76e94149fc55e7ad9c5fe3b9af570970ae2cf51205f8452f39753e9497fe849";
-pub const MAP_CLASS_HASH_V2: &str =
-    "0x5e8e8e76fcdc72f519ff2697fb5a774f8a029b45f2b61f9664298ab288e4bb1";
-pub const CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V1: &str =
-    "0x02bb3d35dba2984b3d0cd0901b4e7de5411daff6bff5e072060bcfadbbd257b1";
-pub const CONTRACT_WITH_CONSTRUCTOR_CLASS_HASH_V2: &str =
-    "0x01a8f37a7de9da1336190b6d34a961d6ef881239e85431335c33fa2b95926543";
+pub const DEVNET_ENV_FILE: &str = ".env.devnet_hashes_and_addresses";
+pub const MULTICALL_CONFIGS_DIR: &str = "crates/cast/tests/data/multicall_configs";
+
 pub const DECLARE_TRANSACTION_HASH: &str =
     "0x03000a327c4651c8317a88000c11830e4988d94ed130e875987521d7b173763d";
-pub const FEE_CONTRACT_ADDRESS: &str =
-    "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
 pub const DEVNET_OZ_CLASS_HASH: &str =
     "0x646a72e2aab2fca75d713fbe4a58f2d12cbd64105621b89dc9ce7045b5bf02b";
-
-pub const MULTICALL_CONFIGS_DIR: &str = "crates/cast/tests/data/multicall_configs";

--- a/crates/cast/tests/helpers/devnet.rs
+++ b/crates/cast/tests/helpers/devnet.rs
@@ -69,22 +69,22 @@ fn start_devnet() {
     rt.block_on(declare_deploy_contract(
         "user1",
         "/v1/map/target/dev/map_v1_Map",
-        "MAP_V1",
+        "CAST_MAP_V1",
     ));
     rt.block_on(declare_deploy_contract(
         "user2",
         "/v2/map/target/dev/map_v2_Map",
-        "MAP_V2",
+        "CAST_MAP_V2",
     ));
     rt.block_on(declare_contract(
         "user3",
         "/v1/constructor_with_params/target/dev/constructor_with_params_v1_ConstructorWithParams",
-        "WITH_CONSTRUCTOR_V1",
+        "CAST_WITH_CONSTRUCTOR_V1",
     ));
     rt.block_on(declare_contract(
         "user4",
         "/v2/constructor_with_params/target/dev/constructor_with_params_v2_ConstructorWithParams",
-        "WITH_CONSTRUCTOR_V2",
+        "CAST_WITH_CONSTRUCTOR_V2",
     ));
     dotenv::from_filename(DEVNET_ENV_FILE).unwrap();
 }

--- a/crates/cast/tests/helpers/devnet.rs
+++ b/crates/cast/tests/helpers/devnet.rs
@@ -1,5 +1,5 @@
-use crate::helpers::constants::{COMPILER_VERSION, SEED, URL};
-use crate::helpers::fixtures::{declare_contract, declare_deploy_contract};
+use crate::helpers::constants::{COMPILER_VERSION, DEVNET_ENV_FILE, SEED, URL};
+use crate::helpers::fixtures::{declare_contract, declare_deploy_contract, remove_devnet_env};
 use ctor::{ctor, dtor};
 use std::net::TcpStream;
 use std::process::{Command, Stdio};
@@ -15,6 +15,7 @@ fn start_devnet() {
         TcpStream::connect(address).is_ok()
     }
 
+    remove_devnet_env();
     let port = Url::parse(URL).unwrap().port().unwrap_or(80).to_string();
     let host = Url::parse(URL)
         .unwrap()
@@ -68,19 +69,24 @@ fn start_devnet() {
     rt.block_on(declare_deploy_contract(
         "user1",
         "/v1/map/target/dev/map_v1_Map",
+        "MAP_V1",
     ));
     rt.block_on(declare_deploy_contract(
         "user2",
         "/v2/map/target/dev/map_v2_Map",
+        "MAP_V2",
     ));
     rt.block_on(declare_contract(
         "user3",
         "/v1/constructor_with_params/target/dev/constructor_with_params_v1_ConstructorWithParams",
+        "WITH_CONSTRUCTOR_V1",
     ));
     rt.block_on(declare_contract(
         "user4",
         "/v2/constructor_with_params/target/dev/constructor_with_params_v2_ConstructorWithParams",
+        "WITH_CONSTRUCTOR_V2",
     ));
+    dotenv::from_filename(DEVNET_ENV_FILE).unwrap();
 }
 
 #[cfg(test)]
@@ -94,4 +100,5 @@ fn stop_devnet() {
         ])
         .spawn()
         .expect("Failed to kill devnet processes");
+    remove_devnet_env();
 }

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -1,6 +1,8 @@
-use crate::helpers::constants::{ACCOUNT_FILE_PATH, CONTRACTS_DIR, URL};
+use crate::helpers::constants::{ACCOUNT_FILE_PATH, CONTRACTS_DIR, DEVNET_ENV_FILE, URL};
 use camino::Utf8PathBuf;
+use cast::helpers::constants::UDC_ADDRESS;
 use cast::{get_account, get_provider, parse_number};
+use primitive_types::U256;
 use serde_json::{json, Value};
 use starknet::accounts::{Account, Call};
 use starknet::contract::ContractFactory;
@@ -12,10 +14,12 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use std::collections::HashMap;
 use std::fs;
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::sync::Arc;
 use url::Url;
 
-pub async fn declare_contract(account: &str, path: &str) -> FieldElement {
+pub async fn declare_contract(account: &str, path: &str, shortname: &str) -> FieldElement {
     let provider = get_provider(URL).expect("Could not get the provider");
     let account = get_account(
         account,
@@ -50,11 +54,13 @@ pub async fn declare_contract(account: &str, path: &str) -> FieldElement {
         casm_class_hash,
     );
 
-    declaration.send().await.unwrap().class_hash
+    let hash = declaration.send().await.unwrap().class_hash;
+    write_devnet_env(format!("{shortname}_CLASS_HASH").as_str(), &hash);
+    hash
 }
 
-pub async fn declare_deploy_contract(account: &str, path: &str) {
-    let class_hash = declare_contract(account, path).await;
+pub async fn declare_deploy_contract(account: &str, path: &str, shortname: &str) {
+    let class_hash = declare_contract(account, path, shortname).await;
 
     let provider = get_provider(URL).expect("Could not get the provider");
     let account = get_account(
@@ -68,7 +74,24 @@ pub async fn declare_deploy_contract(account: &str, path: &str) {
 
     let factory = ContractFactory::new(class_hash, &account);
     let deployment = factory.deploy(Vec::new(), FieldElement::ONE, true);
-    deployment.send().await.unwrap();
+
+    let transaction_hash = deployment.send().await.unwrap().transaction_hash;
+    let receipt = get_transaction_receipt(transaction_hash).await;
+    let mut address = None;
+    match receipt {
+        TransactionReceipt::Invoke(invoke_receipt) => {
+            for event in invoke_receipt.events {
+                if event.from_address == FieldElement::from_hex_be(UDC_ADDRESS).unwrap() {
+                    address = event.data.first().copied();
+                    break;
+                }
+            }
+        }
+        _ => {
+            panic!("Unexpected TransactionReceipt variant");
+        }
+    };
+    write_devnet_env(format!("{shortname}_ADDRESS").as_str(), &address.unwrap());
 }
 
 pub async fn invoke_map_contract(key: &str, value: &str, account: &str, contract_address: &str) {
@@ -199,4 +222,26 @@ pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt:
         .expect("Unable to change contract code");
 
     dest_path
+}
+
+pub fn remove_devnet_env() {
+    if Utf8PathBuf::from(DEVNET_ENV_FILE).is_file() {
+        fs::remove_file(DEVNET_ENV_FILE).unwrap();
+    }
+}
+
+fn write_devnet_env(key: &str, value: &FieldElement) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(DEVNET_ENV_FILE)
+        .unwrap();
+
+    writeln!(file, "{key}={value}").unwrap();
+}
+
+#[must_use]
+pub fn convert_to_hex(value: &str) -> String {
+    let dec = U256::from_dec_str(value).expect("Invalid decimal string");
+    format!("{dec:#x}")
 }

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -13,6 +13,7 @@ use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -244,4 +245,11 @@ fn write_devnet_env(key: &str, value: &FieldElement) {
 pub fn convert_to_hex(value: &str) -> String {
     let dec = U256::from_dec_str(value).expect("Invalid decimal string");
     format!("{dec:#x}")
+}
+
+pub fn from_env(name: &str) -> Result<String, String> {
+    match env::var(name) {
+        Ok(value) => Ok(value),
+        Err(_) => Err(format!("Variable {name} not available in env!")),
+    }
 }

--- a/crates/cast/tests/integration/wait_for_tx.rs
+++ b/crates/cast/tests/integration/wait_for_tx.rs
@@ -1,13 +1,12 @@
 use crate::helpers::{
     constants::{ACCOUNT, ACCOUNT_FILE_PATH, DECLARE_TRANSACTION_HASH},
-    fixtures::create_test_provider,
+    fixtures::{create_test_provider, from_env},
 };
 use camino::Utf8PathBuf;
 use cast::{get_account, helpers::constants::DEFAULT_RETRIES};
 use cast::{handle_wait_for_tx, parse_number, wait_for_tx};
 use starknet::contract::ContractFactory;
 use starknet::core::types::FieldElement;
-use std::env;
 
 #[tokio::test]
 async fn test_happy_path() {
@@ -34,10 +33,9 @@ async fn test_rejected_transaction() {
     )
     .await
     .expect("Could not get the account");
-    let class_hash =
-        &env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!");
+    let class_hash = from_env("CAST_MAP_V1_CLASS_HASH").unwrap();
 
-    let factory = ContractFactory::new(parse_number(class_hash).unwrap(), account);
+    let factory = ContractFactory::new(parse_number(&class_hash).unwrap(), account);
     let deployment = factory
         .deploy(&Vec::new(), FieldElement::ONE, false)
         .max_fee(FieldElement::ONE);

--- a/crates/cast/tests/integration/wait_for_tx.rs
+++ b/crates/cast/tests/integration/wait_for_tx.rs
@@ -35,7 +35,7 @@ async fn test_rejected_transaction() {
     .await
     .expect("Could not get the account");
     let class_hash =
-        &env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!");
+        &env::var("CAST_MAP_V1_CLASS_HASH").expect("CAST_MAP_V1_CLASS_HASH not available in env!");
 
     let factory = ContractFactory::new(parse_number(class_hash).unwrap(), account);
     let deployment = factory

--- a/crates/cast/tests/integration/wait_for_tx.rs
+++ b/crates/cast/tests/integration/wait_for_tx.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{
-    constants::{ACCOUNT, ACCOUNT_FILE_PATH, DECLARE_TRANSACTION_HASH, MAP_CLASS_HASH_V1},
+    constants::{ACCOUNT, ACCOUNT_FILE_PATH, DECLARE_TRANSACTION_HASH},
     fixtures::create_test_provider,
 };
 use camino::Utf8PathBuf;
@@ -7,6 +7,7 @@ use cast::{get_account, helpers::constants::DEFAULT_RETRIES};
 use cast::{handle_wait_for_tx, parse_number, wait_for_tx};
 use starknet::contract::ContractFactory;
 use starknet::core::types::FieldElement;
+use std::env;
 
 #[tokio::test]
 async fn test_happy_path() {
@@ -33,8 +34,10 @@ async fn test_rejected_transaction() {
     )
     .await
     .expect("Could not get the account");
+    let class_hash =
+        &env::var("MAP_V1_CLASS_HASH").expect("MAP_V1_CLASS_HASH not available in env!");
 
-    let factory = ContractFactory::new(parse_number(MAP_CLASS_HASH_V1).unwrap(), account);
+    let factory = ContractFactory::new(parse_number(class_hash).unwrap(), account);
     let deployment = factory
         .deploy(&Vec::new(), FieldElement::ONE, false)
         .max_fee(FieldElement::ONE);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

This PR does not close any issue, but is a part of https://github.com/foundry-rs/starknet-foundry/issues/429
Hashes and addresses changed every time we updated devnet/compilers. This is a bit tiresome to update them each time, plus there probably is no need for that. This PR makes the tests to use hashes and addresses taken directly from our code.

## Introduced changes

<!-- A brief description of the changes -->

- do not use hard coded hashes and addresses

## Breaking changes

<!-- List of all breaking changes, if applicable -->
None

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
