### PR TITLE
Calldata IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - `account add` command for importing accounts to the accounts file
+- allow the `id` property in multicalls to be referenced in the inputs of `deploy` and `invoke` calls
 
 ## [0.6.0] - 2023-09-13
 

--- a/crates/cast/src/starknet_commands/multicall/run.rs
+++ b/crates/cast/src/starknet_commands/multicall/run.rs
@@ -91,7 +91,7 @@ pub async fn run(
                     salt,
                     deploy_call.class_hash,
                     &udc_uniqueness(deploy_call.unique, account.address()),
-                    &parsed_inputs
+                    &parsed_inputs,
                 );
                 contracts.insert(deploy_call.id, contract_address.to_string());
             }
@@ -122,14 +122,15 @@ pub async fn run(
     execute_calls(account, parsed_calls, max_fee, wait).await
 }
 
-fn parse_inputs(inputs: &Vec<String>, contracts: &HashMap<String, String>) -> Result<Vec<FieldElement>> {
+fn parse_inputs(
+    inputs: &Vec<String>,
+    contracts: &HashMap<String, String>,
+) -> Result<Vec<FieldElement>> {
     let mut parsed_inputs = Vec::new();
     for input in inputs {
         let current_input = contracts.get(input).unwrap_or(input);
-        parsed_inputs.push(
-            parse_number(current_input)
-                .context("Unable to parse input to FieldElement")?,
-        );
+        parsed_inputs
+            .push(parse_number(current_input).context("Unable to parse input to FieldElement")?);
     }
 
     Ok(parsed_inputs)

--- a/crates/cast/src/starknet_commands/multicall/run.rs
+++ b/crates/cast/src/starknet_commands/multicall/run.rs
@@ -43,7 +43,7 @@ struct InvokeCall {
     call_type: String,
     contract_address: String,
     function: String,
-    inputs: Vec<FieldElement>,
+    inputs: Vec<String>,
 }
 
 pub async fn run(
@@ -104,11 +104,20 @@ pub async fn run(
                     contract_address = addr;
                 }
 
+                let mut calldata = Vec::new();
+                for input in invoke_call.inputs {
+                    let current_input = contracts.get(&input).unwrap_or(&input);
+                    calldata.push(
+                        parse_number(current_input)
+                            .context("Unable to parse input to FieldElement")?,
+                    );
+                }
+
                 parsed_calls.push(Call {
                     to: parse_number(contract_address)
                         .context("Unable to parse contract address to FieldElement")?,
                     selector: get_selector_from_name(&invoke_call.function)?,
-                    calldata: invoke_call.inputs,
+                    calldata,
                 });
             }
             Some(unsupported) => {

--- a/crates/cast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
+++ b/crates/cast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
@@ -11,3 +11,10 @@ contract_address = "0x6a9b1c31fa25ca8f3cecb58142f3ec4d1f7611ed9520b4d3ae598d02d6
 function = "put"
 inputs = ["0x123", "map_contract"]
 
+[[call]]
+call_type = "deploy"
+class_hash = "0x2bb3d35dba2984b3d0cd0901b4e7de5411daff6bff5e072060bcfadbbd257b1"
+inputs = ["map_contract", "0x1", "0x1"]
+id = "constructor-params"
+unique = false
+

--- a/crates/cast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
+++ b/crates/cast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
@@ -1,0 +1,13 @@
+[[call]]
+call_type = "deploy"
+class_hash = "0x076e94149fc55e7ad9c5fe3b9af570970ae2cf51205f8452f39753e9497fe849"
+inputs = []
+id = "map_contract"
+unique = false
+
+[[call]]
+call_type = "invoke"
+contract_address = "0x6a9b1c31fa25ca8f3cecb58142f3ec4d1f7611ed9520b4d3ae598d02d625e41"
+function = "put"
+inputs = ["0x123", "map_contract"]
+

--- a/crates/cast/tests/e2e/multicall/run.rs
+++ b/crates/cast/tests/e2e/multicall/run.rs
@@ -29,6 +29,30 @@ async fn test_happy_case() {
 }
 
 #[tokio::test]
+async fn test_calldata_ids() {
+    let mut args = default_cli_args();
+    args.append(&mut vec!["--account", "user2"]);
+
+    let path = project_root::get_project_root().expect("failed to get project root path");
+    let path = Path::new(&path)
+        .join(MULTICALL_CONFIGS_DIR)
+        .join("deploy_invoke_calldata_ids.toml");
+    let path_str = path.to_str().expect("failed converting path to str");
+
+    args.append(&mut vec!["multicall", "run", "--path", path_str]);
+
+    let snapbox = runner(&args);
+    let bdg = snapbox.assert();
+    let out = bdg.get_output();
+
+    let stdout_str =
+        std::str::from_utf8(&out.stdout).expect("failed to convert command output to string");
+
+    assert!(out.stderr.is_empty());
+    assert!(stdout_str.contains("command: multicall"));
+}
+
+#[tokio::test]
 async fn test_invalid_path() {
     let mut args = default_cli_args();
     args.append(&mut vec!["--account", "user2"]);

--- a/docs/src/appendix/cast/multicall/run.md
+++ b/docs/src/appendix/cast/multicall/run.md
@@ -38,7 +38,6 @@ inputs = ["0x123", "234"]
 [[call]]
 call_type = "deploy"
 class_hash = "0x2bb3d35dba2984b3d0cd0901b4e7de5411daff6bff5e072060bcfadbbd257b1"
-inputs = ["map_contract", "0x123", "234"]
-id = "constructor-params"
+inputs = ["0x123", "map_contract"]
 unique = false
 ```

--- a/docs/src/appendix/cast/multicall/run.md
+++ b/docs/src/appendix/cast/multicall/run.md
@@ -34,4 +34,11 @@ call_type = "invoke"
 contract_address = "map_contract"
 function = "put"
 inputs = ["0x123", "234"]
+
+[[call]]
+call_type = "deploy"
+class_hash = "0x2bb3d35dba2984b3d0cd0901b4e7de5411daff6bff5e072060bcfadbbd257b1"
+inputs = ["map_contract", "0x123", "234"]
+id = "constructor-params"
+unique = false
 ```

--- a/docs/src/starknet/multicall.md
+++ b/docs/src/starknet/multicall.md
@@ -37,7 +37,8 @@ inputs = ["0x123", "234"]
 After running `sncast multicall run --path file.toml`, a declared contract will be first deployed, and then its function `put` will be invoked.
 
 > 📝 **Note**
-> The example above demonstrates the use of the `id` property in a deploy call, which is then referenced as the `contract address` in an invoke call 🔥
+> The example above demonstrates the use of the `id` property in a deploy call, which is then referenced as the `contract address` in an invoke call.
+Additionally, the `id` can be referenced in the inputs of deploy and invoke calls 🔥
 
 ```shell
 $ sncast multicall run --path /Users/john/Desktop/multicall_example.toml


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Enabled `id` property referencing in multicall for `deploy` call inputs.
- Enabled `id` property referencing in multicall for `invoke` call inputs.

An example multicall illustrating this:
```toml
[[call]]
call_type = "deploy"
class_hash = "0x06835a4591dc71821bfc769372d2da76e428d5eef7dccc048e036e8ca80aa740"
inputs = ["0x123", "0xabc"]
id = "first"
unique = false

[[call]]
call_type = "deploy"
class_hash = "0x02d505685c0bf351d41c0a8d8645c48fa7c1b1ee956da23414e725ff2de35807"
inputs = ["first"]
id = "second"
unique = false

[[call]]
call_type = "invoke"
contract_address = "first"
function = "set_second"
inputs = ["second"]
```

## Breaking changes

<!-- List of all breaking changes, if applicable -->

None

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
