### PR TITLE
Make sure race condition does not take place for account create with hex test

### DIFF
--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -391,7 +391,7 @@ pub fn test_keystore_already_exists(keystore_path: &str, account_path: &str, err
 
 #[tokio::test]
 pub async fn test_happy_case_keystore_int_format() {
-    let keystore_path = "my_key.json";
+    let keystore_path = "my_key_int.json";
     let account_path = "my_account_int.json";
     _ = fs::remove_file(keystore_path);
     _ = fs::remove_file(account_path);
@@ -432,7 +432,7 @@ pub async fn test_happy_case_keystore_int_format() {
 
 #[tokio::test]
 pub async fn test_happy_case_keystore_hex_format() {
-    let keystore_path = "my_key.json";
+    let keystore_path = "my_key_hex.json";
     let account_path = "my_account_hex.json";
     _ = fs::remove_file(keystore_path);
     _ = fs::remove_file(account_path);


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

- Get rid of non-deterministic behaviour of hex test, hopefully

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
