### PR TITLE
Fixed diagnostic paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Changed
+
+- fixed diagnostic paths referring to `tests` folder
+
 ## [0.9.0] - 2023-10-25
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Forge
 
-#### Changed
+#### Fixed
 
-- fixed diagnostic paths referring to `tests` folder
+- diagnostic paths referring to `tests` folder
 
 ## [0.9.0] - 2023-10-25
 

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -5,43 +5,43 @@ use crate::e2e::common::runner::{setup_package, test_runner};
 
 #[test]
 fn print_error_if_attributes_incorrect() {
-    let temp = setup_package("diagnostics_and_plugins");
-    let temp_dir_path = temp.path().canonicalize().unwrap();
-    let temp_dir_path_str = temp_dir_path.to_str().unwrap();
+    let mock_tests_dir = setup_package("diagnostics_and_plugins");
+    let mock_tests_dir_path = mock_tests_dir.path().canonicalize().unwrap();
+    let mock_tests_dir_path_str = mock_tests_dir_path.to_str().unwrap();
 
     let snapbox = test_runner();
 
-    let output = snapbox.current_dir(&temp).assert().code(2);
+    let output = snapbox.current_dir(&mock_tests_dir).assert().code(2);
     assert_stderr_contains!(
         output,
         &formatdoc! {r#"
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> {temp_dir_path_str}/src/lib.cairo:4:11
+             --> {mock_tests_dir_path_str}/src/lib.cairo:4:11
                 #[fork(url: "https://lib.com")]
                       ^**********************^
             
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> {temp_dir_path_str}/src/lib.cairo:4:11
+             --> {mock_tests_dir_path_str}/src/lib.cairo:4:11
                 #[fork(url: "https://lib.com")]
                       ^**********************^
             
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> {temp_dir_path_str}/tests/test_fork.cairo:2:7
+             --> {mock_tests_dir_path_str}/tests/test_fork.cairo:2:7
             #[fork(url: "https://test.com")]
                   ^***********************^
             
             error: Plugin diagnostic: Expected fuzzer config must be of the form `runs: <u32>, seed: <u64>`
-             --> {temp_dir_path_str}/tests/test_fuzzer.cairo:2:9
+             --> {mock_tests_dir_path_str}/tests/test_fuzzer.cairo:2:9
             #[fuzzer(test: 10)]
                     ^********^
             
             error: Plugin diagnostic: Expected fuzzer config must be of the form `runs: <u32>, seed: <u64>`
-             --> {temp_dir_path_str}/tests/test_fuzzer.cairo:8:9
+             --> {mock_tests_dir_path_str}/tests/test_fuzzer.cairo:8:9
             #[fuzzer()]
                     ^^
 
             error: Plugin diagnostic: Expected panic must be of the form `expected = <tuple of felts>`.
-             --> {temp_dir_path_str}/tests/test_should_panic.cairo:2:15
+             --> {mock_tests_dir_path_str}/tests/test_should_panic.cairo:2:15
             #[should_panic(url: "https://test.com")]
                           ^***********************^
 

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -1,44 +1,47 @@
 use crate::assert_stderr_contains;
-use indoc::indoc;
+use indoc::formatdoc;
 
 use crate::e2e::common::runner::{setup_package, test_runner};
 
 #[test]
 fn print_error_if_attributes_incorrect() {
     let temp = setup_package("diagnostics_and_plugins");
+    let temp_dir_path = temp.path().canonicalize().unwrap();
+    let temp_dir_path_str = temp_dir_path.to_str().unwrap();
+
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(&temp).assert().code(2);
     assert_stderr_contains!(
         output,
-        indoc! {r#"
+        &formatdoc! {r#"
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> [..]/src/lib.cairo:4:11
+             --> {temp_dir_path_str}/src/lib.cairo:4:11
                 #[fork(url: "https://lib.com")]
                       ^**********************^
             
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> [..]/src/lib.cairo:4:11
+             --> {temp_dir_path_str}/src/lib.cairo:4:11
                 #[fork(url: "https://lib.com")]
                       ^**********************^
             
             error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
-             --> [..]/tests/test_fork.cairo:2:7
+             --> {temp_dir_path_str}/tests/test_fork.cairo:2:7
             #[fork(url: "https://test.com")]
                   ^***********************^
             
             error: Plugin diagnostic: Expected fuzzer config must be of the form `runs: <u32>, seed: <u64>`
-             --> [..]/tests/test_fuzzer.cairo:2:9
+             --> {temp_dir_path_str}/tests/test_fuzzer.cairo:2:9
             #[fuzzer(test: 10)]
                     ^********^
             
             error: Plugin diagnostic: Expected fuzzer config must be of the form `runs: <u32>, seed: <u64>`
-             --> [..]/tests/test_fuzzer.cairo:8:9
+             --> {temp_dir_path_str}/tests/test_fuzzer.cairo:8:9
             #[fuzzer()]
                     ^^
 
             error: Plugin diagnostic: Expected panic must be of the form `expected = <tuple of felts>`.
-             --> [..]/tests/test_should_panic.cairo:2:15
+             --> {temp_dir_path_str}/tests/test_should_panic.cairo:2:15
             #[should_panic(url: "https://test.com")]
                           ^***********************^
 

--- a/crates/test-collector/src/lib.rs
+++ b/crates/test-collector/src/lib.rs
@@ -4,11 +4,12 @@ use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
 use cairo_lang_debug::DebugWithDb;
-use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleItemId};
+use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::ids::{FreeFunctionId, FunctionWithBodyId, ModuleId, ModuleItemId};
 use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::cfg::{Cfg, CfgSet};
-use cairo_lang_filesystem::db::FilesGroup;
+use cairo_lang_filesystem::db::{AsFilesGroupMut, FilesGroup, FilesGroupEx};
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId, Directory};
 use cairo_lang_lowering::ids::ConcreteFunctionWithBodyId;
 use cairo_lang_project::{ProjectConfig, ProjectConfigContent};
@@ -36,7 +37,7 @@ use plugin::TestPlugin;
 use smol_str::SmolStr;
 use starknet::core::types::{BlockId, BlockTag};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 mod plugin;
@@ -467,19 +468,19 @@ pub struct TestCase {
 }
 
 pub fn collect_tests(
-    crate_root: &str,
-    output_path: Option<&str>,
     crate_name: &str,
+    crate_root: &Path,
+    lib_content: &str,
     linked_libraries: &[LinkedLibrary],
     builtins: &[&str],
     corelib_path: PathBuf,
+    output_path: Option<&str>,
 ) -> Result<(Program, Vec<TestCase>)> {
-    let mut crate_roots: OrderedHashMap<SmolStr, PathBuf> = linked_libraries
+    let crate_roots: OrderedHashMap<SmolStr, PathBuf> = linked_libraries
         .iter()
         .cloned()
         .map(|source_root| (source_root.name.into(), source_root.path))
         .collect();
-    crate_roots.insert(crate_name.into(), PathBuf::from(crate_root));
 
     let project_config = ProjectConfig {
         base_path: crate_root.into(),
@@ -498,7 +499,18 @@ pub fn collect_tests(
         b.build()?
     };
 
+    // region: Modified code from setup_single_project_file from cairo-lang-compiler/src/project.rs
     let main_crate_id = db.intern_crate(CrateLongId::Real(SmolStr::from(crate_name)));
+    db.set_crate_root(
+        main_crate_id,
+        Some(Directory::Real(crate_root.to_path_buf())),
+    );
+
+    let module_id = ModuleId::CrateRoot(main_crate_id);
+    let file_id = db.module_main_file(module_id).unwrap();
+    db.as_files_group_mut()
+        .override_file_content(file_id, Some(Arc::new(lib_content.to_string())));
+    // endregion
 
     if DiagnosticsReporter::stderr().check(db) {
         return Err(anyhow!(


### PR DESCRIPTION
## Introduced changes

- Diagnostic paths to `tests` folder now refer to real files (not the ones from tmp dir). The approach was to manually insert the lib entrypoint content into the compiler db, that's what `lib_content` field in `TestCompilationTarget` is for.

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
