### PR TITLE
Fix parsing `EntryPointExecutionError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Argument `max-fee` in `account deploy` is now optional
 
+#### Fixed
+
+- Parsing panic data from call contract result
+
 ## [0.13.0] - 2023-12-14
 
 ### Forge
@@ -226,7 +230,7 @@ from now on the only officially supported cairo compiler version is 2
 
 - `var` library function for reading environmental variables
 
-### Fixed
+#### Fixed
 - Using any concrete `block_id` when using forking mode, would lead to crashes 
 
 ## [0.7.0] - 2023-09-27
@@ -268,7 +272,7 @@ from now on the only officially supported cairo compiler version is 2
 - printing failures summary at the end of an execution
 - filtering tests now uses an absolute module tree path — it is possible to filter tests by module names, etc.
 
-### Fixed
+#### Fixed
 
 - non-zero exit code is returned when any tests fail
 - mock_call works with dispatchers if contract does not exists

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_lang_runner::casm_run::format_next_item;
-use cairo_lang_runner::short_string::as_cairo_short_string;
 use std::sync::Arc;
 
 use crate::constants::TEST_ADDRESS;

--- a/crates/cheatnet/tests/builtins/mod.rs
+++ b/crates/cheatnet/tests/builtins/mod.rs
@@ -1,2 +1,2 @@
-mod segment_arena;
 mod panic_call;
+mod segment_arena;

--- a/crates/cheatnet/tests/builtins/mod.rs
+++ b/crates/cheatnet/tests/builtins/mod.rs
@@ -1,1 +1,2 @@
 mod segment_arena;
+mod panic_call;

--- a/crates/cheatnet/tests/builtins/panic_call.rs
+++ b/crates/cheatnet/tests/builtins/panic_call.rs
@@ -1,0 +1,59 @@
+use crate::common::state::create_cheatnet_state;
+use crate::common::{deploy_contract, felt_selector_from_name, state::create_cached_state};
+use crate::{assert_error, assert_panic};
+use cairo_felt::Felt252;
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
+use conversions::felt252::FromShortString;
+use num_traits::Bounded;
+
+#[test]
+fn call_contract_error() {
+    let mut cached_state = create_cached_state();
+    let (mut blockifier_state, mut cheatnet_state) = create_cheatnet_state(&mut cached_state);
+
+    let contract_address =
+        deploy_contract(&mut blockifier_state, &mut cheatnet_state, "PanicCall", &[]);
+
+    let selector = felt_selector_from_name("panic_call");
+
+    let output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &contract_address,
+        &selector,
+        &[Felt252::from(420)],
+    )
+    .unwrap();
+
+    assert_error!(output, "0x496e70757420746f6f206c6f6e6720666f7220617267756d656e7473 ('Input too long for arguments')");
+}
+
+#[test]
+fn call_contract_panic() {
+    let mut cached_state = create_cached_state();
+    let (mut blockifier_state, mut cheatnet_state) = create_cheatnet_state(&mut cached_state);
+
+    let contract_address =
+        deploy_contract(&mut blockifier_state, &mut cheatnet_state, "PanicCall", &[]);
+
+    let selector = felt_selector_from_name("panic_call");
+
+    let output = call_contract(
+        &mut blockifier_state,
+        &mut cheatnet_state,
+        &contract_address,
+        &selector,
+        &[],
+    )
+    .unwrap();
+
+    assert_panic!(
+        output,
+        vec![
+            Felt252::from_short_string("shortstring").unwrap(),
+            Felt252::from(0),
+            Felt252::max_value(),
+            Felt252::from_short_string("shortstring2").unwrap()
+        ]
+    );
+}

--- a/crates/cheatnet/tests/builtins/segment_arena.rs
+++ b/crates/cheatnet/tests/builtins/segment_arena.rs
@@ -1,3 +1,4 @@
+use crate::assert_success;
 use crate::common::state::create_cheatnet_state;
 use crate::common::{deploy_contract, felt_selector_from_name, state::create_cached_state};
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
@@ -19,7 +20,8 @@ fn segment_arena_simple() {
         &contract_address,
         &selector,
         &[],
-    );
+    )
+    .unwrap();
 
-    assert!(matches!(output, Result::Ok(_)));
+    assert_success!(output, &[]);
 }

--- a/crates/cheatnet/tests/cheatcodes/deploy.rs
+++ b/crates/cheatnet/tests/cheatcodes/deploy.rs
@@ -246,7 +246,7 @@ fn deploy_missing_arguments_in_constructor() {
 
     assert!(match output {
         Err(CheatcodeError::Unrecoverable(EnhancedHintError::Hint(HintError::CustomHint(msg)))) =>
-            msg.as_ref() == "Failed to deserialize param #2",
+            msg.as_ref() == "0x4661696c656420746f20646573657269616c697a6520706172616d202332 ('Failed to deserialize param #2')",
         _ => false,
     });
 }
@@ -270,7 +270,7 @@ fn deploy_too_many_arguments_in_constructor() {
 
     assert!(match output {
         Err(CheatcodeError::Unrecoverable(EnhancedHintError::Hint(HintError::CustomHint(msg)))) =>
-            msg.as_ref() == "Input too long for arguments",
+            msg.as_ref() == "0x496e70757420746f6f206c6f6e6720666f7220617267756d656e7473 ('Input too long for arguments')",
         _ => false,
     });
 }

--- a/crates/cheatnet/tests/common/assertions.rs
+++ b/crates/cheatnet/tests/common/assertions.rs
@@ -20,8 +20,8 @@ macro_rules! assert_panic {
         assert!(
             matches!(
                 $call_contract_output.result,
-                cheatnet::rpc::CallContractResult::Failure(
-                    cheatnet::rpc::CallContractFailure::Panic { panic_data, .. }
+                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractResult::Failure(
+                    cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractFailure::Panic { panic_data, .. }
                 )
                 if panic_data == $expected_data
             )

--- a/crates/cheatnet/tests/contracts/src/lib.cairo
+++ b/crates/cheatnet/tests/contracts/src/lib.cairo
@@ -9,4 +9,5 @@ mod elect;
 mod starknet;
 mod warp;
 mod segment_arena_user;
+mod panic_call;
 mod store_load;

--- a/crates/cheatnet/tests/contracts/src/panic_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/panic_call.cairo
@@ -1,0 +1,10 @@
+#[starknet::contract]
+mod PanicCall {
+    #[storage]
+    struct Storage {}
+
+    #[external(v0)]
+    fn panic_call(ref self: ContractState) {
+        panic(array!['shortstring', 0, 0x800000000000011000000000000000000000000000000000000000000000000, 'shortstring2']);
+    }
+}

--- a/crates/cheatnet/tests/contracts/src/panic_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/panic_call.cairo
@@ -5,6 +5,13 @@ mod PanicCall {
 
     #[external(v0)]
     fn panic_call(ref self: ContractState) {
-        panic(array!['shortstring', 0, 0x800000000000011000000000000000000000000000000000000000000000000, 'shortstring2']);
+        panic(
+            array![
+                'shortstring',
+                0,
+                0x800000000000011000000000000000000000000000000000000000000000000,
+                'shortstring2'
+            ]
+        );
     }
 }

--- a/crates/cheatnet/tests/contracts/src/segment_arena_user.cairo
+++ b/crates/cheatnet/tests/contracts/src/segment_arena_user.cairo
@@ -2,7 +2,8 @@
 mod SegmentArenaUser {
     #[storage]
     struct Storage {}
-    #[abi(embed_v0)]
+
+    #[external(v0)]
     fn interface_function(ref self: ContractState) {
         let felt_dict: Felt252Dict<felt252> = Default::default();
     }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1406

## Introduced changes

<!-- A brief description of the changes -->

- Fix `invalid entry point error` in segment arena test
- Fix `assert_panic` macro
- The error string from `CallContractFailure::Error` looks now like:
```rust
0x73686f7274737472696e67 ('shortstring')\n0x0 ('')\n0x800000000000011000000000000000000000000000000000000000000000000\n0x73686f7274737472696e6732 ('shortstring2')
```

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
