### PR TITLE
Add option to get private key from file in `account add`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cast
+
+### Added
+
+- `--private-key-file` option to `account add` command that allows to provide a path to the file holding account private key
+
 ## [0.11.0] - 2023-11-22
 
 ### Forge

--- a/crates/cast/src/starknet_commands/account/add.rs
+++ b/crates/cast/src/starknet_commands/account/add.rs
@@ -64,12 +64,12 @@ pub async fn add(
     provider: &JsonRpcClient<HttpTransport>,
     add: &Add,
 ) -> Result<AccountAddResponse> {
-    let private_key_field_element = match &add.private_key_file_path {
+    let private_key = match &add.private_key_file_path {
         Some(file_path) => get_private_key_from_file(file_path)
             .with_context(|| format!("Failed to obtain private key from the file {file_path}"))?,
         None => add.private_key.unwrap(),
     };
-    let private_key = &SigningKey::from_secret_scalar(private_key_field_element);
+    let private_key = &SigningKey::from_secret_scalar(private_key);
     if let Some(public_key) = &add.public_key {
         ensure!(
             public_key == &private_key.verifying_key().scalar(),

--- a/docs/src/appendix/cast/account/add.md
+++ b/docs/src/appendix/cast/account/add.md
@@ -30,16 +30,14 @@ Specify account deployment status as deployed.
 If not passed, sncast will check whether the account is deployed or not.
 
 ## `--private-key <PRIVATE_KEY>`
-Optional.
+Optional. Required if `--private-key-file` is not passed.
 
 Account private key.
-Required if `--private-key-file` is not passed.
 
 ## `--private-key-file <PRIVATE_KEY_FILE_PATH>`
-Optional.
+Optional. Required if `--private-key-file` is not passed.
 
 Path to the file holding account private key.
-Required if `--private-key-file` is not passed.
 
 ## `--public-key <PUBLIC_KEY>`
 Optional.

--- a/docs/src/appendix/cast/account/add.md
+++ b/docs/src/appendix/cast/account/add.md
@@ -30,9 +30,16 @@ Specify account deployment status as deployed.
 If not passed, sncast will check whether the account is deployed or not.
 
 ## `--private-key <PRIVATE_KEY>`
-Required.
+Optional.
 
 Account private key.
+Required if `--private-key-file` is not passed.
+
+## `--private-key-file <PRIVATE_KEY_FILE_PATH>`
+Optional.
+
+Path to the file holding account private key.
+Required if `--private-key-file` is not passed.
 
 ## `--public-key <PUBLIC_KEY>`
 Optional.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #696 

## Introduced changes

<!-- A brief description of the changes -->

- Allow user to provide account private key from a file in `account add` command

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
