### PR TITLE
Remove breaking changes section from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,10 +9,6 @@ Closes #
 -
 -
 
-## Breaking changes
-
-<!-- List of all breaking changes, if applicable -->
-
 ## Checklist
 
 <!-- Make sure all of these are complete -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,6 @@ Closes #
 <!-- A brief description of the changes -->
 
 -
--
 
 ## Checklist
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-Removed breaking changes section: In most cases it's left empty even if it's relevant to the PR. It doesn't make sense to keep it if it's not being enforced.

## Breaking changes

<!-- List of all breaking changes, if applicable -->

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
