### PR TITLE
Fix Spelling Error in cairo_deployment_scripts.md

### DIFF
--- a/design_documents/cairo_deployment_scripts.md
+++ b/design_documents/cairo_deployment_scripts.md
@@ -31,7 +31,7 @@ Propose a solution with an example syntax, that would allow to write deployment 
 This section is split into smaller subsections describing things we will need to tackle while implementing the solution.
 
 ### sncast commands
-Specific sncast commands (declare, deploy, account) could be imported as regular functions to the scipts, and called as such.
+Specific sncast commands (declare, deploy, account) could be imported as regular functions to the scripts, and called as such.
 Our functions return specific types (structs defined in `cast/src/helpers/response_structs.rs`), that make retrieving
 essential information easier, so we should be good on that front.
 


### PR DESCRIPTION

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes
**Description:**
Fixes a spelling error in the word "scipts" by correcting it to "scripts."

<!-- A brief description of the changes -->

**Changes Made:**
Corrected the spelling of "scipts" to "scripts" for accuracy and clarity.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
