### PR TITLE
feat: assert_not_emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Forge
 
+#### Added
+
+- `assert_not_emitted` assert to check if an event was not emitted
+
 #### Changed 
 
 - fields from `starknet::info::v2::TxInfo` are now part of `TxInfoMock` from `snforge_std::cheatcodes::tx_info`

--- a/crates/forge/tests/integration/spy_events.rs
+++ b/crates/forge/tests/integration/spy_events.rs
@@ -480,3 +480,145 @@ fn emit_unnamed_event() {
 
     assert_passed!(result);
 }
+
+#[test]
+fn assert_not_emitted_pass() {
+    let test = test_case!(
+        indoc!(
+            r"
+            use array::ArrayTrait;
+            use result::ResultTrait;
+            use starknet::ContractAddress;
+            use snforge_std::{ declare, ContractClassTrait, spy_events, EventSpy,
+                EventAssertions, SpyOn };
+
+            #[starknet::interface]
+            trait ISpyEventsChecker<TContractState> {
+                fn do_not_emit(ref self: TContractState);
+            }
+
+            #[starknet::contract]
+            mod SpyEventsChecker {
+                use starknet::ContractAddress;
+
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    FirstEvent: FirstEvent,
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct FirstEvent {
+                    some_data: felt252
+                }
+            }
+
+            #[test]
+            fn assert_not_emitted_pass() {
+                let contract = declare('SpyEventsChecker');
+                let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = ISpyEventsCheckerDispatcher { contract_address };
+
+                let mut spy = spy_events(SpyOn::One(contract_address));
+                dispatcher.do_not_emit();
+
+                spy.assert_not_emitted(@array![
+                    (
+                        contract_address,
+                        SpyEventsChecker::Event::FirstEvent(
+                            SpyEventsChecker::FirstEvent { some_data: 123 }
+                        )
+                    )
+                ]);
+            }
+        "
+        ),
+        Contract::from_code_path(
+            "SpyEventsChecker".to_string(),
+            Path::new("tests/data/contracts/spy_events_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+fn assert_not_emitted_fails() {
+    let test = test_case!(
+        indoc!(
+            r"
+            use array::ArrayTrait;
+            use result::ResultTrait;
+            use starknet::ContractAddress;
+            use snforge_std::{ declare, ContractClassTrait, spy_events, EventSpy, EventFetcher,
+                event_name_hash, EventAssertions, SpyOn };
+
+            #[starknet::interface]
+            trait ISpyEventsChecker<TContractState> {
+                fn emit_one_event(ref self: TContractState, some_data: felt252);
+            }
+
+            #[starknet::contract]
+            mod SpyEventsChecker {
+                use starknet::ContractAddress;
+
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    FirstEvent: FirstEvent
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct FirstEvent {
+                    some_data: felt252
+                }
+            }
+
+            #[test]
+            fn spy_events_simple() {
+                let contract = declare('SpyEventsChecker');
+                let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = ISpyEventsCheckerDispatcher { contract_address };
+
+                let mut spy = spy_events(SpyOn::One(contract_address));
+                assert(spy._id == 0, 'Id should be 0');
+
+                dispatcher.emit_one_event(123);
+
+                spy.assert_not_emitted(@array![
+                    (
+                        contract_address,
+                        SpyEventsChecker::Event::FirstEvent(
+                            SpyEventsChecker::FirstEvent { some_data: 123 }
+                        )
+                    )
+                ]);
+            }
+        "
+        ),
+        Contract::from_code_path(
+            "SpyEventsChecker".to_string(),
+            Path::new("tests/data/contracts/spy_events_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_failed!(result);
+    assert_case_output_contains!(
+        result,
+        "assert_not_emitted_fails",
+        "Event with matching data and"
+    );
+    assert_case_output_contains!(result, "assert_not_emitted_fails", "keys was emitted");
+}

--- a/crates/forge/tests/integration/spy_events.rs
+++ b/crates/forge/tests/integration/spy_events.rs
@@ -584,7 +584,7 @@ fn assert_not_emitted_fails() {
             }
 
             #[test]
-            fn spy_events_simple() {
+            fn assert_not_emitted_fails() {
                 let contract = declare('SpyEventsChecker');
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpyEventsCheckerDispatcher { contract_address };

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -165,7 +165,25 @@ The flow is much simpler (thanks to `EventAssertions` trait). Let's go through i
 
 - After the assertion, found events are removed from the spy. It stays clean and ready for the next events.
 
-In cases where you want to test an event was *not* emitted, use the `assert_not_emitted` function. It works similarly as `assert_emitted` with the only difference that it fails if an event was emitted during the execution.
+## Asserting event was not emitted
+
+In cases where you want to test an event was *not* emitted, use the `assert_not_emitted` function.
+It works similarly as `assert_emitted` with the only difference that it fails if an event was emitted during the execution.
+
+Given the example above, we can check that a different `FirstEvent` was not emitted:
+
+```rust
+spy.assert_not_emitted(@array![
+    (
+        contract_address,
+        SpyEventsChecker::Event::FirstEvent(
+            SpyEventsChecker::FirstEvent { some_data: 456 }
+        )
+    )
+]);
+```
+
+Note that both the event name and event data are checked. If a function emitted an event with the same name but a different payload, the `assert_not_emitted` function will pass.
 
 ## Splitting Events Between Multiple Spies
 

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -165,6 +165,8 @@ The flow is much simpler (thanks to `EventAssertions` trait). Let's go through i
 
 - After the assertion, found events are removed from the spy. It stays clean and ready for the next events.
 
+In cases where you want to test an event was *not* emitted, use the `assert_not_emitted` function. It works similarly as `assert_emitted` with the only difference that it fails if an event was emitted during the execution.
+
 ## Splitting Events Between Multiple Spies
 
 Sometimes it is easier to split events between multiple spies. Let's do it.

--- a/docs/src/appendix/cheatcodes/spy_events.md
+++ b/docs/src/appendix/cheatcodes/spy_events.md
@@ -35,6 +35,7 @@ trait EventFetcher {
 
 trait EventAssertions<T, impl TEvent: starknet::Event<T>, impl TDrop: Drop<T>> {
     fn assert_emitted(ref self: EventSpy, events: @Array<(ContractAddress, T)>);
+    fn assert_not_emitted(ref self: EventSpy, events: @Array<(ContractAddress, T)>);
 }
 ```
 
@@ -67,7 +68,7 @@ mod SpyEventsChecker {
 ```rust
 use snforge_std::{declare, ContractClassTrait, spy_events, SpyOn, EventSpy, EventFetcher,
     event_name_hash, Event};
-    
+
 #[starknet::interface]
 trait ISpyEventsChecker<TContractState> {
     fn emit_one_event(ref self: TContractState, some_data: felt252);
@@ -84,15 +85,15 @@ fn test_complex_assertions() {
     dispatcher.emit_one_event(123);
 
     spy.fetch_events();
-    
+
     assert(spy.events.len() == 1, 'There should be one event');
-    
+
     let (from, event) = spy.events.at(0);
     assert(from == @contract_address, 'Emitted from wrong address');
     assert(event.keys.len() == 1, 'There should be one key');
     assert(event.keys.at(0) == @event_name_hash('FirstEvent'), 'Wrong event name');
     assert(event.data.len() == 1, 'There should be one data');
-    
+
     dispatcher.emit_one_event(123);
     assert(spy.events.len() == 1, 'There should be one event');
 
@@ -112,7 +113,7 @@ Let's go through important parts of the provided code:
 
 > 📝 **Note**
 > To assert the `name` property we have to hash a shortstring with the `event_name_hash` cheatcode.
-> 
+>
 > `fn event_name_hash(name: felt252) -> felt252`
 
 - It is worth noting that when we call the method which emits an event, `spy` is not updated immediately.
@@ -125,7 +126,7 @@ use snforge_std::{declare, ContractClassTrait, spy_events, SpyOn, EventSpy,
     EventAssertions};
 
 use SpyEventsChecker;
-    
+
 #[starknet::interface]
 trait ISpyEventsChecker<TContractState> {
     fn emit_one_event(ref self: TContractState, some_data: felt252);
@@ -172,7 +173,7 @@ Sometimes it is easier to split events between multiple spies. Let's do it.
 use snforge_std::{declare, ContractClassTrait, spy_events, SpyOn, EventSpy, EventAssertions};
 
 use SpyEventsChecker;
-    
+
 #[starknet::interface]
 trait ISpyEventsChecker<TContractState> {
     fn emit_one_event(ref self: TContractState, some_data: felt252);
@@ -184,7 +185,7 @@ fn test_simple_assertions() {
     let first_address = contract.deploy(array![]).unwrap();
     let second_address = contract.deploy(array![]).unwrap();
     let third_address = contract.deploy(array![]).unwrap();
-    
+
     let first_dispatcher = ISpyEventsCheckerDispatcher { first_address };
     let second_dispatcher = ISpyEventsCheckerDispatcher { second_address };
     let third_dispatcher = ISpyEventsCheckerDispatcher { third_address };

--- a/snforge_std/src/cheatcodes/events.cairo
+++ b/snforge_std/src/cheatcodes/events.cairo
@@ -107,9 +107,7 @@ impl EventAssertionsImpl<
 
             if emitted {
                 panic(
-                    array![
-                        'Event with matching data and', 'keys was emitted from', (*from).into()
-                    ]
+                    array!['Event with matching data and', 'keys was emitted from', (*from).into()]
                 );
             }
 

--- a/snforge_std/src/cheatcodes/events.cairo
+++ b/snforge_std/src/cheatcodes/events.cairo
@@ -63,6 +63,7 @@ impl EventFetcherImpl of EventFetcher {
 
 trait EventAssertions<T, impl TEvent: starknet::Event<T>, impl TDrop: Drop<T>> {
     fn assert_emitted(ref self: EventSpy, events: @Array<(ContractAddress, T)>);
+    fn assert_not_emitted(ref self: EventSpy, events: @Array<(ContractAddress, T)>);
 }
 
 impl EventAssertionsImpl<
@@ -78,7 +79,7 @@ impl EventAssertionsImpl<
             }
 
             let (from, event) = events.at(i);
-            let emitted = assert_if_emitted(ref self, from, event);
+            let emitted = is_emitted(ref self, from, event);
 
             if !emitted {
                 panic(
@@ -91,9 +92,33 @@ impl EventAssertionsImpl<
             i += 1;
         };
     }
+
+    fn assert_not_emitted(ref self: EventSpy, events: @Array<(ContractAddress, T)>) {
+        self.fetch_events();
+
+        let mut i = 0;
+        loop {
+            if i >= events.len() {
+                break;
+            }
+
+            let (from, event) = events.at(i);
+            let emitted = is_emitted(ref self, from, event);
+
+            if emitted {
+                panic(
+                    array![
+                        'Event with matching data and', 'keys was emitted from', (*from).into()
+                    ]
+                );
+            }
+
+            i += 1;
+        };
+    }
 }
 
-fn assert_if_emitted<T, impl TEvent: starknet::Event<T>, impl TDrop: Drop<T>>(
+fn is_emitted<T, impl TEvent: starknet::Event<T>, impl TDrop: Drop<T>>(
     ref self: EventSpy, expected_from: @ContractAddress, expected_event: @T
 ) -> bool {
     let emitted_events = @self.events;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1409

## Introduced changes

Adding a `assert_not_emitted` check to verify an event was *not* emitted. The counterparty to `assert_emitted`.

I've also renamed the `assert_if_emitted` helper function to `is_emitted` because 1) it didn't assert and 2) there's no operation on "if emitted". I'm guessing it's just a relic from some refactoring.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
