### PR TITLE
Move structs to appropriate crates

### DIFF
--- a/crates/forge/src/collecting.rs
+++ b/crates/forge/src/collecting.rs
@@ -4,15 +4,13 @@ use cairo_lang_sierra::program::Program;
 use camino::{Utf8Path, Utf8PathBuf};
 use forge_runner::BUILTINS;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
-use test_collector::{collect_tests, ForkConfig, LinkedLibrary, RawForkConfig, TestCase};
+use test_collector::{collect_tests, LinkedLibrary, TestCaseRaw};
 use walkdir::WalkDir;
 
-pub(crate) type CompiledTestCrateRaw = CompiledTestCrate<RawForkConfig>;
-
 #[derive(Debug, Clone)]
-pub(crate) struct CompiledTestCrate<T: ForkConfig> {
+pub(crate) struct CompiledTestCrateRaw {
     pub sierra_program: Program,
-    pub test_cases: Vec<TestCase<T>>,
+    pub test_cases: Vec<TestCaseRaw>,
     pub tests_location: CrateLocation,
 }
 
@@ -40,7 +38,7 @@ impl TestCompilationTarget {
             None,
         )?;
 
-        Ok(CompiledTestCrate {
+        Ok(CompiledTestCrateRaw {
             sierra_program,
             test_cases,
             tests_location: self.crate_location,

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 
 use forge_runner::test_crate_summary::TestCrateSummary;
 use forge_runner::{
-    CompiledTestCrate, RunnerConfig, RunnerParams, TestCaseRunnable, TestCrateRunResult,
+    CompiledTestCrateRunnable, RunnerConfig, RunnerParams, TestCaseRunnable, TestCrateRunResult,
     ValidatedForkConfig,
 };
 use test_collector::{RawForkConfig, RawForkParams};
 
 use crate::collecting::{collect_test_compilation_targets, compile_tests, CompiledTestCrateRaw};
+use crate::scarb::config::ForkTarget;
 use crate::test_filter::TestsFilter;
 
 pub mod pretty_printing;
@@ -30,13 +31,12 @@ pub enum CrateLocation {
 
 fn replace_id_with_params(
     raw_fork_config: RawForkConfig,
-    runner_config: &RunnerConfig,
+    fork_targets: &[ForkTarget],
 ) -> Result<RawForkParams> {
     match raw_fork_config {
         RawForkConfig::Params(raw_fork_params) => Ok(raw_fork_params),
         RawForkConfig::Id(name) => {
-            let fork_target_from_runner_config = runner_config
-                .fork_targets
+            let fork_target_from_runner_config = fork_targets
                 .iter()
                 .find(|fork| fork.name() == name)
                 .ok_or_else(|| {
@@ -50,13 +50,13 @@ fn replace_id_with_params(
 
 fn to_runnable(
     compiled_test_crate: CompiledTestCrateRaw,
-    runner_config: &RunnerConfig,
-) -> Result<CompiledTestCrate> {
+    fork_targets: &[ForkTarget],
+) -> Result<CompiledTestCrateRunnable> {
     let mut test_cases = vec![];
 
     for case in compiled_test_crate.test_cases {
         let fork_config = if let Some(fc) = case.fork_config {
-            let raw_fork_params = replace_id_with_params(fc, runner_config)?;
+            let raw_fork_params = replace_id_with_params(fc, fork_targets)?;
             let fork_config = ValidatedForkConfig::try_from(raw_fork_params)?;
             Some(fork_config)
         } else {
@@ -73,7 +73,7 @@ fn to_runnable(
         });
     }
 
-    Ok(CompiledTestCrate::new(
+    Ok(CompiledTestCrateRunnable::new(
         compiled_test_crate.sierra_program,
         test_cases,
     ))
@@ -100,6 +100,7 @@ pub async fn run(
     tests_filter: &TestsFilter,
     runner_config: Arc<RunnerConfig>,
     runner_params: Arc<RunnerParams>,
+    fork_targets: &[ForkTarget],
 ) -> Result<Vec<TestCrateSummary>> {
     let compilation_targets =
         collect_test_compilation_targets(package_path, package_name, package_source_dir_path)?;
@@ -126,7 +127,7 @@ pub async fn run(
             compiled_test_crate.test_cases.len(),
         );
 
-        let compiled_test_crate = to_runnable(compiled_test_crate, &runner_config)?;
+        let compiled_test_crate = to_runnable(compiled_test_crate, fork_targets)?;
         let compiled_test_crate = Arc::new(compiled_test_crate);
         let runner_config = runner_config.clone();
         let runner_params = runner_params.clone();
@@ -169,23 +170,23 @@ pub async fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::collecting::CompiledTestCrate;
+    use crate::collecting::CompiledTestCrateRaw;
     use cairo_lang_sierra::program::Program;
-    use forge_runner::ForkTarget;
     use starknet::core::types::BlockId;
     use starknet::core::types::BlockTag::Latest;
-    use test_collector::{ExpectedTestResult, TestCase};
+    use test_collector::ExpectedTestResult;
+    use test_collector::TestCaseRaw;
 
     #[test]
     fn to_runnable_unparsable_url() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: Program {
                 type_declarations: vec![],
                 libfunc_declarations: vec![],
                 statements: vec![],
                 funcs: vec![],
             },
-            test_cases: vec![TestCase {
+            test_cases: vec![TestCaseRaw {
                 name: "crate1::do_thing".to_string(),
                 available_gas: None,
                 ignored: false,
@@ -198,9 +199,8 @@ mod tests {
             }],
             tests_location: CrateLocation::Lib,
         };
-        let config = RunnerConfig::new(Default::default(), false, vec![], 256, 12345);
 
-        assert!(to_runnable(mocked_tests, &config).is_err());
+        assert!(to_runnable(mocked_tests, &[]).is_err());
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
                 statements: vec![],
                 funcs: vec![],
             },
-            test_cases: vec![TestCase::<RawForkConfig> {
+            test_cases: vec![TestCaseRaw {
                 name: "crate1::do_thing".to_string(),
                 available_gas: None,
                 ignored: false,
@@ -222,20 +222,17 @@ mod tests {
             }],
             tests_location: CrateLocation::Lib,
         };
-        let config = RunnerConfig::new(
-            Default::default(),
-            false,
-            vec![ForkTarget::new(
+
+        assert!(to_runnable(
+            mocked_tests,
+            &[ForkTarget::new(
                 "definitely_non_existing".to_string(),
                 RawForkParams {
                     url: "https://not_taken.com".to_string(),
                     block_id: BlockId::Number(120),
                 },
             )],
-            256,
-            12345,
-        );
-
-        assert!(to_runnable(mocked_tests, &config).is_err());
+        )
+        .is_err());
     }
 }

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -129,7 +129,6 @@ fn combine_configs(
     RunnerConfig::new(
         workspace_root.to_path_buf(),
         exit_first || forge_config.exit_first,
-        forge_config.fork.clone(),
         fuzzer_runs
             .or(forge_config.fuzzer_runs)
             .unwrap_or(FUZZER_RUNS_DEFAULT),
@@ -220,6 +219,7 @@ fn test_workspace(args: TestArgs) -> Result<bool> {
                     ),
                     runner_config,
                     runner_params,
+                    &forge_config.fork,
                 )
                 .await?;
 
@@ -291,7 +291,6 @@ mod tests {
             RunnerConfig::new(
                 workspace_root,
                 false,
-                vec![],
                 FUZZER_RUNS_DEFAULT,
                 config.fuzzer_seed
             )
@@ -309,10 +308,7 @@ mod tests {
         let workspace_root: Utf8PathBuf = Default::default();
 
         let config = combine_configs(&workspace_root, false, None, None, &config_from_scarb);
-        assert_eq!(
-            config,
-            RunnerConfig::new(workspace_root, true, vec![], 1234, 500)
-        );
+        assert_eq!(config, RunnerConfig::new(workspace_root, true, 1234, 500));
     }
 
     #[test]
@@ -332,9 +328,6 @@ mod tests {
             Some(32),
             &config_from_scarb,
         );
-        assert_eq!(
-            config,
-            RunnerConfig::new(workspace_root, true, vec![], 100, 32)
-        );
+        assert_eq!(config, RunnerConfig::new(workspace_root, true, 100, 32));
     }
 }

--- a/crates/forge/src/scarb.rs
+++ b/crates/forge/src/scarb.rs
@@ -32,11 +32,11 @@ pub fn config_from_scarb_for_package(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scarb::config::ForkTarget;
     use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
     use assert_fs::TempDir;
     use camino::Utf8PathBuf;
     use conversions::StarknetConversions;
-    use forge_runner::ForkTarget;
     use indoc::{formatdoc, indoc};
     use scarb_metadata::MetadataCommand;
     use starknet::core::types::BlockId;

--- a/crates/forge/src/scarb/config.rs
+++ b/crates/forge/src/scarb/config.rs
@@ -1,6 +1,5 @@
 use anyhow::{bail, Result};
 use conversions::StarknetConversions;
-use forge_runner::ForkTarget;
 use itertools::Itertools;
 use serde::Deserialize;
 use starknet::core::types::{BlockId, BlockTag};
@@ -17,6 +16,29 @@ pub struct ForgeConfig {
     pub fuzzer_seed: Option<u64>,
 
     pub fork: Vec<ForkTarget>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ForkTarget {
+    name: String,
+    params: RawForkParams,
+}
+
+impl ForkTarget {
+    #[must_use]
+    pub fn new(name: String, params: RawForkParams) -> Self {
+        Self { name, params }
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    pub fn params(&self) -> &RawForkParams {
+        &self.params
+    }
 }
 
 /// Represents forge config deserialized from Scarb.toml using basic types like String etc.

--- a/crates/forge/src/test_filter.rs
+++ b/crates/forge/src/test_filter.rs
@@ -1,4 +1,4 @@
-use crate::collecting::{CompiledTestCrate, CompiledTestCrateRaw};
+use crate::collecting::CompiledTestCrateRaw;
 use forge_runner::{TestCaseFilter, TestCaseRunnable};
 
 #[derive(Debug, PartialEq)]
@@ -82,7 +82,7 @@ impl TestsFilter {
             IgnoredFilter::Ignored => cases.into_iter().filter(|tc| tc.ignored).collect(),
         };
 
-        CompiledTestCrate {
+        CompiledTestCrateRaw {
             test_cases: cases,
             ..test_crate
         }
@@ -101,11 +101,11 @@ impl TestCaseFilter for TestsFilter {
 
 #[cfg(test)]
 mod tests {
-    use crate::collecting::CompiledTestCrate;
+    use crate::collecting::CompiledTestCrateRaw;
     use crate::test_filter::TestsFilter;
     use crate::CrateLocation;
     use cairo_lang_sierra::program::Program;
-    use test_collector::{ExpectedTestResult, TestCase};
+    use test_collector::{ExpectedTestResult, TestCaseRaw};
 
     fn program_for_testing() -> Program {
         Program {
@@ -131,10 +131,10 @@ mod tests {
     #[test]
     #[allow(clippy::too_many_lines)]
     fn filtering_tests() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: program_for_testing(),
             test_cases: vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -142,7 +142,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -150,7 +150,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate2::execute_next_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -158,7 +158,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -174,7 +174,7 @@ mod tests {
         let filtered = tests_filter.filter_tests(mocked_tests.clone());
         assert_eq!(
             filtered.test_cases,
-            vec![TestCase {
+            vec![TestCaseRaw {
                 name: "crate1::do_thing".to_string(),
                 available_gas: None,
                 ignored: false,
@@ -189,7 +189,7 @@ mod tests {
         let filtered = tests_filter.filter_tests(mocked_tests.clone());
         assert_eq!(
             filtered.test_cases,
-            vec![TestCase {
+            vec![TestCaseRaw {
                 name: "crate2::run_other_thing".to_string(),
                 available_gas: None,
                 ignored: true,
@@ -204,7 +204,7 @@ mod tests {
         assert_eq!(
             filtered.test_cases,
             vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     expected_result: ExpectedTestResult::Success,
@@ -212,7 +212,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     expected_result: ExpectedTestResult::Success,
@@ -220,7 +220,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate2::execute_next_thing".to_string(),
                     available_gas: None,
                     expected_result: ExpectedTestResult::Success,
@@ -228,7 +228,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -249,7 +249,7 @@ mod tests {
         assert_eq!(
             filtered.test_cases,
             vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -257,7 +257,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -265,7 +265,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate2::execute_next_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -273,7 +273,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn filtering_with_no_tests() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: program_for_testing(),
             test_cases: vec![],
             tests_location: CrateLocation::Lib,
@@ -304,10 +304,10 @@ mod tests {
 
     #[test]
     fn filtering_with_exact_match() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: program_for_testing(),
             test_cases: vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -315,7 +315,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -323,7 +323,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate3::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -331,7 +331,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -356,7 +356,7 @@ mod tests {
         let filtered = tests_filter.filter_tests(mocked_tests.clone());
         assert_eq!(
             filtered.test_cases,
-            vec![TestCase {
+            vec![TestCaseRaw {
                 name: "do_thing".to_string(),
                 available_gas: None,
                 ignored: false,
@@ -371,7 +371,7 @@ mod tests {
         let filtered = tests_filter.filter_tests(mocked_tests.clone());
         assert_eq!(
             filtered.test_cases,
-            vec![TestCase {
+            vec![TestCaseRaw {
                 name: "crate1::do_thing".to_string(),
                 available_gas: None,
                 ignored: false,
@@ -399,7 +399,7 @@ mod tests {
         let filtered = tests_filter.filter_tests(mocked_tests.clone());
         assert_eq!(
             filtered.test_cases,
-            vec![TestCase {
+            vec![TestCaseRaw {
                 name: "outer::crate3::run_other_thing".to_string(),
                 available_gas: None,
                 ignored: true,
@@ -412,10 +412,10 @@ mod tests {
 
     #[test]
     fn filtering_with_only_ignored() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: program_for_testing(),
             test_cases: vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -423,7 +423,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -431,7 +431,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate3::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -439,7 +439,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -456,7 +456,7 @@ mod tests {
         assert_eq!(
             filtered.test_cases,
             vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -464,7 +464,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate3::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -478,10 +478,10 @@ mod tests {
 
     #[test]
     fn filtering_with_include_ignored() {
-        let mocked_tests = CompiledTestCrate {
+        let mocked_tests = CompiledTestCrateRaw {
             sierra_program: program_for_testing(),
             test_cases: vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -489,7 +489,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -497,7 +497,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate3::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -505,7 +505,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -522,7 +522,7 @@ mod tests {
         assert_eq!(
             filtered.test_cases,
             vec![
-                TestCase {
+                TestCaseRaw {
                     name: "crate1::do_thing".to_string(),
                     available_gas: None,
                     ignored: false,
@@ -530,7 +530,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "crate2::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -538,7 +538,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "outer::crate3::run_other_thing".to_string(),
                     available_gas: None,
                     ignored: true,
@@ -546,7 +546,7 @@ mod tests {
                     fork_config: None,
                     fuzzer_config: None,
                 },
-                TestCase {
+                TestCaseRaw {
                     name: "do_thing".to_string(),
                     available_gas: None,
                     ignored: false,

--- a/crates/forge/test_utils/src/running_tests.rs
+++ b/crates/forge/test_utils/src/running_tests.rs
@@ -22,7 +22,6 @@ pub fn run_test_case(test: &TestCase) -> Vec<TestCrateSummary> {
         Arc::new(RunnerConfig::new(
             Utf8PathBuf::from_path_buf(PathBuf::from(tempdir().unwrap().path())).unwrap(),
             false,
-            vec![],
             256,
             12345,
         )),
@@ -32,6 +31,7 @@ pub fn run_test_case(test: &TestCase) -> Vec<TestCrateSummary> {
             test.env().clone(),
             test.linked_libraries(),
         )),
+        &[],
     ))
     .expect("Runner fail")
 }

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 
 use camino::Utf8PathBuf;
 use forge::run;
+use forge::scarb::config::ForkTarget;
 use forge::test_filter::TestsFilter;
 use starknet::core::types::BlockId;
 use starknet::core::types::BlockTag::Latest;
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
 
-use forge_runner::{ForkTarget, RunnerConfig, RunnerParams};
+use forge_runner::{RunnerConfig, RunnerParams};
 use test_collector::RawForkParams;
 use test_utils::corelib::corelib_path;
 use test_utils::runner::Contract;
@@ -110,13 +111,6 @@ fn fork_aliased_decorator() {
             Arc::new(RunnerConfig::new(
                 Utf8PathBuf::from_path_buf(PathBuf::from(tempdir().unwrap().path())).unwrap(),
                 false,
-                vec![ForkTarget::new(
-                    "FORK_NAME_FROM_SCARB_TOML".to_string(),
-                    RawForkParams {
-                        url: CHEATNET_RPC_URL.to_string(),
-                        block_id: BlockId::Tag(Latest),
-                    },
-                )],
                 256,
                 12345,
             )),
@@ -126,6 +120,13 @@ fn fork_aliased_decorator() {
                 Default::default(),
                 test.linked_libraries(),
             )),
+            &[ForkTarget::new(
+                "FORK_NAME_FROM_SCARB_TOML".to_string(),
+                RawForkParams {
+                    url: CHEATNET_RPC_URL.to_string(),
+                    block_id: BlockId::Tag(Latest),
+                },
+            )],
         ))
         .expect("Runner fail");
 

--- a/crates/test-collector/src/lib.rs
+++ b/crates/test-collector/src/lib.rs
@@ -91,10 +91,6 @@ impl From<TestExpectation> for ExpectedTestResult {
     }
 }
 
-pub trait ForkConfig {}
-
-impl ForkConfig for RawForkConfig {}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum RawForkConfig {
     Id(String),
@@ -404,15 +400,13 @@ pub struct LinkedLibrary {
     pub path: PathBuf,
 }
 
-pub type TestCaseRaw = TestCase<RawForkConfig>;
-
 #[derive(Debug, PartialEq, Clone)]
-pub struct TestCase<T: ForkConfig> {
+pub struct TestCaseRaw {
     pub name: String,
     pub available_gas: Option<usize>,
     pub ignored: bool,
     pub expected_result: ExpectedTestResult,
-    pub fork_config: Option<T>,
+    pub fork_config: Option<RawForkConfig>,
     pub fuzzer_config: Option<FuzzerConfig>,
 }
 
@@ -500,7 +494,7 @@ pub fn collect_tests(
             if config.available_gas.is_some() {
                 bail!("{} - Attribute `available_gas` is not supported: Contract functions execution cost would not be included in the gas calculation.", test_name)
             };
-            Ok(TestCase {
+            Ok(TestCaseRaw {
                 name: test_name,
                 available_gas: config.available_gas,
                 ignored: config.ignored,


### PR DESCRIPTION
Preparation for Scarb decoupling

`TestCaseRaw` and `TestCaseRunnable` instead of `TestCase<T>` since one can appear only in `forge` other one only in `forge-runner`. Resulted in removing `trait ForkConfig` too (not needed anymore)

Fork targets moved out of `RunnerConfig` as those are used only in `forge`