### PR TITLE
Adding snfoundryup support 🔨

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,21 @@ Starknet Foundry, like its [Ethereum counterpart](https://github.com/foundry-rs/
 
 ## Installation
 
-To install Starknet Foundry, run:
+To install Starknet Foundry, first install `snfoundryup` by running:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
+curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash
+```
+Follow the instructions and then run
+
+```shell
+snfoundryup
 ```
 
 You can also specify a version you wish to install:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh -s -- -v 0.3.0
+snfoundryup -v 0.9.0
 ```
 
 To verify that the Starknet Foundry is installed correctly, run `snforge --version` and `sncast --version`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Starknet Foundry, like its [Ethereum counterpart](https://github.com/foundry-rs/
 To install Starknet Foundry, first install `snfoundryup` by running:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash
+curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
 ```
 Follow the instructions and then run
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -10,7 +10,7 @@ and added to your `PATH` environment variable.
 You can find what version of Scarb is compatible with your version of Starknet Foundry
 in [release notes](https://github.com/foundry-rs/starknet-foundry/releases).
 
-### Install via Snfoundryup
+### Install via `snfoundryup`
 
 Snfoundryup is the Starknet Foundry toolchain installer. You can find more about it [here](https://github.com/foundry-rs/starknet-foundry/tree/master/scripts).
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -17,7 +17,7 @@ Snfoundryup is the Starknet Foundry toolchain installer.
 You can install it by running:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash
+curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
 ```
 Follow the instructions and then run:
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -12,7 +12,7 @@ in [release notes](https://github.com/foundry-rs/starknet-foundry/releases).
 
 ### Install via `snfoundryup`
 
-Snfoundryup is the Starknet Foundry toolchain installer. You can find more about it [here](https://github.com/foundry-rs/starknet-foundry/tree/master/scripts).
+Snfoundryup is the Starknet Foundry toolchain installer.
 
 First install `snfoundryup` by running:
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -33,6 +33,7 @@ snfoundryup -v 0.9.0
 See `snfoundryup --help` for more options, like installing from a specific version or commit.
 
 To verify that the Starknet Foundry is installed correctly, run `snforge --version` and `sncast --version`.
+
 ## How to build Starknet Foundry from source code
 
 If you are unable to install Starknet Foundry using the instructions above, you can try building it from

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -25,12 +25,7 @@ Follow the instructions and then run:
 snfoundryup
 ```
 
-You can also specify a version you wish to install:
-
-```shell
-snfoundryup -v 0.9.0
-```
-See `snfoundryup --help` for more options, like installing from a specific version or commit.
+See `snfoundryup --help` for more options.
 
 To verify that the Starknet Foundry is installed correctly, run `snforge --version` and `sncast --version`.
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -14,7 +14,7 @@ in [release notes](https://github.com/foundry-rs/starknet-foundry/releases).
 
 Snfoundryup is the Starknet Foundry toolchain installer.
 
-First install `snfoundryup` by running:
+You can install it by running:
 
 ```shell
 curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -10,23 +10,29 @@ and added to your `PATH` environment variable.
 You can find what version of Scarb is compatible with your version of Starknet Foundry
 in [release notes](https://github.com/foundry-rs/starknet-foundry/releases).
 
-### Install via installation script
+### Install via Snfoundryup
 
-1. Open a terminal and run the following command:
+Snfoundryup is the Starknet Foundry toolchain installer. You can find more about it [here](https://github.com/foundry-rs/starknet-foundry/tree/master/scripts).
+
+First install `snfoundryup` by running:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh
+curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | bash
 ```
+Follow the instructions and then run:
 
-2. To verify that the Starknet Foundry is installed correctly, run `snforge --version` and `sncast --version`.
-   In some cases, you may need to close and reopen the terminal.
+```shell
+snfoundryup
+```
 
 You can also specify a version you wish to install:
 
 ```shell
-curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh -s -- -v 0.3.0
+snfoundryup -v 0.9.0
 ```
+See `snfoundryup --help` for more options, like installing from a specific version or commit.
 
+To verify that the Starknet Foundry is installed correctly, run `snforge --version` and `sncast --version`.
 ## How to build Starknet Foundry from source code
 
 If you are unable to install Starknet Foundry using the instructions above, you can try building it from

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,11 +4,9 @@ set -e
 echo Installing snfoundryup...
 
 
-REPO="https://github.com/foundry-rs/starknet-foundry"
 XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
 INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
-LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
 
 SNFOUNDRYUP_URL="https://raw.githubusercontent.com/partychad/starknet-foundry/fork-master/scripts/snfoundryup"
 SNFOUNDRYUP_PATH="${LOCAL_BIN}/snfoundryup"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,7 +8,7 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
 INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 
-SNFOUNDRYUP_URL="https://raw.githubusercontent.com/partychad/starknet-foundry/fork-master/scripts/snfoundryup"
+SNFOUNDRYUP_URL="https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/snfoundryup"
 SNFOUNDRYUP_PATH="${LOCAL_BIN}/snfoundryup"
 
 # Check for curl

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,9 +3,6 @@ set -e
 
 echo Installing snfoundryup...
 
-
-XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
-INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 
 SNFOUNDRYUP_URL="https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/snfoundryup"
@@ -19,9 +16,9 @@ fi
 
 
 # Create the ${HOME}/.local/bin bin directory and snfoundryup binary if it doesn't exist.
-mkdir -p ${LOCAL_BIN}
-curl -# -L ${SNFOUNDRYUP_URL} -o ${SNFOUNDRYUP_PATH}
-chmod +x ${SNFOUNDRYUP_PATH}
+mkdir -p "${LOCAL_BIN}"
+curl -# -L "${SNFOUNDRYUP_URL}" -o "${SNFOUNDRYUP_PATH}"
+chmod +x "${SNFOUNDRYUP_PATH}"
 
 
 # Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
@@ -54,5 +51,6 @@ if [ ":$PATH:" != *":${LOCAL_BIN}:"* ]; then
 fi
 
 
-echo && echo "Detected your preferred shell is ${PREF_SHELL} and added snfoundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use snfoundryup."
-echo "Then, simply run 'snfoundryup' to install Starknet-Foundry."
+printf "\nDetected your preferred shell is %s and added snfoundryup to PATH. Run 'source %s' or start a new terminal session to use snfoundryup.\n" "$PREF_SHELL" "$PROFILE"
+printf "Then, simply run 'snfoundryup' to install Starknet-Foundry.\n"
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,10 +12,11 @@ SNFOUNDRYUP_URL="https://raw.githubusercontent.com/foundry-rs/starknet-foundry/m
 SNFOUNDRYUP_PATH="${LOCAL_BIN}/snfoundryup"
 
 # Check for curl
-if ! command -v curl &> /dev/null; then
+if ! command -v curl > /dev/null 2>&1; then
     echo "curl could not be found, please install it first."
     exit 1
 fi
+
 
 # Create the ${HOME}/.local/bin bin directory and snfoundryup binary if it doesn't exist.
 mkdir -p ${LOCAL_BIN}
@@ -47,9 +48,9 @@ case $SHELL in
 esac
 
 # Only add snfoundryup if it isn't already in PATH.
-if [[ ":$PATH:" != *":${LOCAL_BIN}:"* ]]; then
+if [ ":$PATH:" != *":${LOCAL_BIN}:"* ]; then
     # Add the snfoundryup directory to the path and ensure the old PATH variables remain.
-    echo >> $PROFILE && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> $PROFILE
+    echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> "$PROFILE"
 fi
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
 
 echo Installing snfoundryup...

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,17 +1,8 @@
-#!/bin/sh
-# shellcheck shell=dash
-# shellcheck disable=SC2039
+#!/usr/bin/env bash
+set -e
 
-# This is just a little script that can be downloaded from the internet to install Starknet Foundry.
-# It just does platform detection, downloads the release archive, extracts it and tries to make
-# the `snforge` and `sncast` binaries available in $PATH in least invasive way possible.
-#
-# It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local` extension.
-# Note: Most shells limit `local` to 1 var per line, contra bash.
-#
-# Most of this code is based on/copy-pasted from rustup and protostar installers.
+echo Installing snfoundryup...
 
-set -u
 
 REPO="https://github.com/foundry-rs/starknet-foundry"
 XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
@@ -19,472 +10,46 @@ INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
 
-usage() {
-  cat <<EOF
-The installer for Starknet Foundry
+SNFOUNDRYUP_URL="https://raw.githubusercontent.com/partychad/starknet-foundry/fork-master/scripts/snfoundryup"
+SNFOUNDRYUP_PATH="${LOCAL_BIN}/snfoundryup"
 
-Usage: install.sh [OPTIONS]
 
-Options:
-  -p, --no-modify-path   Skip PATH variable modification
-  -h, --help             Print help
-  -v, --version          Specify Starknet Foundry version to install
+# Create the .foundry bin directory and foundryup binary if it doesn't exist.
+mkdir -p ${LOCAL_BIN}
+curl -# -L ${SNFOUNDRYUP_URL} -o ${SNFOUNDRYUP_PATH}
+chmod +x ${SNFOUNDRYUP_PATH}
 
-For more information, check out https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html
-EOF
-}
+# Create the man directory for future man files if it doesn't exist.
 
-main() {
-  need_cmd chmod
-  need_cmd curl
-  need_cmd grep
-  need_cmd mkdir
-  need_cmd mktemp
-  need_cmd rm
-  need_cmd sed
-  need_cmd tar
-  need_cmd uname
-
-  # Transform long options to short ones.
-  for arg in "$@"; do
-    shift
-    case "$arg" in
-      '--help')           set -- "$@" '-h'   ;;
-      '--no-modify-path') set -- "$@" '-p'   ;;
-      '--version')        set -- "$@" '-v'   ;;
-      *)                  set -- "$@" "$arg" ;;
-    esac
-  done
-
-  local _requested_ref="latest"
-  local _requested_version="latest"
-  local _do_modify_path=1
-  while getopts ":hpv:" opt; do
-    case $opt in
-    p)
-      _do_modify_path=0
-      ;;
-    h)
-      usage
-      exit 0
-      ;;
-    v)
-      _requested_ref="tag/v${OPTARG}"
-      _requested_version="$OPTARG"
-      ;;
-    \?)
-      err "invalid option -$OPTARG"
-      ;;
-    :)
-      err "option -$OPTARG requires an argument"
-      ;;
-    esac
-  done
-
-  resolve_version "$_requested_version" "$_requested_ref" || return 1
-  local _resolved_version=$RETVAL
-  assert_nz "$_resolved_version" "resolved_version"
-
-  get_architecture || return 1
-  local _arch="$RETVAL"
-  assert_nz "$_arch" "arch"
-
-  local _tempdir
-  if ! _tempdir="$(ensure mktemp -d)"; then
-    # Because the previous command ran in a subshell, we must manually propagate exit status.
+# Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
+case $SHELL in
+*/zsh)
+    PROFILE=${ZDOTDIR-"$HOME"}/.zshenv
+    PREF_SHELL=zsh
+    ;;
+*/bash)
+    PROFILE=$HOME/.bashrc
+    PREF_SHELL=bash
+    ;;
+*/fish)
+    PROFILE=$HOME/.config/fish/config.fish
+    PREF_SHELL=fish
+    ;;
+*/ash)
+    PROFILE=$HOME/.profile
+    PREF_SHELL=ash
+    ;;
+*)
+    echo "snfoundryup: could not detect shell, manually add ${LOCAL_BIN} to your PATH."
     exit 1
