### PR TITLE
Remove "Projects" section from docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -7,9 +7,6 @@
 * [Installation](getting-started/installation.md)
 * [First Steps with Starknet Foundry](getting-started/first-steps.md)
 * [Scarb](getting-started/scarb.md)
-
-# Projects
-
 * [Project Configuration](projects/configuration.md)
 
 # Forge overview

--- a/docs/src/projects/configuration.md
+++ b/docs/src/projects/configuration.md
@@ -16,6 +16,42 @@ exit_first = true
 
 Forge automatically looks for `Scarb.toml` in the directory you are running the tests in or in any of its parents.
 
+### Configuring Fork in `Scarb.toml`
+
+Forge makes things easier by letting you set up fork configurations inside the Scarb.toml file. Instead of repeatedly typing out the same details on the command line, you can define them in the file. 
+
+For example, you can set up different forks like this:
+
+```toml
+[[tool.snforge.fork]]
+name = "ethereum_mainnet"
+url = "http://your.rpc.url"
+block_id.tag = "Latest"
+
+[[tool.snforge.fork]]
+name = "custom_fork"
+url = "http://your.second.rpc.url"
+block_id.tag = "Pending"
+```
+
+Once you've done that, you can simply refer to these forks by name when you run your tests:
+
+```toml
+#[test]
+#[fork("ethereum_mainnet")]
+fn test_using_ethereum_mainnet() {
+    // ...
+}
+
+#[test]
+#[fork("custom_fork")]
+fn test_using_custom_fork() {
+    // ...
+}
+```
+This way, you can easily configure and reference different forks for your tests using meaningful names.
+To learn more, check out the page about [Fork Testing](../testing/fork-testing.md).
+
 ## Cast
 
 ### Defining Profiles in `Scarb.toml`

--- a/docs/src/projects/configuration.md
+++ b/docs/src/projects/configuration.md
@@ -16,21 +16,6 @@ exit_first = true
 
 Forge automatically looks for `Scarb.toml` in the directory you are running the tests in or in any of its parents.
 
-### Configuring Fork in `Scarb.toml`
-
-Forge makes things easier by letting you set up fork configurations inside the Scarb.toml file. Instead of repeatedly typing out the same details on the command line, you can define them in the file. 
-
-For example, you can set up different forks like this:
-
-```toml
-[[tool.snforge.fork]]
-name = "Starknet"
-url = "http://your.rpc.url"
-block_id.tag = "Latest"
-```
-
-To learn more, check out the page about [Fork Testing](../testing/fork-testing.md).
-
 ## Cast
 
 ### Defining Profiles in `Scarb.toml`

--- a/docs/src/projects/configuration.md
+++ b/docs/src/projects/configuration.md
@@ -24,32 +24,11 @@ For example, you can set up different forks like this:
 
 ```toml
 [[tool.snforge.fork]]
-name = "ethereum_mainnet"
+name = "Starknet"
 url = "http://your.rpc.url"
 block_id.tag = "Latest"
-
-[[tool.snforge.fork]]
-name = "custom_fork"
-url = "http://your.second.rpc.url"
-block_id.tag = "Pending"
 ```
 
-Once you've done that, you can simply refer to these forks by name when you run your tests:
-
-```toml
-#[test]
-#[fork("ethereum_mainnet")]
-fn test_using_ethereum_mainnet() {
-    // ...
-}
-
-#[test]
-#[fork("custom_fork")]
-fn test_using_custom_fork() {
-    // ...
-}
-```
-This way, you can easily configure and reference different forks for your tests using meaningful names.
 To learn more, check out the page about [Fork Testing](../testing/fork-testing.md).
 
 ## Cast


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #932

## Introduced changes

<!-- A brief description of the changes -->

The project configuration section has been relocated beneath the "Getting Started" category, and the Forge section has been finalized within this context.

## Breaking changes

<!-- List of all breaking changes, if applicable -->
-Nil-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
