### PR TITLE
Make syscall handlers naming consistent

### DIFF
--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -31,10 +31,10 @@ pub mod pretty_printing;
 pub mod scarb;
 pub mod test_case_summary;
 
-mod test_execution_syscall_handler;
 mod fuzzer;
 mod running;
 mod test_crate_summary;
+mod test_execution_syscall_handler;
 
 const FUZZER_RUNS_DEFAULT: u32 = 256;
 

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -31,7 +31,7 @@ pub mod pretty_printing;
 pub mod scarb;
 pub mod test_case_summary;
 
-mod cheatcodes_hint_processor;
+mod test_execution_syscall_handler;
 mod fuzzer;
 mod running;
 mod test_crate_summary;

--- a/crates/forge/src/running.rs
+++ b/crates/forge/src/running.rs
@@ -35,7 +35,7 @@ use starknet_api::patricia_key;
 use starknet_api::transaction::Calldata;
 use test_collector::{ForkConfig, TestCase};
 
-use crate::cheatcodes_hint_processor::CheatcodesSyscallHandler;
+use crate::test_execution_syscall_handler::TestExecutionSyscallHandler;
 use crate::scarb::{ForkTarget, StarknetContractArtifacts};
 use crate::test_case_summary::TestCaseSummary;
 
@@ -147,7 +147,7 @@ pub(crate) fn run_from_test_case(
         cheatnet_state: &mut CheatnetState::default(),
     };
 
-    let mut cheatcodes_hint_processor = CheatcodesSyscallHandler {
+    let mut cheatcodes_hint_processor = TestExecutionSyscallHandler {
         cheatable_syscall_handler,
         contracts,
         hints: &string_to_hint,

--- a/crates/forge/src/running.rs
+++ b/crates/forge/src/running.rs
@@ -35,9 +35,9 @@ use starknet_api::patricia_key;
 use starknet_api::transaction::Calldata;
 use test_collector::{ForkConfig, TestCase};
 
-use crate::test_execution_syscall_handler::TestExecutionSyscallHandler;
 use crate::scarb::{ForkTarget, StarknetContractArtifacts};
 use crate::test_case_summary::TestCaseSummary;
+use crate::test_execution_syscall_handler::TestExecutionSyscallHandler;
 
 // snforge_std/src/cheatcodes.cairo::TEST
 const TEST_ADDRESS: &str = "0x01724987234973219347210837402";

--- a/crates/forge/src/test_execution_syscall_handler.rs
+++ b/crates/forge/src/test_execution_syscall_handler.rs
@@ -40,7 +40,7 @@ use cairo_lang_runner::{
     insert_value_to_cellref,
 };
 
-use crate::cheatcodes_hint_processor::file_operations::string_into_felt;
+use crate::test_execution_syscall_handler::file_operations::string_into_felt;
 use cairo_lang_starknet::contract::starknet_keccak;
 use cairo_lang_utils::bigint::BigIntAsHex;
 use cairo_vm::types::relocatable::Relocatable;
@@ -63,7 +63,7 @@ impl From<&StarknetContractArtifacts> for ContractArtifacts {
 
 // This hint processor provides an implementation logic for functions from snforge_std library.
 // If cannot execute a hint it falls back to the CheatableSyscallHandler
-pub struct CheatcodesSyscallHandler<'a> {
+pub struct TestExecutionSyscallHandler<'a> {
     pub cheatable_syscall_handler: CheatableSyscallHandler<'a>,
     pub contracts: &'a HashMap<String, StarknetContractArtifacts>,
     pub hints: &'a HashMap<String, Hint>,
@@ -73,7 +73,7 @@ pub struct CheatcodesSyscallHandler<'a> {
 }
 
 // crates/blockifier/src/execution/syscalls/hint_processor.rs:472 (ResourceTracker for SyscallHintProcessor)
-impl ResourceTracker for CheatcodesSyscallHandler<'_> {
+impl ResourceTracker for TestExecutionSyscallHandler<'_> {
     fn consumed(&self) -> bool {
         self.cheatable_syscall_handler
             .syscall_handler
@@ -107,7 +107,7 @@ impl ResourceTracker for CheatcodesSyscallHandler<'_> {
     }
 }
 
-impl HintProcessorLogic for CheatcodesSyscallHandler<'_> {
+impl HintProcessorLogic for TestExecutionSyscallHandler<'_> {
     fn execute_hint(
         &mut self,
         vm: &mut VirtualMachine,
@@ -167,7 +167,7 @@ impl HintProcessorLogic for CheatcodesSyscallHandler<'_> {
     }
 }
 
-impl CheatcodesSyscallHandler<'_> {
+impl TestExecutionSyscallHandler<'_> {
     #[allow(clippy::trivially_copy_pass_by_ref, clippy::too_many_arguments)]
     pub fn execute_cheatcode_hint(
         &mut self,

--- a/crates/forge/src/test_execution_syscall_handler/file_operations.rs
+++ b/crates/forge/src/test_execution_syscall_handler/file_operations.rs
@@ -94,7 +94,7 @@ pub(super) fn string_into_felt(string: &str) -> Result<Felt252> {
 
 #[cfg(test)]
 mod tests {
-    use crate::cheatcodes_hint_processor::file_operations::string_into_felt;
+    use crate::test_execution_syscall_handler::file_operations::string_into_felt;
     use cairo_felt::Felt252;
     use num_bigint::BigUint;
     use num_traits::One;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #784 

## Introduced changes

<!-- A brief description of the changes -->

- Renames CheatcodesHintProcessor to TestExecutionSyscallHandler
-

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
