### PR TITLE
Build devnet instead of installing it directly from git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Run tests
         run: cargo test --release -p cast
 
+# test
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
       - name: Set starknet-devnet-rs rev
         id: devnet-rev
         run: |
@@ -100,7 +99,7 @@ jobs:
         with:
           scarb-version: ${{ env.SCARB_VERSION }}
       - name: Run tests
-        run: cargo test --release -p cast
+        run: cargo test --release -p cast -- --nocapture
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,10 +80,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
+      - name: Set starknet-devnet-rs rev
+        id: devnet-rev
+        run: |
+          devnetrev=$(grep "DEVNET_REV=" ./scripts/install_devnet.sh | awk -F '=' '{print $2}')
+          echo "devnet_rev=${devnetrev//\"}" >> $GITHUB_OUTPUT
+      - name: Cache starknet-devnet-rs
+        id: cache-devnet
+        uses: actions/cache@v3
         with:
-          cache-directories: crates/cast/tests/utils/devnet
+          path: ./crates/cast/tests/utils/devnet/bin
+          key: starknet-devnet-rs-${{ steps.devnet-rev.outputs.devnet_rev }}
       - name: Install starknet-devnet-rs
+        if: steps.cache-devnet.outputs.cache-hit != 'true'
         run: ./scripts/install_devnet.sh
       - uses: software-mansion/setup-scarb@v1.3.2
         with:
@@ -91,7 +100,6 @@ jobs:
       - name: Run tests
         run: cargo test --release -p cast
 
-# test
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
       - name: Install starknet-devnet-rs
         if: steps.cache-devnet.outputs.cache-hit != 'true'
         run: ./scripts/install_devnet.sh
+      - name: debug
+        run: ls -la . && ls -la ./crates/cast/tests/utils/devnet/bin
       - uses: software-mansion/setup-scarb@v1.3.2
         with:
           scarb-version: ${{ env.SCARB_VERSION }}

--- a/scripts/install_devnet.sh
+++ b/scripts/install_devnet.sh
@@ -5,7 +5,13 @@ DEVNET_INSTALL_DIR="$(git rev-parse --show-toplevel)/crates/cast/tests/utils/dev
 DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs.git"
 DEVNET_REV="72c11f6"
 
-cargo install --git "$DEVNET_REPO" --rev "$DEVNET_REV" --root "$DEVNET_INSTALL_DIR"
+git clone "$DEVNET_REPO" "$DEVNET_INSTALL_DIR/$DEVNET_REV" || echo "Repo already checked out!"
+pushd "$DEVNET_INSTALL_DIR/$DEVNET_REV"
+cargo build --release
+popd
+
+mkdir -p "$DEVNET_INSTALL_DIR/bin/"
+cp "$DEVNET_INSTALL_DIR/$DEVNET_REV/target/release/starknet-devnet" "$DEVNET_INSTALL_DIR/bin/."
 
 echo "All done!"
 exit 0


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

The `cargo install --bin` started to have some dependency issues when installing devnet-rs, that are not there if we run `cargo build --release` instead. Given that this is how devnet-rs tests if it compiles, let's just use the same approach.

Sadly, the rust cache action did not behave with this as it should, resulting in building a binary each time. That's why this was changed to github's own cache action.

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
