### PR TITLE
Remove usage of env variable for rpc url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-CHEATNET_RPC_URL=http://your.integration.rpc.url

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,7 @@ jobs:
         with:
           scarb-version: ${{ env.SCARB_VERSION }}
       - name: Run Cheatnet tests
-        run: |
-          echo CHEATNET_RPC_URL=${{ secrets.CHEATNET_RPC_URL }} >> .env
-          cargo test -p cheatnet
+        run: cargo test -p cheatnet
 
   test-cast:
     name: Test Cast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,7 +1133,6 @@ dependencies = [
  "camino",
  "conversions",
  "ctor",
- "dotenv",
  "flate2",
  "include_dir",
  "indoc",
@@ -1598,12 +1597,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dyn-clone"

--- a/crates/cheatnet/Cargo.toml
+++ b/crates/cheatnet/Cargo.toml
@@ -31,7 +31,6 @@ tokio.workspace = true
 num-bigint.workspace = true
 conversions = { path = "../conversions" }
 flate2 = "1.0.26"
-dotenv = "0.15.0"
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/cheatnet/tests/common/state.rs
+++ b/crates/cheatnet/tests/common/state.rs
@@ -23,6 +23,6 @@ pub fn create_cheatnet_fork_state() -> CheatnetState {
 
     CheatnetState::new(ExtendedStateReader {
         dict_state_reader: build_testing_state(&predeployed_contracts),
-        fork_state_reader: Some(ForkStateReader::new(&node_url, BlockId::Tag(Latest))),
+        fork_state_reader: Some(ForkStateReader::new(node_url, BlockId::Tag(Latest))),
     })
 }

--- a/crates/cheatnet/tests/common/state.rs
+++ b/crates/cheatnet/tests/common/state.rs
@@ -19,8 +19,7 @@ pub fn create_cheatnet_state() -> CheatnetState {
 #[allow(clippy::module_name_repetitions)]
 pub fn create_cheatnet_fork_state() -> CheatnetState {
     let predeployed_contracts = Utf8PathBuf::from("predeployed-contracts");
-    let node_url =
-        std::env::var("CHEATNET_RPC_URL").expect("CHEATNET_RPC_URL must be set in the .env file");
+    let node_url = "http://188.34.188.184:9545/rpc/v0.4";
 
     CheatnetState::new(ExtendedStateReader {
         dict_state_reader: build_testing_state(&predeployed_contracts),

--- a/crates/cheatnet/tests/main.rs
+++ b/crates/cheatnet/tests/main.rs
@@ -1,5 +1,3 @@
-use dotenv::dotenv;
-
 mod cheatcodes;
 pub(crate) mod common;
 mod starknet;
@@ -10,7 +8,6 @@ mod starknet;
 fn init() {
     use camino::Utf8PathBuf;
     let contracts_path = Utf8PathBuf::from("tests").join("contracts");
-    dotenv().ok();
 
     let output = std::process::Command::new("scarb")
         .current_dir(contracts_path)

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -76,8 +76,7 @@ fn try_deploying_undeclared_class() {
 #[test]
 fn test_forking_at_block_number() {
     let predeployed_contracts = Utf8PathBuf::from("predeployed-contracts");
-    let node_url =
-        std::env::var("CHEATNET_RPC_URL").expect("CHEATNET_RPC_URL must be set in the .env file");
+    let node_url = "http://188.34.188.184:9545/rpc/v0.4";
 
     let mut state_before_deploy = CheatnetState::new(ExtendedStateReader {
         dict_state_reader: build_testing_state(&predeployed_contracts),

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -80,12 +80,12 @@ fn test_forking_at_block_number() {
 
     let mut state_before_deploy = CheatnetState::new(ExtendedStateReader {
         dict_state_reader: build_testing_state(&predeployed_contracts),
-        fork_state_reader: Some(ForkStateReader::new(&node_url, BlockId::Number(309_780))),
+        fork_state_reader: Some(ForkStateReader::new(node_url, BlockId::Number(309_780))),
     });
 
     let mut state_after_deploy = CheatnetState::new(ExtendedStateReader {
         dict_state_reader: build_testing_state(&predeployed_contracts),
-        fork_state_reader: Some(ForkStateReader::new(&node_url, BlockId::Number(309_781))),
+        fork_state_reader: Some(ForkStateReader::new(node_url, BlockId::Number(309_781))),
     });
 
     let contract_address = Felt252::from(
@@ -202,7 +202,7 @@ fn call_forked_contract_from_constructor() {
     let output = call_contract(
         &contract_address,
         &selector,
-        &[forked_class_hash.clone()],
+        &[forked_class_hash],
         &mut state,
     )
     .unwrap();

--- a/docs/src/development/environment-setup.md
+++ b/docs/src/development/environment-setup.md
@@ -22,15 +22,6 @@ To run Starknet Foundry tests, you must install these tools on your computer:
 
 It is not possible to run tests without these installed.
 
-## Forking tests
-
-To be able to run tests from `crates/cheatnet/tests/starknet/forking.rs`, you must have RPC node
-set up on the `integration` network. 
-See `.env.example` file in the root directory to see how your `.env` file should look like.
-
-> 📝 **Note**
-> This is only a temporary solution. We will use local node when `starknet-devnet-rs` supports RPC 0.4.0 specification.
-
 ## Running Tests
 
 > ⚠️ Make sure you run `./scripts/prepare_for_tests.sh`


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #651 

## Introduced changes
- Remove usage of `.env`

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
