### PR TITLE
Trigger docs build only on released release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,7 @@ name: Deploy mdBook site to Pages
 on:
   # Runs on release
   release:
-    types: [ published ]
+    types: [ released ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #452 

## Introduced changes

<!-- A brief description of the changes -->

- Changed the `release` trigger type for docs build from `published` to `released`. This way docs should only build once we actually publish the release and not when draft is created.

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
