### PR TITLE
Update invalid `--rpc-url` flag in Invoke section

### DIFF
--- a/docs/src/starknet/invoke.md
+++ b/docs/src/starknet/invoke.md
@@ -18,7 +18,7 @@ For detailed CLI description, see [invoke command reference](../appendix/sncast/
 
 ```shell
 $ sncast \
-  --rpc_url http://127.0.0.1:5050 \
+  --url http://127.0.0.1:5050 \
   --account example_user \
   invoke \
   --contract-address 0x4a739ab73aa3cac01f9da5d55f49fb67baee4919224454a2e3f85b16462a911 \


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1429 

## Introduced changes

This PR replaces `--rpc-url` invalid flag with `--url` in invoke section.

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
