### PR TITLE
Using sentence case to edit headers with inconsistent capitalization in all .md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,7 @@ snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v
 
 ## [0.1.1] - 2023-07-26
 
-### Forge & Cast
+### Forge & cast
 
 #### Fixed
 
@@ -289,7 +289,7 @@ snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v
 
 ## [0.1.0] - 2023-07-19
 
-### Forge & Cast
+### Forge & cast
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,3 +294,6 @@ snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v
 #### Added
 
 - Initial release
+
+#### Changed
+- changed every inconsistent headings in folders from title case to sentence case format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribution Guideline
+# Contribution guideline
 
 Starknet Foundry is under active development and is open for contributions!
 Want to get started?
@@ -13,7 +13,7 @@ a [GitHub discussion](https://github.com/foundry-rs/starknet-foundry/discussions
 See [development guide](https://foundry-rs.github.io/starknet-foundry/development/environment-setup.html) in Starknet
 Foundry book for environment setup.
 
-### Running Tests and Checks
+### Running tests and checks
 
 To run tests scripts, you have to install:
 
@@ -67,17 +67,17 @@ to add hasn't been already discussed.
 We also appreciate creating a feature request before making a contribution, so it can be discussed before you get to
 work.
 
-### Writing Tests
+### Writing tests
 
 Please make sure the feature you are implementing is thoroughly tested with automatic tests.
 You can check existing tests in the repository to see the recommended approach to testing.
 
-### Breaking Changes
+### Breaking changes
 
 If the change you are introducing is changing or breaking the behavior of any already existing features, make sure to
 include that information in the pull request description.
 
-### Pull Request Size
+### Pull request size
 
 Try to make your pull request self-contained, only introducing the necessary changes.
 If your feature is complicated,

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Forge achieves performance comparable to the Cairo Test Runner with improved use
 
 To learn more about our benchmark methodology check [here](./benchmarks/).
 
-## Getting Help
+## Getting help
 
 You haven't found your answer to your question in
 the [Starknet Foundry Book](https://foundry-rs.github.io/starknet-foundry/)?

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,11 @@
-# Instruction For Creating New Starknet Forge Releases
+# Instruction for creating new Starknet Forge releases
 
 1. Create a new branch.
 2. Run `./scripts/release.sh MAJOR.MINOR.PATCH`.
 3. Merge introduced changes to master branch.
 4. Wait for release workflows to pass. A new release will be created on GitHub.
 
-## Manually Creating a Release
+## Manually creating a release
 
 In case a manual creation of release is necessary, for example when
 cherry-picking changes, a release can also be triggered by creating a tag

--- a/design_documents/accessing_emitted_events.md
+++ b/design_documents/accessing_emitted_events.md
@@ -20,7 +20,7 @@ Some contract functions can emit events. It is important to test if they were em
 
 Propose a solution that will allow checking if events were emitted.
 
-## Considered Solutions
+## Considered solutions
 
 1. `expect_events` cheatcode 
 2. `spy_events` cheatcode

--- a/design_documents/cairo_deployment_scripts.md
+++ b/design_documents/cairo_deployment_scripts.md
@@ -42,13 +42,13 @@ We should allow for all flags passed to sncast to be propagated to the script. C
 and usable from script if someone wishes so, but we should not require it. That means, we might have to review our subcommands
 and if some of them requires it directly (`account create` is one), we should try to get rid of this dependency. 
 
-### interacting with contract
+### Interacting with contract
 We will use contracts dispatchers to be able to call/invoke its functions directly 
 (e.g. if contract named `mycontract` has a function `myfunction`, we should be able to just do `mycontractDispatcher.myfunction();`).
 We should also support our subcommands (`invoke`, `call`) to call/invoke so dispatchers are able to use them, and for calling/invoking 
 contracts without dispatchers.
 
-### running the script
+### Running the script
 The script would essentially run an entrypoint function - `main`. Inside our script subcommand, we will have to compile 
 the cairo script file using a custom builder/extension, and then run it using some form of a custom runner - all similarly
 to how it is done in snforge.
@@ -79,7 +79,7 @@ that sets up the devnet to be used for dry running for users.
 The behaviour would be changed with `--broadcast` flag, that would actually execute needed transactions. We should also
 include a warning message about potential incurring cost.
 
-### error handling
+### Error handling
 If the transaction fails, we should put all the relevant info about it to the state file, output log information and stop
 script execution.
 If the script fails (for any reason that is not connected to transactions - eg rpc node down), we should output relevant
@@ -91,7 +91,7 @@ In case of failed transaction, we should allow to:
 we should allow users to just re-run the script - all the previous (succeeded) transactions should not be replayed, the
 erroneous transaction should be retried and its output should be put into [state file](#example-state-file).
 
-### idempotency
+### Idempotency
 At the later stages we will want to have the script to be able to track the on chain state using a state file, which would 
 in turn allow the script to be called multiple times without any modifications, to ensure desired state. To achieve that
 we must ensure idempotency of calls to the network.
@@ -220,7 +220,7 @@ Picking those would ensure us that:
 
 
 
-### example script
+### Example script
 An example deployment script could look like this:
 
 ```cairo
@@ -259,7 +259,7 @@ fn main() {
 }
 ```
 
-### example state file
+### Example state file
 The state file by default should be written to the current working directory, with a name `<script file name>.state.json`.
 Its schema could look like this:
 

--- a/design_documents/contract_verification.md
+++ b/design_documents/contract_verification.md
@@ -1,4 +1,4 @@
-# Cairo Contract Verification via Block Explorers
+# Cairo contract verification via block explorers
 
 ## Context
 
@@ -8,7 +8,7 @@ Cairo smart contracts deployed to Starknet are only visible as a Cairo Bytecode 
 
 This proposal includes an extension to `sncast` utility enabling a contract owner to perform contract verification against a selected Blockchain Explorer API. We propose to create a first, reference implementation for the Voyager APIs.
 
-## Proposed Solution
+## Proposed solution
 
 We propose to design a dedicated `verify` command for the `sncast` tool, and add a mechanism whereby this command can be implemented for various Blockchain Explorers. We define a "generic" contract verification interface and propose to implement the interface by "adapters" specific to respective explorers. 
 
@@ -54,7 +54,7 @@ Options are:
  - mainnet - for verification at mainnet
  - goerli -  for verification on testnet
 
-### Contract Verification interface
+### Contract verification interface
 
 To implement contract verification for a specific explorer, it is required to implement a generic interface (request/response), as described below. The data structures proposed can be eventually extended to cater for detailed requirements of subsequent explorer adapters.
 

--- a/design_documents/loading_data_from_files.md
+++ b/design_documents/loading_data_from_files.md
@@ -24,7 +24,7 @@ let file_data = read_array_from_file('file.txt').unwrap();
 assert(*array[0] == *file_data[0] && *array[1] == *file_data[1], 'arrays are not equal');
 ```
 
-## Proposed Solution
+## Proposed solution
 
 Create traits that are responsible for reading data from a file and loading it into Cairo memory
 as an array of felts, returning a Result if something goes wrong (file does not exist, short string is too long, etc.).

--- a/design_documents/prepare_cheatcode.md
+++ b/design_documents/prepare_cheatcode.md
@@ -33,7 +33,7 @@ the address in advance with the current cheatcodes.
 
 Propose a solution that will allow knowing the address of a contract before the deployment.
 
-## Considered Solutions
+## Considered solutions
 
 ### Require Calling the `prepare` Cheatcode Before Every Deployment
 
@@ -55,7 +55,7 @@ Users would have to perform an often unnecessary extra step with every deploymen
 Introducing the `precalculate_address` cheatcode that would return the contract address of the contract that would be
 deployed with `deploy` cheatcode.
 
-#### Salt "Counter"
+#### Salt "counter"
 
 Introduce an internal "counter" and use its value to salt the otherwise deterministic contract address.
 Every time the `deploy` is called, increment this counter, so subsequent calls of `deploy` with the same `class_hash`
@@ -73,7 +73,7 @@ That will use the same method of calculating the contract address as `deploy` us
 This way the user will have an ability to know the address of the contract that will be deployed, and the current
 deployment flow will remain unchanged.
 
-#### Known Problems With This Solution
+#### Known problems with this solution
 
 For the address returned by `precalculate_address` to match the address from `deploy`, the user will have to
 call `precalculate_address` immediately before the deployment or at least before any other calls to `deploy` as the
@@ -81,7 +81,7 @@ internal counter will then be incremented.
 
 This could be remedied by having separate counters for all `class_hashe`es, but it will still remain a limiting factor.
 
-#### Example Usage
+#### Example usage
 
 ```cairo
 mod HelloStarknet {
@@ -132,7 +132,7 @@ fn call_and_invoke() {
 }
 ```
 
-## Proposed Solution
+## Proposed solution
 
 Change the current deployment flow, so it can better facilitate precalculating of contract addresses.
 
@@ -162,16 +162,16 @@ And remove the `deploy` cheatcode entirely.
 
 Both `precalculate_address` and `deploy` should use the same way of calculating the contract address.
 
-### Salt "Counter"
+### Salt "counter"
 
 Introduce the same salt counter as [discussed here](#salt-counter).
 This will allow deterministic address calculation and deploying of multiple instances of the same contract.
 
-### Known Problems With This Solution
+### Known problems with this solution
 
 Same problems as [indicated here](#known-problems-with-this-solution) apply to Proposed Solution 2 as well.
 
-### Example Usage
+### Example usage
 
 ```cairo
 mod HelloStarknet {

--- a/design_documents/test_design.md
+++ b/design_documents/test_design.md
@@ -13,7 +13,7 @@ Current test design in Starknet Forge has some issues:
 
 Propose a solution of test design that solves most of the aforementioned issues.
 
-## Proposed Solution
+## Proposed solution
 
 Tests should be contracts (just like in the early days of Protostar).
 Basically, the code in test should behave as if it was a function called in an invoke transaction.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Starknet Foundry Book
+# Starknet Foundry book
 
 ## Installation
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 [Introduction](./README.md)
 
-# Getting Started
+# Getting started
 
 * [Installation](getting-started/installation.md)
 * [First Steps with Starknet Foundry](getting-started/first-steps.md)
@@ -24,7 +24,7 @@
 * [Fuzz Testing](testing/fuzz-testing.md)
 * [Test Collection](testing/test-collection.md)
 
-# Cast Overview
+# Cast overview
 
 * [Outline](starknet/index.md)
 * [Creating And Deploying Accounts](starknet/account.md)
@@ -34,7 +34,7 @@
 * [Calling Contracts](starknet/call.md)
 * [Performing Multicall](starknet/multicall.md)
 
-# Foundry Development
+# Foundry development
 
 * [Environment Setup](development/environment-setup.md)
 

--- a/docs/src/appendix/cast.md
+++ b/docs/src/appendix/cast.md
@@ -1,4 +1,4 @@
-# Cast CLI Reference
+# Cast CLI reference
 
 * [common flags](./cast/common.md)
 * [account](./cast/account/account.md)

--- a/docs/src/appendix/cast/account/add.md
+++ b/docs/src/appendix/cast/account/add.md
@@ -4,7 +4,7 @@ Import an account to accounts file.
 Account information will be saved to the file specified by `--accounts-file` argument,
 which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
 
-## Required common arguments - passed by CLI or specified in Scarb.toml
+## Required Common Arguments - passed by CLI or specified in Scarb.toml
 
 * [`url`](../common.md#--url--u-rpc_url)
 

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -1,4 +1,4 @@
-# Cheatcodes Reference
+# Cheatcodes reference
 
 - [`start_prank`](cheatcodes/start_prank.md) - changes the caller address for a contract
 - [`stop_prank`](cheatcodes/stop_prank.md) - cancels the `start_prank` for the contract

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -24,7 +24,7 @@ enum SpyOn {
 
 > ⚠️ **Warning**
 >
-> Spying on the same contract with multiple spies can result in unexpected behavior — avoid it if possible.
+> Spying on the same contract with multiple spies can result in unexpected Behavior — Avoid it if Possible.
 
 `EventSpy` implements `EventFetcher` and `EventAssertions` traits.
 

--- a/docs/src/appendix/forge-library.md
+++ b/docs/src/appendix/forge-library.md
@@ -1,4 +1,4 @@
-# Library Functions References
+# Library functions references
 
 * [`declare`](forge-library/declare.md) - declares a contract and returns a struct on
   which [`precalculate_address`](forge-library/precalculate_address.md) and [`deploy`](forge-library/deploy.md) can be

--- a/docs/src/appendix/forge.md
+++ b/docs/src/appendix/forge.md
@@ -1,4 +1,4 @@
-# Forge CLI Reference
+# Forge CLI reference
 
 * [`snforge test`](./forge/test.md)
 * [`snforge init`](./forge/init.md)

--- a/docs/src/development/environment-setup.md
+++ b/docs/src/development/environment-setup.md
@@ -1,4 +1,4 @@
-# Environment Setup
+# Environment setup
 
 Install the latest stable [Rust](https://www.rust-lang.org/tools/install) version.
 If you already have Rust installed make sure to upgrade it by running
@@ -13,7 +13,7 @@ To verify that project was cloned and set up correctly, you can run
 $ cargo check
 ```
 
-## External Dependencies
+## External dependencies
 
 To run Starknet Foundry tests, you must install these tools on your computer:
 
@@ -22,7 +22,7 @@ To run Starknet Foundry tests, you must install these tools on your computer:
 
 It is not possible to run tests without these installed.
 
-## Running Tests
+## Running tests
 
 > ⚠️ Make sure you run `./scripts/prepare_for_tests.sh`
 > and then set [Scarb](https://docs.swmansion.com/scarb/) version 
@@ -35,7 +35,7 @@ Tests can be run with:
 $ cargo test
 ```
 
-## Formatting and Lints
+## Formatting and lints
 
 Starknet Foundry uses [rustfmt](https://github.com/rust-lang/rustfmt) for formatting. You can run the formatter with
 

--- a/docs/src/getting-started/first-steps.md
+++ b/docs/src/getting-started/first-steps.md
@@ -48,7 +48,7 @@ Running 2 test(s) from tests/
 Tests: 2 passed, 0 failed, 0 skipped
 ```
 
-## Using `snforge` With Existing Scarb Projects
+## Using `snforge` with existing Scarb projects
 
 To use `snforge` with existing Scarb projects, make sure you have declared the `snforge_std` package as your project
 dependency.

--- a/docs/src/projects/configuration.md
+++ b/docs/src/projects/configuration.md
@@ -1,8 +1,8 @@
-# Project Configuration
+# Project configuration
 
 ## Forge
 
-### Configuring Forge Settings in `Scarb.toml`
+### Configuring Forge settings in `Scarb.toml`
 
 It is possible to configure forge for all test runs through `Scarb.toml`.
 Instead of passing arguments in the command line, set them directly in the file.
@@ -18,7 +18,7 @@ Forge automatically looks for `Scarb.toml` in the directory you are running the 
 
 ## Cast
 
-### Defining Profiles in `Scarb.toml`
+### Defining profiles in `Scarb.toml`
 
 To be able to work with the network, you need to supply cast with a few parameters —
 namely the rpc node url and an account name that should be used to interact with it.
@@ -58,11 +58,11 @@ command: call
 response: [0x0]
 ```
 
-### Multiple Profiles
+### Multiple profiles
 
 You can have multiple profiles defined in the `Scarb.toml`.
 
-### Default Profile
+### Default profile
 
 If you don't need multiple profiles, you can define the parameters without specifying one:
 

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -1,4 +1,4 @@
-# Creating And Deploying Accounts
+# Creating and deploying accounts
 
 Account is required to perform interactions with Starknet (only calls can be done without it). Starknet Foundry cast supports
 entire account management flow with the `sncast account create` and `sncast account deploy` commands.

--- a/docs/src/starknet/call.md
+++ b/docs/src/starknet/call.md
@@ -1,4 +1,4 @@
-# Calling Contracts
+# Calling contracts
 
 ## Overview
 

--- a/docs/src/starknet/deploy.md
+++ b/docs/src/starknet/deploy.md
@@ -1,4 +1,4 @@
-# Deploying New Contracts
+# Deploying new contracts
 
 ## Overview
 

--- a/docs/src/starknet/invoke.md
+++ b/docs/src/starknet/invoke.md
@@ -1,4 +1,4 @@
-# Invoking Contracts
+# Invoking contracts
 
 ## Overview
 

--- a/docs/src/starknet/multicall.md
+++ b/docs/src/starknet/multicall.md
@@ -1,4 +1,4 @@
-# Performing Multicall
+# Performing multicall
 
 ## Overview
 

--- a/docs/src/starknet/show_config.md
+++ b/docs/src/starknet/show_config.md
@@ -1,4 +1,4 @@
-# Printing Current Configuration
+# Printing current configuration
 
 ## Overview
 

--- a/docs/src/testing/contracts.md
+++ b/docs/src/testing/contracts.md
@@ -1,4 +1,4 @@
-# Testing Smart Contracts
+# Testing smart contracts
 
 > ℹ️ **Info**
 > To use the library functions designed for testing smart contracts,
@@ -13,7 +13,7 @@
 Using unit testing as much as possible is a good practice, as it makes your test suites run faster. However, when
 writing smart contracts, you often want to test their interactions with the blockchain state and with other contracts.
 
-## The Test Contract
+## The test contract
 
 In this tutorial we will be using this Starknet contract
 
@@ -48,7 +48,7 @@ mod HelloStarknet {
 
 Note that the name after `mod` will be used as the contract name for testing purposes.
 
-## Writing Tests
+## Writing tests
 
 Let's write a test that will deploy the `HelloStarknet` contract and call some functions.
 
@@ -88,7 +88,7 @@ Running 1 test(s) from tests/
 Tests: 1 passed, 0 failed, 0 skipped
 ```
 
-## Handling Errors
+## Handling errors
 
 Sometimes we want to test contracts functions that can panic, like testing that function that verifies caller address
 panics on invalid address. For that purpose Starknet also provides a `SafeDispatcher`, that returns a `Result` instead of
@@ -188,7 +188,7 @@ Running 1 test(s) from tests/
 Tests: 1 passed, 0 failed, 0 skipped
 ```
 
-### Expecting Test Failure
+### Expecting test failure
 
 Sometimes the test code failing can be a desired behavior.
 Instead of manually handling it, you can simply mark your test as `#[should_panic(...)]`.

--- a/docs/src/testing/fork-testing.md
+++ b/docs/src/testing/fork-testing.md
@@ -1,4 +1,4 @@
-# Fork Testing
+# Fork testing
 
 Forge supports testing in a forked environment. Each test can fork the state of a specified real
 network and perform actions on top of it.

--- a/docs/src/testing/fuzz-testing.md
+++ b/docs/src/testing/fuzz-testing.md
@@ -1,4 +1,4 @@
-# Fuzz Testing
+# Fuzz testing
 
 In many cases, a test needs to verify function behavior for multiple possible values.
 While it is possible to come up with these cases on your own, it is often impractical, especially when you want to test
@@ -10,7 +10,7 @@ against a large number of possible arguments.
 > other fuzzer runs.
 > In the future, more advanced fuzzing execution modes will be added.
 
-## Random Fuzzing
+## Random fuzzing
 
 To convert a test to a random fuzz test, simply add arguments to the test function.
 These arguments can then be used in the test body.
@@ -39,7 +39,7 @@ Tests: 1 passed, 0 failed, 0 skipped
 Fuzzer seed: [..]
 ```
 
-## Types Supported by the Fuzzer
+## Types supported by the Fuzzer
 
 Fuzzer currently supports generating values of these types
 
@@ -53,7 +53,7 @@ Fuzzer currently supports generating values of these types
 
 Trying to use arguments of different type in test definition will result in an error.
 
-## Fuzzer Configuration
+## Fuzzer configuration
 
 It is possible to configure the number of runs of the random fuzzer as well as its seed for a specific test case:
 

--- a/docs/src/testing/running-tests.md
+++ b/docs/src/testing/running-tests.md
@@ -1,4 +1,4 @@
-# Running Tests
+# Running tests
 
 To run tests with Forge, simply run the `snforge test` command from the package directory.
 
@@ -12,7 +12,7 @@ Running 3 test(s) from src/
 Tests: 3 passed, 0 failed, 0 skipped
 ```
 
-## Filtering Tests
+## Filtering tests
 
 You can pass a filter string after the `snforge test` command to filter tests.
 By default, any test with an [absolute module tree path](https://book.cairo-lang.org/ch07-03-paths-for-referring-to-an-item-in-the-module-tree.html#paths-for-referring-to-an-item-in-the-module-tree)
@@ -27,7 +27,7 @@ Running 2 test(s) from src/
 Tests: 2 passed, 0 failed, 0 skipped
 ```
 
-## Running a Specific Test
+## Running a specific test
 
 To run a specific test, you can pass a filter string along with an `--exact` flag.
 Note, you have to use a fully qualified test name, including a module name.
@@ -40,7 +40,7 @@ Running 1 test(s) from src/
 Tests: 1 passed, 0 failed, 0 skipped
 ```
 
-## Stopping Test Execution After First Failed Test
+## Stopping test execution after first failed test
 
 To stop the test execution after first failed test, you can pass an `--exit-first` flag along with `snforge test` command.
 

--- a/docs/src/testing/test-collection.md
+++ b/docs/src/testing/test-collection.md
@@ -1,4 +1,4 @@
-## Test Collection
+## Test collection
 
 Forge considers all functions in your project marked with `#[test]` attribute as tests.
 By default, test functions run without any arguments.
@@ -11,7 +11,7 @@ Starknet Forge will collect tests only from these places:
 these have to be in a module annotated with `#[cfg(test)]`
 - files inside the [`tests`](#the-tests-directory) directory
 
-## The *tests* Directory
+## The *tests* directory
 
 Forge collects tests from `tests` directory.
 Depending on the presence of `tests/lib.cairo` file, the behavior of the test collector will be different.
@@ -86,7 +86,7 @@ mod utils;
 
 tests from `tests/test_contract.cairo`, `tests/common.cairo` and `tests/common/utils.cairo` will be collected.
 
-### Sharing Code Between Tests
+### Sharing code between tests
 
 Sometimes you may want a share some code between tests to organize them. 
 The package structure of tests makes it easy! 

--- a/docs/src/testing/testing.md
+++ b/docs/src/testing/testing.md
@@ -1,4 +1,4 @@
-# Writing Tests
+# Writing tests
 
 Forge lets you test standalone functions from your smart contracts. This technique is referred to as unit testing. You
 should write as many unit tests as possible as these are faster than integration tests.
@@ -98,7 +98,7 @@ Running 1 test(s) from tests/
 Tests: 1 passed, 0 failed, 0 skipped
 ```
 
-## Ignoring Some Tests Unless Specifically Requested
+## Ignoring some tests unless specifically requested
 
 Sometimes you may have tests that you want to exclude during most runs of `snforge test`.
 You can achieve it using `#[ignore]` - tests marked with this attribute will be skipped by default.

--- a/docs/src/testing/testing_contract_internals.md
+++ b/docs/src/testing/testing_contract_internals.md
@@ -1,4 +1,4 @@
-# Testing Contracts' Internals
+# Testing contracts' internals
 
 Sometimes, you want to test a function which uses Starknet context (like block number, timestamp, storage access) 
 without deploying the actual contract. 
@@ -9,7 +9,7 @@ Since every test is treated like a contract, using the aforementioned pattern yo
 - functions performing specific operations on the contracts' storage or context data
 - library calls directly in the tests
 
-## Utilities For Testing Internals
+## Utilities For testing internals
 To facilitate such use cases, we have a handful of utilities which make a test behave like a contract. 
 
 ### `contract_state_for_testing()` - State of Test Contract
@@ -50,7 +50,7 @@ This code contains some caveats:
 2. To test internal functions, you need to pass the created state explicitly to the function, since `self` context is not available (we're using it as a static function).
 3. This function will always return the struct keeping track of the state of the test. It means that within one test every result of `contract_state_for_testing` actually points to the same state.
 
-### `snforge_std::test_address()` - Address of Test Contract
+### `snforge_std::test_address()` - Address of test contract
 
 That function returns the contract address of the test.
 It is useful, when you want to:
@@ -174,7 +174,7 @@ fn test_expect_events_simple() {
 }
 ```
 
-## Using Library Calls with the test state context
+## Using library calls with the test state context
 
 Using the above utilities, you can avoid deploying a mock contract, to test a `library_call` with a `LibraryCallDispatcher`.
 

--- a/docs/src/testing/using-cheatcodes.md
+++ b/docs/src/testing/using-cheatcodes.md
@@ -13,7 +13,7 @@ When testing smart contracts, often there are parts of code that are dependent o
 Instead of trying to replicate these conditions in tests, you can emulate them
 using [cheatcodes](../appendix/cheatcodes.md).
 
-## The Test Contract
+## The test contract
 
 In this tutorial will be using this Starknet contract:
 
@@ -55,7 +55,7 @@ mod HelloStarknet {
 Note that this is the same contract as on the [Testing Smart Contracts](./testing.md) page with
 the `assert_is_allowed_user` function added.
 
-## Writing Tests
+## Writing tests
 
 We can try to create a test that will increase and verify the balance.
 
@@ -94,14 +94,14 @@ Failures:
 
 Our user validation is not letting us call the contract, because the default caller address is not `123`.
 
-## Using Cheatcodes in Tests
+## Using Cheatcodes in tests
 
 By using cheatcodes, we can change various properties of transaction info, block info, etc.
 For example, we can use the [`start_prank`](../appendix/cheatcodes/start_prank.md) cheatcode to change the caller
 address,
 so it passes our validation.
 
-### Pranking the Address
+### Pranking the address
 
 ```rust
 use snforge_std::{ declare, ContractClassTrait, start_prank };
@@ -136,7 +136,7 @@ Running 1 test(s) from tests/
 Tests: 1 passed, 0 failed, 0 skipped
 ```
 
-### Canceling the Prank
+### Canceling the prank
 
 Most cheatcodes come with corresponding `start_` and `stop_` functions that can be used to start and stop the state
 change.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- In this pull request `.md files` with inconsistent headers contained formats with title case but with professional documentation style. I ensured that all headers are written with sentence case format to enhance readability for docs users. This edit covers two folders and addresses the issue of #710 



## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