-  fi
+esac
 
-  ensure mkdir -p "$_tempdir"
+# Only add foundryup if it isn't already in PATH.
+if [[ ":$PATH:" != *":${LOCAL_BIN}:"* ]]; then
+    # Add the foundryup directory to the path and ensure the old PATH variables remain.
+    echo >> $PROFILE && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> $PROFILE
+fi
 
-  create_install_dir "$_requested_version"
-  local _installdir=$RETVAL
-  assert_nz "$_installdir" "installdir"
 
-  download "$_resolved_version" "$_arch" "$_installdir" "$_tempdir"
-
-  say "installed snforge and sncast to ${_installdir}"
-
-  create_symlinks "$_installdir"
-  local _retval=$?
-
-  echo
-  if echo ":$PATH:" | grep -q ":${LOCAL_BIN}:"; then
-    echo "Starknet Foundry has been successfully installed and should be already available in your PATH."
-    echo "Run 'snforge --version' and 'sncast --version' to verify your installation. Happy coding!"
-  else
-    if [ $_do_modify_path -eq 1 ]; then
-      add_local_bin_to_path
-      _retval=$?
-    else
-      echo "Skipping PATH modification, please manually add '${LOCAL_BIN_ESCAPED}' to your PATH."
-    fi
-
-    echo "Then, run 'snforge --version' and 'sncast --version' to verify your installation. Happy coding!"
-  fi
-
-  ignore rm -rf "$_tempdir"
-  return "$_retval"
-}
-
-# This function has been copied verbatim from rustup install script.
-check_proc() {
-    # Check for /proc by looking for the /proc/self/exe link
-    # This is only run on Linux
-    if ! test -L /proc/self/exe ; then
-        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
-    fi
-}
-
-# This function has been copied verbatim from rustup install script.
-get_bitness() {
-    need_cmd head
-    # Architecture detection without dependencies beyond coreutils.
-    # ELF files start out "\x7fELF", and the following byte is
-    #   0x01 for 32-bit and
-    #   0x02 for 64-bit.
-    # The printf builtin on some shells like dash only supports octal
-    # escape sequences, so we use those.
-    local _current_exe_head
-    _current_exe_head=$(head -c 5 /proc/self/exe )
-    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
-        echo 32
-    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
-        echo 64
-    else
-        err "unknown platform bitness"
-    fi
-}
-
-say() {
-  printf 'starknet-foundry-install: %s\n' "$1"
-}
-
-err() {
-  say "$1" >&2
-  exit 1
-}
-
-need_cmd() {
-  if ! check_cmd "$1"; then
-    err "need '$1' (command not found)"
-  fi
-}
-
-check_cmd() {
-  command -v "$1" >/dev/null 2>&1
-}
-
-assert_nz() {
-  if [ -z "$1" ]; then err "assert_nz $2"; fi
-}
-
-# Run a command that should never fail.
-# If the command fails execution will immediately terminate with an error showing the failing command.
-ensure() {
-  if ! "$@"; then err "command failed: $*"; fi
-}
-
-# This is just for indicating that commands' results are being intentionally ignored.
-# Usually, because it's being executed as part of error handling.
-ignore() {
-  "$@"
-}
-
-# This function has been copied verbatim from rustup install script.
-get_architecture() {
-  local _ostype _cputype _bitness _arch _clibtype
-  _ostype="$(uname -s)"
-  _cputype="$(uname -m)"
-  _clibtype="gnu"
-
-  if [ "$_ostype" = Linux ]; then
-    if [ "$(uname -o)" = Android ]; then
-      _ostype=Android
-    fi
-    if ldd --_requested_version 2>&1 | grep -q 'musl'; then
-      _clibtype="musl"
-    fi
-  fi
-
-  if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
-    # Darwin `uname -m` lies
-    if sysctl hw.optional.x86_64 | grep -q ': 1'; then
-      _cputype=x86_64
-    fi
-  fi
-
-  if [ "$_ostype" = SunOS ]; then
-    # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
-    # so use "uname -o" to disambiguate.  We use the full path to the
-    # system uname in case the user has coreutils uname first in PATH,
-    # which has historically sometimes printed the wrong value here.
-    if [ "$(/usr/bin/uname -o)" = illumos ]; then
-      _ostype=illumos
-    fi
-
-    # illumos systems have multi-arch userlands, and "uname -m" reports the
-    # machine hardware name; e.g., "i86pc" on both 32- and 64-bit x86
-    # systems.  Check for the native (widest) instruction set on the
-    # running kernel:
-    if [ "$_cputype" = i86pc ]; then
-      _cputype="$(isainfo -n)"
-    fi
-  fi
-
-  case "$_ostype" in
-  Android)
-    _ostype=linux-android
-    ;;
-
-  Linux)
-    check_proc
-    _ostype=unknown-linux-$_clibtype
-    _bitness=$(get_bitness)
-    ;;
-
-  FreeBSD)
-    _ostype=unknown-freebsd
-    ;;
-
-  NetBSD)
-    _ostype=unknown-netbsd
-    ;;
-
-  DragonFly)
-    _ostype=unknown-dragonfly
-    ;;
-
-  Darwin)
-    _ostype=apple-darwin
-    ;;
-
-  illumos)
-    _ostype=unknown-illumos
-    ;;
-
-  MINGW* | MSYS* | CYGWIN* | Windows_NT)
-    _ostype=pc-windows-gnu
-    ;;
-
-  *)
-    err "unrecognized OS type: $_ostype"
-    ;;
-  esac
-
-  case "$_cputype" in
-  i386 | i486 | i686 | i786 | x86)
-    _cputype=i686
-    ;;
-
-  xscale | arm)
-    _cputype=arm
-    if [ "$_ostype" = "linux-android" ]; then
-      _ostype=linux-androideabi
-    fi
-    ;;
-
-  armv6l)
-    _cputype=arm
-    if [ "$_ostype" = "linux-android" ]; then
-      _ostype=linux-androideabi
-    else
-      _ostype="${_ostype}eabihf"
-    fi
-    ;;
-
-  armv7l | armv8l)
-    _cputype=armv7
-    if [ "$_ostype" = "linux-android" ]; then
-      _ostype=linux-androideabi
-    else
-      _ostype="${_ostype}eabihf"
-    fi
-    ;;
-
-  aarch64 | arm64)
-    _cputype=aarch64
-    ;;
-
-  x86_64 | x86-64 | x64 | amd64)
-    _cputype=x86_64
-    ;;
-
-  mips)
-    _cputype=$(get_endianness mips '' el)
-    ;;
-
-  mips64)
-    if [ "$_bitness" -eq 64 ]; then
-      # only n64 ABI is supported for now
-      _ostype="${_ostype}abi64"
-      _cputype=$(get_endianness mips64 '' el)
-    fi
-    ;;
-
-  ppc)
-    _cputype=powerpc
-    ;;
-
-  ppc64)
-    _cputype=powerpc64
-    ;;
-
-  ppc64le)
-    _cputype=powerpc64le
-    ;;
-
-  s390x)
-    _cputype=s390x
-    ;;
-  riscv64)
-    _cputype=riscv64gc
-    ;;
-  loongarch64)
-    _cputype=loongarch64
-    ;;
-  *)
-    err "unknown CPU type: $_cputype"
-    ;;
-  esac
-
-  # Detect 64-bit linux with 32-bit userland
-  if [ "${_ostype}" = unknown-linux-gnu ] && [ "${_bitness}" -eq 32 ]; then
-    case $_cputype in
-    x86_64)
-      if [ -n "${RUSTUP_CPUTYPE:-}" ]; then
-        _cputype="$RUSTUP_CPUTYPE"
-      else {
-        # 32-bit executable for amd64 = x32
-        if is_host_amd64_elf; then
-          err "x86_64 linux with x86 userland unsupported"
-        else
-          _cputype=i686
-        fi
-      }; fi
-      ;;
-    mips64)
-      _cputype=$(get_endianness mips '' el)
-      ;;
-    powerpc64)
-      _cputype=powerpc
-      ;;
-    aarch64)
-      _cputype=armv7
-      if [ "$_ostype" = "linux-android" ]; then
-        _ostype=linux-androideabi
-      else
-        _ostype="${_ostype}eabihf"
-      fi
-      ;;
-    riscv64gc)
-      err "riscv64 with 32-bit userland unsupported"
-      ;;
-    esac
-  fi
-
-  # Detect armv7 but without the CPU features Rust needs in that build,
-  # and fall back to arm.
-  # See https://github.com/rust-lang/rustup.rs/issues/587.
-  if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
-    if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
-      # At least one processor does not have NEON.
-      _cputype=arm
-    fi
-  fi
-
-  _arch="${_cputype}-${_ostype}"
-
-  RETVAL="$_arch"
-}
-
-resolve_version() {
-  local _requested_version=$1
-  local _requested_ref=$2
-
-  local _response
-
-  say "retrieving $_requested_version version from ${REPO}..."
-  _response=$(ensure curl -Ls -H 'Accept: application/json' "${REPO}/releases/${_requested_ref}")
-  if [ "{\"error\":\"Not Found\"}" = "$_response" ]; then
-    err "version $_requested_version not found"
-  fi
-
-  RETVAL=$(echo "$_response" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
-}
-
-create_install_dir() {
-  local _requested_version=$1
-
-  local _installdir="${INSTALL_ROOT}/${_requested_version}"
-
-  if [ -d "$_installdir" ]; then
-    ensure rm -rf "$_installdir"
-    say "removed existing snforge and sncast installation at ${_installdir}"
-  fi
-
-  ensure mkdir -p "$_installdir"
-
-  RETVAL=$_installdir
-}
-
-download() {
-  local _resolved_version=$1
-  local _arch=$2
-  local _installdir=$3
-  local _tempdir=$4
-
-  local _tarball="starknet-foundry-${_resolved_version}-${_arch}.tar.gz"
-  local _url="${REPO}/releases/download/${_resolved_version}/${_tarball}"
-  local _dl="$_tempdir/starknet-foundry.tar.gz"
-
-  say "downloading ${_tarball}..."
-
-  ensure curl -fLS -o "$_dl" "$_url"
-  ensure tar -xz -C "$_installdir" --strip-components=1 -f "$_dl"
-}
-
-create_symlinks() {
-  for binary in "snforge" "sncast"; do
-    local _binary="${_installdir}/bin/${binary}"
-    local _symlink="${LOCAL_BIN}/${binary}"
-
-    ensure mkdir -p "$LOCAL_BIN"
-    ensure ln -fs "$_binary" "$_symlink"
-    ensure chmod u+x "$_symlink"
-    say "created symlink ${_symlink} -> ${_binary}"
-  done
-}
-
-add_local_bin_to_path() {
-  local _profile
-  local _pref_shell
-  case ${SHELL:-""} in
-  */zsh)
-    _profile=$HOME/.zshrc
-    _pref_shell=zsh
-    ;;
-  */ash)
-    _profile=$HOME/.profile
-    _pref_shell=ash
-    ;;
-  */bash)
-    _profile=$HOME/.bashrc
-    _pref_shell=bash
-    ;;
-  */fish)
-    _profile=$HOME/.config/fish/config.fish
-    _pref_shell=fish
-    ;;
-  *)
-    err "could not detect shell, manually add '${LOCAL_BIN_ESCAPED}' to your PATH."
-    ;;
-  esac
-
-  echo >>"$_profile" && echo "export PATH=\"\$PATH:${LOCAL_BIN_ESCAPED}\"" >>"$_profile"
-  echo \
-    "Detected your preferred shell is ${_pref_shell} and added '${LOCAL_BIN_ESCAPED}' to PATH." \
-    "Run 'source ${_profile}' or start a new terminal session to use Starknet Foundry."
-}
-
-main "$@" || exit 1
+echo && echo "Detected your preferred shell is ${PREF_SHELL} and added snfoundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use foundryup."
+echo "Then, simply run 'snfoundryup' to install Starknet-Foundry."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,10 +45,16 @@ case $SHELL in
 esac
 
 # Only add snfoundryup if it isn't already in PATH.
