### PR TITLE
Fix parsing storage from cache

### DIFF
--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -6,7 +6,7 @@ use fs2::FileExt;
 use num_bigint::BigUint;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use starknet::core::types::{BlockId, BlockTag, ContractClass, FieldElement};
+use starknet::core::types::{BlockId, BlockTag, ContractClass};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;

--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -182,9 +182,11 @@ impl ForkCache {
             .get(&storage_key_str)?;
 
         Some(
-            FieldElement::from_hex_be(cache_hit)
-                .unwrap_or_else(|_| panic!("Could not parse {cache_hit}"))
-                .to_stark_felt(),
+            Felt252::from(
+                BigUint::parse_bytes(cache_hit.as_bytes(), 10)
+                    .expect("Parsing class_hash_at entry failed"),
+            )
+            .to_stark_felt(),
         )
     }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Follow up task:
https://github.com/foundry-rs/starknet-foundry/issues/1073


## Introduced changes

<!-- A brief description of the changes -->

- Fix the issue where decimal values would be parsed as hex, resulting in felt overflows

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
