### PR TITLE
Add reusable workflow for fetching supported scarb version for latest tag

### DIFF
--- a/.github/workflows/scarb_version.yml
+++ b/.github/workflows/scarb_version.yml
@@ -1,0 +1,22 @@
+name: Get Scarb version from top-level .tool-versions file for latest release
+
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: "Version of Scarb from tol-level .tool-versions for latest release"
+        value: ${{ jobs.get-scarb-version.outputs.version }}
+
+jobs:
+  get-scarb-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extractScarbVersion.outputs.scarbVersion }}
+    steps:
+      - name: Get scarb version
+        id: extractScarbVersion
+        run: |
+          snfoundry_version=$(curl -s https://api.github.com/repos/foundry-rs/starknet-foundry/releases/latest | grep tarball_url | awk -F '/' '{print $8}' | tr -d '",')
+          version=$(curl -s https://raw.githubusercontent.com/foundry-rs/starknet-foundry/$snfoundry_version/.tool-versions | awk '{print $2}')
+
+          echo "scarbVersion=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added reusable workflow for fetching supported scarb version for latest tag

Usage here: https://github.com/foundry-rs/setup-snfoundry/pull/14/files

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
