### PR TITLE
fix Docs Forge - Library Function: precalculate_address typo

### DIFF
--- a/docs/src/appendix/forge-library/precalculate_address.md
+++ b/docs/src/appendix/forge-library/precalculate_address.md
@@ -31,7 +31,7 @@ fn test_deploy() {
     constructor_calldata.append(21);
     constructor_calldata.append(37);
 
-    let contract_address = contract.precalculate_address(@constructor_calldata).unwrap();
+    let contract_address = contract.precalculate_address(@constructor_calldata);
     // ...
 }
 ```


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`