### PR TITLE
Refactor spoof tests

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/spoof.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/spoof.rs
@@ -2,7 +2,7 @@ use crate::state::{start_cheat, stop_cheat, CheatTarget};
 use crate::CheatnetState;
 use cairo_felt::Felt252;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct TxInfoMock {
     pub version: Option<Felt252>,
     pub account_contract_address: Option<Felt252>,
@@ -21,43 +21,12 @@ pub struct TxInfoMock {
 
 impl CheatnetState {
     #[allow(clippy::too_many_arguments)]
-    pub fn start_spoof(
-        &mut self,
-        target: CheatTarget,
-        version: Option<Felt252>,
-        account_contract_address: Option<Felt252>,
-        max_fee: Option<Felt252>,
-        signature: Option<Vec<Felt252>>,
-        transaction_hash: Option<Felt252>,
-        chain_id: Option<Felt252>,
-        nonce: Option<Felt252>,
-        resource_bounds: Option<Vec<Felt252>>,
-        tip: Option<Felt252>,
-        paymaster_data: Option<Vec<Felt252>>,
-        nonce_data_availability_mode: Option<Felt252>,
-        fee_data_availability_mode: Option<Felt252>,
-        account_deployment_data: Option<Vec<Felt252>>,
-    ) {
-        let tx_info = TxInfoMock {
-            version,
-            account_contract_address,
-            max_fee,
-            signature,
-            transaction_hash,
-            chain_id,
-            nonce,
-            resource_bounds,
-            tip,
-            paymaster_data,
-            nonce_data_availability_mode,
-            fee_data_availability_mode,
-            account_deployment_data,
-        };
+    pub fn start_spoof(&mut self, target: CheatTarget, tx_info_mock: TxInfoMock) {
         start_cheat(
             &mut self.global_spoof,
             &mut self.spoofed_contracts,
             target,
-            tx_info,
+            tx_info_mock,
         );
     }
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -551,6 +551,7 @@ fn deserialize_cheat_target(inputs: &[Felt252]) -> (CheatTarget, usize) {
     }
 }
 
+#[must_use]
 pub fn cheatcode_panic_result(panic_data: Vec<Felt252>) -> Vec<Felt252> {
     let mut result = vec![Felt252::from(1), Felt252::from(panic_data.len())];
     result.extend(panic_data);

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -200,7 +200,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 let nonce = read_option_felt(&inputs, &mut idx);
                 let resource_bounds =
                     read_option_felt(&inputs, &mut idx).map(|resource_bounds_len| {
-                        read_vec_count(
+                        read_vec_sized(
                             &inputs,
                             &mut idx,
                             3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
@@ -564,13 +564,13 @@ pub fn read_felt(buffer: &[Felt252], idx: &mut usize) -> Felt252 {
 }
 
 pub fn read_vec(buffer: &[Felt252], idx: &mut usize) -> Vec<Felt252> {
-    let count = read_felt(buffer, idx).to_usize().unwrap();
-    read_vec_count(buffer, idx, count)
+    let size = read_felt(buffer, idx).to_usize().unwrap();
+    read_vec_sized(buffer, idx, size)
 }
 
-pub fn read_vec_count(buffer: &[Felt252], idx: &mut usize, count: usize) -> Vec<Felt252> {
-    *idx += count;
-    buffer[*idx - count..*idx].to_vec()
+pub fn read_vec_sized(buffer: &[Felt252], idx: &mut usize, size: usize) -> Vec<Felt252> {
+    *idx += size;
+    buffer[*idx - size..*idx].to_vec()
 }
 
 pub fn read_option_felt(buffer: &[Felt252], idx: &mut usize) -> Option<Felt252> {
@@ -579,8 +579,7 @@ pub fn read_option_felt(buffer: &[Felt252], idx: &mut usize) -> Option<Felt252> 
 }
 
 pub fn read_option_vec(buffer: &[Felt252], idx: &mut usize) -> Option<Vec<Felt252>> {
-    read_option_felt(buffer, idx)
-        .map(|count| read_vec_count(buffer, idx, count.to_usize().unwrap()))
+    read_option_felt(buffer, idx).map(|size| read_vec_sized(buffer, idx, size.to_usize().unwrap()))
 }
 
 #[must_use]

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -9,7 +9,7 @@ use crate::{
 use cairo_felt::Felt252;
 use cheatnet::runtime_extensions::forge_runtime_extension::{
     cheatcodes::{deploy::deploy, spoof::TxInfoMock},
-    read_felt, read_vec, read_vec_count,
+    read_felt, read_vec, read_vec_sized,
 };
 use cheatnet::state::CheatTarget;
 use cheatnet::{
@@ -38,13 +38,13 @@ pub struct TxInfo {
 }
 
 impl TxInfo {
-    fn apply_mock_fields(tx_info_mock: &TxInfoMock, default_tx_info: &Self) -> Self {
+    fn apply_mock_fields(tx_info_mock: &TxInfoMock, tx_info: &Self) -> Self {
         macro_rules! clone_field {
             ($field:ident) => {
                 tx_info_mock
                     .$field
                     .clone()
-                    .unwrap_or(default_tx_info.$field.clone())
+                    .unwrap_or(tx_info.$field.clone())
             };
         }
 
@@ -76,7 +76,7 @@ impl TxInfo {
         let chain_id = read_felt(data, &mut idx);
         let nonce = read_felt(data, &mut idx);
         let resource_bounds_len = read_felt(data, &mut idx);
-        let resource_bounds = read_vec_count(
+        let resource_bounds = read_vec_sized(
             data,
             &mut idx,
             3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -7,261 +7,127 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
+use cheatnet::runtime_extensions::forge_runtime_extension::{
+    cheatcodes::{deploy::deploy, spoof::TxInfoMock},
+    read_felt, read_vec, read_vec_count,
+};
 use cheatnet::state::CheatTarget;
 use cheatnet::{
     runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract,
     state::{BlockifierState, CheatnetState},
 };
 use conversions::{felt252::FromShortString, IntoConv};
+use num_traits::ToPrimitive;
 use starknet_api::core::ContractAddress;
 
-#[allow(clippy::too_many_arguments)]
-fn assert_all_mock_checker_getters(
-    blockifier_state: &mut BlockifierState,
-    cheatnet_state: &mut CheatnetState,
-    contract_address: &ContractAddress,
-    expected_version: &[Felt252],
-    expected_account_address: &[Felt252],
-    expected_max_fee: &[Felt252],
-    expected_signature: &[Felt252],
-    expected_tx_hash: &[Felt252],
-    expected_chain_id: &[Felt252],
-    expected_nonce: &[Felt252],
-    expected_resource_bounds: &[Felt252],
-    expected_tip: &[Felt252],
-    expected_paymaster_data: &[Felt252],
-    expected_nonce_data_availability_mode: &[Felt252],
-    expected_fee_data_availability_mode: &[Felt252],
-    expected_account_deployment_data: &[Felt252],
-) {
-    let tx_hash = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_tx_hash",
-    );
-    assert_success!(tx_hash, expected_tx_hash);
-    let nonce = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_nonce",
-    );
-    assert_success!(nonce, expected_nonce);
-    let account_address = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_account_contract_address",
-    );
-    assert_success!(account_address, expected_account_address);
-    let version = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_version",
-    );
-    assert_success!(version, expected_version);
-    let chain_id = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_chain_id",
-    );
-    assert_success!(chain_id, expected_chain_id);
-    let max_fee = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_max_fee",
-    );
-    assert_success!(max_fee, expected_max_fee);
-    let signature = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_signature",
-    );
-    assert_success!(signature, expected_signature);
-    let resource_bounds = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_resource_bounds",
-    );
-    assert_success!(resource_bounds, expected_resource_bounds);
-    let tip = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_tip",
-    );
-    assert_success!(tip, expected_tip);
-    let paymaster_data = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_paymaster_data",
-    );
-    assert_success!(paymaster_data, expected_paymaster_data);
-    let nonce_data_availability_mode = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_nonce_data_availability_mode",
-    );
-    assert_success!(
-        nonce_data_availability_mode,
-        expected_nonce_data_availability_mode
-    );
-    let fee_data_availability_mode = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_fee_data_availability_mode",
-    );
-    assert_success!(
-        fee_data_availability_mode,
-        expected_fee_data_availability_mode
-    );
-    let account_deployment_data = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_account_deployment_data",
-    );
-    assert_success!(account_deployment_data, expected_account_deployment_data);
+#[derive(Clone, Default, Debug, PartialEq)]
+pub struct TxInfo {
+    pub version: Felt252,
+    pub account_contract_address: Felt252,
+    pub max_fee: Felt252,
+    pub signature: Vec<Felt252>,
+    pub transaction_hash: Felt252,
+    pub chain_id: Felt252,
+    pub nonce: Felt252,
+    pub resource_bounds: Vec<Felt252>,
+    pub tip: Felt252,
+    pub paymaster_data: Vec<Felt252>,
+    pub nonce_data_availability_mode: Felt252,
+    pub fee_data_availability_mode: Felt252,
+    pub account_deployment_data: Vec<Felt252>,
 }
 
-#[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_lines)]
-fn call_mock_checker_getters(
+impl TxInfo {
+    fn apply_mock_fields(tx_info_mock: &TxInfoMock, default_tx_info: &Self) -> Self {
+        macro_rules! clone_field {
+            ($field:ident) => {
+                tx_info_mock
+                    .$field
+                    .clone()
+                    .unwrap_or(default_tx_info.$field.clone())
+            };
+        }
+
+        TxInfo {
+            version: clone_field!(version),
+            account_contract_address: clone_field!(account_contract_address),
+            max_fee: clone_field!(max_fee),
+            signature: clone_field!(signature),
+            transaction_hash: clone_field!(transaction_hash),
+            chain_id: clone_field!(chain_id),
+            nonce: clone_field!(nonce),
+            resource_bounds: clone_field!(resource_bounds),
+            tip: clone_field!(tip),
+            paymaster_data: clone_field!(paymaster_data),
+            nonce_data_availability_mode: clone_field!(nonce_data_availability_mode),
+            fee_data_availability_mode: clone_field!(fee_data_availability_mode),
+            account_deployment_data: clone_field!(account_deployment_data),
+        }
+    }
+
+    fn deserialize(data: Vec<Felt252>) -> TxInfo {
+        let mut idx = 0;
+
+        let version = read_felt(&data, &mut idx);
+        let account_contract_address = read_felt(&data, &mut idx);
+        let max_fee = read_felt(&data, &mut idx);
+        let signature = read_vec(&data, &mut idx);
+        let transaction_hash = read_felt(&data, &mut idx);
+        let chain_id = read_felt(&data, &mut idx);
+        let nonce = read_felt(&data, &mut idx);
+        let resource_bounds_len = read_felt(&data, &mut idx);
+        let resource_bounds = read_vec_count(
+            &data,
+            &mut idx,
+            3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
+        );
+        let tip = read_felt(&data, &mut idx);
+        let paymaster_data = read_vec(&data, &mut idx);
+        let nonce_data_availability_mode = read_felt(&data, &mut idx);
+        let fee_data_availability_mode = read_felt(&data, &mut idx);
+        let account_deployment_data = read_vec(&data, &mut idx);
+
+        TxInfo {
+            version,
+            account_contract_address,
+            max_fee,
+            signature,
+            transaction_hash,
+            chain_id,
+            nonce,
+            resource_bounds,
+            tip,
+            paymaster_data,
+            nonce_data_availability_mode,
+            fee_data_availability_mode,
+            account_deployment_data,
+        }
+    }
+}
+
+fn assert_tx_info(
     blockifier_state: &mut BlockifierState,
     cheatnet_state: &mut CheatnetState,
     contract_address: &ContractAddress,
-) -> (
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
-    Vec<Felt252>,
+    expected_tx_info: TxInfo,
 ) {
-    let nonce = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_nonce",
-    );
-    let nonce = recover_data(nonce);
-    let account_address = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_account_contract_address",
-    );
-    let account_address = recover_data(account_address);
-    let version = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_version",
-    );
-    let version = recover_data(version);
-    let chain_id = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_chain_id",
-    );
-    let chain_id = recover_data(chain_id);
-    let max_fee = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_max_fee",
-    );
-    let max_fee = recover_data(max_fee);
-    let signature = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_signature",
-    );
-    let signature = recover_data(signature);
-    let tx_hash = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_tx_hash",
-    );
-    let tx_hash = recover_data(tx_hash);
-    let resource_bounds = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_resource_bounds",
-    );
-    let resource_bounds = recover_data(resource_bounds);
-    let tip = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_tip",
-    );
-    let tip = recover_data(tip);
-    let paymaster_data = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_paymaster_data",
-    );
-    let paymaster_data = recover_data(paymaster_data);
-    let nonce_data_availability_mode = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_nonce_data_availability_mode",
-    );
-    let nonce_data_availability_mode = recover_data(nonce_data_availability_mode);
-    let fee_data_availability_mode = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_fee_data_availability_mode",
-    );
-    let fee_data_availability_mode = recover_data(fee_data_availability_mode);
-    let account_deployment_data = call_contract_getter_by_name(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        "get_account_deployment_data",
-    );
-    let account_deployment_data = recover_data(account_deployment_data);
+    let tx_info = get_tx_info(blockifier_state, cheatnet_state, contract_address);
+    assert_eq!(tx_info, expected_tx_info);
+}
 
