### PR TITLE
Fix path to scarb toml in declare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cast
+
+#### Fixed
+- scarb metadata in declare subcommand now takes manifest path from cli if passed instead of looking for it
+
 ## [0.10.0] - 2023-11-08
 
 ### Forge

--- a/crates/cast/src/starknet_commands/declare.rs
+++ b/crates/cast/src/starknet_commands/declare.rs
@@ -64,6 +64,7 @@ pub async fn declare(
     }
 
     let metadata = scarb_metadata::MetadataCommand::new()
+        .manifest_path(&manifest_path)
         .inherit_stderr()
         .exec()
         .context("Failed to obtain scarb metadata")?;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- it seems that after recent scarb metadata bump the manifest path is sometimes ommited in declare, causing errors:
```
command: declare
error: Failed to obtain scarb metadata: `scarb metadata` exited with error

stdout:
{"type":"error","message":"failed to read manifest at: /Users/wojciech/git-repos/starkware/starknet.swift/Scarb.toml\n\nCaused by:\n    No such file or directory (os error 2)"}

stderr:
```

this PR fixes this problem.

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
