### PR TITLE
Improve cast tests 

### DIFF
--- a/crates/cast/tests/e2e/account/add.rs
+++ b/crates/cast/tests/e2e/account/add.rs
@@ -86,7 +86,7 @@ pub async fn test_happy_case_add_profile() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&current_dir.path())
+        .current_dir(current_dir.path())
         .args(args);
 
     snapbox.assert().stdout_matches(indoc! {r#"

--- a/crates/cast/tests/e2e/account/add.rs
+++ b/crates/cast/tests/e2e/account/add.rs
@@ -58,11 +58,11 @@ pub async fn test_happy_case() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
+    let current_dir = duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "30",
-    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    );
 
     let accounts_file = "./accounts.json";
 
@@ -89,15 +89,15 @@ pub async fn test_happy_case_add_profile() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&current_dir)
+        .current_dir(&current_dir.path())
         .args(args);
 
     snapbox.assert().stdout_matches(indoc! {r#"
         command: account add
         add_profile: Profile successfully added to Scarb.toml
     "#});
-
-    let mut file = current_dir.clone();
+    let current_dir_utf8 = Utf8PathBuf::from_path_buf(current_dir.into_path()).expect("Path contains invalid UTF-8"); // current_dir is consumed but the tmp folder is not deleted, it will persist until a reboot
+    let mut file = current_dir_utf8.clone();
     file.push(Utf8PathBuf::from(accounts_file));
 
     let contents = fs::read_to_string(file).expect("Unable to read created file");
@@ -121,11 +121,10 @@ pub async fn test_happy_case_add_profile() {
     );
 
     let contents =
-        fs::read_to_string(current_dir.join("Scarb.toml")).expect("Unable to read Scarb.toml");
+        fs::read_to_string(current_dir_utf8.join("Scarb.toml")).expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account_add]"));
     assert!(contents.contains("account = \"my_account_add\""));
 
-    fs::remove_dir_all(current_dir).unwrap();
 }
 
 #[tokio::test]

--- a/crates/cast/tests/e2e/account/add.rs
+++ b/crates/cast/tests/e2e/account/add.rs
@@ -58,11 +58,12 @@ pub async fn test_happy_case() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = Utf8PathBuf::from(duplicate_directory_with_salt(
+    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "30",
-    ));
+    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+
     let accounts_file = "./accounts.json";
 
     let args = vec![

--- a/crates/cast/tests/e2e/account/add.rs
+++ b/crates/cast/tests/e2e/account/add.rs
@@ -58,11 +58,8 @@ pub async fn test_happy_case() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/map",
-        "put",
-        "30",
-    );
+    let current_dir =
+        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "30");
 
     let accounts_file = "./accounts.json";
 
@@ -96,7 +93,8 @@ pub async fn test_happy_case_add_profile() {
         command: account add
         add_profile: Profile successfully added to Scarb.toml
     "#});
-    let current_dir_utf8 = Utf8PathBuf::from_path_buf(current_dir.into_path()).expect("Path contains invalid UTF-8"); // current_dir is consumed but the tmp folder is not deleted, it will persist until a reboot
+    let current_dir_utf8 =
+        Utf8PathBuf::from_path_buf(current_dir.into_path()).expect("Path contains invalid UTF-8"); // current_dir is consumed but the tmp folder is not deleted, it will persist until a reboot
     let mut file = current_dir_utf8.clone();
     file.push(Utf8PathBuf::from(accounts_file));
 
@@ -124,7 +122,6 @@ pub async fn test_happy_case_add_profile() {
         fs::read_to_string(current_dir_utf8.join("Scarb.toml")).expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account_add]"));
     assert!(contents.contains("account = \"my_account_add\""));
-
 }
 
 #[tokio::test]

