### PR TITLE
Override forge and cast names in clap

### DIFF
--- a/crates/cast/src/main.rs
+++ b/crates/cast/src/main.rs
@@ -19,6 +19,7 @@ mod starknet_commands;
 #[derive(Parser)]
 #[command(version)]
 #[command(about = "Cast - a Starknet Foundry CLI", long_about = None)]
+#[clap(name = "sncast")]
 #[allow(clippy::struct_excessive_bools)]
 struct Cli {
     /// Profile name in Scarb.toml config file

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -27,6 +27,7 @@ static PREDEPLOYED_CONTRACTS: Dir = include_dir!("crates/cheatnet/predeployed-co
 
 #[derive(Parser, Debug)]
 #[command(version)]
+#[clap(name = "snforge")]
 struct Cli {
     #[command(subcommand)]
     subcommand: ForgeSubcommand,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #958 

## Introduced changes

<!-- A brief description of the changes -->

- Override forge and cast names in clap so outputs of `snforge -V` and `sncast -V` use `snforge` and `sncast` instead of `forge` and `cast`.

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