-if [ ":$PATH:" != *":${LOCAL_BIN}:"* ]; then
-    # Add the snfoundryup directory to the path and ensure the old PATH variables remain.
-    echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> "$PROFILE"
-fi
+case ":$PATH:" in
+    *":${LOCAL_BIN}:"*)
+        # The path is already in PATH, do nothing
+        ;;
+    *)
+        # Add the snfoundryup directory to the path
+        echo >> "$PROFILE" && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> "$PROFILE"
+        ;;
+esac
+
 
 
 printf "\nDetected your preferred shell is %s and added snfoundryup to PATH. Run 'source %s' or start a new terminal session to use snfoundryup.\n" "$PREF_SHELL" "$PROFILE"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,12 +17,11 @@ if ! command -v curl &> /dev/null; then
     exit 1
 fi
 
-# Create the .foundry bin directory and foundryup binary if it doesn't exist.
+# Create the ${HOME}/.local/bin bin directory and snfoundryup binary if it doesn't exist.
 mkdir -p ${LOCAL_BIN}
 curl -# -L ${SNFOUNDRYUP_URL} -o ${SNFOUNDRYUP_PATH}
 chmod +x ${SNFOUNDRYUP_PATH}
 
-# Create the man directory for future man files if it doesn't exist.
 
 # Store the correct profile file (i.e. .profile for bash or .zshenv for ZSH).
 case $SHELL in
