### PR TITLE
Fix nonce typo in docs

### DIFF
--- a/docs/src/appendix/sncast-library/get_nonce.md
+++ b/docs/src/appendix/sncast-library/get_nonce.md
@@ -11,7 +11,7 @@ use sncast_std::{get_nonce};
 use debug::PrintTrait;
 
 fn main() {
-    let nonce = get_once('latest');
+    let nonce = get_nonce('latest');
     nonce.print();
 }
 ```


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Fix typo in nonce

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
