### PR TITLE
Add `stop_prank` (`stop_roll`) proxy and libcall tests

### DIFF
--- a/crates/cheatnet/tests/cheatcodes/prank.rs
+++ b/crates/cheatnet/tests/cheatcodes/prank.rs
@@ -1,3 +1,4 @@
+use crate::common::assertions::compare_outputs;
 use crate::{
     assert_success,
     common::{
@@ -225,29 +226,15 @@ fn prank_proxy() {
         &[],
     );
 
-    cheatnet_state.start_prank(contract_address, ContractAddress::from(123_u128));
-
-    let selector = felt_selector_from_name("get_caller_address");
-
-    let output = call_contract(
-        &mut blockifier_state,
-        &mut cheatnet_state,
-        &contract_address,
-        &selector,
-        &[],
-    )
-    .unwrap();
-
-    assert_success!(output, vec![Felt252::from(123)]);
-
     let proxy_address = deploy_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         "PrankCheckerProxy",
         &[],
     );
+
     let proxy_selector = felt_selector_from_name("get_prank_checkers_caller_address");
-    let output = call_contract(
+    let before_prank_output = call_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         &proxy_address,
@@ -256,7 +243,31 @@ fn prank_proxy() {
     )
     .unwrap();
 
-    assert_success!(output, vec![Felt252::from(123)]);
+    cheatnet_state.start_prank(contract_address, ContractAddress::from(123_u128));
+
+    let after_prank_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &proxy_address,
+        &proxy_selector,
+        &[contract_address.to_felt252()],
+    )
+    .unwrap();
+
+    assert_success!(after_prank_output, vec![Felt252::from(123)]);
+
+    cheatnet_state.stop_prank(contract_address);
+
+    let after_prank_cancellation_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &proxy_address,
+        &proxy_selector,
+        &[contract_address.to_felt252()],
+    )
+    .unwrap();
+
+    compare_outputs(before_prank_output, after_prank_cancellation_output);
 }
 
 #[test]
@@ -277,10 +288,8 @@ fn prank_library_call() {
         &[],
     );
 
-    cheatnet_state.start_prank(lib_call_address, ContractAddress::from(123_u128));
-
     let lib_call_selector = felt_selector_from_name("get_caller_address_with_lib_call");
-    let output = call_contract(
+    let before_prank_output = call_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         &lib_call_address,
@@ -289,5 +298,29 @@ fn prank_library_call() {
     )
     .unwrap();
 
-    assert_success!(output, vec![Felt252::from(123)]);
+    cheatnet_state.start_prank(lib_call_address, ContractAddress::from(123_u128));
+
+    let after_prank_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &lib_call_address,
+        &lib_call_selector,
+        &[class_hash.to_felt252()],
+    )
+    .unwrap();
+
+    assert_success!(after_prank_output, vec![Felt252::from(123)]);
+
+    cheatnet_state.stop_prank(lib_call_address);
+
+    let after_prank_cancellation_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &lib_call_address,
+        &lib_call_selector,
+        &[class_hash.to_felt252()],
+    )
+    .unwrap();
+
+    compare_outputs(before_prank_output, after_prank_cancellation_output);
 }

--- a/crates/cheatnet/tests/cheatcodes/roll.rs
+++ b/crates/cheatnet/tests/cheatcodes/roll.rs
@@ -1,3 +1,4 @@
+use crate::common::assertions::compare_outputs;
 use crate::{
     assert_success,
     common::{
@@ -224,29 +225,15 @@ fn roll_proxy() {
         &[],
     );
 
-    cheatnet_state.start_roll(contract_address, Felt252::from(123_u128));
-
-    let selector = felt_selector_from_name("get_block_number");
-
-    let output = call_contract(
-        &mut blockifier_state,
-        &mut cheatnet_state,
-        &contract_address,
-        &selector,
-        &[],
-    )
-    .unwrap();
-
-    assert_success!(output, vec![Felt252::from(123)]);
-
     let proxy_address = deploy_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         "RollCheckerProxy",
         &[],
     );
+
     let proxy_selector = felt_selector_from_name("get_roll_checkers_block_number");
-    let output = call_contract(
+    let before_roll_output = call_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         &proxy_address,
@@ -255,7 +242,31 @@ fn roll_proxy() {
     )
     .unwrap();
 
-    assert_success!(output, vec![Felt252::from(123)]);
+    cheatnet_state.start_roll(contract_address, Felt252::from(123_u128));
+
+    let after_roll_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &proxy_address,
+        &proxy_selector,
+        &[contract_address.to_felt252()],
+    )
+    .unwrap();
+
+    assert_success!(after_roll_output, vec![Felt252::from(123)]);
+
+    cheatnet_state.stop_roll(contract_address);
+
+    let after_roll_cancellation_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &proxy_address,
+        &proxy_selector,
+        &[contract_address.to_felt252()],
+    )
+    .unwrap();
+
+    compare_outputs(before_roll_output, after_roll_cancellation_output);
 }
 
 #[test]
@@ -276,10 +287,8 @@ fn roll_library_call() {
         &[],
     );
 
-    cheatnet_state.start_roll(lib_call_address, Felt252::from(123_u128));
-
     let lib_call_selector = felt_selector_from_name("get_block_number_with_lib_call");
-    let output = call_contract(
+    let before_roll_output = call_contract(
         &mut blockifier_state,
         &mut cheatnet_state,
         &lib_call_address,
@@ -288,5 +297,29 @@ fn roll_library_call() {
     )
     .unwrap();
 
-    assert_success!(output, vec![Felt252::from(123)]);
+    cheatnet_state.start_roll(lib_call_address, Felt252::from(123_u128));
+
+    let after_roll_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &lib_call_address,
+        &lib_call_selector,
+        &[class_hash.to_felt252()],
+    )
+    .unwrap();
+
+    assert_success!(after_roll_output, vec![Felt252::from(123)]);
+
+    cheatnet_state.stop_roll(lib_call_address);
+
+    let after_roll_cancellation_output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &lib_call_address,
+        &lib_call_selector,
+        &[class_hash.to_felt252()],
+    )
+    .unwrap();
+
+    compare_outputs(before_roll_output, after_roll_cancellation_output);
 }

--- a/crates/cheatnet/tests/common/assertions.rs
+++ b/crates/cheatnet/tests/common/assertions.rs
@@ -1,3 +1,4 @@
+use cheatnet::rpc::{CallContractOutput, CallContractResult};
 #[allow(clippy::module_name_repetitions)]
 #[macro_export]
 macro_rules! assert_success {
@@ -42,4 +43,22 @@ macro_rules! assert_error {
             )
         )
     };
+}
+
+pub fn compare_outputs(output1: CallContractOutput, output2: CallContractOutput) {
+    let CallContractResult::Success {
+        ret_data: before_ret_data,
+    } = output1.result
+    else {
+        panic!("Unexpected failure")
+    };
+
+    let CallContractResult::Success {
+        ret_data: after_ret_data,
+    } = output2.result
+    else {
+        panic!("Unexpected failure")
+    };
+
+    assert_eq!(before_ret_data, after_ret_data);
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #529 
Closes #530 

## Introduced changes

<!-- A brief description of the changes -->

- stop_prank (stop_roll) are added to the proxy and libcall tests

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