--- a/crates/cast/tests/e2e/account/add.rs
+++ b/crates/cast/tests/e2e/account/add.rs
@@ -94,7 +94,7 @@ pub async fn test_happy_case_add_profile() {
         add_profile: Profile successfully added to Scarb.toml
     "#});
     let current_dir_utf8 =
-        Utf8PathBuf::from_path_buf(current_dir.into_path()).expect("Path contains invalid UTF-8"); // current_dir is consumed but the tmp folder is not deleted, it will persist until a reboot
+        Utf8PathBuf::from_path_buf(current_dir.into_path()).expect("Path contains invalid UTF-8");
     let mut file = current_dir_utf8.clone();
     file.push(Utf8PathBuf::from(accounts_file));
 

--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -90,11 +90,11 @@ pub async fn test_happy_case_generate_salt() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
+    let current_dir = duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "10",
-    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    );
     let accounts_file = "./accounts.json";
 
     let args = vec![
@@ -122,11 +122,10 @@ pub async fn test_happy_case_add_profile() {
     assert!(stdout_str.contains("add_profile: Profile successfully added to Scarb.toml"));
 
     let contents =
-        fs::read_to_string(current_dir.join("Scarb.toml")).expect("Unable to read Scarb.toml");
+        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account]"));
     assert!(contents.contains("account = \"my_account\""));
 
-    fs::remove_dir_all(current_dir).unwrap();
 }
 
 #[tokio::test]
@@ -179,11 +178,11 @@ pub async fn test_happy_case_accounts_file_already_exists() {
 
 #[tokio::test]
 pub async fn test_profile_already_exists() {
-    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/map",
+    let current_dir = duplicate_directory_with_salt(
+        CONTRACTS_DIR.to_string() + "/constructor_with_params",
         "put",
         "20",
-    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    );
     let accounts_file = "./accounts.json";
 
     let args = vec![
@@ -201,7 +200,7 @@ pub async fn test_profile_already_exists() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&current_dir)
+        .current_dir(&current_dir.path())
         .args(args);
     let bdg = snapbox.assert();
     let out = bdg.get_output();
@@ -212,7 +211,6 @@ pub async fn test_profile_already_exists() {
         "error: Failed to add myprofile profile to the Scarb.toml. Profile already exists"
     ));
 
-    fs::remove_dir_all(current_dir).unwrap();
 }
 
 #[tokio::test]