@@ -47,12 +46,12 @@ case $SHELL in
     exit 1
 esac
 
-# Only add foundryup if it isn't already in PATH.
+# Only add snfoundryup if it isn't already in PATH.
 if [[ ":$PATH:" != *":${LOCAL_BIN}:"* ]]; then
-    # Add the foundryup directory to the path and ensure the old PATH variables remain.
+    # Add the snfoundryup directory to the path and ensure the old PATH variables remain.
     echo >> $PROFILE && echo "export PATH=\"\$PATH:$LOCAL_BIN\"" >> $PROFILE
 fi
 
 
-echo && echo "Detected your preferred shell is ${PREF_SHELL} and added snfoundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use foundryup."
+echo && echo "Detected your preferred shell is ${PREF_SHELL} and added snfoundryup to PATH. Run 'source ${PROFILE}' or start a new terminal session to use snfoundryup."
 echo "Then, simply run 'snfoundryup' to install Starknet-Foundry."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,11 @@ LOCAL_BIN="${HOME}/.local/bin"
 SNFOUNDRYUP_URL="https://raw.githubusercontent.com/partychad/starknet-foundry/fork-master/scripts/snfoundryup"
 SNFOUNDRYUP_PATH="${LOCAL_BIN}/snfoundryup"
 
+# Check for curl
+if ! command -v curl &> /dev/null; then
+    echo "curl could not be found, please install it first."
+    exit 1
+fi
 
 # Create the .foundry bin directory and foundryup binary if it doesn't exist.
 mkdir -p ${LOCAL_BIN}

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -18,7 +18,7 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
 INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