-    (
-        nonce,
-        account_address,
-        version,
-        chain_id,
-        max_fee,
-        signature,
-        tx_hash,
-        resource_bounds,
-        tip,
-        paymaster_data,
-        nonce_data_availability_mode,
-        fee_data_availability_mode,
-        account_deployment_data,
-    )
+fn get_tx_info(
+    blockifier_state: &mut BlockifierState,
+    cheatnet_state: &mut CheatnetState,
+    contract_address: &ContractAddress,
+) -> TxInfo {
+    let get_tx_info_output = call_contract_getter_by_name(
+        blockifier_state,
+        cheatnet_state,
+        contract_address,
+        "get_tx_info",
+    );
+    let tx_info_data = recover_data(get_tx_info_output);
+    TxInfo::deserialize(tx_info_data)
 }
 
 #[test]
@@ -276,65 +142,30 @@ fn spoof_simple() {
         vec![].as_slice(),
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        _,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    assert_all_mock_checker_getters(
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
+
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &[Felt252::from(123)],
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 }
 
 #[test]
-#[allow(clippy::too_many_lines)]
 fn start_spoof_multiple_times() {
     let mut cached_state = create_cached_state();
     let (mut blockifier_state, mut cheatnet_state) = create_cheatnet_state(&mut cached_state);
@@ -346,163 +177,96 @@ fn start_spoof_multiple_times() {
         vec![].as_slice(),
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        tx_hash_before,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    let expected_version = Felt252::from(13);
-    let expected_account_address = Felt252::from(66);
-    let expected_max_fee = Felt252::from(77);
-    let expected_signature = vec![Felt252::from(88), Felt252::from(89)];
-    let expected_tx_hash = Felt252::from(123);
-    let expected_chain_id = Felt252::from(22);
-    let expected_nonce = Felt252::from(33);
-    let expected_resource_bounds = vec![
-        Felt252::from(111),
-        Felt252::from(222),
-        Felt252::from(333),
-        Felt252::from(444),
-        Felt252::from(555),
-        Felt252::from(666),
-    ];
-    let expected_tip = Felt252::from(777);
-    let expected_paymaster_data = vec![
-        Felt252::from(11),
-        Felt252::from(22),
-        Felt252::from(33),
-        Felt252::from(44),
-    ];
-    let expected_nonce_data_availability_mode = Felt252::from(55);
-    let expected_fee_data_availability_mode = Felt252::from(66);
-    let expected_account_deployment_data =
-        vec![Felt252::from(777), Felt252::from(888), Felt252::from(999)];
+    let initial_tx_info_mock = TxInfoMock {
+        version: Some(Felt252::from(13)),
+        account_contract_address: Some(Felt252::from(66)),
+        max_fee: Some(Felt252::from(77)),
+        signature: Some(vec![Felt252::from(88), Felt252::from(89)]),
+        transaction_hash: Some(Felt252::from(123)),
+        chain_id: Some(Felt252::from(22)),
+        nonce: Some(Felt252::from(33)),
+        resource_bounds: Some(vec![
+            Felt252::from(111),
+            Felt252::from(222),
+            Felt252::from(333),
+            Felt252::from(444),
+            Felt252::from(555),
+            Felt252::from(666),
+        ]),
+        tip: Some(Felt252::from(777)),
+        paymaster_data: Some(vec![
+            Felt252::from(11),
+            Felt252::from(22),
+            Felt252::from(33),
+            Felt252::from(44),
+        ]),
+        nonce_data_availability_mode: Some(Felt252::from(55)),
+        fee_data_availability_mode: Some(Felt252::from(66)),
+        account_deployment_data: Some(vec![
+            Felt252::from(777),
+            Felt252::from(888),
+            Felt252::from(999),
+        ]),
+    };
+    let expected_tx_info = TxInfo::apply_mock_fields(&initial_tx_info_mock, &tx_info_before);
 
     cheatnet_state.start_spoof(
         CheatTarget::One(contract_address),
-        Some(expected_version.clone()),
-        Some(expected_account_address.clone()),
-        Some(expected_max_fee.clone()),
-        Some(expected_signature.clone()),
-        Some(expected_tx_hash.clone()),
-        Some(expected_chain_id.clone()),
-        Some(expected_nonce.clone()),
-        Some(expected_resource_bounds.clone()),
-        Some(expected_tip.clone()),
-        Some(expected_paymaster_data.clone()),
-        Some(expected_nonce_data_availability_mode.clone()),
-        Some(expected_fee_data_availability_mode.clone()),
-        Some(expected_account_deployment_data.clone()),
+        initial_tx_info_mock.clone(),
     );
 
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &[expected_version.clone()],
-        &[expected_account_address.clone()],
-        &[expected_max_fee.clone()],
-        &[vec![Felt252::from(2)], expected_signature.clone()].concat(),
-        &[expected_tx_hash.clone()],
-        &[expected_chain_id.clone()],
-        &[expected_nonce.clone()],
-        &[vec![Felt252::from(2)], expected_resource_bounds.clone()].concat(),
-        &[expected_tip.clone()],
-        &[vec![Felt252::from(4)], expected_paymaster_data.clone()].concat(),
-        &[expected_nonce_data_availability_mode.clone()],
-        &[expected_fee_data_availability_mode.clone()],
-        &[
-            vec![Felt252::from(3)],
-            expected_account_deployment_data.clone(),
-        ]
-        .concat(),
+        expected_tx_info,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        Some(expected_account_address.clone()),
-        None,
-        Some(expected_signature.clone()),
-        None,
-        Some(expected_chain_id.clone()),
-        None,
-        Some(expected_resource_bounds.clone()),
-        None,
-        Some(expected_paymaster_data.clone()),
-        None,
-        Some(expected_fee_data_availability_mode.clone()),
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        version: None,
+        max_fee: None,
+        transaction_hash: None,
+        nonce: None,
+        tip: None,
+        nonce_data_availability_mode: None,
+        account_deployment_data: None,
+        ..initial_tx_info_mock
+    };
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
 
-    assert_all_mock_checker_getters(
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &[expected_account_address],
-        &max_fee_before,
-        &[vec![Felt252::from(2)], expected_signature].concat(),
-        &tx_hash_before,
-        &[expected_chain_id],
-        &nonce_before,
-        &[vec![Felt252::from(2)], expected_resource_bounds].concat(),
-        &tip_before,
-        &[vec![Felt252::from(4)], expected_paymaster_data].concat(),
-        &nonce_data_availability_mode_before,
-        &[expected_fee_data_availability_mode],
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        Some(expected_version.clone()),
-        None,
-        Some(expected_max_fee.clone()),
-        None,
-        Some(expected_tx_hash.clone()),
-        None,
-        Some(expected_nonce.clone()),
-        None,
-        Some(expected_tip.clone()),
-        None,
-        Some(expected_nonce_data_availability_mode.clone()),
-        None,
-        Some(expected_account_deployment_data.clone()),
-    );
+    let tx_info_mock = TxInfoMock {
+        account_contract_address: None,
+        signature: None,
+        chain_id: None,
+        resource_bounds: None,
+        paymaster_data: None,
+        fee_data_availability_mode: None,
+        ..initial_tx_info_mock
+    };
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
 
-    assert_all_mock_checker_getters(
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &[expected_version],
-        &account_address_before,
-        &[expected_max_fee],
-        &signature_before,
-        &[expected_tx_hash],
-        &chain_id_before,
-        &[expected_nonce],
-        &resource_bounds_before,
-        &[expected_tip],
-        &paymaster_data_before,
-        &[expected_nonce_data_availability_mode],
-        &fee_data_availability_mode_before,
-        &[vec![Felt252::from(3)], expected_account_deployment_data].concat(),
+        expected_tx_info,
     );
 }
 
@@ -518,81 +282,35 @@ fn spoof_start_stop() {
         vec![].as_slice(),
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        tx_hash_before,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    assert_all_mock_checker_getters(
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
+
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &[Felt252::from(123)],
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 
     cheatnet_state.stop_spoof(CheatTarget::One(contract_address));
 
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &tx_hash_before,
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        tx_info_before,
     );
 }
 
@@ -608,21 +326,7 @@ fn spoof_stop_no_effect() {
         vec![].as_slice(),
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        tx_hash_before,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
@@ -630,23 +334,11 @@ fn spoof_stop_no_effect() {
 
     cheatnet_state.stop_spoof(CheatTarget::One(contract_address));
 
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &tx_hash_before,
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        tx_info_before,
     );
 }
 
@@ -662,22 +354,12 @@ fn spoof_with_other_syscall() {
         vec![].as_slice(),
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
+
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
 
     let selector = felt_selector_from_name("get_tx_hash_and_emit_event");
 
@@ -706,22 +388,12 @@ fn spoof_in_constructor() {
         .unwrap();
     let precalculated_address = cheatnet_state.precalculate_address(&class_hash, vec![].as_slice());
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(precalculated_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
+
+    cheatnet_state.start_spoof(CheatTarget::One(precalculated_address), tx_info_mock);
 
     let contract_address = deploy(&mut blockifier_state, &mut cheatnet_state, &class_hash, &[])
         .unwrap()
@@ -755,24 +427,14 @@ fn spoof_proxy() {
         vec![].as_slice(),
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    let selector = felt_selector_from_name("get_tx_hash");
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    let selector = felt_selector_from_name("get_transaction_hash");
 
     let output = call_contract(
         &mut blockifier_state,
@@ -822,22 +484,12 @@ fn spoof_library_call() {
         vec![].as_slice(),
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(lib_call_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
+
+    cheatnet_state.start_spoof(CheatTarget::One(lib_call_address), tx_info_mock);
 
     let lib_call_selector = felt_selector_from_name("get_tx_hash_with_lib_call");
     let output = call_contract(
@@ -864,60 +516,26 @@ fn spoof_all_simple() {
         &[],
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        _,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::All,
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    assert_all_mock_checker_getters(
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
+
+    cheatnet_state.start_spoof(CheatTarget::All, tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &[Felt252::from(123)],
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 }
 
@@ -933,77 +551,29 @@ fn spoof_all_then_one() {
         &[],
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        _,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::All,
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let mut tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(321)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    cheatnet_state.start_spoof(CheatTarget::All, tx_info_mock.clone());
 
-    assert_all_mock_checker_getters(
+    tx_info_mock.transaction_hash = Some(Felt252::from(321));
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
+
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &[Felt252::from(321)],
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 }
 
@@ -1019,77 +589,29 @@ fn spoof_one_then_all() {
         &[],
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        _,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::One(contract_address),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let mut tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
 
-    cheatnet_state.start_spoof(
-        CheatTarget::All,
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(321)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    cheatnet_state.start_spoof(CheatTarget::One(contract_address), tx_info_mock.clone());
 
-    assert_all_mock_checker_getters(
+    tx_info_mock.transaction_hash = Some(Felt252::from(321));
+    let expected_tx_info = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before);
+
+    cheatnet_state.start_spoof(CheatTarget::All, tx_info_mock);
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &[Felt252::from(321)],
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        expected_tx_info,
     );
 }
 
@@ -1105,66 +627,29 @@ fn spoof_all_stop() {
         &[],
     );
 
-    let (
-        nonce_before,
-        account_address_before,
-        version_before,
-        chain_id_before,
-        max_fee_before,
-        signature_before,
-        txn_hash_before,
-        resource_bounds_before,
-        tip_before,
-        paymaster_data_before,
-        nonce_data_availability_mode_before,
-        fee_data_availability_mode_before,
-        account_deployment_data_before,
-    ) = call_mock_checker_getters(
+    let tx_info_before = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
     );
 
-    cheatnet_state.start_spoof(
-        CheatTarget::All,
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
+
+    cheatnet_state.start_spoof(CheatTarget::All, tx_info_mock);
 
     cheatnet_state.stop_spoof(CheatTarget::All);
 
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        &version_before,
-        &account_address_before,
-        &max_fee_before,
-        &signature_before,
-        &txn_hash_before,
-        &chain_id_before,
-        &nonce_before,
-        &resource_bounds_before,
-        &tip_before,
-        &paymaster_data_before,
-        &nonce_data_availability_mode_before,
-        &fee_data_availability_mode_before,
-        &account_deployment_data_before,
+        tx_info_before,
     );
 }
 
-#[allow(clippy::too_many_lines)]
 #[test]
 fn spoof_multiple() {
     let mut cached_state = create_cached_state();
@@ -1181,133 +666,55 @@ fn spoof_multiple() {
     let contract_address_2 = deploy(&mut blockifier_state, &mut cheatnet_state, &class_hash, &[])
         .unwrap()
         .contract_address;
-    let (
-        nonce_before_1,
-        account_address_before_1,
-        version_before_1,
-        chain_id_before_1,
-        max_fee_before_1,
-        signature_before_1,
-        txn_hash_before_1,
-        resource_bounds_before_1,
-        tip_before_1,
-        paymaster_data_before_1,
-        nonce_data_availability_mode_before_1,
-        fee_data_availability_mode_before_1,
-        account_deployment_data_before_1,
-    ) = call_mock_checker_getters(
+
+    let tx_info_before_1 = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_1,
     );
-    let (
-        nonce_before_2,
-        account_address_before_2,
-        version_before_2,
-        chain_id_before_2,
-        max_fee_before_2,
-        signature_before_2,
-        txn_hash_before_2,
-        resource_bounds_before_2,
-        tip_before_2,
-        paymaster_data_before_2,
-        nonce_data_availability_mode_before_2,
-        fee_data_availability_mode_before_2,
-        account_deployment_data_before_2,
-    ) = call_mock_checker_getters(
+    let tx_info_before_2 = get_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_2,
     );
+
+    let tx_info_mock = TxInfoMock {
+        transaction_hash: Some(Felt252::from(123)),
+        ..Default::default()
+    };
+    let expected_tx_info_1 = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before_1);
+    let expected_tx_info_2 = TxInfo::apply_mock_fields(&tx_info_mock, &tx_info_before_2);
 
     cheatnet_state.start_spoof(
         CheatTarget::Multiple(vec![contract_address_1, contract_address_2]),
-        None,
-        None,
-        None,
-        None,
-        Some(Felt252::from(123)),
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+        tx_info_mock,
     );
-    assert_all_mock_checker_getters(
+
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_1,
-        &version_before_1,
-        &account_address_before_1,
-        &max_fee_before_1,
-        &signature_before_1,
-        &[Felt252::from(123)],
-        &chain_id_before_1,
-        &nonce_before_1,
-        &resource_bounds_before_1,
-        &tip_before_1,
-        &paymaster_data_before_1,
-        &nonce_data_availability_mode_before_1,
-        &fee_data_availability_mode_before_1,
-        &account_deployment_data_before_1,
+        expected_tx_info_1,
     );
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_2,
-        &version_before_2,
-        &account_address_before_2,
-        &max_fee_before_2,
-        &signature_before_2,
-        &[Felt252::from(123)],
-        &chain_id_before_2,
-        &nonce_before_2,
-        &resource_bounds_before_2,
-        &tip_before_2,
-        &paymaster_data_before_2,
-        &nonce_data_availability_mode_before_2,
-        &fee_data_availability_mode_before_2,
-        &account_deployment_data_before_2,
+        expected_tx_info_2,
     );
+
     cheatnet_state.stop_spoof(CheatTarget::All);
 
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_1,
-        &version_before_1,
-        &account_address_before_1,
-        &max_fee_before_1,
-        &signature_before_1,
-        &txn_hash_before_1,
-        &chain_id_before_1,
-        &nonce_before_1,
-        &resource_bounds_before_1,
-        &tip_before_1,
-        &paymaster_data_before_1,
-        &nonce_data_availability_mode_before_1,
-        &fee_data_availability_mode_before_1,
-        &account_deployment_data_before_1,
+        tx_info_before_1,
     );
-    assert_all_mock_checker_getters(
+    assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_2,
-        &version_before_2,
-        &account_address_before_2,
-        &max_fee_before_2,
-        &signature_before_2,
-        &txn_hash_before_2,
-        &chain_id_before_2,
-        &nonce_before_2,
-        &resource_bounds_before_2,
-        &tip_before_2,
-        &paymaster_data_before_2,
-        &nonce_data_availability_mode_before_2,
-        &fee_data_availability_mode_before_2,
-        &account_deployment_data_before_2,
+        tx_info_before_2,
     );
 }

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -48,7 +48,7 @@ impl TxInfo {
             };
         }
 
-        TxInfo {
+        Self {
             version: clone_field!(version),
             account_contract_address: clone_field!(account_contract_address),
             max_fee: clone_field!(max_fee),
@@ -65,29 +65,29 @@ impl TxInfo {
         }
     }
 
-    fn deserialize(data: Vec<Felt252>) -> TxInfo {
+    fn deserialize(data: &[Felt252]) -> Self {
         let mut idx = 0;
 
-        let version = read_felt(&data, &mut idx);
-        let account_contract_address = read_felt(&data, &mut idx);
-        let max_fee = read_felt(&data, &mut idx);
-        let signature = read_vec(&data, &mut idx);
-        let transaction_hash = read_felt(&data, &mut idx);
-        let chain_id = read_felt(&data, &mut idx);
-        let nonce = read_felt(&data, &mut idx);
-        let resource_bounds_len = read_felt(&data, &mut idx);
+        let version = read_felt(data, &mut idx);
+        let account_contract_address = read_felt(data, &mut idx);
+        let max_fee = read_felt(data, &mut idx);
+        let signature = read_vec(data, &mut idx);
+        let transaction_hash = read_felt(data, &mut idx);
+        let chain_id = read_felt(data, &mut idx);
+        let nonce = read_felt(data, &mut idx);
+        let resource_bounds_len = read_felt(data, &mut idx);
         let resource_bounds = read_vec_count(
-            &data,
+            data,
             &mut idx,
             3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
         );
-        let tip = read_felt(&data, &mut idx);
-        let paymaster_data = read_vec(&data, &mut idx);
-        let nonce_data_availability_mode = read_felt(&data, &mut idx);
-        let fee_data_availability_mode = read_felt(&data, &mut idx);
-        let account_deployment_data = read_vec(&data, &mut idx);
+        let tip = read_felt(data, &mut idx);
+        let paymaster_data = read_vec(data, &mut idx);
+        let nonce_data_availability_mode = read_felt(data, &mut idx);
+        let fee_data_availability_mode = read_felt(data, &mut idx);
+        let account_deployment_data = read_vec(data, &mut idx);
 
-        TxInfo {
+        Self {
             version,
             account_contract_address,
             max_fee,
@@ -109,10 +109,10 @@ fn assert_tx_info(
     blockifier_state: &mut BlockifierState,
     cheatnet_state: &mut CheatnetState,
     contract_address: &ContractAddress,
-    expected_tx_info: TxInfo,
+    expected_tx_info: &TxInfo,
 ) {
     let tx_info = get_tx_info(blockifier_state, cheatnet_state, contract_address);
-    assert_eq!(tx_info, expected_tx_info);
+    assert_eq!(tx_info, expected_tx_info.to_owned());
 }
 
 fn get_tx_info(
@@ -127,7 +127,7 @@ fn get_tx_info(
         "get_tx_info",
     );
     let tx_info_data = recover_data(get_tx_info_output);
-    TxInfo::deserialize(tx_info_data)
+    TxInfo::deserialize(&tx_info_data)
 }
 
 #[test]
@@ -161,7 +161,7 @@ fn spoof_simple() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 }
 
@@ -225,7 +225,7 @@ fn start_spoof_multiple_times() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 
     let tx_info_mock = TxInfoMock {
@@ -246,7 +246,7 @@ fn start_spoof_multiple_times() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 
     let tx_info_mock = TxInfoMock {
@@ -266,7 +266,7 @@ fn start_spoof_multiple_times() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 }
 
@@ -301,7 +301,7 @@ fn spoof_start_stop() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 
     cheatnet_state.stop_spoof(CheatTarget::One(contract_address));
@@ -310,7 +310,7 @@ fn spoof_start_stop() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        tx_info_before,
+        &tx_info_before,
     );
 }
 
@@ -338,7 +338,7 @@ fn spoof_stop_no_effect() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        tx_info_before,
+        &tx_info_before,
     );
 }
 
@@ -535,7 +535,7 @@ fn spoof_all_simple() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 }
 
@@ -573,7 +573,7 @@ fn spoof_all_then_one() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 }
 
@@ -611,7 +611,7 @@ fn spoof_one_then_all() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        expected_tx_info,
+        &expected_tx_info,
     );
 }
 
@@ -646,7 +646,7 @@ fn spoof_all_stop() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address,
-        tx_info_before,
+        &tx_info_before,
     );
 }
 
@@ -694,13 +694,13 @@ fn spoof_multiple() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_1,
-        expected_tx_info_1,
+        &expected_tx_info_1,
     );
     assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_2,
-        expected_tx_info_2,
+        &expected_tx_info_2,
     );
 
     cheatnet_state.stop_spoof(CheatTarget::All);
@@ -709,12 +709,12 @@ fn spoof_multiple() {
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_1,
-        tx_info_before_1,
+        &tx_info_before_1,
     );
     assert_tx_info(
         &mut blockifier_state,
         &mut cheatnet_state,
         &contract_address_2,
-        tx_info_before_2,
+        &tx_info_before_2,
     );
 }

