### PR TITLE
647 performance pack all tests from standalone test files into one phantom package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for scarb workspaces.
 
-### Changed
+#### Changed
 
 - Tests are collected only from `tests` folder and a package tree
+- Performance improvement: tests from `tests` folder are packed into a single phantom package
 
 ### Cast
 

--- a/crates/forge/src/test_crate_summary.rs
+++ b/crates/forge/src/test_crate_summary.rs
@@ -1,19 +1,18 @@
 use crate::test_case_summary::TestCaseSummary;
-use crate::RunnerStatus;
-use camino::Utf8PathBuf;
+use crate::{RunnerStatus, TestCrateType};
 
 /// Summary of the test run in the file
 #[derive(Debug, PartialEq, Clone)]
-pub struct TestFileSummary {
+pub struct TestCrateSummary {
     /// Summaries of each test case in the file
     pub test_case_summaries: Vec<TestCaseSummary>,
     /// Status of the runner after executing tests in the file
     pub runner_exit_status: RunnerStatus,
-    /// Relative path to the test file
-    pub relative_path: Utf8PathBuf,
+    /// Type of the test crate
+    pub test_crate_type: TestCrateType,
 }
 
-impl TestFileSummary {
+impl TestCrateSummary {
     pub(crate) fn count_passed(&self) -> usize {
         self.test_case_summaries
             .iter()


### PR DESCRIPTION
## Breaking changes

- Treat tests folder as separate test crate.  If there is a lib.cairo file in `tests` folder - pass `tests` folder as separate test crate. Otherwise all test files from `tests` folder are treated as modules - the modules are added to  single virtual `lib.cairo` - it happens by copying and creating files in temporary directory.

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
