### PR TITLE
fix: typos, bump to v0.12.0

### DIFF
--- a/docs/src/appendix/cast-library/declare.md
+++ b/docs/src/appendix/cast-library/declare.md
@@ -19,12 +19,13 @@ struct DeclareResult {
 ```rust
 use sncast_std::{declare, DeclareResult};
 use debug::PrintTrait;
+use starknet::class_hash_to_felt252
 
 fn main() {
     let max_fee = 9999999;
     let declare_result = declare('HelloStarknet', Option::Some(max_fee), Option::None);
 
     let class_hash = declare_result.class_hash;
-    class_hash.print();
+    class_hash_to_felt252(class_hash).print();
 }
 ```

--- a/docs/src/appendix/cast-library/declare.md
+++ b/docs/src/appendix/cast-library/declare.md
@@ -22,7 +22,7 @@ use debug::PrintTrait;
 
 fn main() {
     let max_fee = 9999999;
-    let declare_result = declare('HelloStarknet', Option::Some(max_fee), nonce::None);
+    let declare_result = declare('HelloStarknet', Option::Some(max_fee), Option::None);
 
     let class_hash = declare_result.class_hash;
     class_hash.print();

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -24,5 +24,5 @@
 >
 > ```toml
 > [dependencies]
-> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.7.1" }
+> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 > ```

--- a/docs/src/appendix/forge-library.md
+++ b/docs/src/appendix/forge-library.md
@@ -17,5 +17,5 @@
 > using appropriate release tag.
 >```toml
 > [dependencies]
-> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.7.1" }
+> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 > ```

--- a/docs/src/getting-started/first-steps.md
+++ b/docs/src/getting-started/first-steps.md
@@ -50,14 +50,14 @@ Add the following line under `[dependencies]` section in the `Scarb.toml` file.
 # ...
 
 [dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.7.1" }
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 ```
 
 Make sure that the version in `tag` matches `snforge`. You can check the currently installed version with
 
 ```shell
 $ snforge --version
-forge 0.7.1
+forge 0.12.0
 ```
 
 It is also possible to add this dependency
@@ -67,7 +67,7 @@ command.
 ```shell
 $ scarb add snforge_std \
  --git https://github.com/foundry-rs/starknet-foundry.git \
- --tag v0.7.1
+ --tag v0.12.0
 ```
 
 Additionally, ensure that `casm` codegen is enabled in the `Scarb.toml` file.

--- a/docs/src/starknet/script.md
+++ b/docs/src/starknet/script.md
@@ -4,14 +4,14 @@
 
 > ⚠️⚠️⚠️ Highly experimental code, a subject to change  ⚠️⚠️⚠️
 
-Starknet Foundry cast can be used to run deployment scripts written in Cairo, using `script` subcommand. 
-It aims to provide similar functionality to Foundry's `forge script`. 
+Starknet Foundry cast can be used to run deployment scripts written in Cairo, using `script` subcommand.
+It aims to provide similar functionality to Foundry's `forge script`.
 
 To start writing a deployment script in Cairo just add `cast_std` as a dependency to you scarb package and make sure to
 have a `main` function in the module you want to run. `cast_std` docs can be found [here](../appendix/cast-library.md).
 
-Please note that **`sncast script` is in development**. While it is already possible to declare, deploy, invoke and call 
-contracts from within Cairo, its interface, internals and feature set can change rapidly each version. 
+Please note that **`sncast script` is in development**. While it is already possible to declare, deploy, invoke and call
+contracts from within Cairo, its interface, internals and feature set can change rapidly each version.
 
 Some of the planned features that will be included in future versions are:
 
@@ -93,15 +93,14 @@ use debug::PrintTrait;
 fn main() {
     let max_fee = 99999999999999999;
     let salt = 0x3;
-    let nonce = get_nonce('latest');
 
-    let declare_result = declare('Map', Option::Some(max_fee), Option::Nonce);
+    let declare_result = declare('Map', Option::Some(max_fee), Option::None);
 
     let class_hash = declare_result.class_hash;
     let deploy_result = deploy(
         class_hash, ArrayTrait::new(), Option::Some(salt), true, Option::Some(max_fee), Option::Some(nonce)
     );
-    
+
     'Deployed the contract to address'.print();
     deploy_result.contract_address.print();
 
@@ -109,7 +108,7 @@ fn main() {
     let invoke_result = invoke(
         deploy_result.contract_address, 'put', array![0x1, 0x2], Option::Some(max_fee), Option::Some(invoke_nonce)
     );
-    
+
     'Invoke tx hash is'.print();
     invoke_result.transaction_hash.print();
 
@@ -165,7 +164,7 @@ $ sncast \
   --url http://127.0.0.1:5050 \
   --account example_user \
   script map_script
-  
+
 [DEBUG]	Contract address               	(raw: 0x436f6e74726163742061646472657373
 [DEBUG]	                               	(raw: 0x6f9492c9c2751ba5ccab5b7611068a6347d7b313c6f073d2edea864f062d730
 [DEBUG]	Invoke tx hash                 	(raw: 0x496e766f6b652074782068617368

--- a/docs/src/starknet/script.md
+++ b/docs/src/starknet/script.md
@@ -96,6 +96,7 @@ fn main() {
 
     let declare_result = declare('Map', Option::Some(max_fee), Option::None);
 
+    let nonce = get_nonce('latest');
     let class_hash = declare_result.class_hash;
     let deploy_result = deploy(
         class_hash, ArrayTrait::new(), Option::Some(salt), true, Option::Some(max_fee), Option::Some(nonce)

--- a/docs/src/testing/contracts.md
+++ b/docs/src/testing/contracts.md
@@ -3,11 +3,11 @@
 > ℹ️ **Info**
 > To use the library functions designed for testing smart contracts,
 > you need to add `snforge_std` package as a dependency in
-> your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#adding-a-dependency) 
+> your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#adding-a-dependency)
 > using appropriate release tag.
 >```toml
 > [dependencies]
-> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.7.1" }
+> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 > ```
 
 Using unit testing as much as possible is a good practice, as it makes your test suites run faster. However, when
@@ -38,7 +38,7 @@ mod HelloStarknet {
             self.balance.write(self.balance.read() + amount);
         }
 
-        // Gets the balance. 
+        // Gets the balance.
         fn get_balance(self: @ContractState) -> felt252 {
             self.balance.read()
         }
@@ -61,7 +61,7 @@ fn call_and_invoke() {
     let contract = declare('HelloStarknet');
     // Alternatively we could use `deploy_syscall` here
     let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
-    
+
     // Create a Dispatcher object that will allow interacting with the deployed contract
     let dispatcher = IHelloStarknetDispatcher { contract_address };
 
@@ -108,7 +108,7 @@ mod HelloStarknet {
     use array::ArrayTrait;
 
     // ...
-    
+
     #[external(v0)]
     impl HelloStarknetImpl of super::IHelloStarknet<ContractState> {
         // ...
@@ -163,7 +163,7 @@ Using `SafeDispatcher` we can test that the function in fact panics with an expe
 #[test]
 fn handling_errors() {
     // ...
-    
+
     let contract_address = contract.deploy(@calldata).unwrap();
     let safe_dispatcher = IHelloStarknetSafeDispatcher { contract_address };
 

--- a/docs/src/testing/debugging.md
+++ b/docs/src/testing/debugging.md
@@ -2,11 +2,11 @@
 
 > ℹ️ **Info**
 > To use `PrintTrait` you need to add `snforge_std` package as a dependency in
-> your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#adding-a-dependency) 
+> your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#adding-a-dependency)
 > using appropriate release tag.
 >```toml
 > [dependencies]
-> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.7.1" }
+> snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.12.0" }
 > ```
 
 Starknet Foundry standard library adds a utility method for printing inside tests and contracts to facilitate simple debugging.
@@ -88,8 +88,8 @@ Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 
 ## In contracts
 > ⚠️ **Warning**
-> 
-> - Make sure to remove all of the prints before compiling the final version of your contract. 
+>
+> - Make sure to remove all of the prints before compiling the final version of your contract.
 > - This feature is highly experimental and breaking changes are to be expected.
 
 Here is an example contract:
@@ -102,7 +102,7 @@ mod HelloStarknet {
 
     #[storage]
     struct Storage {
-        balance: felt252, 
+        balance: felt252,
         // ...
     }
 
@@ -115,7 +115,7 @@ mod HelloStarknet {
             self.balance.read().print();
         }
     }
-    
+
     // ...
 }
 ```
@@ -125,7 +125,7 @@ With a test:
 fn test_increase_balance() {
     let contract_address = deploy_contract('HelloStarknet');
     let dispatcher = IHelloStarknetDispatcher { contract_address };
-    
+
     safe_dispatcher.increase_balance(42);
 
     // ...
@@ -133,7 +133,7 @@ fn test_increase_balance() {
 ```
 We get the following output:
 ```shell
-$ snforge test                                                                                    
+$ snforge test
 Collected 1 test(s) from package_name package
 Running 0 test(s) from src/
 Running 1 test(s) from tests/
@@ -143,7 +143,7 @@ original value: [42], converted to a string: [*]
 Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 
-**Note**: 
+**Note**:
 - the print output shows **above** the test, this may change in the future.
 - the warning is to be expected as the prints should be removed after debugging.
 


### PR DESCRIPTION
## Introduced changes

* Fixes a bunch of typos around using nonces 
* Bumped the version from 0.7.1 to 0.12.0 in code snippets
* Fixing a snippet in declare to print a class hash

BTW using `get_nonce('latest')` as is in the doc didn't work for me, I always got `error: Got an exception while executing a hint: Hint Error: Invalid transaction nonce` but didn't investigate further.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
