### PR TITLE
Fail a test instead of whole runner when using `available_gas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `start_prank` and `stop_prank` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/start_prank.md).
 - `start_roll` and `stop_roll` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/start_roll.md).
 
+#### Fixed
+
+- using unsupported `available_gas` attribute now fail the specific test case instead of the whole runner
+
 ## [0.10.2] - 2023-11-13
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- using unsupported `available_gas` attribute now fail the specific test case instead of the whole runner
+- using unsupported `available_gas` attribute now fails the specific test case instead of the whole runner
 
 ## [0.10.2] - 2023-11-13
 

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -764,7 +764,22 @@ fn available_gas_error() {
         indoc! {r"
         [..]Compiling[..]
         [..]Finished[..]
-        [ERROR] tests::available_gas::available_gas - Attribute `available_gas` is not supported: Contract functions execution cost would not be included in the gas calculation.
+        
+        
+        Collected 3 test(s) from available_gas package
+        Running 0 test(s) from src/
+        Running 3 test(s) from tests/
+        [FAIL] tests::available_gas::available_gas
+        
+        Failure data:
+            Attribute `available_gas` is not supported
+        
+        [PASS] tests::available_gas::aa_test
+        [PASS] tests::available_gas::test
+        Tests: 2 passed, 1 failed, 0 skipped, 0 ignored, 0 filtered out
+        
+        Failures:
+            tests::available_gas::available_gas
         "}
     );
 }

--- a/crates/test-collector/src/lib.rs
+++ b/crates/test-collector/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::sierra_casm_generator::SierraCasmGenerator;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use cairo_felt::Felt252;
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_compiler::diagnostics::DiagnosticsReporter;
@@ -471,7 +471,7 @@ pub fn collect_tests(
         .context("Compilation failed without any diagnostics")
         .context("Failed to get sierra program")?;
 
-    let collected_tests: Vec<TestCaseRaw> = all_tests
+    let collected_tests = all_tests
         .into_iter()
         .map(|(func_id, test)| {
             (
@@ -490,20 +490,15 @@ pub fn collect_tests(
         })
         .collect_vec()
         .into_iter()
-        .map(|(test_name, config)| {
-            if config.available_gas.is_some() {
-                bail!("{} - Attribute `available_gas` is not supported: Contract functions execution cost would not be included in the gas calculation.", test_name)
-            };
-            Ok(TestCaseRaw {
-                name: test_name,
-                available_gas: config.available_gas,
-                ignored: config.ignored,
-                expected_result: config.expected_result,
-                fork_config: config.fork_config,
-                fuzzer_config: config.fuzzer_config,
-            })
+        .map(|(test_name, config)| TestCaseRaw {
+            name: test_name,
+            available_gas: config.available_gas,
+            ignored: config.ignored,
+            expected_result: config.expected_result,
+            fork_config: config.fork_config,
+            fuzzer_config: config.fuzzer_config,
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect();
 
     let sierra_program = replace_sierra_ids_in_program(db, &sierra_program);
 


### PR DESCRIPTION
We prevented users having both snforge and cairo-test tests in their package from filtering and running only snforge tests (check issue description)

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
