### PR TITLE
feat: Added --cores argument to snforge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `snforge_std::PrintTrait` will not convert values representing ASCII control characters to strings
 
+#### Added
+
+- `--cores` flag to specify the number of cores to use for parallel execution
+
 ### Cast
 
 #### Added

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -139,7 +139,7 @@ fn main_execution() -> Result<bool> {
     if args.clean_cache {
         clean_cache(&workspace_root).context("Failed to clean snforge cache")?;
     }
-    let cores_approx = if let Some(cores) = args.cores {
+    let cores = if let Some(cores) = args.cores {
         cores
     } else {
         match available_parallelism() {
@@ -151,7 +151,7 @@ fn main_execution() -> Result<bool> {
         }
     };
     let rt = Builder::new_multi_thread()
-        .max_blocking_threads(cores_approx)
+        .max_blocking_threads(cores)
         .enable_all()
         .build()?;
     let all_failed_tests = rt.block_on({

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -71,7 +71,7 @@ fn validate_cores_number(val: &str) -> Result<usize> {
     let cores_approx = available_parallelism()?.get();
     if parsed_val > cores_approx {
         bail!(
-            "Number of cores must be less than or equal to the number of cores available on the machine ({})",
+            "Number of cores must be less than or equal to the number of cores available on the machine = {}",
             cores_approx
         );
     }

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -55,6 +55,27 @@ struct Args {
     /// Clean forge cache directory
     #[arg(short, long)]
     clean_cache: bool,
+
+    /// Cores used for parallel tests execution
+    #[arg(short = 't', long, value_parser = validate_cores_number)]
+    cores: Option<usize>,
+}
+
+fn validate_cores_number(val: &str) -> Result<usize> {
+    let parsed_val: usize = val
+        .parse()
+        .map_err(|_| anyhow::anyhow!("Failed to parse '{}' as usize", val))?;
+    if parsed_val == 0 {
+        bail!("Number of cores must be greater than 0");
+    }
+    let cores_approx = available_parallelism()?.get();
+    if parsed_val > cores_approx {
+        bail!(
+            "Number of cores must be less than or equal to the number of cores available on the machine ({})",
+            cores_approx
+        );
+    }
+    Ok(parsed_val)
 }
 
 fn validate_fuzzer_runs_value(val: &str) -> Result<u32> {
@@ -118,7 +139,17 @@ fn main_execution() -> Result<bool> {
     if args.clean_cache {
         clean_cache(&workspace_root).context("Failed to clean snforge cache")?;
     }
-    let cores_approx = available_parallelism()?.get();
+    let cores_approx = if let Some(cores) = args.cores {
+        cores
+    } else {
+        match available_parallelism() {
+            Ok(cores) => cores.get(),
+            Err(_) => {
+                eprintln!("Failed to get the number of available cores, defaulting to 1");
+                1
+            }
+        }
+    };
     let rt = Builder::new_multi_thread()
         .max_blocking_threads(cores_approx)
         .enable_all()

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -56,7 +56,7 @@ struct Args {
     #[arg(short, long)]
     clean_cache: bool,
 
-    /// Cores used for parallel tests execution
+    /// Number of cores used for test execution
     #[arg(long, value_parser = validate_cores_number)]
     cores: Option<usize>,
 }

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -142,8 +142,8 @@ fn main_execution() -> Result<bool> {
 
     let cores = if let Some(cores) = args.cores {
         cores
-    } else if let Ok(cores) = available_parallelism() {
-        cores.get()
+    } else if let Ok(available_cores) = available_parallelism() {
+        available_cores.get()
     } else {
         eprintln!("Failed to get the number of available cores, defaulting to 1");
         1

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -55,7 +55,7 @@ fn with_more_than_one_core() {
     snapbox
         .current_dir(&temp)
         .arg("--cores")
-        .arg("3")
+        .arg("2")
         .assert()
         .code(1)
         .stdout_matches(indoc! {r#"

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -106,6 +106,8 @@ fn with_too_much_cores() {
         .code(2)
         .stderr_matches(indoc! {r#"
             error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine ([..])
+
+            For more information, try '--help'.
         "#});
 }
 
@@ -122,5 +124,7 @@ fn with_zero_core() {
         .code(2)
         .stderr_matches(indoc! {r#"
             error: invalid value '0' for '--cores <CORES>': Number of cores must be greater than 0
+
+            For more information, try '--help'.
         "#});
 }

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -109,10 +109,4 @@ fn with_too_much_cores() {
         String::from_utf8(assert.get_output().stderr.clone()).expect("stderr is not valid UTF-8");
 
     assert!(stderr.contains("error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine"));
-
-    let re = regex::Regex::new(r"\(\d+\)").expect("Invalid regex");
-    assert!(
-        re.is_match(&stderr),
-        "stderr does not contain the expected pattern"
-    );
 }

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -98,15 +98,29 @@ fn with_too_much_cores() {
     let temp = setup_package("simple_package");
     let snapbox = runner();
 
-    let assert = snapbox
+    snapbox
         .current_dir(&temp)
         .arg("--cores")
         .arg("99999")
         .assert()
-        .code(2);
+        .code(2)
+        .stderr_matches(indoc! {r#"
+            error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine ([..])
+        "#});
+}
 
-    let stderr =
-        String::from_utf8(assert.get_output().stderr.clone()).expect("stderr is not valid UTF-8");
+#[test]
+fn with_zero_core() {
+    let temp = setup_package("simple_package");
+    let snapbox = runner();
 
-    assert!(stderr.contains("error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine"));
+    snapbox
+        .current_dir(&temp)
+        .arg("--cores")
+        .arg("0")
+        .assert()
+        .code(2)
+        .stderr_matches(indoc! {r#"
+            error: invalid value '0' for '--cores <CORES>': Number of cores must be greater than 0
+        "#});
 }

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -105,7 +105,7 @@ fn with_too_much_cores() {
         .assert()
         .code(2)
         .stderr_matches(indoc! {r#"
-            error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine ([..])
+            error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine = [..]
 
             For more information, try '--help'.
         "#});

--- a/crates/forge/tests/e2e/cores.rs
+++ b/crates/forge/tests/e2e/cores.rs
@@ -1,0 +1,118 @@
+use crate::e2e::common::runner::{runner, setup_package};
+use indoc::indoc;
+
+#[test]
+fn with_one_core() {
+    let temp = setup_package("simple_package");
+    let snapbox = runner();
+
+    snapbox
+        .current_dir(&temp)
+        .arg("--cores")
+        .arg("1")
+        .assert()
+        .code(1)
+        .stdout_matches(indoc! {r#"
+        [..]Compiling[..]
+        [..]Finished[..]
+
+
+        Collected 11 test(s) from simple_package package
+        Running 1 test(s) from src/
+        [PASS] simple_package::test_fib
+        Running 10 test(s) from tests/
+        [PASS] tests::contract::call_and_invoke
+        [PASS] tests::ext_function_test::test_my_test
+        [PASS] tests::ext_function_test::test_simple
+        [PASS] tests::test_simple::test_simple
+        [PASS] tests::test_simple::test_simple2
+        [PASS] tests::test_simple::test_two
+        [PASS] tests::test_simple::test_two_and_two
+        [FAIL] tests::test_simple::test_failing
+        
+        Failure data:
+            original value: [8111420071579136082810415440747], converted to a string: [failing check]
+        
+        [FAIL] tests::test_simple::test_another_failing
+        
+        Failure data:
+            original value: [8111420071579136082810415440747], converted to a string: [failing check]
+        
+        [PASS] tests::without_prefix::five
+        Tests: 9 passed, 2 failed, 0 skipped
+        
+        Failures:
+            tests::test_simple::test_failing
+            tests::test_simple::test_another_failing
+        "#});
+}
+
+#[test]
+fn with_more_than_one_core() {
+    let temp = setup_package("simple_package");
+    let snapbox = runner();
+
+    snapbox
+        .current_dir(&temp)
+        .arg("--cores")
+        .arg("3")
+        .assert()
+        .code(1)
+        .stdout_matches(indoc! {r#"
+        [..]Compiling[..]
+        [..]Finished[..]
+
+
+        Collected 11 test(s) from simple_package package
+        Running 1 test(s) from src/
+        [PASS] simple_package::test_fib
+        Running 10 test(s) from tests/
+        [PASS] tests::contract::call_and_invoke
+        [PASS] tests::ext_function_test::test_my_test
+        [PASS] tests::ext_function_test::test_simple
+        [PASS] tests::test_simple::test_simple
+        [PASS] tests::test_simple::test_simple2
+        [PASS] tests::test_simple::test_two
+        [PASS] tests::test_simple::test_two_and_two
+        [FAIL] tests::test_simple::test_failing
+        
+        Failure data:
+            original value: [8111420071579136082810415440747], converted to a string: [failing check]
+        
+        [FAIL] tests::test_simple::test_another_failing
+        
+        Failure data:
+            original value: [8111420071579136082810415440747], converted to a string: [failing check]
+        
+        [PASS] tests::without_prefix::five
+        Tests: 9 passed, 2 failed, 0 skipped
+        
+        Failures:
+            tests::test_simple::test_failing
+            tests::test_simple::test_another_failing
+        "#});
+}
+
+#[test]
+fn with_too_much_cores() {
+    let temp = setup_package("simple_package");
+    let snapbox = runner();
+
+    let assert = snapbox
+        .current_dir(&temp)
+        .arg("--cores")
+        .arg("99999")
+        .assert()
+        .code(2);
+
+    let stderr =
+        String::from_utf8(assert.get_output().stderr.clone()).expect("stderr is not valid UTF-8");
+
+    assert!(stderr.contains("error: invalid value '99999' for '--cores <CORES>': Number of cores must be less than or equal to the number of cores available on the machine"));
+
+    let re = regex::Regex::new(r"\(\d+\)").expect("Invalid regex");
+    assert!(
+        re.is_match(&stderr),
+        "stderr does not contain the expected pattern"
+    );
+}

--- a/crates/forge/tests/e2e/mod.rs
+++ b/crates/forge/tests/e2e/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod common;
 
 mod collection;
+mod cores;
 mod diagnostics_and_plugins;
 mod env;
 mod forking;

--- a/docs/src/appendix/forge.md
+++ b/docs/src/appendix/forge.md
@@ -41,6 +41,10 @@ Seed for the fuzzer.
 
 Clean forge cache directory.
 
+## `--cores`, `<NUM_CORES>`
+
+Number of cores to use for parallel execution.
+
 ## `-h`, `--help`
 
 Print help.

--- a/docs/src/appendix/forge.md
+++ b/docs/src/appendix/forge.md
@@ -43,7 +43,7 @@ Clean forge cache directory.
 
 ## `--cores`, `<NUM_CORES>`
 
-Number of cores to use for parallel execution.
+Number of cores to use for test execution.
 
 ## `-h`, `--help`
 


### PR DESCRIPTION
Related: #887

(would not really _close_ the issue, it's more a temporary solution since it does not work with parallel tests for now)

## Introduced changes

- Added a `--cores` argument to the `snforge` command, allows to choose the number of threads for the test executions.

## Comments

If you suggestions for a better name etc let me know!

## Checklist

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