@@ -279,11 +277,11 @@ pub async fn test_happy_case_keystore() {
 
 #[tokio::test]
 pub async fn test_happy_case_keystore_add_profile() {
-    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
+    let current_dir =duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "50",
-    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    );
     let keystore_path = "my_key.json";
     let account_path = "my_account.json";
     let accounts_file = "accounts.json";
@@ -316,18 +314,18 @@ pub async fn test_happy_case_keystore_add_profile() {
     assert!(stdout_str.contains("add_profile: Profile successfully added to Scarb.toml"));
 
     let contents =
-        fs::read_to_string(current_dir.join("Scarb.toml")).expect("Unable to read Scarb.toml");
+        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account]"));
     assert!(contents.contains("account = \"my_account.json\""));
 
     let contents =
-        fs::read_to_string(current_dir.join(account_path)).expect("Unable to read created file");
+        fs::read_to_string(current_dir.path().join(account_path)).expect("Unable to read created file");
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
 
     let contents =
-        fs::read_to_string(current_dir.join("Scarb.toml")).expect("Unable to read Scarb.toml");
+        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
     assert!(contents.contains(r#"[tool.sncast.my_account]"#));
     assert!(contents.contains(r#"account = "my_account.json""#));
     assert!(!contents.contains(r#"accounts-file = "accounts.json""#));

--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -90,11 +90,8 @@ pub async fn test_happy_case_generate_salt() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/map",
-        "put",
-        "10",
-    );
+    let current_dir =
+        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "10");
     let accounts_file = "./accounts.json";
 
     let args = vec![
@@ -121,11 +118,10 @@ pub async fn test_happy_case_add_profile() {
         std::str::from_utf8(&out.stdout).expect("failed to convert command output to string");
     assert!(stdout_str.contains("add_profile: Profile successfully added to Scarb.toml"));
 
-    let contents =
-        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
+    let contents = fs::read_to_string(current_dir.path().join("Scarb.toml"))
+        .expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account]"));
     assert!(contents.contains("account = \"my_account\""));
-
 }
 
 #[tokio::test]
@@ -210,7 +206,6 @@ pub async fn test_profile_already_exists() {
     assert!(std_err.contains(
         "error: Failed to add myprofile profile to the Scarb.toml. Profile already exists"
     ));
-
 }
 
 #[tokio::test]
@@ -277,11 +272,8 @@ pub async fn test_happy_case_keystore() {
 
 #[tokio::test]
 pub async fn test_happy_case_keystore_add_profile() {
-    let current_dir =duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/map",
-        "put",
-        "50",
-    );
+    let current_dir =
+        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "50");
     let keystore_path = "my_key.json";
     let account_path = "my_account.json";
     let accounts_file = "accounts.json";
@@ -313,19 +305,19 @@ pub async fn test_happy_case_keystore_add_profile() {
         std::str::from_utf8(&out.stdout).expect("failed to convert command output to string");
     assert!(stdout_str.contains("add_profile: Profile successfully added to Scarb.toml"));
 
-    let contents =
-        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
+    let contents = fs::read_to_string(current_dir.path().join("Scarb.toml"))
+        .expect("Unable to read Scarb.toml");
     assert!(contents.contains("[tool.sncast.my_account]"));
     assert!(contents.contains("account = \"my_account.json\""));
 
-    let contents =
-        fs::read_to_string(current_dir.path().join(account_path)).expect("Unable to read created file");
+    let contents = fs::read_to_string(current_dir.path().join(account_path))
+        .expect("Unable to read created file");
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
 
-    let contents =
-        fs::read_to_string(current_dir.path().join("Scarb.toml")).expect("Unable to read Scarb.toml");
+    let contents = fs::read_to_string(current_dir.path().join("Scarb.toml"))
+        .expect("Unable to read Scarb.toml");
     assert!(contents.contains(r#"[tool.sncast.my_account]"#));
     assert!(contents.contains(r#"account = "my_account.json""#));
     assert!(!contents.contains(r#"accounts-file = "accounts.json""#));

--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -90,11 +90,11 @@ pub async fn test_happy_case_generate_salt() {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let current_dir = Utf8PathBuf::from(duplicate_directory_with_salt(
+    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "10",
-    ));
+    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
     let accounts_file = "./accounts.json";
 
     let args = vec![
@@ -179,11 +179,11 @@ pub async fn test_happy_case_accounts_file_already_exists() {
 
 #[tokio::test]
 pub async fn test_profile_already_exists() {
-    let current_dir = Utf8PathBuf::from(duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/constructor_with_params",
+    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
+        CONTRACTS_DIR.to_string() + "/map",
         "put",
         "20",
-    ));
+    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
     let accounts_file = "./accounts.json";
 
     let args = vec![
@@ -279,11 +279,11 @@ pub async fn test_happy_case_keystore() {
 
 #[tokio::test]
 pub async fn test_happy_case_keystore_add_profile() {
-    let current_dir = Utf8PathBuf::from(duplicate_directory_with_salt(
+    let current_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/map",
         "put",
         "50",
-    ));
+    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
     let keystore_path = "my_key.json";
     let account_path = "my_account.json";
     let accounts_file = "accounts.json";

--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -6,8 +6,8 @@ use cast::helpers::constants::CREATE_KEYSTORE_PASSWORD_ENV_VAR;
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
 use std::{env, fs};
-use test_case::test_case;
 use tempfile::TempDir;
+use test_case::test_case;
 
 #[tokio::test]
 pub async fn test_happy_case() {
@@ -127,7 +127,6 @@ pub async fn test_happy_case_add_profile() {
 
 #[tokio::test]
 pub async fn test_happy_case_accounts_file_already_exists() {
-
     let accounts_file = "./accounts.json";
     let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
 
@@ -165,11 +164,10 @@ pub async fn test_happy_case_accounts_file_already_exists() {
     assert!(stdout_str.contains("max_fee: "));
     assert!(stdout_str.contains("address: "));
 
-    let contents =
-        fs::read_to_string(temp_dir.path().join(accounts_file)).expect("Unable to read created file");
+    let contents = fs::read_to_string(temp_dir.path().join(accounts_file))
+        .expect("Unable to read created file");
     assert!(contents.contains("my_account"));
     assert!(contents.contains("deployed"));
-
 }
 
 #[tokio::test]

--- a/crates/cast/tests/e2e/account/create.rs
+++ b/crates/cast/tests/e2e/account/create.rs
@@ -153,7 +153,7 @@ pub async fn test_happy_case_accounts_file_already_exists() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&temp_dir.path())
+        .current_dir(temp_dir.path())
         .args(args);
     let bdg = snapbox.assert();
     let out = bdg.get_output();
@@ -194,7 +194,7 @@ pub async fn test_profile_already_exists() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&current_dir.path())
+        .current_dir(current_dir.path())
         .args(args);
     let bdg = snapbox.assert();
     let out = bdg.get_output();

--- a/crates/cast/tests/e2e/account/deploy.rs
+++ b/crates/cast/tests/e2e/account/deploy.rs
@@ -11,8 +11,8 @@ use serde_json::Value;
 use snapbox::cmd::{cargo_bin, Command};
 use starknet::core::types::TransactionReceipt::DeployAccount;
 use std::{env, fs};
-use test_case::test_case;
 use tempfile::TempDir;
+use test_case::test_case;
 
 #[tokio::test]
 pub async fn test_happy_case() {
@@ -129,7 +129,6 @@ fn test_account_deploy_error(accounts_content: &str, error: &str) {
     let stderr_str =
         std::str::from_utf8(&out.stderr).expect("failed to convert command output to string");
     assert!(stderr_str.contains(error));
-
 }
 
 #[tokio::test]

--- a/crates/cast/tests/e2e/account/deploy.rs
+++ b/crates/cast/tests/e2e/account/deploy.rs
@@ -225,7 +225,7 @@ pub async fn test_valid_class_hash() {
 }
 
 pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str) {
-    let created_dir =duplicate_directory_with_salt(
+    let created_dir = duplicate_directory_with_salt(
         CONTRACTS_DIR.to_string() + "/constructor_with_params",
         "put",
         salt,
@@ -264,7 +264,8 @@ pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str
         9_999_999_999_999_999_999,
     )
     .await;
-    let created_dir_utf8 = Utf8PathBuf::from_path_buf(created_dir.into_path()).expect("Path contains invalid UTF-8");
+    let created_dir_utf8 =
+        Utf8PathBuf::from_path_buf(created_dir.into_path()).expect("Path contains invalid UTF-8");
     (created_dir_utf8, accounts_file)
 }
 

--- a/crates/cast/tests/e2e/account/deploy.rs
+++ b/crates/cast/tests/e2e/account/deploy.rs
@@ -121,7 +121,7 @@ fn test_account_deploy_error(accounts_content: &str, error: &str) {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&temp_dir.path())
+        .current_dir(temp_dir.path())
         .args(args);
     let bdg = snapbox.assert();
     let out = bdg.get_output();
@@ -247,7 +247,7 @@ pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str
     }
 
     Command::new(cargo_bin!("sncast"))
-        .current_dir(&created_dir.path())
+        .current_dir(created_dir.path())
         .args(&args)
         .assert()
         .success();

--- a/crates/cast/tests/e2e/account/deploy.rs
+++ b/crates/cast/tests/e2e/account/deploy.rs
@@ -225,13 +225,12 @@ pub async fn test_valid_class_hash() {
 }
 
 pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str) {
-    let created_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/map",
+    let created_dir =duplicate_directory_with_salt(
+        CONTRACTS_DIR.to_string() + "/constructor_with_params",
         "put",
         salt,
-    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    );
     let accounts_file = "./accounts.json";
-
     let mut args = vec![
         "--url",
         URL,
@@ -249,12 +248,12 @@ pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str
     }
 
     Command::new(cargo_bin!("sncast"))
-        .current_dir(&created_dir)
+        .current_dir(&created_dir.path())
         .args(&args)
         .assert()
         .success();
 
-    let contents = fs::read_to_string(created_dir.join(accounts_file)).unwrap();
+    let contents = fs::read_to_string(created_dir.path().join(accounts_file)).unwrap();
     let items: Value =
         serde_json::from_str(&contents).expect("Failed to parse accounts file at {path}");
 
@@ -265,8 +264,8 @@ pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str
         9_999_999_999_999_999_999,
     )
     .await;
-
-    (created_dir, accounts_file)
+    let created_dir_utf8 = Utf8PathBuf::from_path_buf(created_dir.into_path()).expect("Path contains invalid UTF-8");
+    (created_dir_utf8, accounts_file)
 }
 
 #[tokio::test]

--- a/crates/cast/tests/e2e/account/deploy.rs
+++ b/crates/cast/tests/e2e/account/deploy.rs
@@ -225,11 +225,11 @@ pub async fn test_valid_class_hash() {
 }
 
 pub async fn create_account(salt: &str, add_profile: bool) -> (Utf8PathBuf, &str) {
-    let created_dir = Utf8PathBuf::from(duplicate_directory_with_salt(
-        CONTRACTS_DIR.to_string() + "/constructor_with_params",
+    let created_dir = Utf8PathBuf::from_path_buf(duplicate_directory_with_salt(
+        CONTRACTS_DIR.to_string() + "/map",
         "put",
         salt,
-    ));
+    ).path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
     let accounts_file = "./accounts.json";
 
     let mut args = vec![

--- a/crates/cast/tests/e2e/declare.rs
+++ b/crates/cast/tests/e2e/declare.rs
@@ -120,12 +120,13 @@ fn scarb_build_fails(contract_path: &str, accounts_file_path: &str) {
 fn test_too_low_max_fee() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "2");
+        let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
 
     let args = vec![
         "--url",
         URL,
         "--accounts-file",
-        "../../accounts/accounts.json",
+        accounts_json_path.as_str(),
         "--account",
         "user2",
         "--wait",

--- a/crates/cast/tests/e2e/declare.rs
+++ b/crates/cast/tests/e2e/declare.rs
@@ -30,7 +30,7 @@ async fn test_happy_case() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path)
+        .current_dir(&contract_path.path())
         .args(args);
     let output = snapbox.assert().success().get_output().stdout.clone();
 
@@ -137,7 +137,7 @@ fn test_too_low_max_fee() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path)
+        .current_dir(&contract_path.path())
         .args(args);
 
     snapbox.assert().success().stderr_matches(indoc! {r#"

--- a/crates/cast/tests/e2e/declare.rs
+++ b/crates/cast/tests/e2e/declare.rs
@@ -30,7 +30,7 @@ async fn test_happy_case() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path.path())
+        .current_dir(contract_path.path())
         .args(args);
     let output = snapbox.assert().success().get_output().stdout.clone();
 
@@ -138,7 +138,7 @@ fn test_too_low_max_fee() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path.path())
+        .current_dir(contract_path.path())
         .args(args);
 
     snapbox.assert().success().stderr_matches(indoc! {r#"

--- a/crates/cast/tests/e2e/declare.rs
+++ b/crates/cast/tests/e2e/declare.rs
@@ -1,6 +1,6 @@
 use crate::helpers::constants::{CONTRACTS_DIR, URL};
 use crate::helpers::fixtures::{
-    duplicate_directory_with_salt, get_transaction_hash, get_transaction_receipt,
+    duplicate_directory_with_salt, get_transaction_hash, get_transaction_receipt, get_accounts_path
 };
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
@@ -12,12 +12,12 @@ use test_case::test_case;
 async fn test_happy_case() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "1");
-
+    let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
     let args = vec![
         "--url",
         URL,
         "--accounts-file",
-        "../../accounts/accounts.json",
+        accounts_json_path.as_str(),
         "--account",
         "user8",
         "--int-format",

--- a/crates/cast/tests/e2e/declare.rs
+++ b/crates/cast/tests/e2e/declare.rs
@@ -1,6 +1,6 @@
 use crate::helpers::constants::{CONTRACTS_DIR, URL};
 use crate::helpers::fixtures::{
-    duplicate_directory_with_salt, get_transaction_hash, get_transaction_receipt, get_accounts_path
+    duplicate_directory_with_salt, get_accounts_path, get_transaction_hash, get_transaction_receipt,
 };
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
@@ -120,7 +120,7 @@ fn scarb_build_fails(contract_path: &str, accounts_file_path: &str) {
 fn test_too_low_max_fee() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "2");
-        let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
+    let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
 
     let args = vec![
         "--url",

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -236,7 +236,7 @@ async fn test_keystore_undeployed_account() {
 
     env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path.path())
+        .current_dir(contract_path.path())
         .args(args);
 
     snapbox.assert().stderr_matches(indoc! {r#"
@@ -266,7 +266,7 @@ async fn test_keystore_declare() {
 
     env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path.path())
+        .current_dir(contract_path.path())
         .args(args);
 
     snapbox.assert().success().get_output().stderr.is_empty();

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -233,7 +233,7 @@ async fn test_keystore_undeployed_account() {
 
     env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path)
+        .current_dir(&contract_path.path())
         .args(args);
 
     snapbox.assert().stderr_matches(indoc! {r#"
@@ -262,7 +262,7 @@ async fn test_keystore_declare() {
 
     env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(&contract_path)
+        .current_dir(&contract_path.path())
         .args(args);
 
     snapbox.assert().success().get_output().stderr.is_empty();

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -1,5 +1,5 @@
 use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, CONTRACTS_DIR, URL};
-use crate::helpers::fixtures::{duplicate_directory_with_salt, from_env};
+use crate::helpers::fixtures::{duplicate_directory_with_salt, from_env, get_keystores_path};
 use crate::helpers::runner::runner;
 use cast::helpers::constants::KEYSTORE_PASSWORD_ENV_VAR;
 use indoc::indoc;
@@ -247,14 +247,15 @@ async fn test_keystore_undeployed_account() {
 async fn test_keystore_declare() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "999");
-
+        let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
+        let my_account_path = get_keystores_path("tests/data/keystore/my_account.json");
     let args = vec![
         "--url",
         URL,
         "--keystore",
-        "../../keystore/my_key.json",
+        my_key_path.as_str(),
         "--account",
-        "../../keystore/my_account.json",
+        my_account_path.as_str(),
         "declare",
         "--contract-name",
         "Map",

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -218,8 +218,9 @@ async fn test_keystore_inexistent_account() {
 async fn test_keystore_undeployed_account() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "8");
-        let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
-        let my_account_undeployed_path = get_keystores_path("tests/data/keystore/my_account_undeployed.json");
+    let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
+    let my_account_undeployed_path =
+        get_keystores_path("tests/data/keystore/my_account_undeployed.json");
 
     let args = vec![
         "--url",
@@ -249,8 +250,8 @@ async fn test_keystore_undeployed_account() {
 async fn test_keystore_declare() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "999");
-        let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
-        let my_account_path = get_keystores_path("tests/data/keystore/my_account.json");
+    let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
+    let my_account_path = get_keystores_path("tests/data/keystore/my_account.json");
     let args = vec![
         "--url",
         URL,

--- a/crates/cast/tests/e2e/main_tests.rs
+++ b/crates/cast/tests/e2e/main_tests.rs
@@ -218,14 +218,16 @@ async fn test_keystore_inexistent_account() {
 async fn test_keystore_undeployed_account() {
     let contract_path =
         duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "8");
+        let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
+        let my_account_undeployed_path = get_keystores_path("tests/data/keystore/my_account_undeployed.json");
 
     let args = vec![
         "--url",
         URL,
         "--keystore",
-        "../../keystore/my_key.json",
+        my_key_path.as_str(),
         "--account",
-        "../../keystore/my_account_undeployed.json",
+        my_account_undeployed_path.as_str(),
         "declare",
         "--contract-name",
         "Map",

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -21,6 +21,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Arc;
 use url::Url;
+use tempfile::TempDir;
 
 pub async fn declare_contract(account: &str, path: &str, shortname: &str) -> FieldElement {
     let provider = get_provider(URL).expect("Could not get the provider");
@@ -197,15 +198,12 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
 }
 
 #[must_use]
-pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt: &str) -> String {
-    let dest_path = src_path.clone() + salt;
+pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt: &str) -> TempDir {
 
     let src_dir = Utf8PathBuf::from(src_path);
-    let dest_dir = Utf8PathBuf::from(&dest_path);
-
-    _ = fs::remove_dir_all(&dest_dir);
-    fs::create_dir_all(&dest_dir).expect("Unable to create directory");
-
+    let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
+    let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
+    
     fs_extra::dir::copy(
         src_dir.join("src"),
         &dest_dir,
@@ -225,7 +223,7 @@ pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt:
     fs::write(dest_dir.join("src/lib.cairo"), updated_code)
         .expect("Unable to change contract code");
 
-    dest_path
+    temp_dir
 }
 
 pub fn remove_devnet_env() {

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -291,7 +291,7 @@ pub fn get_address_from_keystore(
         FieldElement::ZERO,
     )
 }
-
+#[must_use]
 pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String {
     use std::path::PathBuf;
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
@@ -301,7 +301,7 @@ pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String {
         .expect("Failed to convert path to string")
         .to_string()
 }
-
+#[must_use]
 pub fn get_keystores_path(relative_path_from_cargo_toml: &str) -> String {
     use std::path::PathBuf;
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -291,3 +291,11 @@ pub fn get_address_from_keystore(
         FieldElement::ZERO,
     )
 }
+
+
+pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String {
+    use std::path::PathBuf;
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let binding = PathBuf::from(manifest_dir).join(relative_path_from_cargo_toml);
+    binding.to_str().expect("Failed to convert path to string").to_string()
+}

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -20,8 +20,8 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Arc;
-use url::Url;
 use tempfile::TempDir;
+use url::Url;
 
 pub async fn declare_contract(account: &str, path: &str, shortname: &str) -> FieldElement {
     let provider = get_provider(URL).expect("Could not get the provider");
@@ -199,11 +199,11 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
 
 #[must_use]
 pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt: &str) -> TempDir {
-
     let src_dir = Utf8PathBuf::from(src_path);
     let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
-    let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).expect("Failed to create Utf8PathBuf from PathBuf");
-    
+    let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
+        .expect("Failed to create Utf8PathBuf from PathBuf");
+
     fs_extra::dir::copy(
         src_dir.join("src"),
         &dest_dir,
@@ -292,17 +292,22 @@ pub fn get_address_from_keystore(
     )
 }
 
-
 pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String {
     use std::path::PathBuf;
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let binding = PathBuf::from(manifest_dir).join(relative_path_from_cargo_toml);
-    binding.to_str().expect("Failed to convert path to string").to_string()
+    binding
+        .to_str()
+        .expect("Failed to convert path to string")
+        .to_string()
 }
 
 pub fn get_keystores_path(relative_path_from_cargo_toml: &str) -> String {
     use std::path::PathBuf;
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let binding = PathBuf::from(manifest_dir).join(relative_path_from_cargo_toml);
-    binding.to_str().expect("Failed to convert path to string").to_string()
+    binding
+        .to_str()
+        .expect("Failed to convert path to string")
+        .to_string()
 }

--- a/crates/cast/tests/helpers/fixtures.rs
+++ b/crates/cast/tests/helpers/fixtures.rs
@@ -299,3 +299,10 @@ pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String {
     let binding = PathBuf::from(manifest_dir).join(relative_path_from_cargo_toml);
     binding.to_str().expect("Failed to convert path to string").to_string()
 }
+
+pub fn get_keystores_path(relative_path_from_cargo_toml: &str) -> String {
+    use std::path::PathBuf;
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let binding = PathBuf::from(manifest_dir).join(relative_path_from_cargo_toml);
+    binding.to_str().expect("Failed to convert path to string").to_string()
+}


### PR DESCRIPTION
Resolves: [Issue #436](https://github.com/foundry-rs/starknet-foundry/issues/436)

## Introduced changes

Started using TempDir crate to handle directory creation. Due to it's RAI nature the folder lifetime is tied to file object. To keep files persistent through the function calls, `duplicate_directory_with_salt` function signature is changed to return `TempDir` rather than `String`.

Two additional helper functions have been implemented to obtain the paths for the accounts and keystores directories. Previously, since these directories were created on the fly, relative paths sufficed. However, we have now transitioned to utilizing two new functions that provide paths relative to the cargo.toml file within the sncast crate.

* `pub fn get_accounts_path(relative_path_from_cargo_toml: &str) -> String `
* `pub fn get_keystores_path(relative_path_from_cargo_toml: &str) -> String`

The modifications ensure that the lifespan of the folders is linked to specific objects, which are automatically cleaned up even if tests do not pass. This approach helps to maintain a clean source tree by avoiding the accumulation of temporary files. As the temporary folders are placed in the /tmp directory, (for Unix-like systems) the operating system can handle any necessary cleanup as a secondary measure, should the primary cleanup process fail.


