### PR TITLE
Parse `BlockId` on forges side

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-scarb nightly-2023-11-21
+scarb nightly-2023-12-04

--- a/crates/cast/tests/data/contracts/map/src/lib.cairo
+++ b/crates/cast/tests/data/contracts/map/src/lib.cairo
@@ -12,7 +12,7 @@ mod Map {
         storage: LegacyMap::<felt252, felt252>,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Map of super::IMap<ContractState> {
         fn put(ref self: ContractState, key: felt252, value: felt252) {
             self.storage.write(key, value);

--- a/crates/cast/tests/data/contracts/no_casm/src/lib.cairo
+++ b/crates/cast/tests/data/contracts/no_casm/src/lib.cairo
@@ -2,6 +2,6 @@
 mod minimal_contract {
     #[storage]
     struct Storage {}
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn empty(ref self: ContractState) {}
 }

--- a/crates/cast/tests/data/contracts/no_sierra/src/lib.cairo
+++ b/crates/cast/tests/data/contracts/no_sierra/src/lib.cairo
@@ -2,6 +2,6 @@
 mod minimal_contract {
     #[storage]
     struct Storage {}
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn empty(ref self: ContractState) {}
 }

--- a/crates/cast/tests/data/scripts/map_script/contracts/src/lib.cairo
+++ b/crates/cast/tests/data/scripts/map_script/contracts/src/lib.cairo
@@ -12,7 +12,7 @@ mod Mapa {
         storage: LegacyMap::<felt252, felt252>,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Map of super::IMap<ContractState> {
         fn put(ref self: ContractState, key: felt252, value: felt252) {
             self.storage.write(key, value);
@@ -31,7 +31,7 @@ mod Mapa2 {
         storage: LegacyMap::<felt252, felt252>,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Map of super::IMap<ContractState> {
         fn put(ref self: ContractState, key: felt252, value: felt252) {
             self.storage.write(key, value);

--- a/crates/cheatnet/tests/contracts/src/common/constructor_simple.cairo
+++ b/crates/cheatnet/tests/contracts/src/common/constructor_simple.cairo
@@ -10,14 +10,14 @@ mod ConstructorSimple {
         self.number.write(number);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn add_to_number(ref self: ContractState, number: felt252) -> felt252 {
         let new_number = self.number.read() + number;
         self.number.write(new_number);
         new_number
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn get_number(self: @ContractState) -> felt252 {
         self.number.read()
     }

--- a/crates/cheatnet/tests/contracts/src/common/constructor_simple.cairo
+++ b/crates/cheatnet/tests/contracts/src/common/constructor_simple.cairo
@@ -1,3 +1,9 @@
+#[starknet::interface]
+trait IConstructorSimple<TContractState> {
+    fn add_to_number(ref self: TContractState, number: felt252) -> felt252;
+    fn get_number(self: @TContractState) -> felt252;
+}
+
 #[starknet::contract]
 mod ConstructorSimple {
     #[storage]
@@ -11,14 +17,15 @@ mod ConstructorSimple {
     }
 
     #[abi(embed_v0)]
-    fn add_to_number(ref self: ContractState, number: felt252) -> felt252 {
-        let new_number = self.number.read() + number;
-        self.number.write(new_number);
-        new_number
-    }
+    impl ConstructorSimpleImpl of super::IConstructorSimple<ContractState> {
+        fn add_to_number(ref self: ContractState, number: felt252) -> felt252 {
+            let new_number = self.number.read() + number;
+            self.number.write(new_number);
+            new_number
+        }
 
-    #[abi(embed_v0)]
-    fn get_number(self: @ContractState) -> felt252 {
-        self.number.read()
+        fn get_number(self: @ContractState) -> felt252 {
+            self.number.read()
+        }
     }
 }

--- a/crates/cheatnet/tests/contracts/src/common/constructor_simple2.cairo
+++ b/crates/cheatnet/tests/contracts/src/common/constructor_simple2.cairo
@@ -10,14 +10,14 @@ mod ConstructorSimple2 {
         self.number.write(number + number2);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn add_to_number(ref self: ContractState, number: felt252) -> felt252 {
         let new_number = self.number.read() + number;
         self.number.write(new_number);
         new_number
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn get_number(self: @ContractState) -> felt252 {
         self.number.read()
     }

--- a/crates/cheatnet/tests/contracts/src/common/hello_starknet.cairo
+++ b/crates/cheatnet/tests/contracts/src/common/hello_starknet.cairo
@@ -11,7 +11,7 @@ mod HelloStarknet {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         fn increase_balance(ref self: ContractState, amount: felt252) {
             assert(amount != 0, 'Amount cannot be 0');

--- a/crates/cheatnet/tests/contracts/src/elect/constructor_elect_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/elect/constructor_elect_checker.cairo
@@ -21,7 +21,7 @@ mod ConstructorElectChecker {
         self.seq_addr.write(sequencer_address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorElectChecker of super::IConstructorElectChecker<ContractState> {
         fn get_stored_sequencer_address(ref self: ContractState) -> ContractAddress {
             self.seq_addr.read()

--- a/crates/cheatnet/tests/contracts/src/elect/elect_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/elect/elect_checker.cairo
@@ -24,7 +24,7 @@ mod ElectChecker {
         sequencer_address: ContractAddress
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IElectChecker of super::IElectChecker<ContractState> {
         fn get_sequencer_address(ref self: ContractState) -> ContractAddress {
             starknet::get_block_info().unbox().sequencer_address

--- a/crates/cheatnet/tests/contracts/src/elect/elect_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/elect/elect_checker_library_call.cairo
@@ -20,7 +20,7 @@ mod ElectCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IElectCheckerLibCall of super::IElectCheckerLibCall<ContractState> {
         fn get_sequencer_address_with_lib_call(
             ref self: ContractState, class_hash: ClassHash

--- a/crates/cheatnet/tests/contracts/src/elect/elect_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/elect/elect_checker_proxy.cairo
@@ -21,7 +21,7 @@ mod ElectCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IElectCheckerProxy of super::IElectCheckerProxy<ContractState> {
         fn get_elect_checkers_seq_addr(
             ref self: ContractState, address: ContractAddress

--- a/crates/cheatnet/tests/contracts/src/events/spy_events_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/events/spy_events_checker.cairo
@@ -51,7 +51,7 @@ mod SpyEventsChecker {
         even_more_data: u256
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpyEventsChecker of super::ISpyEventsChecker<ContractState> {
         fn do_not_emit(ref self: ContractState) {}
 

--- a/crates/cheatnet/tests/contracts/src/events/spy_events_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/events/spy_events_checker_proxy.cairo
@@ -58,7 +58,7 @@ mod SpyEventsCheckerProxy {
         self.proxied_address.write(proxied_address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpyEventsChecker of super::ISpyEventsChecker<ContractState> {
         fn do_not_emit(ref self: ContractState) {
             let spy_events_checker = ISpyEventsCheckerDispatcher {

--- a/crates/cheatnet/tests/contracts/src/events/spy_events_lib_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/events/spy_events_lib_call.cairo
@@ -19,7 +19,7 @@ mod SpyEventsLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpyEventsLibCallImpl of super::ISpyEventsLibCall<ContractState> {
         fn call_lib_call(ref self: ContractState, data: felt252, class_hash: ClassHash) {
             let spy_events_checker = ISpyEventsCheckerLibraryDispatcher { class_hash };

--- a/crates/cheatnet/tests/contracts/src/events/spy_events_order_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/events/spy_events_order_checker.cairo
@@ -40,7 +40,7 @@ mod SpyEventsOrderChecker {
         data: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpyEventsOrderCheckerImpl of super::ISpyEventsOrderChecker<ContractState> {
         fn emit_and_call_another(
             ref self: ContractState,

--- a/crates/cheatnet/tests/contracts/src/get_class_hash/get_class_hash_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/get_class_hash/get_class_hash_checker.cairo
@@ -15,7 +15,7 @@ mod GetClassHashCheckerUpg {
         inner: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IUpgradeableImpl of super::IUpgradeable<ContractState> {
         fn upgrade(ref self: ContractState, class_hash: ClassHash) {
             _upgrade(class_hash);

--- a/crates/cheatnet/tests/contracts/src/mock/constructor_mock_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/mock/constructor_mock_checker.cairo
@@ -27,7 +27,7 @@ mod ConstructorMockChecker {
         self.constructor_balance.write(hello_starknet.get_balance());
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorMockCheckerImpl of super::IConstructorMockChecker<ContractState> {
         fn get_constructor_balance(ref self: ContractState) -> felt252 {
             self.constructor_balance.read()

--- a/crates/cheatnet/tests/contracts/src/mock/mock_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/mock/mock_checker.cairo
@@ -29,7 +29,7 @@ mod MockChecker {
         self.stored_thing.write(arg1)
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IMockCheckerImpl of super::IMockChecker<ContractState> {
         fn get_thing(ref self: ContractState) -> felt252 {
             self.stored_thing.read()

--- a/crates/cheatnet/tests/contracts/src/mock/mock_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/mock/mock_checker_library_call.cairo
@@ -18,7 +18,7 @@ mod MockCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IMockCheckerLibCall of super::IMockCheckerLibCall<ContractState> {
         fn get_constant_thing_with_lib_call(
             ref self: ContractState, class_hash: ClassHash

--- a/crates/cheatnet/tests/contracts/src/mock/mock_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/mock/mock_checker_proxy.cairo
@@ -34,7 +34,7 @@ mod MockCheckerProxy {
         thing: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IMockCheckerProxy of super::IMockCheckerProxy<ContractState> {
         fn get_thing_from_contract(ref self: ContractState, address: ContractAddress) -> felt252 {
             let dispatcher = IMockCheckerDispatcher { contract_address: address };

--- a/crates/cheatnet/tests/contracts/src/prank/constructor_prank_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/prank/constructor_prank_checker.cairo
@@ -20,7 +20,7 @@ mod ConstructorPrankChecker {
         self.caller_address.write(address);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorPrankChecker of super::IConstructorPrankChecker<ContractState> {
         fn get_stored_caller_address(ref self: ContractState) -> ContractAddress {
             self.caller_address.read()

--- a/crates/cheatnet/tests/contracts/src/prank/prank_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/prank/prank_checker.cairo
@@ -28,7 +28,7 @@ mod PrankChecker {
         caller_address: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IPrankChecker of super::IPrankChecker<ContractState> {
         fn get_caller_address(ref self: ContractState) -> felt252 {
             starknet::get_caller_address().into()

--- a/crates/cheatnet/tests/contracts/src/prank/prank_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/prank/prank_checker_library_call.cairo
@@ -18,7 +18,7 @@ mod PrankCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IPrankCheckerLibCall of super::IPrankCheckerLibCall<ContractState> {
         fn get_caller_address_with_lib_call(
             ref self: ContractState, class_hash: ClassHash

--- a/crates/cheatnet/tests/contracts/src/prank/prank_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/prank/prank_checker_proxy.cairo
@@ -23,7 +23,7 @@ mod PrankCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IPrankCheckerProxy of super::IPrankCheckerProxy<ContractState> {
         fn get_prank_checkers_caller_address(
             ref self: ContractState, address: ContractAddress

--- a/crates/cheatnet/tests/contracts/src/roll/constructor_roll_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/roll/constructor_roll_checker.cairo
@@ -17,7 +17,7 @@ mod ConstructorRollChecker {
         self.blk_nb.write(block_numb);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorRollChecker of super::IConstructorRollChecker<ContractState> {
         fn get_stored_block_number(ref self: ContractState) -> u64 {
             self.blk_nb.read()

--- a/crates/cheatnet/tests/contracts/src/roll/roll_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/roll/roll_checker.cairo
@@ -23,7 +23,7 @@ mod RollChecker {
         block_number: u64
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IRollChecker of super::IRollChecker<ContractState> {
         fn get_block_number(ref self: ContractState) -> u64 {
             starknet::get_block_info().unbox().block_number

--- a/crates/cheatnet/tests/contracts/src/roll/roll_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/roll/roll_checker_library_call.cairo
@@ -18,7 +18,7 @@ mod RollCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IRollCheckerLibCall of super::IRollCheckerLibCall<ContractState> {
         fn get_block_number_with_lib_call(ref self: ContractState, class_hash: ClassHash) -> u64 {
             let roll_checker = IRollCheckerLibraryDispatcher { class_hash };

--- a/crates/cheatnet/tests/contracts/src/roll/roll_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/roll/roll_checker_proxy.cairo
@@ -19,7 +19,7 @@ mod RollCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IRollCheckerProxy of super::IRollCheckerProxy<ContractState> {
         fn get_roll_checkers_block_number(
             ref self: ContractState, address: ContractAddress

--- a/crates/cheatnet/tests/contracts/src/segment_arena_user.cairo
+++ b/crates/cheatnet/tests/contracts/src/segment_arena_user.cairo
@@ -2,7 +2,7 @@
 mod SegmentArenaUser {
     #[storage]
     struct Storage {}
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn interface_function(ref self: ContractState) {
         let felt_dict: Felt252Dict<felt252> = Default::default();
     }

--- a/crates/cheatnet/tests/contracts/src/spoof/constructor_spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/constructor_spoof_checker.cairo
@@ -17,7 +17,7 @@ mod ConstructorSpoofChecker {
         self.stored_tx_hash.write(tx_hash);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorSpoofChecker of super::IConstructorSpoofChecker<ContractState> {
         fn get_stored_tx_hash(ref self: ContractState) -> felt252 {
             self.stored_tx_hash.read()

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
@@ -39,7 +39,7 @@ mod SpoofChecker {
         tx_hash: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpoofChecker of super::ISpoofChecker<ContractState> {
         fn get_tx_hash(ref self: ContractState) -> felt252 {
             starknet::get_tx_info().unbox().transaction_hash

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
@@ -18,7 +18,7 @@ mod SpoofCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpoofCheckerLibCall of super::ISpoofCheckerLibCall<ContractState> {
         fn get_tx_hash_with_lib_call(ref self: ContractState, class_hash: ClassHash) -> felt252 {
             let spoof_checker = ISpoofCheckerLibraryDispatcher { class_hash };

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
@@ -20,7 +20,7 @@ mod SpoofCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpoofCheckerProxy of super::ISpoofCheckerProxy<ContractState> {
         fn get_spoof_checkers_tx_hash(
             ref self: ContractState, address: ContractAddress

--- a/crates/cheatnet/tests/contracts/src/starknet/block_info_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/block_info_checker_library_call.cairo
@@ -26,7 +26,7 @@ mod BlockInfoCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IBlockInfoCheckerLibCall of super::IBlockInfoCheckerLibCall<ContractState> {
         fn read_block_number_with_lib_call(ref self: ContractState, class_hash: ClassHash) -> u64 {
             let block_info_checker = IBlockInfoCheckerLibraryDispatcher { class_hash };

--- a/crates/cheatnet/tests/contracts/src/starknet/block_info_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/block_info_checker_proxy.cairo
@@ -25,7 +25,7 @@ mod BlockInfoCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IBlockInfoCheckerProxy of super::IBlockInfoCheckerProxy<ContractState> {
         fn read_block_number(ref self: ContractState, address: ContractAddress) -> u64 {
             let block_info_checker = IBlockInfoCheckerDispatcher { contract_address: address };

--- a/crates/cheatnet/tests/contracts/src/starknet/blocker.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/blocker.cairo
@@ -25,7 +25,7 @@ mod Blocker {
         sequencer_address: ContractAddress,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IBlockerImpl of super::IBlocker<ContractState> {
         fn write_block(ref self: ContractState) {
             let block_info = get_block_info().unbox();

--- a/crates/cheatnet/tests/contracts/src/starknet/forking_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/forking_checker.cairo
@@ -36,7 +36,7 @@ mod ForkingChecker {
         }
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IForkingCheckerImpl of super::IForkingChecker<ContractState> {
         fn get_balance_call_contract(
             ref self: ContractState, contract_address: ContractAddress

--- a/crates/cheatnet/tests/contracts/src/starknet/noncer.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/noncer.cairo
@@ -15,7 +15,7 @@ mod Noncer {
         nonce: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl INoncerImpl of super::INoncer<ContractState> {
         fn write_nonce(ref self: ContractState) {
             let tx_info = get_tx_info().unbox();

--- a/crates/cheatnet/tests/contracts/src/starknet/timestamper.cairo
+++ b/crates/cheatnet/tests/contracts/src/starknet/timestamper.cairo
@@ -14,7 +14,7 @@ mod Timestamper {
         time: u64,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ITimestamperImpl of super::ITimestamper<ContractState> {
         fn write_timestamp(ref self: ContractState) {
             let time = get_block_timestamp();

--- a/crates/cheatnet/tests/contracts/src/warp/constructor_warp_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/warp/constructor_warp_checker.cairo
@@ -17,7 +17,7 @@ mod ConstructorWarpChecker {
         self.blk_timestamp.write(blk_timestamp);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IConstructorWarpChecker of super::IConstructorWarpChecker<ContractState> {
         fn get_stored_block_timestamp(ref self: ContractState) -> u64 {
             self.blk_timestamp.read()

--- a/crates/cheatnet/tests/contracts/src/warp/warp_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/warp/warp_checker.cairo
@@ -24,7 +24,7 @@ mod WarpChecker {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl WarpChecker of super::IWarpChecker<ContractState> {
         fn get_block_timestamp(ref self: ContractState) -> u64 {
             starknet::get_block_info().unbox().block_timestamp

--- a/crates/cheatnet/tests/contracts/src/warp/warp_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/warp/warp_checker_library_call.cairo
@@ -18,7 +18,7 @@ mod WarpCheckerLibCall {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IWarpCheckerLibCall of super::IWarpCheckerLibCall<ContractState> {
         fn get_block_timestamp_with_lib_call(
             ref self: ContractState, class_hash: ClassHash

--- a/crates/cheatnet/tests/contracts/src/warp/warp_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/warp/warp_checker_proxy.cairo
@@ -19,7 +19,7 @@ mod WarpCheckerProxy {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IWarpCheckerProxy of super::IWarpCheckerProxy<ContractState> {
         fn get_warp_checkers_block_timestamp(
             ref self: ContractState, address: ContractAddress

--- a/crates/forge/src/compiled_raw.rs
+++ b/crates/forge/src/compiled_raw.rs
@@ -1,8 +1,12 @@
+use cairo_felt::Felt252;
 use cairo_lang_sierra::program::Program;
+use conversions::IntoConv;
 use forge_runner::compiled_runnable::{FuzzerConfig, ValidatedForkConfig};
 use forge_runner::expected_result::ExpectedTestResult;
+use num_bigint::BigInt;
 use serde::Deserialize;
 use starknet::core::types::BlockId;
+use starknet::core::types::BlockTag::Latest;
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct CompiledTestCrateRaw {
@@ -38,16 +42,28 @@ pub enum RawForkConfig {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct RawForkParams {
     pub url: String,
-    pub block_id: BlockId,
+    pub block_id_type: String,
+    pub block_id_value: String,
 }
 
 impl TryFrom<RawForkParams> for ValidatedForkConfig {
     type Error = anyhow::Error;
 
     fn try_from(value: RawForkParams) -> Result<Self, Self::Error> {
+        let block_id = match value.block_id_type.to_lowercase().as_str() {
+            "number" => BlockId::Number(value.block_id_value.parse().unwrap()),
+            "hash" => BlockId::Hash(
+                Felt252::from(value.block_id_value.parse::<BigInt>().unwrap()).into_(),
+            ),
+            "tag" => {
+                assert_eq!(value.block_id_value, "Latest");
+                BlockId::Tag(Latest)
+            }
+            _ => unreachable!(),
+        };
         Ok(ValidatedForkConfig {
             url: value.url.parse()?,
-            block_id: value.block_id,
+            block_id,
         })
     }
 }

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -168,8 +168,6 @@ mod tests {
     use crate::compiled_raw::{CompiledTestCrateRaw, CrateLocation, TestCaseRaw};
     use cairo_lang_sierra::program::Program;
     use forge_runner::expected_result::ExpectedTestResult;
-    use starknet::core::types::BlockId;
-    use starknet::core::types::BlockTag::Latest;
 
     #[test]
     fn to_runnable_unparsable_url() {
@@ -187,7 +185,8 @@ mod tests {
                 expected_result: ExpectedTestResult::Success,
                 fork_config: Some(RawForkConfig::Params(RawForkParams {
                     url: "unparsable_url".to_string(),
-                    block_id: BlockId::Tag(Latest),
+                    block_id_type: "Tag".to_string(),
+                    block_id_value: "Latest".to_string(),
                 })),
                 fuzzer_config: None,
             }],
@@ -223,7 +222,8 @@ mod tests {
                 "definitely_non_existing".to_string(),
                 RawForkParams {
                     url: "https://not_taken.com".to_string(),
-                    block_id: BlockId::Number(120),
+                    block_id_type: "Number".to_string(),
+                    block_id_value: "120".to_string(),
                 },
             )],
         )

--- a/crates/forge/src/scarb.rs
+++ b/crates/forge/src/scarb.rs
@@ -1,7 +1,7 @@
 use scarb_metadata::{Metadata, PackageId};
 use std::process::{Command, Stdio};
 
-use crate::scarb::config::{validate_raw_fork_config, ForgeConfig};
+use crate::scarb::config::{ForgeConfig, RawForgeConfig};
 use anyhow::{anyhow, Context, Result};
 use scarb_ui::args::PackagesFilter;
 
@@ -22,13 +22,14 @@ pub fn config_from_scarb_for_package(
         .ok_or_else(|| anyhow!("Failed to find metadata for package = {package}"))?
         .tool_metadata("snforge");
     let raw_config = if let Some(raw_metadata) = maybe_raw_metadata {
-        serde_json::from_value(raw_metadata.clone())?
+        serde_json::from_value::<RawForgeConfig>(raw_metadata.clone())?
     } else {
         Default::default()
     };
 
-    validate_raw_fork_config(&raw_config).context("Invalid config in Scarb.toml: ")?;
-    raw_config.try_into()
+    raw_config
+        .try_into()
+        .context("Invalid config in Scarb.toml: ")
 }
 
 pub fn build_contracts_with_scarb(filter: PackagesFilter) -> Result<()> {
@@ -71,11 +72,8 @@ mod tests {
     use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
     use assert_fs::TempDir;
     use camino::Utf8PathBuf;
-    use conversions::IntoConv;
     use indoc::{formatdoc, indoc};
     use scarb_metadata::MetadataCommand;
-    use starknet::core::types::BlockId;
-    use starknet::core::types::BlockTag::Latest;
     use std::str::FromStr;
 
     fn setup_package(package_name: &str) -> TempDir {
@@ -154,21 +152,24 @@ mod tests {
                         "FIRST_FORK_NAME".to_string(),
                         RawForkParams {
                             url: "http://some.rpc.url".to_string(),
-                            block_id: BlockId::Number(1)
+                            block_id_type: "number".to_string(),
+                            block_id_value: "1".to_string(),
                         },
                     ),
                     ForkTarget::new(
                         "SECOND_FORK_NAME".to_string(),
                         RawForkParams {
                             url: "http://some.rpc.url".to_string(),
-                            block_id: BlockId::Hash("1".to_string().into_())
+                            block_id_type: "hash".to_string(),
+                            block_id_value: "1".to_string(),
                         },
                     ),
                     ForkTarget::new(
                         "THIRD_FORK_NAME".to_string(),
                         RawForkParams {
                             url: "http://some.rpc.url".to_string(),
-                            block_id: BlockId::Tag(Latest)
+                            block_id_type: "tag".to_string(),
+                            block_id_value: "Latest".to_string(),
                         },
                     )
                 ],
@@ -313,7 +314,7 @@ mod tests {
             config_from_scarb_for_package(&scarb_metadata, &scarb_metadata.workspace.members[0])
                 .unwrap_err();
         assert!(
-            format!("{err:?}").contains("block_id = wrong_variant is not valid. Possible values = are \"number\", \"hash\" and \"tag\"")
+            format!("{err:?}").contains("block_id = wrong_variant is not valid. Possible values are = \"number\", \"hash\" and \"tag\"")
         );
     }
 

--- a/crates/forge/src/scarb/config.rs
+++ b/crates/forge/src/scarb/config.rs
@@ -1,9 +1,7 @@
 use crate::compiled_raw::RawForkParams;
 use anyhow::{bail, Result};
-use conversions::IntoConv;
 use itertools::Itertools;
 use serde::Deserialize;
-use starknet::core::types::{BlockId, BlockTag};
 use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Default)]
@@ -63,7 +61,7 @@ pub(crate) struct RawForkTarget {
     pub block_id: HashMap<String, String>,
 }
 
-pub(super) fn validate_raw_fork_config(raw_config: &RawForgeConfig) -> Result<()> {
+fn validate_raw_fork_config(raw_config: &RawForgeConfig) -> Result<()> {
     let forks = &raw_config.fork;
     let names: Vec<String> = forks.iter().map(|fork| fork.name.clone()).collect();
     let removed_duplicated_names: Vec<String> = names.clone().into_iter().unique().collect();
@@ -79,7 +77,7 @@ pub(super) fn validate_raw_fork_config(raw_config: &RawForgeConfig) -> Result<()
         };
 
         if !["number", "hash", "tag"].contains(&&**block_id_key) {
-            bail!("block_id = {block_id_key} is not valid. Possible values = are \"number\", \"hash\" and \"tag\"");
+            bail!("block_id = {block_id_key} is not valid. Possible values are = \"number\", \"hash\" and \"tag\"");
         }
 
         if block_id_key == "tag" && block_id_value != "Latest" {
@@ -94,24 +92,13 @@ impl TryFrom<RawForgeConfig> for ForgeConfig {
     type Error = anyhow::Error;
 
     fn try_from(value: RawForgeConfig) -> Result<Self, Self::Error> {
+        validate_raw_fork_config(&value)?;
         let mut fork_targets = vec![];
 
         for raw_fork_target in value.fork {
-            let block_id: Vec<BlockId> = raw_fork_target
-                .block_id
-                .iter()
-                .map(|(id_type, value)| match id_type.as_str() {
-                    "number" => BlockId::Number(value.parse().unwrap()),
-                    "hash" => BlockId::Hash(value.clone().into_()),
-                    "tag" => match value.as_str() {
-                        "Latest" => BlockId::Tag(BlockTag::Latest),
-                        _ => unreachable!(),
-                    },
-                    _ => unreachable!(),
-                })
-                .collect();
-
-            let [block_id] = block_id[..] else {
+            let [(block_id_type, block_id_value)] =
+                raw_fork_target.block_id.iter().collect_vec()[..]
+            else {
                 unreachable!()
             };
 
@@ -119,7 +106,8 @@ impl TryFrom<RawForgeConfig> for ForgeConfig {
                 raw_fork_target.name,
                 RawForkParams {
                     url: raw_fork_target.url,
-                    block_id,
+                    block_id_type: block_id_type.to_string(),
+                    block_id_value: block_id_value.clone(),
                 },
             ));
         }

--- a/crates/forge/test_utils/src/runner.rs
+++ b/crates/forge/test_utils/src/runner.rs
@@ -67,6 +67,7 @@ impl Contract {
         let build_output = Command::new("scarb")
             .current_dir(&dir)
             .arg("build")
+            .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .output()
             .context("Failed to build contracts with Scarb")?;

--- a/crates/forge/tests/data/component_macros/src/example.cairo
+++ b/crates/forge/tests/data/component_macros/src/example.cairo
@@ -51,9 +51,11 @@ mod MyContract {
         self.accesscontrol._grant_role(MINTER_ROLE, minter);
     }
 
-    /// This function can only be called by a minter.
-    #[external(v0)]
-    fn mint(ref self: ContractState) {
-        self.accesscontrol.assert_only_role(MINTER_ROLE);
+    #[abi(embed_v0)]
+    impl MyContractImpl of super::IMyContract<ContractState> {
+        /// This function can only be called by a minter.
+        fn mint(ref self: ContractState) {
+            self.accesscontrol.assert_only_role(MINTER_ROLE);
+        }
     }
 }

--- a/crates/forge/tests/data/contract_printing/src/lib.cairo
+++ b/crates/forge/tests/data/contract_printing/src/lib.cairo
@@ -13,7 +13,7 @@ mod HelloStarknet {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         fn increase_balance(ref self: ContractState, amount: felt252) {
             assert(amount != 0, 'Amount cannot be 0');

--- a/crates/forge/tests/data/contracts/block_hash_checker.cairo
+++ b/crates/forge/tests/data/contracts/block_hash_checker.cairo
@@ -19,7 +19,7 @@ mod BlockHashChecker {
         block_hash: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl BlockHashCheckerImpl of super::BlockHashCheckerInterface<ContractState> {
         fn write_block(ref self: ContractState) {
             let block_info = get_block_info().unbox();

--- a/crates/forge/tests/data/contracts/block_info_checker.cairo
+++ b/crates/forge/tests/data/contracts/block_info_checker.cairo
@@ -18,7 +18,7 @@ mod BlockInfoChecker {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IBlockInfoChecker of super::IBlockInfoChecker<ContractState> {
         fn read_block_number(self: @ContractState) -> u64 {
             get_block_info().unbox().block_number

--- a/crates/forge/tests/data/contracts/deploy_checker.cairo
+++ b/crates/forge/tests/data/contracts/deploy_checker.cairo
@@ -1,3 +1,11 @@
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IDeployChecker<TContractState> {
+    fn get_balance(self: @TContractState) -> felt252;
+    fn get_caller(self: @TContractState) -> ContractAddress;
+}
+
 #[starknet::contract]
 mod DeployChecker {
     use starknet::ContractAddress;
@@ -15,13 +23,14 @@ mod DeployChecker {
         (self.caller.read(), balance)
     }
 
-    #[external(v0)]
-    fn get_balance(self: @ContractState) -> felt252 {
-        self.balance.read()
-    }
+    #[abi(embed_v0)]
+    impl DeployCheckerImpl of super::IDeployChecker<ContractState> {
+        fn get_balance(self: @ContractState) -> felt252 {
+            self.balance.read()
+        }
 
-    #[external(v0)]
-    fn get_caller(self: @ContractState) -> ContractAddress {
-        self.caller.read()
+        fn get_caller(self: @ContractState) -> ContractAddress {
+            self.caller.read()
+        }
     }
 }

--- a/crates/forge/tests/data/contracts/elect_checker.cairo
+++ b/crates/forge/tests/data/contracts/elect_checker.cairo
@@ -24,7 +24,7 @@ mod ElectChecker {
         sequencer_address: ContractAddress
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IElectChecker of super::IElectChecker<ContractState> {
         fn get_sequencer_address(ref self: ContractState) -> ContractAddress {
             starknet::get_block_info().unbox().sequencer_address

--- a/crates/forge/tests/data/contracts/erc20.cairo
+++ b/crates/forge/tests/data/contracts/erc20.cairo
@@ -80,7 +80,7 @@ mod ERC20 {
             );
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IERC20Impl of super::IERC20<ContractState> {
         fn get_name(self: @ContractState) -> felt252 {
             self.name.read()

--- a/crates/forge/tests/data/contracts/gas_checker.cairo
+++ b/crates/forge/tests/data/contracts/gas_checker.cairo
@@ -15,7 +15,7 @@ mod GasChecker {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IGasCheckerImpl of super::IGasChecker<ContractState> {
         fn keccak(self: @ContractState) {
             keccak::keccak_u256s_le_inputs(array![1].span());

--- a/crates/forge/tests/data/contracts/hello_starknet.cairo
+++ b/crates/forge/tests/data/contracts/hello_starknet.cairo
@@ -15,7 +15,7 @@ mod HelloStarknet {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IHelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // Increases the balance by the given amount.
         fn increase_balance(ref self: ContractState, amount: felt252) {

--- a/crates/forge/tests/data/contracts/keccak_usage.cairo
+++ b/crates/forge/tests/data/contracts/keccak_usage.cairo
@@ -12,7 +12,7 @@ mod HelloKeccak {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IHelloKeccakImpl of super::IHelloKeccak<ContractState> {
         fn run_keccak(ref self: ContractState, input: Array<u64>) -> u256 {
             keccak_syscall(input.span()).unwrap_syscall()

--- a/crates/forge/tests/data/contracts/l1_handler_execute_checker.cairo
+++ b/crates/forge/tests/data/contracts/l1_handler_execute_checker.cairo
@@ -27,7 +27,7 @@ mod l1_handler_executor {
         self.l1_caller.write(l1_caller);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IBalanceTokenImpl of super::IBalanceToken<ContractState> {
         // Returns the current balance.
         fn get_balance(self: @ContractState) -> felt252 {

--- a/crates/forge/tests/data/contracts/mock_checker.cairo
+++ b/crates/forge/tests/data/contracts/mock_checker.cairo
@@ -29,7 +29,7 @@ mod MockChecker {
         self.stored_thing.write(arg1)
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IMockCheckerImpl of super::IMockChecker<ContractState> {
         fn get_thing(ref self: ContractState) -> felt252 {
             self.stored_thing.read()

--- a/crates/forge/tests/data/contracts/prank_checker.cairo
+++ b/crates/forge/tests/data/contracts/prank_checker.cairo
@@ -28,7 +28,7 @@ mod PrankChecker {
         caller_address: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IPrankChecker of super::IPrankChecker<ContractState> {
         fn get_caller_address(ref self: ContractState) -> felt252 {
             starknet::get_caller_address().into()

--- a/crates/forge/tests/data/contracts/roll_checker.cairo
+++ b/crates/forge/tests/data/contracts/roll_checker.cairo
@@ -23,7 +23,7 @@ mod RollChecker {
         block_number: u64
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IRollChecker of super::IRollChecker<ContractState> {
         fn get_block_number(ref self: ContractState) -> u64 {
             starknet::get_block_info().unbox().block_number

--- a/crates/forge/tests/data/contracts/serding.cairo
+++ b/crates/forge/tests/data/contracts/serding.cairo
@@ -15,19 +15,32 @@ struct AnotherCustomStruct {
     e: felt252,
 }
 
+#[starknet::interface]
+trait ISerding<TContractState> {
+    fn add_multiple_parts(
+        self: @TContractState,
+        custom_struct: CustomStruct,
+        another_struct: AnotherCustomStruct,
+        standalone_arg: felt252
+    ) -> felt252;
+}
+
 #[starknet::contract]
 mod Serding {
     use super::{CustomStruct, AnotherCustomStruct};
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
-    fn add_multiple_parts(
-        self: @ContractState,
-        custom_struct: CustomStruct,
-        another_struct: AnotherCustomStruct,
-        standalone_arg: felt252
-    ) -> felt252 {
-        custom_struct.a + custom_struct.b + custom_struct.c.d + another_struct.e + standalone_arg
+    #[abi(embed_v0)]
+    impl SerdingImpl of super::ISerding<ContractState> {
+        fn add_multiple_parts(
+            self: @ContractState,
+            custom_struct: CustomStruct,
+            another_struct: AnotherCustomStruct,
+            standalone_arg: felt252
+        ) -> felt252 {
+            custom_struct.a + custom_struct.b + custom_struct.c.d + another_struct.e + standalone_arg
+        }
     }
+
 }

--- a/crates/forge/tests/data/contracts/spoof_checker.cairo
+++ b/crates/forge/tests/data/contracts/spoof_checker.cairo
@@ -27,7 +27,7 @@ mod SpoofChecker {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpoofChecker of super::ISpoofChecker<ContractState> {
         fn get_tx_hash(ref self: ContractState) -> felt252 {
             starknet::get_tx_info().unbox().transaction_hash

--- a/crates/forge/tests/data/contracts/spy_events_checker.cairo
+++ b/crates/forge/tests/data/contracts/spy_events_checker.cairo
@@ -51,7 +51,7 @@ mod SpyEventsChecker {
         even_more_data: u256
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl ISpyEventsChecker of super::ISpyEventsChecker<ContractState> {
         fn do_not_emit(ref self: ContractState) {}
 

--- a/crates/forge/tests/data/contracts/warp_checker.cairo
+++ b/crates/forge/tests/data/contracts/warp_checker.cairo
@@ -24,7 +24,7 @@ mod WarpChecker {
     }
 
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl WarpChecker of super::IWarpChecker<ContractState> {
         fn get_block_timestamp(ref self: ContractState) -> u64 {
             starknet::get_block_info().unbox().block_timestamp

--- a/crates/forge/tests/data/file_reading/src/lib.cairo
+++ b/crates/forge/tests/data/file_reading/src/lib.cairo
@@ -96,42 +96,42 @@ mod tests {
     #[test]
     fn non_existent() {
         let file = FileTrait::new('data/non_existent.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 
     #[test]
     fn invalid_quotes() {
         let file = FileTrait::new('data/invalid_quotes.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 
     #[test]
     fn negative_number() {
         let file = FileTrait::new('data/negative_number.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 
     #[test]
     fn non_ascii() {
         let file = FileTrait::new('data/non_ascii.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 
     #[test]
     fn not_number_without_quotes() {
         let file = FileTrait::new('data/nan_without_quotes.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 
     #[test]
     fn too_large_number() {
         let file = FileTrait::new('data/too_large_number.txt');
-        let content = read_txt(@file);
+        read_txt(@file);
         assert(1 == 1, '');
     }
 }

--- a/crates/forge/tests/data/file_reading/tests/test.cairo
+++ b/crates/forge/tests/data/file_reading/tests/test.cairo
@@ -109,7 +109,7 @@ fn json_serialization() {
 #[should_panic]
 fn invalid_json() {
     let file = FileTrait::new('data/json/invalid.json');
-    let content = read_json(@file);
+    read_json(@file);
     assert(1 == 1, '');
 }
 
@@ -131,7 +131,7 @@ fn json_deserialization() {
     let content = FileParser::<E>::parse_json(@file).unwrap();
 
     let mut output_array = ArrayTrait::new();
-    let serialized = content.serialize(ref output_array);
+    content.serialize(ref output_array);
     assert(content.a == 23, '');
     assert(content.b.c == 'test', '');
     assert(content.b.e.c == 2, '');
@@ -159,7 +159,7 @@ fn valid_content_different_folder() {
 #[test]
 fn non_existent() {
     let file = FileTrait::new('data/non_existent.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }
 
@@ -167,41 +167,41 @@ fn non_existent() {
 #[should_panic]
 fn json_non_existent() {
     let file = FileTrait::new('data/non_existent.json');
-    let content = read_json(@file);
+    read_json(@file);
     assert(1 == 1, '');
 }
 
 #[test]
 fn invalid_quotes() {
     let file = FileTrait::new('data/invalid_quotes.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }
 
 #[test]
 fn negative_number() {
     let file = FileTrait::new('data/negative_number.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }
 
 #[test]
 fn non_ascii() {
     let file = FileTrait::new('data/non_ascii.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }
 
 #[test]
 fn not_number_without_quotes() {
     let file = FileTrait::new('data/nan_without_quotes.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }
 
 #[test]
 fn too_large_number() {
     let file = FileTrait::new('data/too_large_number.txt');
-    let content = read_txt(@file);
+    read_txt(@file);
     assert(1 == 1, '');
 }

--- a/crates/forge/tests/data/fuzzing/tests/exit_first_fuzz.cairo
+++ b/crates/forge/tests/data/fuzzing/tests/exit_first_fuzz.cairo
@@ -4,7 +4,7 @@ use fuzzing::fib;
 
 #[test]
 fn exit_first_fails_test(b: felt252) {
-    let result = adder(0, 1);
+    adder(0, 1);
     assert(1 == 2, '2 + b == 2 + b');
 }
 

--- a/crates/forge/tests/data/fuzzing/tests/exit_first_single_fail.cairo
+++ b/crates/forge/tests/data/fuzzing/tests/exit_first_single_fail.cairo
@@ -4,7 +4,7 @@ use fuzzing::fib;
 
 #[test]
 fn exit_first_fails_test() {
-    let result = adder(0, 1);
+    adder(0, 1);
     assert(1 == 2, '2 + b == 2 + b');
 }
 

--- a/crates/forge/tests/data/hello_workspaces/crates/addition/src/lib.cairo
+++ b/crates/forge/tests/data/hello_workspaces/crates/addition/src/lib.cairo
@@ -9,7 +9,7 @@ mod AdditionContract {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn answer(ref self: ContractState) -> felt252 {
         add(10, 20)
     }

--- a/crates/forge/tests/data/hello_workspaces/crates/fibonacci/src/lib.cairo
+++ b/crates/forge/tests/data/hello_workspaces/crates/fibonacci/src/lib.cairo
@@ -15,7 +15,7 @@ mod FibonacciContract {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn answer(ref self: ContractState) -> felt252 {
         add(fib(0, 1, 16), fib(0, 1, 8))
     }

--- a/crates/forge/tests/data/hello_workspaces/src/lib.cairo
+++ b/crates/forge/tests/data/hello_workspaces/src/lib.cairo
@@ -6,7 +6,7 @@ mod FibContract {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn answer(ref self: ContractState) -> felt252 {
         add(fib(0, 1, 16), fib(0, 1, 8))
     }

--- a/crates/forge/tests/data/simple_package/src/erc20.cairo
+++ b/crates/forge/tests/data/simple_package/src/erc20.cairo
@@ -80,7 +80,7 @@ mod ERC20 {
             );
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IERC20Impl of super::IERC20<ContractState> {
         fn get_name(self: @ContractState) -> felt252 {
             self.name.read()

--- a/crates/forge/tests/data/simple_package/src/hello_starknet.cairo
+++ b/crates/forge/tests/data/simple_package/src/hello_starknet.cairo
@@ -15,7 +15,7 @@ mod HelloStarknet {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IHelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // Increases the balance by the given amount.
         fn increase_balance(ref self: ContractState, amount: felt252) {

--- a/crates/forge/tests/data/virtual_workspace/dummy_name/fibonacci2/src/lib.cairo
+++ b/crates/forge/tests/data/virtual_workspace/dummy_name/fibonacci2/src/lib.cairo
@@ -15,7 +15,7 @@ mod FibonacciContract {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn answer(ref self: ContractState) -> felt252 {
         subtract(fib(0, 1, 16), fib(0, 1, 8))
     }

--- a/crates/forge/tests/data/virtual_workspace/dummy_name/subtraction/src/lib.cairo
+++ b/crates/forge/tests/data/virtual_workspace/dummy_name/subtraction/src/lib.cairo
@@ -9,7 +9,7 @@ mod SubtractionContract {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn answer(ref self: ContractState) -> felt252 {
         subtract(10, 20)
     }

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -116,19 +116,6 @@ fn print_error_if_attributes_incorrect() {
               ^***************************************************************************************^
         Error: Failed to compile test artifact, for detailed information go through the logs above
 
-
-        Stack backtrace:
-           0: std::backtrace::Backtrace::capture
-           1: anyhow::error::<impl anyhow::Error>::msg
-           2: scarb_snforge_test_collector::compilation::test_collector::collect_tests
-           3: rayon::iter::plumbing::bridge_producer_consumer::helper
-           4: rayon_core::join::join_context::[..].57472
-           5: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
-           6: rayon_core::registry::WorkerThread::wait_until_cold
-           7: std::sys_common::backtrace::__rust_begin_short_backtrace
-           8: core::ops::function::FnOnce::call_once[..]
-           9: std::sys::unix::thread::Thread::new::thread_start
-          10: __pthread_joiner_wake
     "#}
     );
 }

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -116,6 +116,19 @@ fn print_error_if_attributes_incorrect() {
               ^***************************************************************************************^
         Error: Failed to compile test artifact, for detailed information go through the logs above
 
+
+        Stack backtrace:
+           0: std::backtrace::Backtrace::capture
+           1: anyhow::error::<impl anyhow::Error>::msg
+           2: scarb_snforge_test_collector::compilation::test_collector::collect_tests
+           3: rayon::iter::plumbing::bridge_producer_consumer::helper
+           4: rayon_core::join::join_context::[..].57472
+           5: <rayon_core::job::StackJob<L,F,R> as rayon_core::job::Job>::execute
+           6: rayon_core::registry::WorkerThread::wait_until_cold
+           7: std::sys_common::backtrace::__rust_begin_short_backtrace
+           8: core::ops::function::FnOnce::call_once[..]
+           9: std::sys::unix::thread::Thread::new::thread_start
+          10: __pthread_joiner_wake
     "#}
     );
 }

--- a/crates/forge/tests/integration/declare.rs
+++ b/crates/forge/tests/integration/declare.rs
@@ -34,13 +34,13 @@ fn simple_declare() {
                     }
         
                     // Increases the balance by the given amount.
-                    #[external(v0)]
+                    #[abi(embed_v0)]
                     fn increase_balance(ref self: ContractState, amount: felt252) {
                         self.balance.write(self.balance.read() + amount);
                     }
         
                     // Decreases the balance by the given amount.
-                    #[external(v0)]
+                    #[abi(embed_v0)]
                     fn decrease_balance(ref self: ContractState, amount: felt252) {
                         self.balance.write(self.balance.read() - amount);
                     }

--- a/crates/forge/tests/integration/deploy.rs
+++ b/crates/forge/tests/integration/deploy.rs
@@ -66,7 +66,7 @@ fn deploy_syscall() {
             assert(dispatcher.get_balance() == 10, 'balance mismatch');
             assert(dispatcher.get_caller() == test_address(), 'caller mismatch');
 
-            let (contract_address_from_zero, span) = deploy_syscall(contract.class_hash, salt, calldata.span(), true).unwrap();
+            let (contract_address_from_zero, _) = deploy_syscall(contract.class_hash, salt, calldata.span(), true).unwrap();
             assert(contract_address != contract_address_from_zero, 'deploy from zero no effect');
         }
     "

--- a/crates/forge/tests/integration/elect.rs
+++ b/crates/forge/tests/integration/elect.rs
@@ -154,7 +154,6 @@ fn elect_complex() {
                 let elect_checker1 = IElectCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
                 let elect_checker2 = IElectCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
 
-                let old_seq_addr1 = elect_checker1.get_sequencer_address();
                 let old_seq_addr2 = elect_checker2.get_sequencer_address();
 
                 start_elect(CheatTarget::All, 123.try_into().unwrap());

--- a/crates/forge/tests/integration/env.rs
+++ b/crates/forge/tests/integration/env.rs
@@ -52,7 +52,7 @@ fn read_invalid_felt252() {
 
         #[test]
         fn test_read_invalid_felt252() {
-            let result = var('MY_ENV_VAR');
+            var('MY_ENV_VAR');
         }
     "
     ));
@@ -78,7 +78,7 @@ fn read_invalid_short_string() {
 
         #[test]
         fn test_read_invalid_short_string() {
-            let result = var('MY_ENV_VAR');
+            var('MY_ENV_VAR');
         }
     "
     ));
@@ -105,7 +105,7 @@ fn read_non_existent() {
 
         #[test]
         fn test_read_invalid_short_string() {
-            let result = var('MY_ENV_VAR');
+            var('MY_ENV_VAR');
         }
     "
     ));

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -119,7 +119,7 @@ fn test_bitwise_cost() {
         r"
             #[test]
             fn test_bitwise() {
-                let bitwise = 1_u8 & 1_u8;
+                let _bitwise = 1_u8 & 1_u8;
                 assert(1 == 1, 'error message');
             }
         "

--- a/crates/forge/tests/integration/roll.rs
+++ b/crates/forge/tests/integration/roll.rs
@@ -158,7 +158,6 @@ fn roll_complex() {
                 let roll_checker1 = IRollCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
                 let roll_checker2 = IRollCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
 
-                let old_block_number1 = roll_checker1.get_block_number();
                 let old_block_number2 = roll_checker2.get_block_number();
 
                 start_roll(CheatTarget::All, 123);

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -254,7 +254,7 @@ fn test_fork_get_block_info_fails() {
             #[test]
             #[fork(url: "{CHEATNET_RPC_URL}", block_id: BlockId::Number(999999999999))]
             fn test_fork_get_block_info_fails() {{
-                let block_info = starknet::get_block_info().unbox();
+                starknet::get_block_info().unbox();
             }}
         "#
     )

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -9,8 +9,6 @@ use forge::compiled_raw::RawForkParams;
 use forge::run;
 use forge::scarb::config::ForkTarget;
 use forge::test_filter::TestsFilter;
-use starknet::core::types::BlockId;
-use starknet::core::types::BlockTag::Latest;
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
 
@@ -130,7 +128,8 @@ fn fork_aliased_decorator() {
                 "FORK_NAME_FROM_SCARB_TOML".to_string(),
                 RawForkParams {
                     url: CHEATNET_RPC_URL.to_string(),
-                    block_id: BlockId::Tag(Latest),
+                    block_id_type: "Tag".to_string(),
+                    block_id_value: "Latest".to_string(),
                 },
             )],
         ))

--- a/crates/forge/tests/integration/spoof.rs
+++ b/crates/forge/tests/integration/spoof.rs
@@ -368,12 +368,8 @@ fn start_spoof_multiple() {
                 let contract_address_1 = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher_1 = ISpoofCheckerDispatcher { contract_address: contract_address_1 };
                 
-                let tx_hash_before_mock_1 = dispatcher_1.get_tx_hash();
-                
                 let contract_address_2 = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher_2 = ISpoofCheckerDispatcher { contract_address: contract_address_2 };
-                
-                let tx_hash_before_mock_2 = dispatcher_2.get_tx_hash();
 
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.transaction_hash = Option::Some(421);
@@ -435,8 +431,6 @@ fn start_spoof_all() {
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
 
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
-
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.transaction_hash = Option::Some(421);
                 start_spoof(CheatTarget::All, tx_info_mock);
@@ -450,8 +444,6 @@ fn start_spoof_all() {
                 let contract = declare('SpoofChecker');
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
-
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
 
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.nonce = Option::Some(411);

--- a/crates/forge/tests/integration/warp.rs
+++ b/crates/forge/tests/integration/warp.rs
@@ -166,7 +166,6 @@ fn warp_complex() {
                 let warp_checker1 = IWarpCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
                 let warp_checker2 = IWarpCheckerDispatcher { contract_address: contract.deploy(@ArrayTrait::new()).unwrap() };
 
-                let old_block_timestamp1 = warp_checker1.get_block_timestamp();
                 let old_block_timestamp2 = warp_checker2.get_block_timestamp();
 
                 start_warp(CheatTarget::All, 123);

--- a/design_documents/accessing_emitted_events.md
+++ b/design_documents/accessing_emitted_events.md
@@ -85,7 +85,7 @@ mod HelloEvent {
         name: felt252
     }
     
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IHelloEventImpl of super::IHelloEvent<ContractState> {
         fn emit_store_name(self: @ContractState, name: felt252) {
             // ...

--- a/docs/src/appendix/cheatcodes/get_class_hash.md
+++ b/docs/src/appendix/cheatcodes/get_class_hash.md
@@ -10,7 +10,7 @@ The main purpose of this cheatcode is to test upgradable contracts. For contract
 
 ```rust
 // ...
-#[external(v0)]
+#[abi(embed_v0)]
 impl IUpgradeableImpl of super::IUpgradeable<ContractState> {
     fn upgrade(ref self: ContractState, class_hash: starknet::ClassHash) {
         starknet::replace_class_syscall(class_hash).unwrap_syscall();

--- a/docs/src/appendix/cheatcodes/start_elect.md
+++ b/docs/src/appendix/cheatcodes/start_elect.md
@@ -17,7 +17,7 @@ struct Storage {
     stored_sequencer_address: ContractAddress
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn set_sequencer_address(ref self: ContractState) {
         self.stored_sequencer_address.write(starknet::get_block_info().unbox().sequencer_address);

--- a/docs/src/appendix/cheatcodes/start_mock_call.md
+++ b/docs/src/appendix/cheatcodes/start_mock_call.md
@@ -27,7 +27,7 @@ For contract implementation:
 
 ```rust
 // ...
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     #[storage]
     struct Storage {
@@ -87,7 +87,7 @@ impl IOtherContract<TContractState> {
     fn function_not_actually_implemented(self: @TContractState) -> felt252;
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn call_not_actually_implemented(self: @ContractState) -> felt252 {
         // ...

--- a/docs/src/appendix/cheatcodes/start_prank.md
+++ b/docs/src/appendix/cheatcodes/start_prank.md
@@ -18,7 +18,7 @@ struct Storage {
     stored_caller_address: ContractAddress
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn set_caller_address(ref self: ContractState) {
         self.stored_caller_address.write(starknet::get_caller_address());

--- a/docs/src/appendix/cheatcodes/start_roll.md
+++ b/docs/src/appendix/cheatcodes/start_roll.md
@@ -18,7 +18,7 @@ struct Storage {
     stored_block_number: u64
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn set_block_number(ref self: ContractState) {
         self.stored_block_number.write(starknet::get_block_info().unbox().block_number);

--- a/docs/src/appendix/cheatcodes/start_spoof.md
+++ b/docs/src/appendix/cheatcodes/start_spoof.md
@@ -36,7 +36,7 @@ struct Storage {
     stored_hash: felt252
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn store_tx_hash(ref self: ContractState) {
         let tx_info = get_tx_info().unbox();

--- a/docs/src/appendix/cheatcodes/start_warp.md
+++ b/docs/src/appendix/cheatcodes/start_warp.md
@@ -18,7 +18,7 @@ struct Storage {
     stored_block_timestamp: u64
 }
 
-#[external(v0)]
+#[abi(embed_v0)]
 impl IContractImpl of IContract<ContractState> {
     fn set_block_timestamp(ref self: ContractState) {
         self.stored_block_timestamp.write(starknet::get_block_timestamp());

--- a/docs/src/testing/contracts.md
+++ b/docs/src/testing/contracts.md
@@ -31,7 +31,7 @@ mod HelloStarknet {
         balance: felt252,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // Increases the balance by the given amount.
         fn increase_balance(ref self: ContractState, amount: felt252) {
@@ -109,7 +109,7 @@ mod HelloStarknet {
 
     // ...
     
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // ...
 

--- a/docs/src/testing/debugging.md
+++ b/docs/src/testing/debugging.md
@@ -106,7 +106,7 @@ mod HelloStarknet {
         // ...
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         fn increase_balance(ref self: ContractState, amount: felt252) {
             self.balance.write(self.balance.read() + amount);

--- a/docs/src/testing/testing_contract_internals.md
+++ b/docs/src/testing/testing_contract_internals.md
@@ -111,7 +111,7 @@ mod Emitter {
     #[storage]
     struct Storage {}
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn emit_event(
         ref self: ContractState,
     ) {
@@ -193,14 +193,14 @@ mod LibraryContract {
         value: felt252
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn get_value(
         self: @ContractState,
     ) -> felt252 {
        self.value.read()
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     fn set_value(
         ref self: ContractState,
         number: felt252

--- a/docs/src/testing/using-cheatcodes.md
+++ b/docs/src/testing/using-cheatcodes.md
@@ -48,7 +48,7 @@ mod HelloStarknet {
         self.blk_timestamp.write(starknet::get_block_info().unbox().block_timestamp);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl IHelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // Increases the balance by the given amount.
         fn increase_balance(ref self: ContractState, amount: felt252) {

--- a/starknet_forge_template/src/lib.cairo
+++ b/starknet_forge_template/src/lib.cairo
@@ -11,7 +11,7 @@ mod HelloStarknet {
         balance: felt252, 
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         fn increase_balance(ref self: ContractState, amount: felt252) {
             assert(amount != 0, 'Amount cannot be 0');


### PR DESCRIPTION
Tests work locally when running scarb built from commit [6d8703abbb9fc7e0e0a4b4c19ba73dd3b04198cb](https://github.com/software-mansion/scarb/commit/6d8703abbb9fc7e0e0a4b4c19ba73dd3b04198cb)
## Introduced changes

- we now get `Strings` instead of `BlockId` from scarb artifacts:
  - we use `ForkParamsString` instead of `RawForkParams` and `ForkConfigString` instead of `RawForkConfig`

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