--- a/crates/cheatnet/tests/contracts/src/spoof/constructor_spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/constructor_spoof_checker.cairo
@@ -1,6 +1,6 @@
 #[starknet::interface]
 trait IConstructorSpoofChecker<TContractState> {
-    fn get_stored_tx_hash(ref self: TContractState) -> felt252;
+    fn get_stored_tx_hash(self: @TContractState) -> felt252;
 }
 
 #[starknet::contract]
@@ -19,7 +19,7 @@ mod ConstructorSpoofChecker {
 
     #[abi(embed_v0)]
     impl IConstructorSpoofChecker of super::IConstructorSpoofChecker<ContractState> {
-        fn get_stored_tx_hash(ref self: ContractState) -> felt252 {
+        fn get_stored_tx_hash(self: @ContractState) -> felt252 {
             self.stored_tx_hash.read()
         }
     }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
@@ -14,14 +14,14 @@ trait ISpoofChecker<TContractState> {
     fn get_transaction_hash(ref self: TContractState) -> felt252;
     fn get_chain_id(ref self: TContractState) -> felt252;
     fn get_nonce(ref self: TContractState) -> felt252;
-    
+
     fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
     fn get_tip(ref self: TContractState) -> u128;
     fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
     fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
     fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
     fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
-    
+
     fn get_tx_hash_and_emit_event(ref self: TContractState) -> felt252;
     fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
 }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
@@ -7,20 +7,23 @@ use starknet::info::v2::ResourceBounds;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_tx_hash(ref self: TContractState) -> felt252;
-    fn get_nonce(ref self: TContractState) -> felt252;
-    fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-    fn get_signature(ref self: TContractState) -> Span<felt252>;
     fn get_version(ref self: TContractState) -> felt252;
+    fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
     fn get_max_fee(ref self: TContractState) -> u128;
+    fn get_signature(ref self: TContractState) -> Span<felt252>;
+    fn get_transaction_hash(ref self: TContractState) -> felt252;
     fn get_chain_id(ref self: TContractState) -> felt252;
+    fn get_nonce(ref self: TContractState) -> felt252;
+    
     fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
     fn get_tip(ref self: TContractState) -> u128;
     fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
     fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
     fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
     fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
+    
     fn get_tx_hash_and_emit_event(ref self: TContractState) -> felt252;
+    fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
 }
 
 #[starknet::contract]
@@ -33,9 +36,7 @@ mod SpoofChecker {
     use starknet::{SyscallResultTrait, SyscallResult, syscalls::get_execution_info_v2_syscall};
 
     #[storage]
-    struct Storage {
-        balance: felt252,
-    }
+    struct Storage {}
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -50,7 +51,7 @@ mod SpoofChecker {
 
     #[abi(embed_v0)]
     impl ISpoofChecker of super::ISpoofChecker<ContractState> {
-        fn get_tx_hash(ref self: ContractState) -> felt252 {
+        fn get_transaction_hash(ref self: ContractState) -> felt252 {
             starknet::get_tx_info().unbox().transaction_hash
         }
 
@@ -106,6 +107,10 @@ mod SpoofChecker {
             let tx_hash = starknet::get_tx_info().unbox().transaction_hash;
             self.emit(Event::TxHashEmitted(TxHashEmitted { tx_hash }));
             tx_hash
+        }
+
+        fn get_tx_info(ref self: ContractState) -> starknet::info::v2::TxInfo {
+            get_tx_info_v2().unbox()
         }
     }
 

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker.cairo
@@ -1,38 +1,12 @@
-use starknet::info::TxInfo;
-use serde::Serde;
-use option::OptionTrait;
-use array::ArrayTrait;
-use starknet::ContractAddress;
-use starknet::info::v2::ResourceBounds;
-
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_version(ref self: TContractState) -> felt252;
-    fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-    fn get_max_fee(ref self: TContractState) -> u128;
-    fn get_signature(ref self: TContractState) -> Span<felt252>;
-    fn get_transaction_hash(ref self: TContractState) -> felt252;
-    fn get_chain_id(ref self: TContractState) -> felt252;
-    fn get_nonce(ref self: TContractState) -> felt252;
-
-    fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
-    fn get_tip(ref self: TContractState) -> u128;
-    fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
-    fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
-    fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
-    fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
-
+    fn get_transaction_hash(self: @TContractState) -> felt252;
     fn get_tx_hash_and_emit_event(ref self: TContractState) -> felt252;
-    fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
+    fn get_tx_info(self: @TContractState) -> starknet::info::v2::TxInfo;
 }
 
 #[starknet::contract]
 mod SpoofChecker {
-    use serde::Serde;
-    use starknet::info::TxInfo;
-    use box::BoxTrait;
-    use starknet::ContractAddress;
-    use starknet::info::v2::ResourceBounds;
     use starknet::{SyscallResultTrait, SyscallResult, syscalls::get_execution_info_v2_syscall};
 
     #[storage]
@@ -51,56 +25,8 @@ mod SpoofChecker {
 
     #[abi(embed_v0)]
     impl ISpoofChecker of super::ISpoofChecker<ContractState> {
-        fn get_transaction_hash(ref self: ContractState) -> felt252 {
+        fn get_transaction_hash(self: @ContractState) -> felt252 {
             starknet::get_tx_info().unbox().transaction_hash
-        }
-
-        fn get_nonce(ref self: ContractState) -> felt252 {
-            starknet::get_tx_info().unbox().nonce
-        }
-
-        fn get_account_contract_address(ref self: ContractState) -> ContractAddress {
-            starknet::get_tx_info().unbox().account_contract_address
-        }
-
-        fn get_signature(ref self: ContractState) -> Span<felt252> {
-            starknet::get_tx_info().unbox().signature
-        }
-
-        fn get_version(ref self: ContractState) -> felt252 {
-            starknet::get_tx_info().unbox().version
-        }
-
-        fn get_max_fee(ref self: ContractState) -> u128 {
-            starknet::get_tx_info().unbox().max_fee
-        }
-
-        fn get_chain_id(ref self: ContractState) -> felt252 {
-            starknet::get_tx_info().unbox().chain_id
-        }
-
-        fn get_resource_bounds(ref self: ContractState) -> Span<ResourceBounds> {
-            get_tx_info_v2().unbox().resource_bounds
-        }
-
-        fn get_tip(ref self: ContractState) -> u128 {
-            get_tx_info_v2().unbox().tip
-        }
-
-        fn get_paymaster_data(ref self: ContractState) -> Span<felt252> {
-            get_tx_info_v2().unbox().paymaster_data
-        }
-
-        fn get_nonce_data_availability_mode(ref self: ContractState) -> u32 {
-            get_tx_info_v2().unbox().nonce_data_availability_mode
-        }
-
-        fn get_fee_data_availability_mode(ref self: ContractState) -> u32 {
-            get_tx_info_v2().unbox().fee_data_availability_mode
-        }
-
-        fn get_account_deployment_data(ref self: ContractState) -> Span<felt252> {
-            get_tx_info_v2().unbox().account_deployment_data
         }
 
         fn get_tx_hash_and_emit_event(ref self: ContractState) -> felt252 {
@@ -109,16 +35,9 @@ mod SpoofChecker {
             tx_hash
         }
 
-        fn get_tx_info(ref self: ContractState) -> starknet::info::v2::TxInfo {
-            get_tx_info_v2().unbox()
+        fn get_tx_info(self: @ContractState) -> starknet::info::v2::TxInfo {
+            let execution_info = get_execution_info_v2_syscall().unwrap_syscall().unbox();
+            execution_info.tx_info.unbox()
         }
-    }
-
-    fn get_execution_info_v2() -> Box<starknet::info::v2::ExecutionInfo> {
-        get_execution_info_v2_syscall().unwrap_syscall()
-    }
-
-    fn get_tx_info_v2() -> Box<starknet::info::v2::TxInfo> {
-        get_execution_info_v2().unbox().tx_info
     }
 }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
@@ -2,12 +2,12 @@ use starknet::ClassHash;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_transaction_hash(ref self: TContractState) -> felt252;
+    fn get_transaction_hash(self: @TContractState) -> felt252;
 }
 
 #[starknet::interface]
 trait ISpoofCheckerLibCall<TContractState> {
-    fn get_tx_hash_with_lib_call(ref self: TContractState, class_hash: ClassHash) -> felt252;
+    fn get_tx_hash_with_lib_call(self: @TContractState, class_hash: ClassHash) -> felt252;
 }
 
 #[starknet::contract]
@@ -20,7 +20,7 @@ mod SpoofCheckerLibCall {
 
     #[abi(embed_v0)]
     impl ISpoofCheckerLibCall of super::ISpoofCheckerLibCall<ContractState> {
-        fn get_tx_hash_with_lib_call(ref self: ContractState, class_hash: ClassHash) -> felt252 {
+        fn get_tx_hash_with_lib_call(self: @ContractState, class_hash: ClassHash) -> felt252 {
             let spoof_checker = ISpoofCheckerLibraryDispatcher { class_hash };
             spoof_checker.get_transaction_hash()
         }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_library_call.cairo
@@ -2,7 +2,7 @@ use starknet::ClassHash;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_tx_hash(ref self: TContractState) -> felt252;
+    fn get_transaction_hash(ref self: TContractState) -> felt252;
 }
 
 #[starknet::interface]
@@ -22,7 +22,7 @@ mod SpoofCheckerLibCall {
     impl ISpoofCheckerLibCall of super::ISpoofCheckerLibCall<ContractState> {
         fn get_tx_hash_with_lib_call(ref self: ContractState, class_hash: ClassHash) -> felt252 {
             let spoof_checker = ISpoofCheckerLibraryDispatcher { class_hash };
-            spoof_checker.get_tx_hash()
+            spoof_checker.get_transaction_hash()
         }
     }
 }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_tx_hash(ref self: TContractState) -> felt252;
+    fn get_transaction_hash(ref self: TContractState) -> felt252;
 }
 
 
@@ -26,7 +26,7 @@ mod SpoofCheckerProxy {
             ref self: ContractState, address: ContractAddress
         ) -> felt252 {
             let spoof_checker = ISpoofCheckerDispatcher { contract_address: address };
-            spoof_checker.get_tx_hash()
+            spoof_checker.get_transaction_hash()
         }
     }
 }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
@@ -22,9 +22,7 @@ mod SpoofCheckerProxy {
 
     #[abi(embed_v0)]
     impl ISpoofCheckerProxy of super::ISpoofCheckerProxy<ContractState> {
-        fn get_spoof_checkers_tx_hash(
-            self: @ContractState, address: ContractAddress
-        ) -> felt252 {
+        fn get_spoof_checkers_tx_hash(self: @ContractState, address: ContractAddress) -> felt252 {
             let spoof_checker = ISpoofCheckerDispatcher { contract_address: address };
             spoof_checker.get_transaction_hash()
         }

--- a/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
+++ b/crates/cheatnet/tests/contracts/src/spoof/spoof_checker_proxy.cairo
@@ -2,13 +2,13 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_transaction_hash(ref self: TContractState) -> felt252;
+    fn get_transaction_hash(self: @TContractState) -> felt252;
 }
 
 
 #[starknet::interface]
 trait ISpoofCheckerProxy<TContractState> {
-    fn get_spoof_checkers_tx_hash(ref self: TContractState, address: ContractAddress) -> felt252;
+    fn get_spoof_checkers_tx_hash(self: @TContractState, address: ContractAddress) -> felt252;
 }
 
 #[starknet::contract]
@@ -23,7 +23,7 @@ mod SpoofCheckerProxy {
     #[abi(embed_v0)]
     impl ISpoofCheckerProxy of super::ISpoofCheckerProxy<ContractState> {
         fn get_spoof_checkers_tx_hash(
-            ref self: ContractState, address: ContractAddress
+            self: @ContractState, address: ContractAddress
         ) -> felt252 {
             let spoof_checker = ISpoofCheckerDispatcher { contract_address: address };
             spoof_checker.get_transaction_hash()

--- a/crates/forge/tests/data/contracts/spoof_checker.cairo
+++ b/crates/forge/tests/data/contracts/spoof_checker.cairo
@@ -7,20 +7,20 @@ use starknet::info::v2::ResourceBounds;
 
 #[starknet::interface]
 trait ISpoofChecker<TContractState> {
-    fn get_tx_hash(ref self: TContractState) -> felt252;
-    fn get_nonce(ref self: TContractState) -> felt252;
-    fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-    fn get_signature(ref self: TContractState) -> Span<felt252>;
-    fn get_version(ref self: TContractState) -> felt252;
-    fn get_max_fee(ref self: TContractState) -> u128;
-    fn get_chain_id(ref self: TContractState) -> felt252;
-    fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
-    fn get_tip(ref self: TContractState) -> u128;
-    fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
-    fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
-    fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
-    fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
-    fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
+    fn get_tx_hash(self: @TContractState) -> felt252;
+    fn get_nonce(self: @TContractState) -> felt252;
+    fn get_account_contract_address(self: @TContractState) -> ContractAddress;
+    fn get_signature(self: @TContractState) -> Span<felt252>;
+    fn get_version(self: @TContractState) -> felt252;
+    fn get_max_fee(self: @TContractState) -> u128;
+    fn get_chain_id(self: @TContractState) -> felt252;
+    fn get_resource_bounds(self: @TContractState) -> Span<ResourceBounds>;
+    fn get_tip(self: @TContractState) -> u128;
+    fn get_paymaster_data(self: @TContractState) -> Span<felt252>;
+    fn get_nonce_data_availability_mode(self: @TContractState) -> u32;
+    fn get_fee_data_availability_mode(self: @TContractState) -> u32;
+    fn get_account_deployment_data(self: @TContractState) -> Span<felt252>;
+    fn get_tx_info(self: @TContractState) -> starknet::info::v2::TxInfo;
 }
 
 #[starknet::contract]
@@ -39,59 +39,59 @@ mod SpoofChecker {
 
     #[abi(embed_v0)]
     impl ISpoofChecker of super::ISpoofChecker<ContractState> {
-        fn get_tx_hash(ref self: ContractState) -> felt252 {
+        fn get_tx_hash(self: @ContractState) -> felt252 {
             starknet::get_tx_info().unbox().transaction_hash
         }
 
-        fn get_nonce(ref self: ContractState) -> felt252 {
+        fn get_nonce(self: @ContractState) -> felt252 {
             starknet::get_tx_info().unbox().nonce
         }
 
-        fn get_account_contract_address(ref self: ContractState) -> ContractAddress {
+        fn get_account_contract_address(self: @ContractState) -> ContractAddress {
             starknet::get_tx_info().unbox().account_contract_address
         }
 
-        fn get_signature(ref self: ContractState) -> Span<felt252> {
+        fn get_signature(self: @ContractState) -> Span<felt252> {
             starknet::get_tx_info().unbox().signature
         }
 
-        fn get_version(ref self: ContractState) -> felt252 {
+        fn get_version(self: @ContractState) -> felt252 {
             starknet::get_tx_info().unbox().version
         }
 
-        fn get_max_fee(ref self: ContractState) -> u128 {
+        fn get_max_fee(self: @ContractState) -> u128 {
             starknet::get_tx_info().unbox().max_fee
         }
 
-        fn get_chain_id(ref self: ContractState) -> felt252 {
+        fn get_chain_id(self: @ContractState) -> felt252 {
             starknet::get_tx_info().unbox().chain_id
         }
 
-        fn get_resource_bounds(ref self: ContractState) -> Span<ResourceBounds> {
+        fn get_resource_bounds(self: @ContractState) -> Span<ResourceBounds> {
             get_tx_info_v2().unbox().resource_bounds
         }
 
-        fn get_tip(ref self: ContractState) -> u128 {
+        fn get_tip(self: @ContractState) -> u128 {
             get_tx_info_v2().unbox().tip
         }
 
-        fn get_paymaster_data(ref self: ContractState) -> Span<felt252> {
+        fn get_paymaster_data(self: @ContractState) -> Span<felt252> {
             get_tx_info_v2().unbox().paymaster_data
         }
 
-        fn get_nonce_data_availability_mode(ref self: ContractState) -> u32 {
+        fn get_nonce_data_availability_mode(self: @ContractState) -> u32 {
             get_tx_info_v2().unbox().nonce_data_availability_mode
         }
 
-        fn get_fee_data_availability_mode(ref self: ContractState) -> u32 {
+        fn get_fee_data_availability_mode(self: @ContractState) -> u32 {
             get_tx_info_v2().unbox().fee_data_availability_mode
         }
 
-        fn get_account_deployment_data(ref self: ContractState) -> Span<felt252> {
+        fn get_account_deployment_data(self: @ContractState) -> Span<felt252> {
             get_tx_info_v2().unbox().account_deployment_data
         }
 
-        fn get_tx_info(ref self: ContractState) -> starknet::info::v2::TxInfo {
+        fn get_tx_info(self: @ContractState) -> starknet::info::v2::TxInfo {
             get_tx_info_v2().unbox()
         }
     }

--- a/crates/forge/tests/data/contracts/spoof_checker.cairo
+++ b/crates/forge/tests/data/contracts/spoof_checker.cairo
@@ -20,6 +20,7 @@ trait ISpoofChecker<TContractState> {
     fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
     fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
     fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
+    fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
 }
 
 #[starknet::contract]
@@ -88,6 +89,10 @@ mod SpoofChecker {
 
         fn get_account_deployment_data(ref self: ContractState) -> Span<felt252> {
             get_tx_info_v2().unbox().account_deployment_data
+        }
+
+        fn get_tx_info(ref self: ContractState) -> starknet::info::v2::TxInfo {
+            get_tx_info_v2().unbox()
         }
     }
 

--- a/crates/forge/tests/integration/spoof.rs
+++ b/crates/forge/tests/integration/spoof.rs
@@ -20,19 +20,7 @@ fn start_and_stop_spoof_single_attribute() {
 
             #[starknet::interface]
             trait ISpoofChecker<TContractState> {
-                fn get_tx_hash(ref self: TContractState) -> felt252;
-                fn get_nonce(ref self: TContractState) -> felt252;
-                fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-                fn get_signature(ref self: TContractState) -> Span<felt252>;
-                fn get_version(ref self: TContractState) -> felt252;
-                fn get_max_fee(ref self: TContractState) -> u128;
-                fn get_chain_id(ref self: TContractState) -> felt252;
-                fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
-                fn get_tip(ref self: TContractState) -> u128;
-                fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
-                fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
+                fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
             }
 
             #[test]
@@ -41,52 +29,21 @@ fn start_and_stop_spoof_single_attribute() {
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
 
-                let nonce_before_mock = dispatcher.get_nonce();
-                let account_address_before_mock = dispatcher.get_account_contract_address();
-                let version_before_mock = dispatcher.get_version();
-                let max_fee_before_mock = dispatcher.get_max_fee();
-                let chain_id_before_mock = dispatcher.get_chain_id();
-                let signature_before_mock = dispatcher.get_signature();
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
-                let mut resource_bounds_before_mock = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds_before_mock);
-                let tip_before_mock = dispatcher.get_tip();
-                let paymaster_data_before_mock = dispatcher.get_paymaster_data();
-                let nonce_data_availability_mode_before_mock = dispatcher.get_nonce_data_availability_mode();
-                let fee_data_availability_mode_before_mock = dispatcher.get_fee_data_availability_mode();
-                let account_deployment_data_before_mock = dispatcher.get_account_deployment_data();
+                let tx_info_before = dispatcher.get_tx_info();
 
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.transaction_hash = Option::Some(421);
+
                 start_spoof(CheatTarget::One(contract_address), tx_info_mock);
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(transaction_hash == 421, 'Invalid tx hash');
+                let mut expected_tx_info = tx_info_before;
+                expected_tx_info.transaction_hash = 421;
 
-                assert(dispatcher.get_nonce() == nonce_before_mock, 'Invalid nonce');
-                assert(
-                    dispatcher.get_account_contract_address() == account_address_before_mock,
-                    'Invalid account address'
-                );
-                assert(dispatcher.get_version() == version_before_mock, 'Invalid version');
-                assert(dispatcher.get_max_fee() == max_fee_before_mock, 'Invalid max_fee');
-                assert(dispatcher.get_chain_id() == chain_id_before_mock, 'Invalid chain_id');
-                assert(dispatcher.get_signature() == signature_before_mock, 'Invalid signature');
-
-                let mut resource_bounds = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds);
-
-                assert(resource_bounds == resource_bounds_before_mock, 'Invalid resource bounds');
-                assert(dispatcher.get_tip() == tip_before_mock, 'Invalid tip');
-                assert(dispatcher.get_paymaster_data() == paymaster_data_before_mock, 'Invalid paymaster data');
-                assert(dispatcher.get_nonce_data_availability_mode() == nonce_data_availability_mode_before_mock, 'Invalid nonce data');
-                assert(dispatcher.get_fee_data_availability_mode() == fee_data_availability_mode_before_mock, 'Invalid fee data');
-                assert(dispatcher.get_account_deployment_data() == account_deployment_data_before_mock, 'Invalid account deployment');
+                assert_tx_info(dispatcher.get_tx_info(), expected_tx_info);
 
                 stop_spoof(CheatTarget::One(contract_address));
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(transaction_hash == tx_hash_before_mock, 'Invalid tx hash');
+                assert_tx_info(dispatcher.get_tx_info(), tx_info_before);
             }
 
             #[test]
@@ -95,19 +52,45 @@ fn start_and_stop_spoof_single_attribute() {
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
 
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
+                let tx_info_before = dispatcher.get_tx_info();
 
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.transaction_hash = Option::Some(421);
+
                 start_spoof(CheatTarget::All, tx_info_mock);
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(transaction_hash == 421, 'Invalid tx hash');
+                let mut expected_tx_info = tx_info_before;
+                expected_tx_info.transaction_hash = 421;
+
+                assert_tx_info(dispatcher.get_tx_info(), expected_tx_info);
 
                 stop_spoof(CheatTarget::One(contract_address));
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(tx_hash_before_mock == transaction_hash, 'Tx hash did not change back');
+                assert_tx_info(dispatcher.get_tx_info(), tx_info_before);
+            }
+
+            fn assert_tx_info(tx_info: starknet::info::v2::TxInfo, expected_tx_info: starknet::info::v2::TxInfo) {
+                assert(tx_info.version == expected_tx_info.version, 'Invalid version');
+                assert(tx_info.account_contract_address == expected_tx_info.account_contract_address, 'Invalid account_contract_addr');
+                assert(tx_info.max_fee == expected_tx_info.max_fee, 'Invalid max_fee');
+                assert(tx_info.signature == expected_tx_info.signature, 'Invalid signature');
+                assert(tx_info.transaction_hash == expected_tx_info.transaction_hash, 'Invalid transaction_hash');
+                assert(tx_info.chain_id == expected_tx_info.chain_id, 'Invalid chain_id');
+                assert(tx_info.nonce == expected_tx_info.nonce, 'Invalid nonce');
+
+                let mut resource_bounds = array![];
+                tx_info.resource_bounds.serialize(ref resource_bounds);
+
+                let mut expected_resource_bounds = array![];
+                expected_tx_info.resource_bounds.serialize(ref expected_resource_bounds);
+
+                assert(resource_bounds == expected_resource_bounds, 'Invalid resource bounds');
+                
+                assert(tx_info.tip == expected_tx_info.tip, 'Invalid tip');
+                assert(tx_info.paymaster_data == expected_tx_info.paymaster_data, 'Invalid paymaster_data');
+                assert(tx_info.nonce_data_availability_mode == expected_tx_info.nonce_data_availability_mode, 'Invalid nonce_data_av_mode');
+                assert(tx_info.fee_data_availability_mode == expected_tx_info.fee_data_availability_mode, 'Invalid fee_data_av_mode');
+                assert(tx_info.account_deployment_data == expected_tx_info.account_deployment_data, 'Invalid account_deployment_data');
             }
         "
         ),
@@ -257,19 +240,7 @@ fn start_spoof_cancel_mock_by_setting_attribute_to_none() {
 
             #[starknet::interface]
             trait ISpoofChecker<TContractState> {
-                fn get_tx_hash(ref self: TContractState) -> felt252;
-                fn get_nonce(ref self: TContractState) -> felt252;
-                fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-                fn get_signature(ref self: TContractState) -> Span<felt252>;
-                fn get_version(ref self: TContractState) -> felt252;
-                fn get_max_fee(ref self: TContractState) -> u128;
-                fn get_chain_id(ref self: TContractState) -> felt252;
-                fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
-                fn get_tip(ref self: TContractState) -> u128;
-                fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
-                fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
+                fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
             }
 
             #[test]
@@ -278,52 +249,45 @@ fn start_spoof_cancel_mock_by_setting_attribute_to_none() {
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
 
-                let nonce_before_mock = dispatcher.get_nonce();
-                let account_address_before_mock = dispatcher.get_account_contract_address();
-                let version_before_mock = dispatcher.get_version();
-                let max_fee_before_mock = dispatcher.get_max_fee();
-                let chain_id_before_mock = dispatcher.get_chain_id();
-                let signature_before_mock = dispatcher.get_signature();
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
-                let mut resource_bounds_before_mock = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds_before_mock);
-                let tip_before_mock = dispatcher.get_tip();
-                let paymaster_data_before_mock = dispatcher.get_paymaster_data();
-                let nonce_data_availability_mode_before_mock = dispatcher.get_nonce_data_availability_mode();
-                let fee_data_availability_mode_before_mock = dispatcher.get_fee_data_availability_mode();
-                let account_deployment_data_before_mock = dispatcher.get_account_deployment_data();
+                let tx_info_before_mock = dispatcher.get_tx_info();
 
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 tx_info_mock.transaction_hash = Option::Some(421);
+
                 start_spoof(CheatTarget::One(contract_address), tx_info_mock);
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(transaction_hash == 421, 'Invalid tx hash');
+                let mut expected_tx_info = tx_info_before_mock;
+                expected_tx_info.transaction_hash = 421;
+
+                assert_tx_info(dispatcher.get_tx_info(), expected_tx_info);
 
                 start_spoof(CheatTarget::One(contract_address), TxInfoMockTrait::default());
 
-                let transaction_hash = dispatcher.get_tx_hash();
-                assert(transaction_hash == tx_hash_before_mock, 'Invalid tx hash');
+                assert_tx_info(dispatcher.get_tx_info(), tx_info_before_mock);
+            }
 
-                assert(dispatcher.get_nonce() == nonce_before_mock, 'Invalid nonce');
-                assert(
-                    dispatcher.get_account_contract_address() == account_address_before_mock,
-                    'Invalid account address'
-                );
-                assert(dispatcher.get_version() == version_before_mock, 'Invalid version');
-                assert(dispatcher.get_max_fee() == max_fee_before_mock, 'Invalid max_fee');
-                assert(dispatcher.get_chain_id() == chain_id_before_mock, 'Invalid chain_id');
-                assert(dispatcher.get_signature() == signature_before_mock, 'Invalid signature');
+            fn assert_tx_info(tx_info: starknet::info::v2::TxInfo, expected_tx_info: starknet::info::v2::TxInfo) {
+                assert(tx_info.version == expected_tx_info.version, 'Invalid version');
+                assert(tx_info.account_contract_address == expected_tx_info.account_contract_address, 'Invalid account_contract_addr');
+                assert(tx_info.max_fee == expected_tx_info.max_fee, 'Invalid max_fee');
+                assert(tx_info.signature == expected_tx_info.signature, 'Invalid signature');
+                assert(tx_info.transaction_hash == expected_tx_info.transaction_hash, 'Invalid transaction_hash');
+                assert(tx_info.chain_id == expected_tx_info.chain_id, 'Invalid chain_id');
+                assert(tx_info.nonce == expected_tx_info.nonce, 'Invalid nonce');
 
                 let mut resource_bounds = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds);
+                tx_info.resource_bounds.serialize(ref resource_bounds);
 
-                assert(resource_bounds == resource_bounds_before_mock, 'Invalid resource bounds');
-                assert(dispatcher.get_tip() == tip_before_mock, 'Invalid tip');
-                assert(dispatcher.get_paymaster_data() == paymaster_data_before_mock, 'Invalid paymaster data');
-                assert(dispatcher.get_nonce_data_availability_mode() == nonce_data_availability_mode_before_mock, 'Invalid nonce data');
-                assert(dispatcher.get_fee_data_availability_mode() == fee_data_availability_mode_before_mock, 'Invalid fee data');
-                assert(dispatcher.get_account_deployment_data() == account_deployment_data_before_mock, 'Invalid account deployment');
+                let mut expected_resource_bounds = array![];
+                expected_tx_info.resource_bounds.serialize(ref expected_resource_bounds);
+
+                assert(resource_bounds == expected_resource_bounds, 'Invalid resource bounds');
+                
+                assert(tx_info.tip == expected_tx_info.tip, 'Invalid tip');
+                assert(tx_info.paymaster_data == expected_tx_info.paymaster_data, 'Invalid paymaster_data');
+                assert(tx_info.nonce_data_availability_mode == expected_tx_info.nonce_data_availability_mode, 'Invalid nonce_data_av_mode');
+                assert(tx_info.fee_data_availability_mode == expected_tx_info.fee_data_availability_mode, 'Invalid fee_data_av_mode');
+                assert(tx_info.account_deployment_data == expected_tx_info.account_deployment_data, 'Invalid account_deployment_data');
             }
         "
         ),
@@ -357,19 +321,7 @@ fn start_spoof_no_attributes_mocked() {
 
             #[starknet::interface]
             trait ISpoofChecker<TContractState> {
-                fn get_tx_hash(ref self: TContractState) -> felt252;
-                fn get_nonce(ref self: TContractState) -> felt252;
-                fn get_account_contract_address(ref self: TContractState) -> ContractAddress;
-                fn get_signature(ref self: TContractState) -> Span<felt252>;
-                fn get_version(ref self: TContractState) -> felt252;
-                fn get_max_fee(ref self: TContractState) -> u128;
-                fn get_chain_id(ref self: TContractState) -> felt252;
-                fn get_resource_bounds(ref self: TContractState) -> Span<ResourceBounds>;
-                fn get_tip(ref self: TContractState) -> u128;
-                fn get_paymaster_data(ref self: TContractState) -> Span<felt252>;
-                fn get_nonce_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_fee_data_availability_mode(ref self: TContractState) -> u32;
-                fn get_account_deployment_data(ref self: TContractState) -> Span<felt252>;
+                fn get_tx_info(ref self: TContractState) -> starknet::info::v2::TxInfo;
             }
 
             #[test]
@@ -378,45 +330,36 @@ fn start_spoof_no_attributes_mocked() {
                 let contract_address = contract.deploy(@ArrayTrait::new()).unwrap();
                 let dispatcher = ISpoofCheckerDispatcher { contract_address };
 
-                let nonce_before_mock = dispatcher.get_nonce();
-                let tx_hash_before_mock = dispatcher.get_tx_hash();
-                let account_address_before_mock = dispatcher.get_account_contract_address();
-                let version_before_mock = dispatcher.get_version();
-                let max_fee_before_mock = dispatcher.get_max_fee();
-                let chain_id_before_mock = dispatcher.get_chain_id();
-                let signature_before_mock = dispatcher.get_signature();
+                let tx_info_before_mock = dispatcher.get_tx_info();
 
-                let mut resource_bounds_before_mock = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds_before_mock);
-                let tip_before_mock = dispatcher.get_tip();
-                let paymaster_data_before_mock = dispatcher.get_paymaster_data();
-                let nonce_data_availability_mode_before_mock = dispatcher.get_nonce_data_availability_mode();
-                let fee_data_availability_mode_before_mock = dispatcher.get_fee_data_availability_mode();
-                let account_deployment_data_before_mock = dispatcher.get_account_deployment_data();
-                
                 let mut tx_info_mock = TxInfoMockTrait::default();
                 start_spoof(CheatTarget::One(contract_address), tx_info_mock);
 
-                assert(dispatcher.get_tx_hash() == tx_hash_before_mock, 'Invalid tx hash');
-                assert(dispatcher.get_nonce() == nonce_before_mock, 'Invalid nonce');
-                assert(
-                    dispatcher.get_account_contract_address() == account_address_before_mock,
-                    'Invalid account address'
-                );
-                assert(dispatcher.get_version() == version_before_mock, 'Invalid version');
-                assert(dispatcher.get_max_fee() == max_fee_before_mock, 'Invalid max_fee');
-                assert(dispatcher.get_chain_id() == chain_id_before_mock, 'Invalid chain_id');
-                assert(dispatcher.get_signature() == signature_before_mock, 'Invalid signature');
+                assert_tx_info(dispatcher.get_tx_info(), tx_info_before_mock);
+            }
+
+            fn assert_tx_info(tx_info: starknet::info::v2::TxInfo, expected_tx_info: starknet::info::v2::TxInfo) {
+                assert(tx_info.version == expected_tx_info.version, 'Invalid version');
+                assert(tx_info.account_contract_address == expected_tx_info.account_contract_address, 'Invalid account_contract_addr');
+                assert(tx_info.max_fee == expected_tx_info.max_fee, 'Invalid max_fee');
+                assert(tx_info.signature == expected_tx_info.signature, 'Invalid signature');
+                assert(tx_info.transaction_hash == expected_tx_info.transaction_hash, 'Invalid transaction_hash');
+                assert(tx_info.chain_id == expected_tx_info.chain_id, 'Invalid chain_id');
+                assert(tx_info.nonce == expected_tx_info.nonce, 'Invalid nonce');
+
                 let mut resource_bounds = array![];
-                dispatcher.get_resource_bounds().serialize(ref resource_bounds);
+                tx_info.resource_bounds.serialize(ref resource_bounds);
 
-                assert(resource_bounds == resource_bounds_before_mock, 'Invalid resource bounds');
-                assert(dispatcher.get_tip() == tip_before_mock, 'Invalid tip');
-                assert(dispatcher.get_paymaster_data() == paymaster_data_before_mock, 'Invalid paymaster data');
-                assert(dispatcher.get_nonce_data_availability_mode() == nonce_data_availability_mode_before_mock, 'Invalid nonce data');
-                assert(dispatcher.get_fee_data_availability_mode() == fee_data_availability_mode_before_mock, 'Invalid fee data');
-                assert(dispatcher.get_account_deployment_data() == account_deployment_data_before_mock, 'Invalid account deployment');
+                let mut expected_resource_bounds = array![];
+                expected_tx_info.resource_bounds.serialize(ref expected_resource_bounds);
 
+                assert(resource_bounds == expected_resource_bounds, 'Invalid resource bounds');
+                
+                assert(tx_info.tip == expected_tx_info.tip, 'Invalid tip');
+                assert(tx_info.paymaster_data == expected_tx_info.paymaster_data, 'Invalid paymaster_data');
+                assert(tx_info.nonce_data_availability_mode == expected_tx_info.nonce_data_availability_mode, 'Invalid nonce_data_av_mode');
+                assert(tx_info.fee_data_availability_mode == expected_tx_info.fee_data_availability_mode, 'Invalid fee_data_av_mode');
+                assert(tx_info.account_deployment_data == expected_tx_info.account_deployment_data, 'Invalid account_deployment_data');
             }
         "
         ),


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1331

## Introduced changes

<!-- A brief description of the changes -->

- Remove duplicated code in spoof tests
- `start_spoof` in rust takes in `TxInfoMock` instead of all unpacked values

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
