### PR TITLE
L1 Handler on execution layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `#[fuzzer(...)]` attribute allowing to specify a fuzzer configuration for a single test case
 - Support for `u8`, `u16`, `u32`, `u64`, `u128`, `u256` types to fuzzer
 - `--clean-cache` flag
+- Changed interface of `L1Handler.execute` and `L1Handler` (dropped `fee` parameter, added result handling with `RevertedTransaction`)
 
 #### Changed
 

--- a/crates/cheatnet/src/cheatcodes/l1_handler_execute.rs
+++ b/crates/cheatnet/src/cheatcodes/l1_handler_execute.rs
@@ -13,10 +13,9 @@ impl BlockifierState<'_> {
         from_address: &Felt252,
         payload: &[Felt252],
     ) -> CallContractOutput {
-        let selector = Felt252::try_from(starknet_keccak(&function_name.to_bytes_be()))
-            .expect("Computing selector from short string failed");
+        let selector = starknet_keccak(&function_name.to_bytes_be());
 
-        let mut calldata = vec![from_address.to_owned()];
+        let mut calldata = vec![from_address.clone()];
         calldata.extend_from_slice(payload);
 
         call_l1_handler(

--- a/crates/cheatnet/src/cheatcodes/l1_handler_execute.rs
+++ b/crates/cheatnet/src/cheatcodes/l1_handler_execute.rs
@@ -1,101 +1,31 @@
-use super::CheatcodeError;
-use crate::state::BlockifierState;
-use anyhow::Result;
+use crate::rpc::{call_l1_handler, CallContractOutput};
+use crate::state::{BlockifierState, CheatnetState};
+use blockifier::abi::abi_utils::starknet_keccak;
 use cairo_felt::Felt252;
 use starknet_api::core::ContractAddress;
 
 impl BlockifierState<'_> {
     pub fn l1_handler_execute(
         &mut self,
-        _contract_address: ContractAddress,
-        _function_name: &Felt252,
-        _from_address: &Felt252,
-        _paid_fee_on_l1: &Felt252,
-        _payload: &[Felt252],
-    ) -> Result<(), CheatcodeError> {
-        panic!("l1_handler_execute is temporarily not supported in this version, use a different version of starknet foundry");
-        // TODO this will not work with the current design as transactions cannot be executed on State trait. We should make it work.
+        cheatable_state: &mut CheatnetState,
+        contract_address: ContractAddress,
+        function_name: &Felt252,
+        from_address: &Felt252,
+        payload: &[Felt252],
+    ) -> CallContractOutput {
+        let selector = Felt252::try_from(starknet_keccak(&function_name.to_bytes_be()))
+            .expect("Computing selector from short string failed");
 
-        // let blockifier_state: &mut CachedState<ExtendedStateReader> = &mut self.blockifier_state;
+        let mut calldata = vec![from_address.to_owned()];
+        calldata.extend_from_slice(payload);
 
-        // let block_context = build_block_context();
-
-        // let selector = Felt252::try_from(starknet_keccak(&function_name.to_bytes_be()))
-        //     .context("Computing selector from short string failed")
-        //     .map_err::<EnhancedHintError, _>(From::from)?;
-
-        // let entry_point_selector = EntryPointSelector(felt_to_stark_felt(&selector));
-
-        // let mut calldata: Vec<StarkFelt> = vec![felt_to_stark_felt(from_address)];
-        // calldata.extend(
-        //     payload
-        //         .iter()
-        //         .map(felt_to_stark_felt)
-        //         .collect::<Vec<StarkFelt>>(),
-        // );
-
-        // let calldata = Calldata(calldata.into());
-
-        // let fee = fee_from_felt252(paid_fee_on_l1)
-        //     .context("Converting fee felt252 into Fee failed")
-        //     .map_err::<EnhancedHintError, _>(From::from)?;
-
-        // let tx = L1HandlerTransaction {
-        //     tx: starknet_api::transaction::L1HandlerTransaction {
-        //         contract_address,
-        //         entry_point_selector,
-        //         calldata,
-        //         ..Default::default()
-        //     },
-        //     tx_hash: TransactionHash::default(),
-        //     paid_fee_on_l1: fee,
-        // };
-
-        // match tx.execute(blockifier_state, &block_context, true, true) {
-        //     Ok(exec_info) => {
-        //         if let Some(revert_error) = &exec_info.revert_error {
-        //             let extracted_panic_data = try_extract_panic_data(revert_error)
-        //                 .expect("L1Transaction revert error: {revert_error}");
-
-        //             return Err(CheatcodeError::Recoverable(extracted_panic_data));
-        //         }
-        //         Ok(())
-        //     }
-        //     Err(err) => {
-        //         let reason = if let TransactionExecutionError::ExecutionError(
-        //             EntryPointExecutionError::ExecutionFailed { error_data: felts },
-        //         ) = err
-        //         {
-        //             felts_as_str(&felts)
-        //         } else {
-        //             format!("{err:?}")
-        //         };
-
-        //         // TODO: may we need a EnhancedHintError::Execution/Blockifier?
-        //         // Or is it VirtualMachineError expected here?
-        //         Err(CheatcodeError::Unrecoverable(EnhancedHintError::Anyhow(
-        //             anyhow!(reason),
-        //         )))
-        //     }
-        // }
+        call_l1_handler(
+            self,
+            cheatable_state,
+            &contract_address,
+            &selector,
+            calldata.as_slice(),
+        )
+        .expect("Calling l1 handler failed")
     }
 }
-
-// /// Converts a felt252 into Fee.
-// fn fee_from_felt252(fee: &Felt252) -> Result<Fee> {
-//     // cairo-felt is not including leading 0 when using `to_bytes_be`.
-//     let mut fee_bytes = fee.to_bytes_be();
-//     if fee_bytes.len() > 16 {
-//         return Err(anyhow!("Felt252 value too large for u128 value"));
-//     }
-
-//     if fee_bytes.len() < 16 {
-//         let leading_zeros = vec![0; 16 - fee_bytes.len()];
-//         fee_bytes.splice(0..0, leading_zeros);
-//     }
-
-//     // Unwrap here because we ensured above that we always have a 16 bytes buffer.
-//     Ok(Fee(u128::from_be_bytes(
-//         fee_bytes[0..16].try_into().unwrap(),
-//     )))
-// }

--- a/crates/cheatnet/src/rpc.rs
+++ b/crates/cheatnet/src/rpc.rs
@@ -60,13 +60,48 @@ pub enum CallContractOutput {
 
 // This does contract call without the transaction layer. This way `call_contract` can return data and modify state.
 // `call` and `invoke` on the transactional layer use such method under the hood.
-#[allow(clippy::too_many_lines)]
 pub fn call_contract(
     blockifier_state: &mut BlockifierState,
     cheatnet_state: &mut CheatnetState,
     contract_address: &ContractAddress,
     entry_point_selector: &Felt252,
     calldata: &[Felt252],
+) -> Result<CallContractOutput> {
+    call_entry_point(
+        blockifier_state,
+        cheatnet_state,
+        contract_address,
+        entry_point_selector,
+        calldata,
+        EntryPointType::External,
+    )
+}
+
+pub fn call_l1_handler(
+    blockifier_state: &mut BlockifierState,
+    cheatnet_state: &mut CheatnetState,
+    contract_address: &ContractAddress,
+    entry_point_selector: &Felt252,
+    calldata: &[Felt252],
+) -> Result<CallContractOutput> {
+    call_entry_point(
+        blockifier_state,
+        cheatnet_state,
+        contract_address,
+        entry_point_selector,
+        calldata,
+        EntryPointType::L1Handler,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn call_entry_point(
+    blockifier_state: &mut BlockifierState,
+    cheatnet_state: &mut CheatnetState,
+    contract_address: &ContractAddress,
+    entry_point_selector: &Felt252,
+    calldata: &[Felt252],
+    entry_point_type: EntryPointType,
 ) -> Result<CallContractOutput> {
     let entry_point_selector =
         EntryPointSelector(StarkHash::new(entry_point_selector.to_be_bytes())?);
@@ -80,7 +115,7 @@ pub fn call_contract(
     let mut entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(*contract_address),
-        entry_point_type: EntryPointType::External,
+        entry_point_type,
         entry_point_selector,
         calldata,
         storage_address: *contract_address,

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -174,7 +174,7 @@ fn collect_tests_from_package(
             .map_err(|_| anyhow!("Failed to convert tests temporary directory to Utf8PathBuf"))?;
 
         all_test_roots.push(TestCrate {
-            crate_root: tests_tmp_dir_path.clone(),
+            crate_root: tests_tmp_dir_path,
             crate_name: "tests".to_string(),
             crate_type: TestCrateType::Tests,
         });

--- a/crates/forge/src/test_execution_syscall_handler.rs
+++ b/crates/forge/src/test_execution_syscall_handler.rs
@@ -468,13 +468,12 @@ impl TestExecutionSyscallHandler<'_> {
                 let contract_address = inputs[0].to_contract_address();
                 let function_name = inputs[1].clone();
                 let from_address = inputs[2].clone();
-                let fee = inputs[3].clone();
-                let payload_length: usize = inputs[4]
+                let payload_length: usize = inputs[3]
                     .clone()
                     .to_usize()
                     .expect("Payload length is expected to fit into usize type");
 
-                let payload = Vec::from(&inputs[5..inputs.len()]);
+                let payload = Vec::from(&inputs[4..inputs.len()]);
 
                 let mut blockifier_state =
                     BlockifierState::from(self.cheatable_syscall_handler.syscall_handler.state);

--- a/crates/forge/src/test_execution_syscall_handler.rs
+++ b/crates/forge/src/test_execution_syscall_handler.rs
@@ -484,7 +484,6 @@ impl TestExecutionSyscallHandler<'_> {
                     contract_address,
                     &function_name,
                     &from_address,
-                    &fee,
                     &payload,
                 ) {
                     CallContractOutput::Success { .. } => {

--- a/crates/forge/tests/data/contracts/l1_handler_execute_checker.cairo
+++ b/crates/forge/tests/data/contracts/l1_handler_execute_checker.cairo
@@ -46,4 +46,9 @@ mod l1_handler_executor {
         self.balance.write(data.balance);
         self.token_id.write(data.token_id);
     }
+
+    #[l1_handler]
+    fn panicking_l1_handler(ref self: ContractState, from_address: felt252) {
+        panic(array!['custom', 'panic']);
+    }
 }

--- a/crates/forge/tests/integration/l1_handler_executor.rs
+++ b/crates/forge/tests/integration/l1_handler_executor.rs
@@ -5,12 +5,10 @@ use indoc::indoc;
 use std::path::Path;
 
 #[test]
-#[ignore] // TODO make it work
 fn l1_handler_executor() {
     let test = test_case!(
         indoc!(
             r#"
-
             #[derive(Copy, Serde, Drop)]
             struct L1Data {
                 balance: felt252,
@@ -26,7 +24,7 @@ fn l1_handler_executor() {
             use serde::Serde;
             use array::{ArrayTrait, SpanTrait};
             use core::result::ResultTrait;
-            use snforge_std::{declare, ContractClassTrait, L1Handler, L1HandlerTrait};
+            use snforge_std::{declare, ContractClassTrait, L1Handler, L1HandlerTrait, RevertedTransaction};
 
             #[test]
             fn test_l1_handler_execute() {
@@ -51,11 +49,35 @@ fn l1_handler_executor() {
                 l1_handler.from_address = 0x123;
                 l1_handler.payload = payload.span();
 
-                l1_handler.execute();
-
+                l1_handler.execute().unwrap();
+                    
                 let dispatcher = IBalanceTokenDispatcher { contract_address };
-                assert(dispatcher.get_balance() == 42, 'Invalid balance');
+                assert(dispatcher.get_balance() == 42, dispatcher.get_balance());
                 assert(dispatcher.get_token_id() == 8888_u256, 'Invalid token id');
+            }
+             
+            #[test]
+            fn test_l1_handler_execute_panicking() {
+                let calldata = array![0x123];
+
+                let contract = declare('l1_handler_executor');
+                let contract_address = contract.deploy(@calldata).unwrap();
+
+
+                let mut l1_handler = L1HandlerTrait::new(
+                    contract_address,
+                    function_name: 'panicking_l1_handler'
+                );
+
+                l1_handler.from_address = 0x123;
+                l1_handler.payload = array![].span();
+                match l1_handler.execute() {
+                    Result::Ok(_) => {},
+                    Result::Err(RevertedTransaction { panic_data }) => {
+                        assert(*panic_data.at(0) == 'custom', 'Wrong 1st panic datum');
+                        assert(*panic_data.at(1) == 'panic', 'Wrong 2nd panic datum');
+                    },
+                }
             }
         "#
         ),

--- a/crates/forge/tests/integration/l1_handler_executor.rs
+++ b/crates/forge/tests/integration/l1_handler_executor.rs
@@ -72,7 +72,7 @@ fn l1_handler_executor() {
                 l1_handler.from_address = 0x123;
                 l1_handler.payload = array![].span();
                 match l1_handler.execute() {
-                    Result::Ok(_) => {},
+                    Result::Ok(_) => panic_with_felt252('should have panicked'),
                     Result::Err(RevertedTransaction { panic_data }) => {
                         assert(*panic_data.at(0) == 'custom', 'Wrong 1st panic datum');
                         assert(*panic_data.at(1) == 'panic', 'Wrong 2nd panic datum');

--- a/crates/test-collector/src/lib.rs
+++ b/crates/test-collector/src/lib.rs
@@ -476,7 +476,7 @@ pub fn collect_tests(
     let mut crate_roots: OrderedHashMap<SmolStr, PathBuf> = linked_libraries
         .iter()
         .cloned()
-        .map(|source_root| (source_root.name.into(), source_root.path.clone()))
+        .map(|source_root| (source_root.name.into(), source_root.path))
         .collect();
     crate_roots.insert(crate_name.into(), PathBuf::from(crate_root));
 

--- a/docs/src/appendix/cheatcodes/l1_handler_execute.md
+++ b/docs/src/appendix/cheatcodes/l1_handler_execute.md
@@ -1,17 +1,24 @@
 # `l1_handler_execute`
 
-> `fn execute(self: L1Handler)`
+> `fn execute(self: L1Handler) -> Result<(), RevertedTransaction>`
 
 Executes a `#[l1_handler]` function to mock a
 [message](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/)
 arriving from Ethereum.
+
+> 📝 **Note**
+> 
+> Execution of the `#[l1_handler]` function may panic like any other function.
+> If you'd like to assert the panic data, use `RevertedTransaction` returned by the function.
+> It works like a regular `SafeDispatcher` would with a function call.
+> For more info check out [handling panic errors](../../testing/contracts.html#handling-errors)
+
 
 ```rust
 struct L1Handler {
     contract_address: ContractAddress,
     function_name: felt252,
     from_address: felt252,
-    fee: u128,
     payload: Span::<felt252>,
 }
 ```
@@ -21,7 +28,6 @@ where:
 - `contract_address` - The target contract address
 - `function_name` - Name of the `#[l1_handler]` function
 - `from_address` - Ethereum address of the contract that sends the message
-- `fee` - The fees paid on L1
 - `payload` - The message payload that may contain any Cairo data structure that can be serialized with
 [Serde](https://book.cairo-lang.org/appendix-03-derivable-traits.html?highlight=serde#serializing-with-serde)
 
@@ -70,7 +76,7 @@ fn test_l1_handler_execute() {
     l1_handler.from_address = 0x123;
     l1_handler.payload = payload.span();
 
-    l1_handler.execute();
+    l1_handler.execute().unwrap();
     //...
 }
 ```

--- a/snforge_std/src/cheatcodes/l1_handler.cairo
+++ b/snforge_std/src/cheatcodes/l1_handler.cairo
@@ -27,7 +27,6 @@ impl L1HandlerImpl of L1HandlerTrait {
             self.contract_address.into(),
             self.function_name,
             self.from_address,
-            self.fee.into(),
             self.payload.len().into(),
         ];
 

--- a/snforge_std/src/cheatcodes/l1_handler.cairo
+++ b/snforge_std/src/cheatcodes/l1_handler.cairo
@@ -1,29 +1,28 @@
 use starknet::{ContractAddress, testing::cheatcode};
 use traits::Into;
-
+use snforge_std::cheatcodes::contract_class::RevertedTransaction;
 
 #[derive(Drop, Clone)]
 struct L1Handler {
     contract_address: ContractAddress,
     function_name: felt252,
     from_address: felt252,
-    fee: u128,
     payload: Span::<felt252>,
 }
 
 trait L1HandlerTrait {
     fn new(contract_address: ContractAddress, function_name: felt252) -> L1Handler;
-    fn execute(self: L1Handler);
+    fn execute(self: L1Handler) -> Result::<(), RevertedTransaction>;
 }
 
 impl L1HandlerImpl of L1HandlerTrait {
     fn new(contract_address: ContractAddress, function_name: felt252) -> L1Handler {
         L1Handler {
-            contract_address, function_name, from_address: 0, fee: 1_u128, payload: array![].span(),
+            contract_address, function_name, from_address: 0, payload: array![].span(),
         }
     }
 
-    fn execute(self: L1Handler) {
+    fn execute(self: L1Handler) -> Result::<(), RevertedTransaction> {
         let mut inputs: Array::<felt252> = array![
             self.contract_address.into(),
             self.function_name,
@@ -42,6 +41,27 @@ impl L1HandlerImpl of L1HandlerTrait {
             i += 1;
         };
 
-        cheatcode::<'l1_handler_execute'>(inputs.span());
+        let outputs = cheatcode::<'l1_handler_execute'>(inputs.span());
+        let exit_code = *outputs[0];
+
+        if exit_code == 0 {
+            Result::<(), RevertedTransaction>::Ok(())
+        } else {
+            let panic_data_len_felt = *outputs[1];
+            let panic_data_len = panic_data_len_felt.try_into().unwrap();
+            let mut panic_data = array![];
+
+            let offset = 2;
+            let mut i = offset;
+            loop {
+                if panic_data_len + offset == i {
+                    break ();
+                }
+                panic_data.append(*outputs[i]);
+                i += 1;
+            };
+
+            Result::<(), RevertedTransaction>::Err(RevertedTransaction { panic_data })
+        }
     }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #785 

## Introduced changes

<!-- A brief description of the changes -->

- L1 handler on execution layer
- Interface change for `L1Handler` & corresponding `.execute()` function 
- Docs update

## Breaking changes

- L1 handler does not take a l1 `fee` parameter now, since it's not needed

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