-BINARIES="snforge sncast" # Array synthax for shells. List can be expanded for new binaries
+BINARIES="snforge sncast" # Array syntax for shells. List can be expanded for new binaries
 usage() {
   cat <<EOF
 The installer for Starknet Foundry
@@ -79,8 +79,8 @@ main() {
       need_cmd cargo
       banner
       _commit_hash="$OPTARG"
-       clone_and_build "$_commit_hash"
-       exit 0
+      clone_and_build "$_commit_hash"
+      exit 0
       ;;
     \?)
       err "invalid option -$OPTARG"

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -507,7 +507,7 @@ clone_and_build() {
   fi
 
   say "Cloning repository at commit $_commit_hash..."
-  ensure git clone "$REPO" $_tempdir
+  ensure git clone "$REPO" "$_tempdir"
   ensure cd "$_tempdir"
   ensure git fetch --all
   ensure git checkout "$_commit_hash"
@@ -518,7 +518,7 @@ clone_and_build() {
   local _build_output_dir="$PWD/target/release"
 
   create_install_dir "${_commit_hash}/bin"
-  local _installdir=${RETVAL%????} # Assign with the last four characters removed.
+  local _installdir=${RETVAL%????} # create_symlinks expects a PATH with /bin stripped, rather than modifiyng the function, we just strip it here.
   assert_nz "$_installdir" "installdir"
 
   ensure cp "$_build_output_dir/snforge" "$_installdir/bin/snforge"

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -526,6 +526,7 @@ clone_and_build() {
 
   create_symlinks "$_installdir"
 
+  ensure cd - > /dev/null  # Go back to the previous directory and suppress output
 }
 
 banner() {

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -74,9 +74,11 @@ main() {
       _requested_ref="tag/v${OPTARG}"
       _requested_version="$OPTARG"
       ;;
-    c)  # Add this case for the new -c option
+    c)
+      need_cmd cargo
       _commit_hash="$OPTARG"
        clone_and_build "$_commit_hash"
+       exit 0
       ;;
     \?)
       err "invalid option -$OPTARG"
@@ -504,7 +506,7 @@ clone_and_build() {
 
   say "Cloning repository at commit $_commit_hash..."
   ensure git clone "$REPO" $_tempdir
-  ensure cd "$_tempdir/starknet-foundry"
+  ensure cd "$_tempdir"
   ensure git fetch --all
   ensure git checkout "$_commit_hash"
 

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -97,7 +97,7 @@ main() {
 
   ensure mkdir -p "$_tempdir"
 
-  create_install_dir "$_requested_version"
+  create_install_dir "$_resolved_version"
   local _installdir=$RETVAL
   assert_nz "$_installdir" "installdir"
 

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -97,7 +97,7 @@ main() {
 
   ensure mkdir -p "$_tempdir"
 
-  create_install_dir "$_resolved_version"
+  create_install_dir "${_resolved_version:1}"
   local _installdir=$RETVAL
   assert_nz "$_installdir" "installdir"
 

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -1,0 +1,490 @@
+#!/bin/sh
+# shellcheck shell=dash
+# shellcheck disable=SC2039
+
+# This is just a little script that can be downloaded from the internet to install Starknet Foundry.
+# It just does platform detection, downloads the release archive, extracts it and tries to make
+# the `snforge` and `sncast` binaries available in $PATH in least invasive way possible.
+#
+# It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local` extension.
+# Note: Most shells limit `local` to 1 var per line, contra bash.
+#
+# Most of this code is based on/copy-pasted from rustup and protostar installers.
+
+set -u
+
+REPO="https://github.com/foundry-rs/starknet-foundry"
+XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
+INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
+LOCAL_BIN="${HOME}/.local/bin"
+LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
+
+usage() {
+  cat <<EOF
+The installer for Starknet Foundry
+
+Usage: install.sh [OPTIONS]
+
+Options:
+  -p, --no-modify-path   Skip PATH variable modification
+  -h, --help             Print help
+  -v, --version          Specify Starknet Foundry version to install
+
+For more information, check out https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html
+EOF
+}
+
+main() {
+  need_cmd chmod
+  need_cmd curl
+  need_cmd grep
+  need_cmd mkdir
+  need_cmd mktemp
+  need_cmd rm
+  need_cmd sed
+  need_cmd tar
+  need_cmd uname
+
+  # Transform long options to short ones.
+  for arg in "$@"; do
+    shift
+    case "$arg" in
+      '--help')           set -- "$@" '-h'   ;;
+      '--no-modify-path') set -- "$@" '-p'   ;;
+      '--version')        set -- "$@" '-v'   ;;
+      *)                  set -- "$@" "$arg" ;;
+    esac
+  done
+
+  local _requested_ref="latest"
+  local _requested_version="latest"
+  local _do_modify_path=1
+  while getopts ":hpv:" opt; do
+    case $opt in
+    p)
+      _do_modify_path=0
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    v)
+      _requested_ref="tag/v${OPTARG}"
+      _requested_version="$OPTARG"
+      ;;
+    \?)
+      err "invalid option -$OPTARG"
+      ;;
+    :)
+      err "option -$OPTARG requires an argument"
+      ;;
+    esac
+  done
+
+  resolve_version "$_requested_version" "$_requested_ref" || return 1
+  local _resolved_version=$RETVAL
+  assert_nz "$_resolved_version" "resolved_version"
+
+  get_architecture || return 1
+  local _arch="$RETVAL"
+  assert_nz "$_arch" "arch"
+
+  local _tempdir
+  if ! _tempdir="$(ensure mktemp -d)"; then
+    # Because the previous command ran in a subshell, we must manually propagate exit status.
+    exit 1
+  fi
+
+  ensure mkdir -p "$_tempdir"
+
+  create_install_dir "$_requested_version"
+  local _installdir=$RETVAL
+  assert_nz "$_installdir" "installdir"
+
+  download "$_resolved_version" "$_arch" "$_installdir" "$_tempdir"
+
+  say "installed snforge and sncast to ${_installdir}"
+
+  create_symlinks "$_installdir"
+  local _retval=$?
+
+  echo
+  if echo ":$PATH:" | grep -q ":${LOCAL_BIN}:"; then
+    echo "Starknet Foundry has been successfully installed and should be already available in your PATH."
+    echo "Run 'snforge --version' and 'sncast --version' to verify your installation. Happy coding!"
+  else
+    if [ $_do_modify_path -eq 1 ]; then
+      add_local_bin_to_path
+      _retval=$?
+    else
+      echo "Skipping PATH modification, please manually add '${LOCAL_BIN_ESCAPED}' to your PATH."
+    fi
+
+    echo "Then, run 'snforge --version' and 'sncast --version' to verify your installation. Happy coding!"
+  fi
+
+  ignore rm -rf "$_tempdir"
+  return "$_retval"
+}
+
+# This function has been copied verbatim from rustup install script.
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
+# This function has been copied verbatim from rustup install script.
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+say() {
+  printf 'starknet-foundry-install: %s\n' "$1"
+}
+
+err() {
+  say "$1" >&2
+  exit 1
+}
+
+need_cmd() {
+  if ! check_cmd "$1"; then
+    err "need '$1' (command not found)"
+  fi
+}
+
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+assert_nz() {
+  if [ -z "$1" ]; then err "assert_nz $2"; fi
+}
+
+# Run a command that should never fail.
+# If the command fails execution will immediately terminate with an error showing the failing command.
+ensure() {
+  if ! "$@"; then err "command failed: $*"; fi
+}
+
+# This is just for indicating that commands' results are being intentionally ignored.
+# Usually, because it's being executed as part of error handling.
+ignore() {
+  "$@"
+}
+
+# This function has been copied verbatim from rustup install script.
+get_architecture() {
+  local _ostype _cputype _bitness _arch _clibtype
+  _ostype="$(uname -s)"
+  _cputype="$(uname -m)"
+  _clibtype="gnu"
+
+  if [ "$_ostype" = Linux ]; then
+    if [ "$(uname -o)" = Android ]; then
+      _ostype=Android
+    fi
+    if ldd --_requested_version 2>&1 | grep -q 'musl'; then
+      _clibtype="musl"
+    fi
+  fi
+
+  if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
+    # Darwin `uname -m` lies
+    if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+      _cputype=x86_64
+    fi
+  fi
+
+  if [ "$_ostype" = SunOS ]; then
+    # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
+    # so use "uname -o" to disambiguate.  We use the full path to the
+    # system uname in case the user has coreutils uname first in PATH,
+    # which has historically sometimes printed the wrong value here.
+    if [ "$(/usr/bin/uname -o)" = illumos ]; then
+      _ostype=illumos
+    fi
+
+    # illumos systems have multi-arch userlands, and "uname -m" reports the
+    # machine hardware name; e.g., "i86pc" on both 32- and 64-bit x86
+    # systems.  Check for the native (widest) instruction set on the
+    # running kernel:
+    if [ "$_cputype" = i86pc ]; then
+      _cputype="$(isainfo -n)"
+    fi
+  fi
+
+  case "$_ostype" in
+  Android)
+    _ostype=linux-android
+    ;;
+
+  Linux)
+    check_proc
+    _ostype=unknown-linux-$_clibtype
+    _bitness=$(get_bitness)
+    ;;
+
+  FreeBSD)
+    _ostype=unknown-freebsd
+    ;;
+
+  NetBSD)
+    _ostype=unknown-netbsd
+    ;;
+
+  DragonFly)
+    _ostype=unknown-dragonfly
+    ;;
+
+  Darwin)
+    _ostype=apple-darwin
+    ;;
+
+  illumos)
+    _ostype=unknown-illumos
+    ;;
+
+  MINGW* | MSYS* | CYGWIN* | Windows_NT)
+    _ostype=pc-windows-gnu
+    ;;
+
+  *)
+    err "unrecognized OS type: $_ostype"
+    ;;
+  esac
+
+  case "$_cputype" in
+  i386 | i486 | i686 | i786 | x86)
+    _cputype=i686
+    ;;
+
+  xscale | arm)
+    _cputype=arm
+    if [ "$_ostype" = "linux-android" ]; then
+      _ostype=linux-androideabi
+    fi
+    ;;
+
+  armv6l)
+    _cputype=arm
+    if [ "$_ostype" = "linux-android" ]; then
+      _ostype=linux-androideabi
+    else
+      _ostype="${_ostype}eabihf"
+    fi
+    ;;
+
+  armv7l | armv8l)
+    _cputype=armv7
+    if [ "$_ostype" = "linux-android" ]; then
+      _ostype=linux-androideabi
+    else
+      _ostype="${_ostype}eabihf"
+    fi
+    ;;
+
+  aarch64 | arm64)
+    _cputype=aarch64
+    ;;
+
+  x86_64 | x86-64 | x64 | amd64)
+    _cputype=x86_64
+    ;;
+
+  mips)
+    _cputype=$(get_endianness mips '' el)
+    ;;
+
+  mips64)
+    if [ "$_bitness" -eq 64 ]; then
+      # only n64 ABI is supported for now
+      _ostype="${_ostype}abi64"
+      _cputype=$(get_endianness mips64 '' el)
+    fi
+    ;;
+
+  ppc)
+    _cputype=powerpc
+    ;;
+
+  ppc64)
+    _cputype=powerpc64
+    ;;
+
+  ppc64le)
+    _cputype=powerpc64le
+    ;;
+
+  s390x)
+    _cputype=s390x
+    ;;
+  riscv64)
+    _cputype=riscv64gc
+    ;;
+  loongarch64)
+    _cputype=loongarch64
+    ;;
+  *)
+    err "unknown CPU type: $_cputype"
+    ;;
+  esac
+
+  # Detect 64-bit linux with 32-bit userland
+  if [ "${_ostype}" = unknown-linux-gnu ] && [ "${_bitness}" -eq 32 ]; then
+    case $_cputype in
+    x86_64)
+      if [ -n "${RUSTUP_CPUTYPE:-}" ]; then
+        _cputype="$RUSTUP_CPUTYPE"
+      else {
+        # 32-bit executable for amd64 = x32
+        if is_host_amd64_elf; then
+          err "x86_64 linux with x86 userland unsupported"
+        else
+          _cputype=i686
+        fi
+      }; fi
+      ;;
+    mips64)
+      _cputype=$(get_endianness mips '' el)
+      ;;
+    powerpc64)
+      _cputype=powerpc
+      ;;
+    aarch64)
+      _cputype=armv7
+      if [ "$_ostype" = "linux-android" ]; then
+        _ostype=linux-androideabi
+      else
+        _ostype="${_ostype}eabihf"
+      fi
+      ;;
+    riscv64gc)
+      err "riscv64 with 32-bit userland unsupported"
+      ;;
+    esac
+  fi
+
+  # Detect armv7 but without the CPU features Rust needs in that build,
+  # and fall back to arm.
+  # See https://github.com/rust-lang/rustup.rs/issues/587.
+  if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
+    if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
+      # At least one processor does not have NEON.
+      _cputype=arm
+    fi
+  fi
+
+  _arch="${_cputype}-${_ostype}"
+
+  RETVAL="$_arch"
+}
+
+resolve_version() {
+  local _requested_version=$1
+  local _requested_ref=$2
+
+  local _response
+
+  say "retrieving $_requested_version version from ${REPO}..."
+  _response=$(ensure curl -Ls -H 'Accept: application/json' "${REPO}/releases/${_requested_ref}")
+  if [ "{\"error\":\"Not Found\"}" = "$_response" ]; then
+    err "version $_requested_version not found"
+  fi
+
+  RETVAL=$(echo "$_response" | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+}
+
+create_install_dir() {
+  local _requested_version=$1
+
+  local _installdir="${INSTALL_ROOT}/${_requested_version}"
+
+  if [ -d "$_installdir" ]; then
+    ensure rm -rf "$_installdir"
+    say "removed existing snforge and sncast installation at ${_installdir}"
+  fi
+
+  ensure mkdir -p "$_installdir"
+
+  RETVAL=$_installdir
+}
+
+download() {
+  local _resolved_version=$1
+  local _arch=$2
+  local _installdir=$3
+  local _tempdir=$4
+
+  local _tarball="starknet-foundry-${_resolved_version}-${_arch}.tar.gz"
+  local _url="${REPO}/releases/download/${_resolved_version}/${_tarball}"
+  local _dl="$_tempdir/starknet-foundry.tar.gz"
+
+  say "downloading ${_tarball}..."
+
+  ensure curl -fLS -o "$_dl" "$_url"
+  ensure tar -xz -C "$_installdir" --strip-components=1 -f "$_dl"
+}
+
+create_symlinks() {
+  for binary in "snforge" "sncast"; do
+    local _binary="${_installdir}/bin/${binary}"
+    local _symlink="${LOCAL_BIN}/${binary}"
+
+    ensure mkdir -p "$LOCAL_BIN"
+    ensure ln -fs "$_binary" "$_symlink"
+    ensure chmod u+x "$_symlink"
+    say "created symlink ${_symlink} -> ${_binary}"
+  done
+}
+
+add_local_bin_to_path() {
+  local _profile
+  local _pref_shell
+  case ${SHELL:-""} in
+  */zsh)
+    _profile=$HOME/.zshrc
+    _pref_shell=zsh
+    ;;
+  */ash)
+    _profile=$HOME/.profile
+    _pref_shell=ash
+    ;;
+  */bash)
+    _profile=$HOME/.bashrc
+    _pref_shell=bash
+    ;;
+  */fish)
+    _profile=$HOME/.config/fish/config.fish
+    _pref_shell=fish
+    ;;
+  *)
+    err "could not detect shell, manually add '${LOCAL_BIN_ESCAPED}' to your PATH."
+    ;;
+  esac
+
+  echo >>"$_profile" && echo "export PATH=\"\$PATH:${LOCAL_BIN_ESCAPED}\"" >>"$_profile"
+  echo \
+    "Detected your preferred shell is ${_pref_shell} and added '${LOCAL_BIN_ESCAPED}' to PATH." \
+    "Run 'source ${_profile}' or start a new terminal session to use Starknet Foundry."
+}
+
+main "$@" || exit 1

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -47,19 +47,21 @@ main() {
 
   # Transform long options to short ones.
   for arg in "$@"; do
-    shift
-    case "$arg" in
-      '--help')           set -- "$@" '-h'   ;;
-      '--no-modify-path') set -- "$@" '-p'   ;;
-      '--version')        set -- "$@" '-v'   ;;
-      *)                  set -- "$@" "$arg" ;;
-    esac
+  shift
+  case "$arg" in
+    '--help')           set -- "$@" '-h'   ;;
+    '--no-modify-path') set -- "$@" '-p'   ;;
+    '--version')        set -- "$@" '-v'   ;;
+    '--commit')         set -- "$@" '-c'   ;;
+    *)                  set -- "$@" "$arg" ;;
+  esac
   done
 
   local _requested_ref="latest"
   local _requested_version="latest"
   local _do_modify_path=1
