### PR TITLE
Move printing functions to cheatnet

### DIFF
--- a/crates/cheatnet/src/execution/contract_execution_syscall_handler.rs
+++ b/crates/cheatnet/src/execution/contract_execution_syscall_handler.rs
@@ -68,15 +68,7 @@ impl HintProcessorLogic for ContractExecutionSyscallHandler<'_, '_> {
 
             match selector {
                 "print" => {
-                    for value in inputs {
-                        if let Some(short_string) = as_cairo_short_string(&value) {
-                            println!(
-                                "original value: [{value}], converted to a string: [{short_string}]",
-                            );
-                        } else {
-                            println!("original value: [{value}]");
-                        }
-                    }
+                    print(inputs);
                     Ok(())
                 }
                 _ => Err(HintError::CustomHint(
@@ -135,5 +127,24 @@ impl ResourceTracker for ContractExecutionSyscallHandler<'_, '_> {
             .context
             .vm_run_resources
             .run_resources()
+    }
+}
+
+fn as_printable_short_string(value: &Felt252) -> Option<String> {
+    let bytes: Vec<u8> = value.to_bytes_be();
+    if bytes.iter().any(u8::is_ascii_control) {
+        return None;
+    }
+
+    as_cairo_short_string(value)
+}
+
+pub fn print(inputs: Vec<Felt252>) {
+    for value in inputs {
+        if let Some(short_string) = as_printable_short_string(&value) {
+            println!("original value: [{value}], converted to a string: [{short_string}]",);
+        } else {
+            println!("original value: [{value}]");
+        }
     }
 }

--- a/crates/forge/src/test_execution_syscall_handler.rs
+++ b/crates/forge/src/test_execution_syscall_handler.rs
@@ -47,7 +47,9 @@ use cairo_vm::vm::errors::hint_errors::HintError::CustomHint;
 use cairo_vm::vm::runners::cairo_runner::{ResourceTracker, RunResources};
 use cheatnet::cheatcodes::spy_events::SpyTarget;
 use cheatnet::execution::cheated_syscalls::SingleSegmentResponse;
-use cheatnet::execution::contract_execution_syscall_handler::ContractExecutionSyscallHandler;
+use cheatnet::execution::contract_execution_syscall_handler::{
+    print, ContractExecutionSyscallHandler,
+};
 use starknet::signers::SigningKey;
 
 mod file_operations;
@@ -867,25 +869,6 @@ fn execute_call_contract(
         &call_args.calldata,
     )
     .unwrap_or_else(|err| panic!("Transaction execution error: {err}"))
-}
-
-fn as_printable_short_string(value: &Felt252) -> Option<String> {
-    let bytes: Vec<u8> = value.to_bytes_be();
-    if bytes.iter().any(u8::is_ascii_control) {
-        return None;
-    }
-
-    as_cairo_short_string(value)
-}
-
-fn print(inputs: Vec<Felt252>) {
-    for value in inputs {
-        if let Some(short_string) = as_printable_short_string(&value) {
-            println!("original value: [{value}], converted to a string: [{short_string}]",);
-        } else {
-            println!("original value: [{value}]");
-        }
-    }
 }
 
 fn write_cheatcode_panic(buffer: &mut MemBuffer, panic_data: &[Felt252]) {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #947 

## Introduced changes

<!-- A brief description of the changes -->

- print function is moved from `forge/src/test_execution_syscall_handler.rs` to `cheatnet/src/execution/contract_execution_syscall_handler.rs`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
