### PR TITLE
Fix failing tests when fork with block number used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.7.1] - 2023-09-13
+
 ### Forge
 
 #### Added
 
 - `var` library function for reading environmental variables
+
+### Fixed
+- Using any concrete `block_id` when using forking mode, would lead to crashes 
 
 ## [0.7.0] - 2023-09-13
 

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -297,6 +297,7 @@ fn try_close_tmp_dir(maybe_tmp_dir: Option<TempDir>) -> Result<()> {
 ///
 #[allow(clippy::implicit_hasher)]
 pub fn run(
+    package_root: &Utf8PathBuf,
     package_path: &Utf8PathBuf,
     package_name: &str,
     lib_path: &Utf8PathBuf,
@@ -325,7 +326,7 @@ pub fn run(
 
     for tests_from_crate in tests_iterator.by_ref() {
         let (summary, was_fuzzed) =
-            run_tests_from_crate(tests_from_crate, runner_config, runner_params)?;
+            run_tests_from_crate(package_root, tests_from_crate, runner_config, runner_params)?;
 
         fuzzing_happened |= was_fuzzed;
 
@@ -363,6 +364,7 @@ pub fn run(
 }
 
 fn run_tests_from_crate(
+    package_root: &Utf8PathBuf,
     tests: TestsFromCrate,
     runner_config: &RunnerConfig,
     runner_params: &RunnerParams,
@@ -386,6 +388,7 @@ fn run_tests_from_crate(
 
         let result = if args.is_empty() {
             let result = run_from_test_case(
+                package_root,
                 &runner,
                 case,
                 runner_config.fork_targets.as_ref(),
@@ -399,8 +402,14 @@ fn run_tests_from_crate(
             result
         } else {
             was_fuzzed = true;
-            let (result, runs) =
-                run_with_fuzzing(runner_config, runner_params, &runner, case, &args)?;
+            let (result, runs) = run_with_fuzzing(
+                package_root,
+                runner_config,
+                runner_params,
+                &runner,
+                case,
+                &args,
+            )?;
             pretty_printing::print_test_result(&result, Some(runs));
 
             result
@@ -437,6 +446,7 @@ fn run_tests_from_crate(
 }
 
 fn run_with_fuzzing(
+    package_root: &Utf8PathBuf,
     runner_config: &RunnerConfig,
     runner_params: &RunnerParams,
     runner: &SierraCasmRunner,
@@ -464,6 +474,7 @@ fn run_with_fuzzing(
         let args = fuzzer.next_felt252_args();
 
         let result = run_from_test_case(
+            package_root,
             runner,
             case,
             runner_config.fork_targets.as_ref(),

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -174,7 +174,7 @@ fn collect_tests_from_package(
     }];
 
     if let Some(tests_tmp_dir) = &maybe_tests_tmp_dir {
-        let tests_tmp_dir_path = Utf8PathBuf::from_path_buf(tests_tmp_dir.to_path_buf().clone())
+        let tests_tmp_dir_path = Utf8PathBuf::from_path_buf(tests_tmp_dir.to_path_buf())
             .map_err(|_| anyhow!("Failed to convert tests temporary directory to Utf8PathBuf"))?;
         let tests_lib_path = tests_tmp_dir_path.join("lib.cairo");
 

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -98,6 +98,7 @@ fn main_execution() -> Result<bool> {
         .match_many(&scarb_metadata)
         .context("Failed to find any packages matching the specified filter")?;
 
+    let package_root = &scarb_metadata.workspace.root;
     let mut all_failed_tests = vec![];
     for package in &packages {
         let forge_config = config_from_scarb_for_package(&scarb_metadata, &package.id)?;
@@ -144,6 +145,7 @@ fn main_execution() -> Result<bool> {
         );
 
         let tests_file_summaries = run(
+            package_root,
             &package_path,
             &package_name,
             &lib_path,

--- a/crates/forge/src/running.rs
+++ b/crates/forge/src/running.rs
@@ -68,6 +68,7 @@ fn build_hints_dict<'b>(
     (hints_dict, string_to_hint)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_from_test_case(
     package_root: &Utf8PathBuf,
     runner: &SierraCasmRunner,

--- a/crates/forge/src/running.rs
+++ b/crates/forge/src/running.rs
@@ -69,6 +69,7 @@ fn build_hints_dict<'b>(
 }
 
 pub(crate) fn run_from_test_case(
+    package_root: &Utf8PathBuf,
     runner: &SierraCasmRunner,
     case: &TestCase,
     fork_targets: &[ForkTarget],
@@ -142,7 +143,7 @@ pub(crate) fn run_from_test_case(
         contracts,
         cheatnet_state: CheatnetState::new(ExtendedStateReader {
             dict_state_reader: build_testing_state(predeployed_contracts),
-            fork_state_reader: get_fork_state_reader(fork_targets, &case.fork_config),
+            fork_state_reader: get_fork_state_reader(package_root, fork_targets, &case.fork_config),
         }),
         hints: &string_to_hint,
         run_resources: RunResources::default(),
@@ -174,17 +175,25 @@ pub(crate) fn run_from_test_case(
 }
 
 fn get_fork_state_reader(
+    package_root: &Utf8PathBuf,
     fork_targets: &[ForkTarget],
     fork_config: &Option<ForkConfig>,
 ) -> Option<ForkStateReader> {
     match &fork_config {
-        Some(ForkConfig::Params(url, block_id)) => Some(ForkStateReader::new(url, *block_id, None)),
-        Some(ForkConfig::Id(name)) => find_params_and_build_fork_state_reader(fork_targets, name),
+        Some(ForkConfig::Params(url, block_id)) => Some(ForkStateReader::new(
+            url,
+            *block_id,
+            Some(package_root.join(".snfoundry_cache").as_ref()),
+        )),
+        Some(ForkConfig::Id(name)) => {
+            find_params_and_build_fork_state_reader(package_root, fork_targets, name)
+        }
         _ => None,
     }
 }
 
 fn find_params_and_build_fork_state_reader(
+    package_root: &Utf8PathBuf,
     fork_targets: &[ForkTarget],
     fork_alias: &str,
 ) -> Option<ForkStateReader> {
@@ -208,5 +217,9 @@ fn find_params_and_build_fork_state_reader(
         return None;
     };
 
-    Some(ForkStateReader::new(&fork?.url, block_id, None))
+    Some(ForkStateReader::new(
+        &fork?.url,
+        block_id,
+        Some(package_root.join(".snfoundry_cache").as_ref()),
+    ))
 }

--- a/crates/forge/tests/integration/common/running_tests.rs
+++ b/crates/forge/tests/integration/common/running_tests.rs
@@ -3,9 +3,12 @@ use crate::integration::common::runner::TestCase;
 use camino::Utf8PathBuf;
 use forge::TestCrateSummary;
 use forge::{run, RunnerParams};
+use std::path::PathBuf;
+use tempfile::tempdir;
 
 pub fn run_test_case(test: &TestCase) -> Vec<TestCrateSummary> {
     run(
+        &Utf8PathBuf::from_path_buf(PathBuf::from(tempdir().unwrap().path())).unwrap(),
         &test.path().unwrap(),
         &String::from("src"),
         &test.path().unwrap().join("src/lib.cairo"),

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -6,6 +6,8 @@ use forge::scarb::{ForgeConfig, ForkTarget};
 use forge::{run, RunnerConfig, RunnerParams};
 use indoc::formatdoc;
 use std::collections::HashMap;
+use std::path::PathBuf;
+use tempfile::tempdir;
 
 static CHEATNET_RPC_URL: &str = "http://188.34.188.184:9545/rpc/v0.4";
 
@@ -29,7 +31,7 @@ fn fork_simple_decorator() {
             }}
 
             #[test]
-            #[fork(url: "{}", block_id: BlockId::Tag(BlockTag::Latest))]
+            #[fork(url: "{}", block_id: BlockId::Number(313388))]
             fn test_fork_simple() {{
                 let dispatcher = IHelloStarknetDispatcher {{
                     contract_address: contract_address_const::<3216637956526895219277698311134811322769343974163380838558193911733621219342>()
@@ -89,6 +91,7 @@ fn fork_aliased_decorator() {
     ).as_str());
 
     let result = run(
+        &Utf8PathBuf::from_path_buf(PathBuf::from(tempdir().unwrap().path())).unwrap(),
         &test.path().unwrap(),
         &String::from("src"),
         &test.path().unwrap().join("src/lib.cairo"),


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- cache is saved under the `.snfoundry_cache` directory

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