-  while getopts ":hpv:" opt; do
+  local _commit_hash=""
+  while getopts ":hpv:c:" opt; do
     case $opt in
     p)
       _do_modify_path=0
@@ -71,6 +73,10 @@ main() {
     v)
       _requested_ref="tag/v${OPTARG}"
       _requested_version="$OPTARG"
+      ;;
+    c)  # Add this case for the new -c option
+      _commit_hash="$OPTARG"
+       clone_and_build "$_commit_hash"
       ;;
     \?)
       err "invalid option -$OPTARG"
@@ -486,6 +492,36 @@ add_local_bin_to_path() {
   echo \
     "Detected your preferred shell is ${_pref_shell} and added '${LOCAL_BIN_ESCAPED}' to PATH." \
     "Run 'source ${_profile}' or start a new terminal session to use Starknet Foundry."
+}
+
+clone_and_build() {
+  local _commit_hash=$1
+  local _tempdir
+
+  if ! _tempdir="$(ensure mktemp -d)"; then
+    exit 1
+  fi
+
+  say "Cloning repository at commit $_commit_hash..."
+  ensure git clone "$REPO" $_tempdir
+  ensure cd "$_tempdir/starknet-foundry"
+  ensure git fetch --all
+  ensure git checkout "$_commit_hash"
+
+  say "Building binaries with cargo..."
+  ensure cargo build --release
+
+  local _build_output_dir="$PWD/target/release"
+
+  create_install_dir "${_commit_hash}/bin"
+  local _installdir=${RETVAL%????} # Assign with the last four characters removed.
+  assert_nz "$_installdir" "installdir"
+
+  ensure cp "$_build_output_dir/snforge" "$_installdir/bin/snforge"
+  ensure cp "$_build_output_dir/sncast" "$_installdir/bin/sncast"
+
+  create_symlinks "$_installdir"
+
 }
 
 main "$@" || exit 1

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -77,6 +77,7 @@ main() {
       ;;
     c)
       need_cmd cargo
