### PR TITLE
Fix `get_class_hash_at` cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - diagnostic paths referring to `tests` folder
+- caching `get_class_hash_at` in forking test mode
 
 ## [0.9.0] - 2023-10-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - diagnostic paths referring to `tests` folder
-- caching `get_class_hash_at` in forking test mode
+- caching `get_class_hash_at` in forking test mode (credits to @jainkunal for catching the bug)
 
 ## [0.9.0] - 2023-10-25
 

--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -1,7 +1,9 @@
 use crate::state::CheatnetBlockInfo;
+use cairo_felt::Felt252;
 use camino::Utf8PathBuf;
 use conversions::StarknetConversions;
 use fs2::FileExt;
+use num_bigint::BigUint;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use starknet::core::types::{BlockId, BlockTag, ContractClass, FieldElement};
@@ -226,9 +228,15 @@ impl ForkCache {
 
     pub(crate) fn get_class_hash_at(&self, contract_address: ContractAddress) -> Option<ClassHash> {
         self.fork_cache_content
-            .nonce_at
+            .class_hash_at
             .get(&contract_address.to_felt252().to_string())
-            .map(StarknetConversions::to_class_hash)
+            .map(|dec_string| {
+                Felt252::from(
+                    BigUint::parse_bytes(dec_string.as_bytes(), 10)
+                        .expect("Parsing class_hash_at entry failed"),
+                )
+                .to_class_hash()
+            }) // Entry encoded as a decimal string
     }
 
     pub(crate) fn cache_get_class_hash_at(


### PR DESCRIPTION
The failing tests in previous PR were due to improper parsing of the values (`StarknetConversions` assume the string is hex-encoded which is not the case here)
## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue (no issue for this)
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
