### PR TITLE
Test benchmarks in CI

### DIFF
--- a/.github/workflows/check_benchmarks.yml
+++ b/.github/workflows/check_benchmarks.yml
@@ -1,0 +1,21 @@
+name: Check benchmarks
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  benchmarks:
+    name: Verify benchmarks are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
+      - uses: software-mansion/setup-scarb@v1.3.2
+
+      - run: cargo test --benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
 
   benchmarks:
     name: Verify benchmarks are up to date
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,3 +177,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: typos-action
         uses: crate-ci/typos@v1.16.23
+
+  benchmarks:
+    name: Verify benchmarks are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
+
+      - run: cargo test --benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,17 +177,3 @@ jobs:
       - uses: actions/checkout@v4
       - name: typos-action
         uses: crate-ci/typos@v1.16.23
-
-  benchmarks:
-    name: Verify benchmarks are up to date
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@439cf607258077187679211f12aa6f19af4a0af7
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
-      - uses: software-mansion/setup-scarb@v1.3.2
-
-      - run: cargo test --benches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,5 +187,6 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8
+      - uses: software-mansion/setup-scarb@v1.3.2
 
       - run: cargo test --benches


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Added a CI step that runs benchmarks using `cargo run --benches` command. This will run each benchmark only once, verifying that it passes, without time measurements etc.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