+      banner
       _commit_hash="$OPTARG"
        clone_and_build "$_commit_hash"
        exit 0
@@ -89,7 +90,7 @@ main() {
       ;;
     esac
   done
-
+  banner
   resolve_version "$_requested_version" "$_requested_ref" || return 1
   local _resolved_version=$RETVAL
   assert_nz "$_resolved_version" "resolved_version"
@@ -525,6 +526,34 @@ clone_and_build() {
 
   create_symlinks "$_installdir"
 
+}
+
+banner() {
+  cat <<"EOF"
+
+
+.---------------------------------------------------------------------------------.
+|                                                                                 |
+|    ____  _             _               _                                        |
+|   / ___|| |_ __ _ _ __| | ___ __   ___| |_      Simplified and streamlined      |
+|   \___ \| __/ _` | '__| |/ / '_ \ / _ \ __|     toolkit for StarkNet            |
+|    ___) | || (_| | |  |   <| | | |  __/ |_      development.                    |
+|   |____/ \__\__,_|_|  |_|\_\_| |_|\___|\__|                                     |
+|   |  ___|__  _   _ _ __   __| |_ __ _   _       Providing a suite of tools      |
+|   | |_ / _ \| | | | '_ \ / _` | '__| | | |      o build on StarkNet with ease.  |
+|   |  _| (_) | |_| | | | | (_| | |  | |_| |                                      |
+|   |_|  \___/ \__,_|_| |_|\__,_|_|   \__, |                                      |
+|                                     |___/                                       |
+.---------------------------------------------------------------------------------.
+|                                                                                 | 
+|   Repo       : https://github.com/foundry-rs/starknet-foundry/                  | 
+|   Book       : https://foundry-rs.github.io/starknet-foundry/                   | 
+|   Support    : https://t.me/starknet_foundry_support/                           |  
+|                                                                                 | 
+'---------------------------------------------------------------------------------'
+
+
+EOF
 }
 
 main "$@" || exit 1

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -29,6 +29,7 @@ Options:
   -p, --no-modify-path   Skip PATH variable modification
   -h, --help             Print help
   -v, --version          Specify Starknet Foundry version to install
+  -c, --commit           Specify a specific commit hash to install from
 
 For more information, check out https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html
 EOF

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -77,7 +77,6 @@ main() {
       ;;
     c)
       need_cmd cargo
-      banner
       _commit_hash="$OPTARG"
       clone_and_build "$_commit_hash"
       exit 0
@@ -90,7 +89,6 @@ main() {
       ;;
     esac
   done
-  banner
   resolve_version "$_requested_version" "$_requested_ref" || return 1
   local _resolved_version=$RETVAL
   assert_nz "$_resolved_version" "resolved_version"
@@ -527,34 +525,6 @@ clone_and_build() {
   create_symlinks "$_installdir"
 
   ensure cd - > /dev/null  # Go back to the previous directory and suppress output
-}
-
-banner() {
-  cat <<"EOF"
-
-
-.---------------------------------------------------------------------------------.
-|                                                                                 |
-|    ____  _             _               _                                        |
-|   / ___|| |_ __ _ _ __| | ___ __   ___| |_      Simplified and streamlined      |
-|   \___ \| __/ _` | '__| |/ / '_ \ / _ \ __|     toolkit for StarkNet            |
-|    ___) | || (_| | |  |   <| | | |  __/ |_      development.                    |
-|   |____/ \__\__,_|_|  |_|\_\_| |_|\___|\__|                                     |
-|   |  ___|__  _   _ _ __   __| |_ __ _   _       Providing a suite of tools      |
-|   | |_ / _ \| | | | '_ \ / _` | '__| | | |      o build on StarkNet with ease.  |
-|   |  _| (_) | |_| | | | | (_| | |  | |_| |                                      |
-|   |_|  \___/ \__,_|_| |_|\__,_|_|   \__, |                                      |
-|                                     |___/                                       |
-.---------------------------------------------------------------------------------.
-|                                                                                 | 
-|   Repo       : https://github.com/foundry-rs/starknet-foundry/                  | 
-|   Book       : https://foundry-rs.github.io/starknet-foundry/                   | 
-|   Support    : https://t.me/starknet_foundry_support/                           |  
-|                                                                                 | 
-'---------------------------------------------------------------------------------'
-
-
-EOF
 }
 
 main "$@" || exit 1

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -405,7 +405,7 @@ resolve_version() {
   local _response
 
   say "retrieving $_requested_version version from ${REPO}..."
-  _response=$(ensure curl -Ls -H 'Accept: application/json' "${REPO}/releases/${_requested_ref}")
+  _response=$(ensure curl -# -Ls -H 'Accept: application/json' "${REPO}/releases/${_requested_ref}")
   if [ "{\"error\":\"Not Found\"}" = "$_response" ]; then
     err "version $_requested_version not found"
   fi
@@ -440,7 +440,7 @@ download() {
 
   say "downloading ${_tarball}..."
 
-  ensure curl -fLS -o "$_dl" "$_url"
+  ensure curl -# -fLS -o "$_dl" "$_url"
   ensure tar -xz -C "$_installdir" --strip-components=1 -f "$_dl"
 }
 

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -18,7 +18,7 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
 INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
-
+BINARIES=("snforge" "sncast")
 usage() {
   cat <<EOF
 The installer for Starknet Foundry
@@ -445,7 +445,7 @@ download() {
 }
 
 create_symlinks() {
-  for binary in "snforge" "sncast"; do
+  for binary in "${BINARIES[@]}"; do
     local _binary="${_installdir}/bin/${binary}"
     local _symlink="${LOCAL_BIN}/${binary}"
 

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -445,6 +445,7 @@ download() {
 }
 
 create_symlinks() {
+  local _installdir=$1
   for binary in "${BINARIES[@]}"; do
     local _binary="${_installdir}/bin/${binary}"
     local _symlink="${LOCAL_BIN}/${binary}"

--- a/scripts/snfoundryup
+++ b/scripts/snfoundryup
@@ -18,7 +18,7 @@ XDG_DATA_HOME="${XDG_DATA_HOME:-"${HOME}/.local/share"}"
 INSTALL_ROOT="${XDG_DATA_HOME}/starknet-foundry-install"
 LOCAL_BIN="${HOME}/.local/bin"
 LOCAL_BIN_ESCAPED="\$HOME/.local/bin"
-BINARIES=("snforge" "sncast")
+BINARIES="snforge sncast" # Array synthax for shells. List can be expanded for new binaries
 usage() {
   cat <<EOF
 The installer for Starknet Foundry
@@ -105,7 +105,7 @@ main() {
 
   ensure mkdir -p "$_tempdir"
 
-  create_install_dir "${_resolved_version:1}"
+  create_install_dir "$(echo "$_resolved_version" | sed 's/^.//')" # truncating first character
   local _installdir=$RETVAL
   assert_nz "$_installdir" "installdir"
 
@@ -454,7 +454,7 @@ download() {
 
 create_symlinks() {
   local _installdir=$1
-  for binary in "${BINARIES[@]}"; do
+  for binary in $BINARIES; do
     local _binary="${_installdir}/bin/${binary}"
     local _symlink="${LOCAL_BIN}/${binary}"
 


### PR DESCRIPTION
Resolves: [Issue #275](https://github.com/foundry-rs/starknet-foundry/issues/275)

## Introduced changes

* Added a new script under `scripts/install.sh` which installs `snfoundryup` script under `$HOME/.local/bin` and adds the path to the profile file of the associated shell. `snfoundryup` can be used to update starknet foundry binaries.

* Added a new CLI option to snfoundryup, which allows to build the binaries from any commit hash with `snfoundryup --commit <COMMIT HASH>`

* Added a new banner to snfoundryup script for cosmetic purposes,because why not :)
![image](https://github.com/foundry-rs/starknet-foundry/assets/96027087/e6311e8b-8760-4ee8-9b9f-4d3369f1ddc6)

* Minor fixes and improvements
  * Added progress bar to curl commands for better visualization
  * Encapsulated snforge and sncast under BINARIES variable
  * The installation directory is determined by the resolved version rather than the requested version. This approach avoids using ambiguous directory names like "latest."
  
  
  ## Testing
  
  Since the download URL `SNFOUNDRYUP_URL="https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/snfoundryup"` isnt a part of the master branch yet, changes can be tested by replacing `line 11` in `scripts/install.sh` with `SNFOUNDRYUP_URL="https://raw.githubusercontent.com/partychad/starknet-foundry/fork-master/scripts/snfoundryup"` so that snfoundryup can be downloaded.



