### PR TITLE
`Display` for trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - maximum number of computational steps per call set to current Starknet limit (3M)
 - `mean` and `std deviation` fields are displayed for gas usage while running fuzzing tests 
 
+#### Fixed
+
+- Safe library dispatchers in test code no longer propagate errors when not intended to
+
 ## [0.13.1] - 2023-12-20
 
 ### Forge

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -34,6 +34,7 @@ pub fn execute_call_entry_point(
 ) -> EntryPointExecutionResult<CallInfo> {
     // region: Modified blockifier code
     // We skip recursion depth validation here.
+    cheatnet_state.trace_info.push(entry_point.clone());
     if let Some(ret_data) = get_ret_data_by_call_entry_point(entry_point, cheatnet_state) {
         return Ok(mocked_call_info(entry_point.clone(), ret_data.clone()));
     }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
@@ -1,29 +1,36 @@
 use std::marker::PhantomData;
 
+use blockifier::execution::entry_point::{CallEntryPoint, CallType};
+use blockifier::execution::execution_utils::felt_from_ptr;
+use blockifier::execution::syscalls::{
+    CallContractRequest, LibraryCallRequest, SyscallRequestWrapper,
+};
 use blockifier::execution::{
     deprecated_syscalls::DeprecatedSyscallSelector,
-    execution_utils::{stark_felt_from_ptr, ReadOnlySegment},
+    execution_utils::ReadOnlySegment,
     syscalls::{
-        hint_processor::{read_felt_array, SyscallExecutionError, SyscallHintProcessor},
-        SyscallRequest, SyscallResponse, SyscallResponseWrapper, SyscallResult,
+        hint_processor::SyscallHintProcessor, SyscallRequest, SyscallResponse,
+        SyscallResponseWrapper,
     },
 };
 
-use cairo_felt::Felt252;
-use cairo_vm::{
-    types::relocatable::Relocatable,
-    vm::{errors::hint_errors::HintError, vm_core::VirtualMachine},
-};
-use conversions::{FromConv, IntoConv};
-use num_traits::ToPrimitive;
+use crate::constants::TEST_ADDRESS;
+use cairo_vm::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
+use conversions::FromConv;
 use runtime::{ExtendedRuntime, ExtensionLogic, SyscallHandlingResult, SyscallPtrAccess};
-use starknet_api::{core::ContractAddress, hash::StarkFelt};
+use starknet_api::core::PatriciaKey;
+use starknet_api::deprecated_contract_class::EntryPointType;
+use starknet_api::hash::StarkHash;
+use starknet_api::{core::ContractAddress, hash::StarkFelt, patricia_key};
 
 use crate::state::{BlockifierState, CheatnetState};
 
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
+    call_entry_point, AddressOrClassHash,
+};
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::{
     execution::cheated_syscalls::SingleSegmentResponse,
-    rpc::{call_contract, CallContractFailure, CallContractOutput, CallContractResult},
+    rpc::{CallFailure, CallOutput, CallResult},
 };
 
 use super::io_runtime_extension::IORuntime;
@@ -48,109 +55,147 @@ impl<'a> ExtensionLogic for CallToBlockifierExtension<'a> {
         extended_runtime: &mut IORuntime<'a>,
     ) -> Result<SyscallHandlingResult, HintError> {
         match selector {
-            // We execute contract calls with modified blockifier
+            // We clear it here to ensure that on each new contract call
+            // deploy syscall and library call made from test code
+            // we start with an empty trace
+            // Same case when handling l1_handler_execute and in `deploy_at`
+            DeprecatedSyscallSelector::CallContract
+            | DeprecatedSyscallSelector::LibraryCall
+            | DeprecatedSyscallSelector::LibraryCallL1Handler
+            | DeprecatedSyscallSelector::Deploy => extended_runtime
+                .extended_runtime
+                .extension
+                .cheatnet_state
+                .trace_info
+                .clear(),
+            _ => (),
+        }
+        match selector {
+            // We execute contract calls and library calls with modified blockifier
             // This is redirected to drop ForgeRuntimeExtension
-            // and to ensure it behaves closely to real on-chain environment
+            // and to enable handling call errors with safe dispatchers in the test code
+            // since call errors cannot be handled on real starknet
+            // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#call_contract
             DeprecatedSyscallSelector::CallContract => {
-                extended_runtime
-                    .extended_runtime
-                    .extension
-                    .cheatnet_state
-                    .trace_info
-                    .clear();
-                let call_args = CallContractArgs::read(vm, extended_runtime.get_mut_syscall_ptr())?;
-                let cheatable_starknet_runtime = &mut extended_runtime.extended_runtime;
-                let cheatnet_state: &mut _ = cheatable_starknet_runtime.extension.cheatnet_state;
-                let syscall_handler = &mut cheatable_starknet_runtime.extended_runtime.hint_handler;
-                let mut blockifier_state = BlockifierState::from(syscall_handler.state);
-
-                let call_result =
-                    execute_call_contract(&mut blockifier_state, cheatnet_state, &call_args);
-                write_call_contract_response(
-                    syscall_handler,
-                    cheatnet_state,
-                    vm,
-                    &call_args,
-                    call_result,
-                )?;
+                execute_syscall::<CallContractRequest>(vm, extended_runtime)?;
                 Ok(SyscallHandlingResult::Handled(()))
             }
-            DeprecatedSyscallSelector::Deploy
-            | DeprecatedSyscallSelector::LibraryCall
-            | DeprecatedSyscallSelector::LibraryCallL1Handler => {
-                // We clear it here and in the first arm to ensure that on each
-                // new call, deploy syscall and library call made from test code
-                // we start with an empty trace
-                // Same case when handling l1_handler_execute and in `deploy_at`
-                extended_runtime
-                    .extended_runtime
-                    .extension
-                    .cheatnet_state
-                    .trace_info
-                    .clear();
-                Ok(SyscallHandlingResult::Forwarded)
+            DeprecatedSyscallSelector::LibraryCall => {
+                execute_syscall::<LibraryCallRequest>(vm, extended_runtime)?;
+                Ok(SyscallHandlingResult::Handled(()))
             }
             _ => Ok(SyscallHandlingResult::Forwarded),
         }
     }
 }
-struct CallContractArgs {
-    _selector: Felt252,
-    gas_counter: u64,
-    contract_address: ContractAddress,
-    entry_point_selector: Felt252,
-    calldata: Vec<Felt252>,
+
+trait ExecuteCall
+where
+    Self: SyscallRequest,
+{
+    fn execute_call(
+        self,
+        blockifier_state: &mut BlockifierState,
+        cheatnet_state: &mut CheatnetState,
+    ) -> CallOutput;
 }
 
-impl SyscallRequest for CallContractArgs {
-    fn read(vm: &VirtualMachine, ptr: &mut Relocatable) -> SyscallResult<CallContractArgs> {
-        let selector = stark_felt_from_ptr(vm, ptr)?.into_();
-        let gas_counter = Felt252::from_(stark_felt_from_ptr(vm, ptr)?)
-            .to_u64()
-            .unwrap();
+impl ExecuteCall for CallContractRequest {
+    fn execute_call(
+        self: CallContractRequest,
+        blockifier_state: &mut BlockifierState,
+        cheatnet_state: &mut CheatnetState,
+    ) -> CallOutput {
+        let contract_address = self.contract_address;
 
-        let contract_address = stark_felt_from_ptr(vm, ptr)?.into_();
-        let entry_point_selector = stark_felt_from_ptr(vm, ptr)?.into_();
+        let entry_point = CallEntryPoint {
+            class_hash: None,
+            code_address: Some(contract_address),
+            entry_point_type: EntryPointType::External,
+            entry_point_selector: self.function_selector,
+            calldata: self.calldata,
+            storage_address: contract_address,
+            caller_address: ContractAddress(patricia_key!(TEST_ADDRESS)),
+            call_type: CallType::Call,
+            initial_gas: u64::MAX,
+        };
 
-        let calldata = read_felt_array::<SyscallExecutionError>(vm, ptr)?
-            .iter()
-            .map(|el| (*el).into_())
-            .collect();
-
-        Ok(CallContractArgs {
-            _selector: selector,
-            gas_counter,
-            contract_address,
-            entry_point_selector,
-            calldata,
-        })
+        call_entry_point(
+            blockifier_state,
+            cheatnet_state,
+            entry_point,
+            &AddressOrClassHash::ContractAddress(contract_address),
+        )
+        .unwrap_or_else(|err| panic!("Transaction execution error: {err}"))
     }
 }
 
-fn execute_call_contract(
-    blockifier_state: &mut BlockifierState,
-    cheatnet_state: &mut CheatnetState,
-    call_args: &CallContractArgs,
-) -> CallContractOutput {
-    call_contract(
-        blockifier_state,
-        cheatnet_state,
-        &call_args.contract_address,
-        &call_args.entry_point_selector,
-        &call_args.calldata,
-    )
-    .unwrap_or_else(|err| panic!("Transaction execution error: {err}"))
+impl ExecuteCall for LibraryCallRequest {
+    fn execute_call(
+        self: LibraryCallRequest,
+        blockifier_state: &mut BlockifierState,
+        cheatnet_state: &mut CheatnetState,
+    ) -> CallOutput {
+        let class_hash = self.class_hash;
+
+        let entry_point = CallEntryPoint {
+            class_hash: Some(class_hash),
+            code_address: None,
+            entry_point_type: EntryPointType::External,
+            entry_point_selector: self.function_selector,
+            calldata: self.calldata,
+            storage_address: ContractAddress(patricia_key!(TEST_ADDRESS)),
+            caller_address: ContractAddress::default(),
+            call_type: CallType::Delegate,
+            initial_gas: u64::MAX,
+        };
+
+        call_entry_point(
+            blockifier_state,
+            cheatnet_state,
+            entry_point,
+            &AddressOrClassHash::ClassHash(class_hash),
+        )
+        .unwrap_or_else(|err| panic!("Transaction execution error: {err}"))
+    }
 }
 
-fn write_call_contract_response(
+fn execute_syscall<Request: ExecuteCall + SyscallRequest>(
+    vm: &mut VirtualMachine,
+    io_runtime: &mut IORuntime,
+) -> Result<(), HintError> {
+    let _selector = felt_from_ptr(vm, io_runtime.get_mut_syscall_ptr())?;
+
+    let SyscallRequestWrapper {
+        gas_counter,
+        request,
+    } = SyscallRequestWrapper::<Request>::read(vm, io_runtime.get_mut_syscall_ptr())?;
+
+    let cheatable_starknet_runtime = &mut io_runtime.extended_runtime;
+    let cheatnet_state: &mut _ = cheatable_starknet_runtime.extension.cheatnet_state;
+    let syscall_handler = &mut cheatable_starknet_runtime.extended_runtime.hint_handler;
+    let mut blockifier_state = BlockifierState::from(syscall_handler.state);
+
+    let call_result = request.execute_call(&mut blockifier_state, cheatnet_state);
+    write_call_response(
+        syscall_handler,
+        cheatnet_state,
+        vm,
+        gas_counter,
+        call_result,
+    )?;
+    Ok(())
+}
+
+fn write_call_response(
     syscall_handler: &mut SyscallHintProcessor<'_>,
     cheatnet_state: &mut CheatnetState,
     vm: &mut VirtualMachine,
-    call_args: &CallContractArgs,
-    call_output: CallContractOutput,
+    gas_counter: u64,
+    call_output: CallOutput,
 ) -> Result<(), HintError> {
     let response_wrapper: SyscallResponseWrapper<SingleSegmentResponse> = match call_output.result {
-        CallContractResult::Success { ret_data, .. } => {
+        CallResult::Success { ret_data, .. } => {
             let memory_segment_start_ptr = syscall_handler
                 .read_only_segments
                 .allocate(vm, &ret_data.iter().map(Into::into).collect())?;
@@ -161,7 +206,7 @@ fn write_call_contract_response(
                 .extend(&call_output.used_resources);
 
             SyscallResponseWrapper::Success {
-                gas_counter: call_args.gas_counter,
+                gas_counter,
                 response: SingleSegmentResponse {
                     segment: ReadOnlySegment {
                         start_ptr: memory_segment_start_ptr,
@@ -170,17 +215,15 @@ fn write_call_contract_response(
                 },
             }
         }
-        CallContractResult::Failure(failure_type) => match failure_type {
-            CallContractFailure::Panic { panic_data, .. } => SyscallResponseWrapper::Failure {
-                gas_counter: call_args.gas_counter,
+        CallResult::Failure(failure_type) => match failure_type {
+            CallFailure::Panic { panic_data, .. } => SyscallResponseWrapper::Failure {
+                gas_counter,
                 error_data: panic_data
                     .iter()
                     .map(|el| StarkFelt::from_(el.clone()))
                     .collect(),
             },
-            CallContractFailure::Error { msg, .. } => {
-                return Err(HintError::CustomHint(Box::from(msg)))
-            }
+            CallFailure::Error { msg, .. } => return Err(HintError::CustomHint(Box::from(msg))),
         },
     };
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -1,10 +1,9 @@
 use anyhow::Result;
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_lang_runner::casm_run::format_next_item;
-use std::sync::Arc;
 
-use crate::constants::TEST_ADDRESS;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::panic_data::try_extract_panic_data;
+use crate::runtime_extensions::common::{create_entry_point_selector, create_execute_calldata};
 use crate::state::BlockifierState;
 use crate::{
     constants::{build_block_context, build_transaction_context},
@@ -20,14 +19,8 @@ use blockifier::execution::{
 };
 use blockifier::state::errors::StateError;
 use cairo_felt::Felt252;
-use starknet_api::core::PatriciaKey;
-use starknet_api::patricia_key;
-use starknet_api::{
-    core::{ContractAddress, EntryPointSelector},
-    deprecated_contract_class::EntryPointType,
-    hash::{StarkFelt, StarkHash},
-    transaction::Calldata,
-};
+use starknet_api::core::ClassHash;
+use starknet_api::{core::ContractAddress, deprecated_contract_class::EntryPointType};
 
 #[derive(Debug, Default)]
 pub struct UsedResources {
@@ -46,35 +39,40 @@ impl UsedResources {
     }
 }
 
-/// Represents contract output, along with the data and the resources consumed during execution
+/// Represents call output, along with the data and the resources consumed during execution
 #[derive(Debug)]
-pub struct CallContractOutput {
-    pub result: CallContractResult,
+pub struct CallOutput {
+    pub result: CallResult,
     pub used_resources: UsedResources,
 }
 
-/// Enum representing possible contract execution result, along with the data
+/// Enum representing possible call execution result, along with the data
 #[derive(Debug)]
-pub enum CallContractResult {
+pub enum CallResult {
     Success { ret_data: Vec<Felt252> },
-    Failure(CallContractFailure),
+    Failure(CallFailure),
 }
 
 /// Enum representing possible call failure and its' type.
 /// `Panic` - Recoverable, meant to be caught by the user.
 /// `Error` - Unrecoverable, equivalent of panic! in rust.
 #[derive(Debug)]
-pub enum CallContractFailure {
+pub enum CallFailure {
     Panic { panic_data: Vec<Felt252> },
     Error { msg: String },
 }
 
-impl CallContractFailure {
+pub enum AddressOrClassHash {
+    ContractAddress(ContractAddress),
+    ClassHash(ClassHash),
+}
+
+impl CallFailure {
     /// Maps blockifier-type error, to one that can be put into memory as panic-data (or re-raised)
     #[must_use]
     pub fn from_execution_error(
         err: &EntryPointExecutionError,
-        contract_address: &ContractAddress,
+        starknet_identifier: &AddressOrClassHash,
     ) -> Self {
         match err {
             EntryPointExecutionError::ExecutionFailed { error_data } => {
@@ -102,52 +100,57 @@ impl CallContractFailure {
                     "Input too long for arguments",
                 ] {
                     if err_data_str.contains(invalid_calldata_msg) {
-                        return CallContractFailure::Error { msg: err_data_str };
+                        return CallFailure::Error { msg: err_data_str };
                     }
                 }
 
-                CallContractFailure::Panic {
+                CallFailure::Panic {
                     panic_data: err_data,
                 }
             }
             EntryPointExecutionError::VirtualMachineExecutionErrorWithTrace { trace, .. } => {
                 if let Some(panic_data) = try_extract_panic_data(trace) {
-                    CallContractFailure::Panic { panic_data }
+                    CallFailure::Panic { panic_data }
                 } else {
-                    CallContractFailure::Error { msg: trace.clone() }
+                    CallFailure::Error { msg: trace.clone() }
                 }
             }
             EntryPointExecutionError::PreExecutionError(PreExecutionError::EntryPointNotFound(
                 selector,
             )) => {
                 let selector_hash = selector.0;
-                let contract_addr = contract_address.0.key();
-                let msg = format!(
-                    "Entry point selector {selector_hash} not found in contract {contract_addr}"
-                );
-                CallContractFailure::Error { msg }
+                let msg = match starknet_identifier {
+                    AddressOrClassHash::ContractAddress(address) => format!(
+                        "Entry point selector {selector_hash} not found in contract {}",
+                        address.0.key()
+                    ),
+                    AddressOrClassHash::ClassHash(class_hash) => format!(
+                        "Entry point selector {selector_hash} not found for class hash {class_hash}"
+                    ),
+                };
+                CallFailure::Error { msg }
             }
             EntryPointExecutionError::PreExecutionError(
                 PreExecutionError::UninitializedStorageAddress(contract_address),
             ) => {
                 let address = contract_address.0.key().to_string();
                 let msg = format!("Contract not deployed at address: {address}");
-                CallContractFailure::Error { msg }
+                CallFailure::Error { msg }
             }
             EntryPointExecutionError::StateError(StateError::StateReadError(msg)) => {
-                CallContractFailure::Error { msg: msg.clone() }
+                CallFailure::Error { msg: msg.clone() }
             }
-            result => CallContractFailure::Error {
+            result => CallFailure::Error {
                 msg: result.to_string(),
             },
         }
     }
 }
 
-impl CallContractResult {
+impl CallResult {
     fn from_execution_result(
         result: &EntryPointExecutionResult<CallInfo>,
-        contract_address: &ContractAddress,
+        starknet_identifier: &AddressOrClassHash,
     ) -> Self {
         match result {
             Ok(call_info) => {
@@ -158,35 +161,15 @@ impl CallContractResult {
                     .map(|data| Felt252::from_bytes_be(data.bytes()))
                     .collect();
 
-                CallContractResult::Success {
+                CallResult::Success {
                     ret_data: return_data,
                 }
             }
-            Err(err) => CallContractResult::Failure(CallContractFailure::from_execution_error(
-                err,
-                contract_address,
-            )),
+            Err(err) => {
+                CallResult::Failure(CallFailure::from_execution_error(err, starknet_identifier))
+            }
         }
     }
-}
-
-// This does contract call without the transaction layer. This way `call_contract` can return data and modify state.
-// `call` and `invoke` on the transactional layer use such method under the hood.
-pub fn call_contract(
-    blockifier_state: &mut BlockifierState,
-    cheatnet_state: &mut CheatnetState,
-    contract_address: &ContractAddress,
-    entry_point_selector: &Felt252,
-    calldata: &[Felt252],
-) -> Result<CallContractOutput> {
-    call_entry_point(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        entry_point_selector,
-        calldata,
-        EntryPointType::External,
-    )
 }
 
 pub fn call_l1_handler(
@@ -195,48 +178,36 @@ pub fn call_l1_handler(
     contract_address: &ContractAddress,
     entry_point_selector: &Felt252,
     calldata: &[Felt252],
-) -> Result<CallContractOutput> {
-    call_entry_point(
-        blockifier_state,
-        cheatnet_state,
-        contract_address,
-        entry_point_selector,
-        calldata,
-        EntryPointType::L1Handler,
-    )
-}
+) -> Result<CallOutput> {
+    let entry_point_selector = create_entry_point_selector(entry_point_selector);
+    let calldata = create_execute_calldata(calldata);
 
-#[allow(clippy::too_many_lines)]
-pub fn call_entry_point(
-    blockifier_state: &mut BlockifierState,
-    cheatnet_state: &mut CheatnetState,
-    contract_address: &ContractAddress,
-    entry_point_selector: &Felt252,
-    calldata: &[Felt252],
-    entry_point_type: EntryPointType,
-) -> Result<CallContractOutput> {
-    let entry_point_selector =
-        EntryPointSelector(StarkHash::new(entry_point_selector.to_be_bytes())?);
-
-    let calldata = Calldata(Arc::new(
-        calldata
-            .iter()
-            .map(|data| StarkFelt::new(data.to_be_bytes()))
-            .collect::<Result<Vec<_>, _>>()?,
-    ));
-    let mut entry_point = CallEntryPoint {
+    let entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(*contract_address),
-        entry_point_type,
+        entry_point_type: EntryPointType::L1Handler,
         entry_point_selector,
         calldata,
         storage_address: *contract_address,
-        // test_contract address
-        caller_address: ContractAddress(patricia_key!(TEST_ADDRESS)),
+        caller_address: ContractAddress::default(),
         call_type: CallType::Call,
         initial_gas: u64::MAX,
     };
 
+    call_entry_point(
+        blockifier_state,
+        cheatnet_state,
+        entry_point,
+        &AddressOrClassHash::ContractAddress(*contract_address),
+    )
+}
+
+pub fn call_entry_point(
+    blockifier_state: &mut BlockifierState,
+    cheatnet_state: &mut CheatnetState,
+    mut entry_point: CallEntryPoint,
+    starknet_identifier: &AddressOrClassHash,
+) -> Result<CallOutput> {
     let mut resources = ExecutionResources::default();
     let account_context = build_transaction_context();
     let block_context = build_block_context(cheatnet_state.block_info);
@@ -257,9 +228,9 @@ pub fn call_entry_point(
         &mut context,
     );
 
-    let result = CallContractResult::from_execution_result(&exec_result, contract_address);
+    let result = CallResult::from_execution_result(&exec_result, starknet_identifier);
 
-    Ok(CallContractOutput {
+    Ok(CallOutput {
         result,
         used_resources: UsedResources {
             execution_resources: resources,

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -1,0 +1,16 @@
+use blockifier::execution::execution_utils::felt_to_stark_felt;
+use cairo_felt::Felt252;
+use conversions::IntoConv;
+use starknet_api::core::EntryPointSelector;
+use starknet_api::hash::StarkFelt;
+use starknet_api::transaction::Calldata;
+
+pub fn create_execute_calldata(calldata: &[Felt252]) -> Calldata {
+    let calldata: Vec<StarkFelt> = calldata.iter().map(felt_to_stark_felt).collect();
+    Calldata(calldata.into())
+}
+
+#[must_use]
+pub fn create_entry_point_selector(entry_point_selector: &Felt252) -> EntryPointSelector {
+    EntryPointSelector((*entry_point_selector).clone().into_())
+}

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
@@ -1,6 +1,8 @@
 use crate::constants::TEST_ADDRESS;
 use crate::constants::{build_block_context, build_transaction_context};
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractFailure;
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
+    AddressOrClassHash, CallFailure,
+};
 use crate::state::BlockifierState;
 use crate::CheatnetState;
 use anyhow::Result;
@@ -83,8 +85,10 @@ pub fn deploy_at(
         contract_address,
     })
     .map_err(|err| {
-        let call_contract_failure =
-            CallContractFailure::from_execution_error(&err, &contract_address);
+        let call_contract_failure = CallFailure::from_execution_error(
+            &err,
+            &AddressOrClassHash::ContractAddress(contract_address),
+        );
         CheatcodeError::from(call_contract_failure)
     });
     cheatnet_state.increment_deploy_salt_base();

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
@@ -38,6 +38,7 @@ pub fn deploy_at(
     calldata: &[Felt252],
     contract_address: ContractAddress,
 ) -> Result<DeployCallPayload, CheatcodeError> {
+    cheatnet_state.trace_info.clear();
     let blockifier_state_raw: &mut dyn State = blockifier_state.blockifier_state;
 
     if let Ok(class_hash) = blockifier_state_raw.get_class_hash_at(contract_address) {

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/l1_handler_execute.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/l1_handler_execute.rs
@@ -1,5 +1,5 @@
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    call_l1_handler, CallContractOutput,
+    call_l1_handler, CallOutput,
 };
 use crate::state::{BlockifierState, CheatnetState};
 use blockifier::abi::abi_utils::starknet_keccak;
@@ -14,7 +14,7 @@ impl BlockifierState<'_> {
         function_name: &Felt252,
         from_address: &Felt252,
         payload: &[Felt252],
-    ) -> CallContractOutput {
+    ) -> CallOutput {
         let selector = starknet_keccak(&function_name.to_bytes_be());
 
         let mut calldata = vec![from_address.clone()];

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
@@ -1,4 +1,4 @@
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractFailure;
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallFailure;
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use runtime::EnhancedHintError;
@@ -30,11 +30,11 @@ impl From<EnhancedHintError> for CheatcodeError {
     }
 }
 
-impl From<CallContractFailure> for CheatcodeError {
-    fn from(value: CallContractFailure) -> Self {
+impl From<CallFailure> for CheatcodeError {
+    fn from(value: CallFailure) -> Self {
         match value {
-            CallContractFailure::Panic { panic_data } => CheatcodeError::Recoverable(panic_data),
-            CallContractFailure::Error { msg } => {
+            CallFailure::Panic { panic_data } => CheatcodeError::Recoverable(panic_data),
+            CallFailure::Error { msg } => {
                 CheatcodeError::Unrecoverable(HintError::CustomHint(Box::from(msg)).into())
             }
         }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/precalculate_address.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/precalculate_address.rs
@@ -1,13 +1,11 @@
 use crate::CheatnetState;
-use blockifier::execution::execution_utils::felt_to_stark_felt;
 use cairo_felt::Felt252;
 use conversions::IntoConv;
 use starknet::core::types::FieldElement;
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress};
-use starknet_api::hash::StarkFelt;
-use starknet_api::transaction::Calldata;
 
 use crate::constants as crate_constants;
+use crate::runtime_extensions::common::create_execute_calldata;
 
 impl CheatnetState {
     #[must_use]
@@ -28,9 +26,4 @@ impl CheatnetState {
         )
         .unwrap()
     }
-}
-
-fn create_execute_calldata(calldata: &[Felt252]) -> Calldata {
-    let calldata: Vec<StarkFelt> = calldata.iter().map(felt_to_stark_felt).collect();
-    Calldata(calldata.into())
 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    CallContractFailure, CallContractResult, UsedResources,
+    CallFailure, CallResult, UsedResources,
 };
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::{
     deploy, deploy_at, DeployCallPayload,
@@ -401,13 +401,13 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     )
                     .result
                 {
-                    CallContractResult::Success { .. } => {
+                    CallResult::Success { .. } => {
                         Ok(CheatcodeHandlingResult::Handled(vec![Felt252::from(0)]))
                     }
-                    CallContractResult::Failure(CallContractFailure::Panic { panic_data }) => Ok(
+                    CallResult::Failure(CallFailure::Panic { panic_data }) => Ok(
                         CheatcodeHandlingResult::Handled(cheatcode_panic_result(panic_data)),
                     ),
-                    CallContractResult::Failure(CallContractFailure::Error { msg }) => Err(
+                    CallResult::Failure(CallFailure::Error { msg }) => Err(
                         EnhancedHintError::from(HintError::CustomHint(Box::from(msg))),
                     ),
                 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -11,6 +11,7 @@ use crate::state::{BlockifierState, CheatTarget};
 use anyhow::{Context, Result};
 use blockifier::execution::call_info::{CallExecution, CallInfo};
 use blockifier::execution::deprecated_syscalls::DeprecatedSyscallSelector;
+use blockifier::execution::entry_point::{CallEntryPoint, CallType};
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError;
@@ -32,6 +33,7 @@ use runtime::{
     SyscallHandlingResult,
 };
 use starknet::signers::SigningKey;
+use starknet_api::deprecated_contract_class::EntryPointType;
 
 use super::call_to_blockifier_runtime_extension::CallToBlockifierRuntime;
 use super::cheatable_starknet_runtime_extension::SyscallSelector;
@@ -384,18 +386,14 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
 
                 let payload = reader.read_vec();
 
-                let cheatnet_runtime = &mut extended_runtime.extended_runtime;
-                let mut blockifier_state = BlockifierState::from(
-                    cheatnet_runtime
-                        .extended_runtime
-                        .extended_runtime
-                        .hint_handler
-                        .state,
-                );
+                let cheatnet_runtime = &mut extended_runtime.extended_runtime.extended_runtime;
+                let mut blockifier_state =
+                    BlockifierState::from(cheatnet_runtime.extended_runtime.hint_handler.state);
 
+                cheatnet_runtime.extension.cheatnet_state.trace_info.clear();
                 match blockifier_state
                     .l1_handler_execute(
-                        cheatnet_runtime.extended_runtime.extension.cheatnet_state,
+                        cheatnet_runtime.extension.cheatnet_state,
                         contract_address,
                         &function_name,
                         &from_address,
@@ -506,6 +504,20 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     ]))
                 }
             }
+            "get_last_call_trace" => {
+                let trace_info = &extended_runtime
+                    .extended_runtime
+                    .extended_runtime
+                    .extension
+                    .cheatnet_state
+                    .trace_info;
+                let mut output = vec![Felt252::from(trace_info.len())];
+
+                for call_entry_point in trace_info {
+                    output.append(&mut serialize_call_entry_point(call_entry_point));
+                }
+                Ok(CheatcodeHandlingResult::Handled(output))
+            }
             _ => Ok(CheatcodeHandlingResult::Forwarded),
         }?;
 
@@ -541,6 +553,38 @@ fn handle_deploy_result(
         )),
         Err(CheatcodeError::Unrecoverable(err)) => Err(err),
     }
+}
+
+fn serialize_call_entry_point(call_entry_point: &CallEntryPoint) -> Vec<Felt252> {
+    let entry_point_type = match call_entry_point.entry_point_type {
+        EntryPointType::Constructor => 0,
+        EntryPointType::External => 1,
+        EntryPointType::L1Handler => 2,
+    };
+
+    let calldata = call_entry_point
+        .calldata
+        .0
+        .iter()
+        .copied()
+        .map(IntoConv::into_)
+        .collect::<Vec<_>>();
+
+    let call_type = match call_entry_point.call_type {
+        CallType::Call => 0,
+        CallType::Delegate => 1,
+    };
+
+    let mut output = vec![];
+    output.push(Felt252::from(entry_point_type));
+    output.push(call_entry_point.entry_point_selector.0.into_());
+    output.push(Felt252::from(calldata.len()));
+    output.extend(calldata);
+    output.push(call_entry_point.storage_address.into_());
+    output.push(call_entry_point.caller_address.into_());
+    output.push(Felt252::from(call_type));
+
+    output
 }
 
 #[must_use]

--- a/crates/cheatnet/src/runtime_extensions/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/mod.rs
@@ -1,4 +1,5 @@
 pub mod call_to_blockifier_runtime_extension;
 pub mod cheatable_starknet_runtime_extension;
+pub mod common;
 pub mod forge_runtime_extension;
 pub mod io_runtime_extension;

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -5,6 +5,7 @@ use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spoof::TxInf
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spy_events::{
     Event, SpyTarget,
 };
+use blockifier::execution::entry_point::CallEntryPoint;
 use blockifier::state::state_api::State;
 use blockifier::{
     execution::contract_class::ContractClass,
@@ -236,6 +237,8 @@ pub struct CheatnetState {
     pub block_info: CheatnetBlockInfo,
     // execution resources used by all contract calls
     pub used_resources: UsedResources,
+    // trace info of the last call
+    pub trace_info: Vec<CallEntryPoint>,
 }
 
 impl CheatnetState {

--- a/crates/cheatnet/tests/builtins/panic_call.rs
+++ b/crates/cheatnet/tests/builtins/panic_call.rs
@@ -1,8 +1,8 @@
+use crate::common::call_contract;
 use crate::common::state::create_cheatnet_state;
 use crate::common::{deploy_contract, felt_selector_from_name, state::create_cached_state};
 use crate::{assert_error, assert_panic};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use conversions::felt252::FromShortString;
 use num_traits::Bounded;
 

--- a/crates/cheatnet/tests/builtins/segment_arena.rs
+++ b/crates/cheatnet/tests/builtins/segment_arena.rs
@@ -1,7 +1,7 @@
 use crate::assert_success;
+use crate::common::call_contract;
 use crate::common::state::create_cheatnet_state;
 use crate::common::{deploy_contract, felt_selector_from_name, state::create_cached_state};
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 
 #[test]
 fn segment_arena_simple() {

--- a/crates/cheatnet/tests/cheatcodes/deploy.rs
+++ b/crates/cheatnet/tests/cheatcodes/deploy.rs
@@ -1,10 +1,10 @@
 use crate::assert_success;
 use crate::common::state::{create_cached_state, create_cheatnet_state};
-use crate::common::{deploy_contract, felt_selector_from_name, get_contracts};
+use crate::common::{call_contract, deploy_contract, felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    call_contract, CallContractFailure, CallContractResult,
+    CallFailure, CallResult,
 };
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::{
     deploy, deploy_at,
@@ -147,7 +147,7 @@ fn deploy_contract_on_predefined_address_after_its_usage() {
     assert!(
         matches!(
             output.result,
-            CallContractResult::Failure(CallContractFailure::Error { msg, .. })
+            CallResult::Failure(CallFailure::Error { msg, .. })
             if msg.contains("Requested contract address") && msg.contains("is not deployed")
         ),
         "Wrong error message"

--- a/crates/cheatnet/tests/cheatcodes/elect.rs
+++ b/crates/cheatnet/tests/cheatcodes/elect.rs
@@ -1,4 +1,5 @@
 use crate::common::assertions::assert_outputs;
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -7,7 +8,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
+++ b/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
@@ -1,7 +1,7 @@
+use crate::common::call_contract;
 use crate::common::state::create_cached_state;
 use crate::common::{felt_selector_from_name, get_contracts, state::create_cheatnet_state};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;

--- a/crates/cheatnet/tests/cheatcodes/load.rs
+++ b/crates/cheatnet/tests/cheatcodes/load.rs
@@ -1,8 +1,8 @@
 use crate::cheatcodes::{map_entry_address, variable_address};
+use crate::common::call_contract;
 use crate::common::state::{create_cached_state, create_cheatnet_state};
 use crate::common::{felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::load;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/cheatcodes/mock_call.rs
+++ b/crates/cheatnet/tests/cheatcodes/mock_call.rs
@@ -1,3 +1,4 @@
+use crate::common::call_contract;
 use crate::common::state::create_cached_state;
 use crate::common::{felt_selector_from_name, recover_data};
 use crate::{
@@ -5,7 +6,6 @@ use crate::{
     common::{deploy_contract, get_contracts, state::create_cheatnet_state},
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;

--- a/crates/cheatnet/tests/cheatcodes/prank.rs
+++ b/crates/cheatnet/tests/cheatcodes/prank.rs
@@ -1,4 +1,5 @@
 use crate::common::assertions::assert_outputs;
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -7,7 +8,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/cheatcodes/roll.rs
+++ b/crates/cheatnet/tests/cheatcodes/roll.rs
@@ -1,4 +1,5 @@
 use crate::common::assertions::assert_outputs;
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -7,7 +8,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -1,3 +1,4 @@
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -11,10 +12,7 @@ use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::{
     deploy::deploy, spoof::TxInfoMock,
 };
 use cheatnet::state::CheatTarget;
-use cheatnet::{
-    runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract,
-    state::{BlockifierState, CheatnetState},
-};
+use cheatnet::state::{BlockifierState, CheatnetState};
 use conversions::{felt252::FromShortString, IntoConv};
 use num_traits::ToPrimitive;
 use runtime::utils::BufferReader;

--- a/crates/cheatnet/tests/cheatcodes/spy_events.rs
+++ b/crates/cheatnet/tests/cheatcodes/spy_events.rs
@@ -1,9 +1,9 @@
+use crate::common::call_contract;
 use crate::common::state::{create_cached_state, create_cheatnet_state};
 use crate::common::{deploy_contract, felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
 use cairo_lang_starknet::contract::starknet_keccak;
 use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::spy_events::{
     Event, SpyTarget,

--- a/crates/cheatnet/tests/cheatcodes/store.rs
+++ b/crates/cheatnet/tests/cheatcodes/store.rs
@@ -1,9 +1,9 @@
 use crate::assert_success;
 use crate::cheatcodes::{map_entry_address, variable_address};
+use crate::common::call_contract;
 use crate::common::state::{create_cached_state, create_cheatnet_state};
 use crate::common::{felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::store;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/cheatcodes/warp.rs
+++ b/crates/cheatnet/tests/cheatcodes/warp.rs
@@ -1,4 +1,5 @@
 use crate::common::assertions::assert_outputs;
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -7,7 +8,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;

--- a/crates/cheatnet/tests/common/assertions.rs
+++ b/crates/cheatnet/tests/common/assertions.rs
@@ -1,5 +1,5 @@
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    CallContractOutput, CallContractResult,
+    CallOutput, CallResult,
 };
 #[macro_export]
 macro_rules! assert_success {
@@ -7,7 +7,7 @@ macro_rules! assert_success {
         assert!(
             matches!(
                 $call_contract_output.result,
-                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractResult::Success { ret_data, .. }
+                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult::Success { ret_data, .. }
                 if ret_data == $expected_data,
             )
         )
@@ -20,8 +20,8 @@ macro_rules! assert_panic {
         assert!(
             matches!(
                 $call_contract_output.result,
-                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractResult::Failure(
-                    cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractFailure::Panic { panic_data, .. }
+                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult::Failure(
+                    cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallFailure::Panic { panic_data, .. }
                 )
                 if panic_data == $expected_data
             )
@@ -35,8 +35,8 @@ macro_rules! assert_error {
         assert!(
             matches!(
                 $call_contract_output.result,
-                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractResult::Failure(
-                    cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallContractFailure::Error { msg, .. }
+                cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult::Failure(
+                    cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallFailure::Error { msg, .. }
                 )
                 if msg == $expected_data,
             )
@@ -44,15 +44,15 @@ macro_rules! assert_error {
     };
 }
 
-pub fn assert_outputs(output1: CallContractOutput, output2: CallContractOutput) {
-    let CallContractResult::Success {
+pub fn assert_outputs(output1: CallOutput, output2: CallOutput) {
+    let CallResult::Success {
         ret_data: before_ret_data,
     } = output1.result
     else {
         panic!("Unexpected failure")
     };
 
-    let CallContractResult::Success {
+    let CallResult::Success {
         ret_data: after_ret_data,
     } = output2.result
     else {

--- a/crates/cheatnet/tests/starknet/block.rs
+++ b/crates/cheatnet/tests/starknet/block.rs
@@ -1,3 +1,4 @@
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -6,10 +7,7 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::{
-    runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract,
-    state::{BlockifierState, CheatnetState},
-};
+use cheatnet::state::{BlockifierState, CheatnetState};
 use starknet_api::core::ContractAddress;
 
 fn check_block(

--- a/crates/cheatnet/tests/starknet/cheat_fork.rs
+++ b/crates/cheatnet/tests/starknet/cheat_fork.rs
@@ -1,9 +1,7 @@
-use crate::common::felt_selector_from_name;
 use crate::common::state::{create_cheatnet_state, create_fork_cached_state};
+use crate::common::{call_contract, felt_selector_from_name};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    call_contract, CallContractResult,
-};
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
 use cheatnet::state::CheatTarget;
 use conversions::IntoConv;
 use num_bigint::BigUint;
@@ -33,7 +31,7 @@ fn prank_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let caller = &ret_data[0];
@@ -51,7 +49,7 @@ fn prank_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let pranked_caller = &ret_data[0];
@@ -66,7 +64,7 @@ fn prank_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let unpranked_caller = &ret_data[0];
@@ -93,7 +91,7 @@ fn roll_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let block_number = &ret_data[0];
@@ -108,7 +106,7 @@ fn roll_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let rolled_block_number = &ret_data[0];
@@ -123,7 +121,7 @@ fn roll_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let unrolled_block_number = &ret_data[0];
@@ -150,7 +148,7 @@ fn warp_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let block_timestamp = &ret_data[0];
@@ -164,7 +162,7 @@ fn warp_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let warped_block_timestamp = &ret_data[0];
@@ -179,7 +177,7 @@ fn warp_cairo0_contract(selector: &str) {
         &[],
     )
     .unwrap();
-    let CallContractResult::Success { ret_data } = output.result else {
+    let CallResult::Success { ret_data } = output.result else {
         panic!("Wrong call output")
     };
     let unwarped_block_timestamp = &ret_data[0];

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -2,14 +2,13 @@ use crate::common::cache::{purge_cache, read_cache};
 use crate::common::state::{
     create_cheatnet_state, create_fork_cached_state, create_fork_cached_state_at,
 };
-use crate::common::{deploy_contract, felt_selector_from_name};
+use crate::common::{call_contract, deploy_contract, felt_selector_from_name};
 use crate::{assert_error, assert_success};
 use blockifier::state::cached_state::{CachedState, GlobalContractCache};
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cheatnet::constants::build_testing_state;
 use cheatnet::forking::state::ForkStateReader;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::CheatcodeError;
 use cheatnet::state::{BlockInfoReader, BlockifierState, CheatnetState, ExtendedStateReader};

--- a/crates/cheatnet/tests/starknet/nonce.rs
+++ b/crates/cheatnet/tests/starknet/nonce.rs
@@ -1,3 +1,4 @@
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -7,10 +8,7 @@ use crate::{
 };
 use cairo_felt::Felt252;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
-use cheatnet::{
-    runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract,
-    state::{BlockifierState, CheatnetState},
-};
+use cheatnet::state::{BlockifierState, CheatnetState};
 use conversions::felt252::FromShortString;
 use starknet_api::core::ContractAddress;
 

--- a/crates/cheatnet/tests/starknet/resources.rs
+++ b/crates/cheatnet/tests/starknet/resources.rs
@@ -7,11 +7,10 @@ use conversions::felt252::FromShortString;
 use std::collections::HashMap;
 
 use crate::common::{
-    deploy_contract, felt_selector_from_name, get_contracts,
+    call_contract, deploy_contract, felt_selector_from_name, get_contracts,
     state::{create_cached_state, create_cheatnet_state},
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 
 // TODO (834): Verify values in this test

--- a/crates/cheatnet/tests/starknet/timestamp.rs
+++ b/crates/cheatnet/tests/starknet/timestamp.rs
@@ -1,3 +1,4 @@
+use crate::common::call_contract;
 use crate::{
     assert_success,
     common::{
@@ -6,10 +7,7 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::{
-    runtime_extensions::call_to_blockifier_runtime_extension::rpc::call_contract,
-    state::{BlockifierState, CheatnetState},
-};
+use cheatnet::state::{BlockifierState, CheatnetState};
 use starknet_api::core::ContractAddress;
 
 fn check_timestamp(

--- a/crates/forge/tests/data/contracts/trace_dummy.cairo
+++ b/crates/forge/tests/data/contracts/trace_dummy.cairo
@@ -1,0 +1,19 @@
+#[starknet::interface]
+trait ITraceDummy<T> {
+    fn from_proxy_dummy(ref self: T);
+}
+
+#[starknet::contract]
+mod TraceDummy {
+    #[storage]
+    struct Storage {
+        balance: u8
+    }
+
+    #[abi(embed_v0)]
+    impl ITraceDummyImpl of super::ITraceDummy<ContractState> {
+        fn from_proxy_dummy(ref self: ContractState) {
+            self.balance.write(7);
+        }
+    }
+}

--- a/crates/forge/tests/data/contracts/trace_info_checker.cairo
+++ b/crates/forge/tests/data/contracts/trace_info_checker.cairo
@@ -1,0 +1,43 @@
+use starknet::{ContractAddress, ClassHash};
+
+#[starknet::interface]
+trait ITraceInfoProxy<T> {
+    fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+    fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+    fn with_panic(self: @T, contract_address: ContractAddress);
+    fn call_two(self: @T, checker_address: ContractAddress, dummy_address: ContractAddress);
+}
+
+#[starknet::interface]
+trait ITraceInfoChecker<T> {
+    fn from_proxy(self: @T, data: felt252) -> felt252;
+    fn panic(self: @T);
+}
+
+#[starknet::contract]
+mod TraceInfoChecker {
+    use super::{ITraceInfoChecker, ITraceInfoProxyDispatcher, ITraceInfoProxyDispatcherTrait};
+    use starknet::{ContractAddress, get_contract_address};
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl ITraceInfoChceckerImpl of ITraceInfoChecker<ContractState> {
+        fn from_proxy(self: @ContractState, data: felt252) -> felt252 {
+            100 + data
+        }
+
+        fn panic(self: @ContractState) {
+            panic_with_felt252('panic');
+        }
+    }
+
+    #[l1_handler]
+    fn handle_l1_message(
+        ref self: ContractState, from_address: felt252, proxy_address: ContractAddress
+    ) -> felt252 {
+        ITraceInfoProxyDispatcher { contract_address: proxy_address }
+            .regular_call(get_contract_address())
+    }
+}

--- a/crates/forge/tests/data/contracts/trace_info_proxy.cairo
+++ b/crates/forge/tests/data/contracts/trace_info_proxy.cairo
@@ -1,0 +1,62 @@
+use starknet::{ContractAddress, ClassHash};
+
+#[starknet::interface]
+trait ITraceInfoProxy<T> {
+    fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+    fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+    fn with_panic(self: @T, contract_address: ContractAddress);
+    fn call_two(self: @T, checker_address: ContractAddress, dummy_address: ContractAddress);
+}
+
+#[starknet::interface]
+trait ITraceInfoChecker<T> {
+    fn from_proxy(self: @T, data: felt252) -> felt252;
+    fn panic(self: @T);
+}
+
+#[starknet::interface]
+trait ITraceDummy<T> {
+    fn from_proxy_dummy(ref self: T);
+}
+
+#[starknet::contract]
+mod TraceInfoProxy {
+    use super::{
+        ITraceInfoCheckerDispatcherTrait, ITraceInfoCheckerDispatcher,
+        ITraceInfoCheckerLibraryDispatcher, ITraceInfoProxy,
+        ITraceDummyDispatcher, ITraceDummyDispatcherTrait
+    };
+    use starknet::{ContractAddress, ClassHash};
+
+    #[storage]
+    struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, contract_address: ContractAddress) {
+        ITraceInfoCheckerDispatcher { contract_address }.from_proxy(1);
+    }
+
+    #[abi(embed_v0)]
+    impl ITraceInfoProxyImpl of ITraceInfoProxy<ContractState> {
+        fn regular_call(self: @ContractState, contract_address: ContractAddress) -> felt252 {
+            ITraceInfoCheckerDispatcher { contract_address }.from_proxy(2)
+        }
+
+        fn with_libcall(self: @ContractState, class_hash: ClassHash) -> felt252 {
+            ITraceInfoCheckerLibraryDispatcher { class_hash }.from_proxy(3)
+        }
+
+        fn with_panic(self: @ContractState, contract_address: ContractAddress) {
+            ITraceInfoCheckerDispatcher { contract_address }.panic();
+            // unreachable code to check if we stop executing after panic
+            ITraceInfoCheckerDispatcher { contract_address }.from_proxy(5);
+        }
+
+        fn call_two(
+            self: @ContractState, checker_address: ContractAddress, dummy_address: ContractAddress
+        ) {
+            ITraceInfoCheckerDispatcher { contract_address: checker_address }.from_proxy(42);
+            ITraceDummyDispatcher { contract_address: dummy_address }.from_proxy_dummy();
+        }
+    }
+}

--- a/crates/forge/tests/data/trace/Scarb.toml
+++ b/crates/forge/tests/data/trace/Scarb.toml
@@ -1,0 +1,10 @@
+[package]
+name = "trace_info"
+version = "0.1.0"
+
+[dependencies]
+starknet = "2.4.0"
+snforge_std = { path = "../../../../../snforge_std" }
+
+[[target.starknet-contract]]
+sierra = true

--- a/crates/forge/tests/data/trace/src/lib.cairo
+++ b/crates/forge/tests/data/trace/src/lib.cairo
@@ -1,0 +1,17 @@
+#[starknet::interface]
+trait ISimpleContract<T> {
+    fn simple_call(self: @T, data: felt252) -> felt252;
+}
+
+#[starknet::contract]
+mod SimpleContract {
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl ISimpleContractImpl of super::ISimpleContract<ContractState> {
+        fn simple_call(self: @ContractState, data: felt252) -> felt252 {
+            2 * data
+        }
+    }
+}

--- a/crates/forge/tests/data/trace/tests/test_trace.cairo
+++ b/crates/forge/tests/data/trace/tests/test_trace.cairo
@@ -1,0 +1,13 @@
+use snforge_std::{declare, ContractClassTrait, PrintTrait};
+use snforge_std::trace::{get_last_call_trace, DisplayArrayCallEntryPoint};
+
+use trace_info::{ISimpleContractDispatcherTrait, ISimpleContractDispatcher};
+
+#[test]
+fn test_trace_print() {
+    let contract_address = declare('SimpleContract').deploy(@array![]).unwrap();
+
+    ISimpleContractDispatcher { contract_address }.simple_call(10);
+
+    println!("{}", get_last_call_trace());
+}

--- a/crates/forge/tests/e2e/mod.rs
+++ b/crates/forge/tests/e2e/mod.rs
@@ -9,4 +9,5 @@ mod forking;
 mod fuzzing;
 mod io_operations;
 mod running;
+mod trace;
 mod workspaces;

--- a/crates/forge/tests/e2e/trace.rs
+++ b/crates/forge/tests/e2e/trace.rs
@@ -27,7 +27,7 @@ fn trace_info_print() {
         Caller address: 469394814521890341860918960550914
         Call type: Call
         
-        [PASS] tests::test_trace::test_trace_print (gas: ~2461)
+        [PASS] tests::test_trace::test_trace_print (gas: ~[..])
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
         "}
     );

--- a/crates/forge/tests/e2e/trace.rs
+++ b/crates/forge/tests/e2e/trace.rs
@@ -1,0 +1,34 @@
+use crate::assert_stdout_contains;
+use crate::e2e::common::runner::{setup_package, test_runner};
+use indoc::indoc;
+
+#[test]
+fn trace_info_print() {
+    let temp = setup_package("trace");
+    let snapbox = test_runner();
+
+    let output = snapbox.current_dir(&temp).assert().success();
+
+    assert_stdout_contains!(
+        output,
+        indoc! {r"
+        [..]Compiling[..]
+        [..]Finished[..]
+        
+        
+        Collected 1 test(s) from trace_info package
+        Running 0 test(s) from src/
+        Running 1 test(s) from tests/
+        
+        Entry point type: External
+        Selector: 1024936690255032842875463015856695803908824911639649964560344728797058303195
+        Calldata: [10]
+        Storage address: 2455907345917140204161489130051965975039431451193458942118883935209731300862
+        Caller address: 469394814521890341860918960550914
+        Call type: Call
+        
+        [PASS] tests::test_trace::test_trace_print (gas: ~2461)
+        Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
+        "}
+    );
+}

--- a/crates/forge/tests/integration/mod.rs
+++ b/crates/forge/tests/integration/mod.rs
@@ -23,4 +23,5 @@ mod spoof;
 mod spy_events;
 mod syscalls;
 mod test_state;
+mod trace;
 mod warp;

--- a/crates/forge/tests/integration/trace.rs
+++ b/crates/forge/tests/integration/trace.rs
@@ -1,0 +1,757 @@
+use indoc::indoc;
+use std::path::Path;
+use test_utils::runner::Contract;
+use test_utils::running_tests::run_test_case;
+use test_utils::{assert_passed, test_case};
+
+#[test]
+fn trace_deploy() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::{SyscallResultTrait, deploy_syscall, ContractAddress};
+            
+            #[test]
+            fn test_deploy_trace_info() {
+                assert_eq!(get_last_call_trace().len(), 0);
+            
+                let proxy = declare('TraceInfoProxy');
+                assert_eq!(get_last_call_trace().len(), 0);
+            
+                let checker = declare('TraceInfoChecker');
+                assert_eq!(get_last_call_trace().len(), 0);
+            
+                let checker_address = checker.deploy(@array![]).unwrap();
+                assert_eq!(get_last_call_trace().len(), 0); // no constructor
+            
+                let proxy_address = proxy.deploy(@array![checker_address.into()]).unwrap();
+                assert_trace_after_proxy_deploy(get_last_call_trace(), proxy_address, checker_address);
+            
+                let (proxy_address_2, _) = deploy_syscall(
+                    proxy.class_hash, 0, array![checker_address.into()].span(), false
+                )
+                    .unwrap_syscall();
+                assert_trace_after_proxy_deploy(get_last_call_trace(), proxy_address_2, checker_address);
+            
+                let proxy_address_3 = proxy
+                    .deploy_at(@array![checker_address.into()], 123.try_into().unwrap())
+                    .unwrap();
+                assert_trace_after_proxy_deploy(get_last_call_trace(), proxy_address_3, checker_address);
+            }
+            
+            fn assert_trace_after_proxy_deploy(
+                trace: Array<CallEntryPoint>, proxy_address: ContractAddress, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::Constructor,
+                        entry_point_selector: selector!("constructor"),
+                        calldata: array![checker_address.into()],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![1],
+                        contract_address: checker_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy deploy');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn trace_call() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::{ContractAddress, ClassHash};
+            
+            #[starknet::interface]
+            trait ITraceInfoProxy<T> {
+                fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+                fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+                fn with_panic(self: @T, contract_address: ContractAddress);
+                fn call_two(self: @T, checker_address: ContractAddress, dummy_address: ContractAddress);
+            }
+            
+            #[starknet::interface]
+            trait ITraceInfoChecker<T> {
+                fn from_proxy(self: @T, data: felt252) -> felt252;
+                fn panic(self: @T);
+            }
+            
+            #[starknet::interface]
+            trait ITraceDummy<T> {
+                fn from_proxy(ref self: T);
+            }
+            
+            #[test]
+            fn test_call_trace_info() {
+                let proxy = declare('TraceInfoProxy');
+                let checker = declare('TraceInfoChecker');
+                let dummy = declare('TraceDummy');
+            
+                let checker_address = checker.deploy(@array![]).unwrap();
+                let proxy_address = proxy.deploy(@array![checker_address.into()]).unwrap();
+                let dummy_address = dummy.deploy(@array![]).unwrap();
+            
+                let proxy_dispatcher = ITraceInfoProxyDispatcher { contract_address: proxy_address };
+            
+                proxy_dispatcher.regular_call(checker_address);
+                assert_trace_after_proxy_regular_call(get_last_call_trace(), proxy_address, checker_address);
+            
+                proxy_dispatcher.with_libcall(checker.class_hash);
+                assert_trace_after_proxy_call_with_libcall(
+                    get_last_call_trace(), proxy_address, checker.class_hash
+                );
+            
+                proxy_dispatcher.call_two(checker_address, dummy_address);
+                assert_trace_after_proxy_call_two(
+                    get_last_call_trace(), proxy_address, checker_address, dummy_address
+                );
+            
+                let chcecker_dispatcher = ITraceInfoCheckerDispatcher { contract_address: checker_address };
+            
+                chcecker_dispatcher.from_proxy(4);
+                assert_trace_after_checker_call_from_test(get_last_call_trace(), checker_address);
+            }
+            
+            fn assert_trace_after_proxy_regular_call(
+                trace: Array<CallEntryPoint>, proxy_address: ContractAddress, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("regular_call"),
+                        calldata: array![checker_address.into()],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![2],
+                        contract_address: checker_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy regular_call');
+            }
+            
+            fn assert_trace_after_proxy_call_with_libcall(
+                trace: Array<CallEntryPoint>, proxy_address: ContractAddress, checker_class_hash: ClassHash
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("with_libcall"),
+                        calldata: array![checker_class_hash.into()],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![3],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Delegate,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy with_libcall');
+            }
+            
+            fn assert_trace_after_proxy_call_two(
+                trace: Array<CallEntryPoint>,
+                proxy_address: ContractAddress,
+                checker_address: ContractAddress,
+                dummy_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("call_two"),
+                        calldata: array![checker_address.into(), dummy_address.into()],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![42],
+                        contract_address: checker_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy_dummy"),
+                        calldata: array![],
+                        contract_address: dummy_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy call_two');
+            }
+            
+            fn assert_trace_after_checker_call_from_test(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![4],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'checker from_proxy');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceDummy".to_string(),
+            Path::new("tests/data/contracts/trace_dummy.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+fn trace_failed_call() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::{ContractAddress, ClassHash};
+            
+            #[starknet::interface]
+            trait ITraceInfoProxy<T> {
+                fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+                fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+                fn with_panic(self: @T, contract_address: ContractAddress);
+            }
+            
+            #[starknet::interface]
+            trait ITraceInfoChecker<T> {
+                fn from_proxy(self: @T, data: felt252) -> felt252;
+                fn panic(self: @T);
+            }
+            
+            #[test]
+            fn test_failed_call_trace_info() {
+                let proxy = declare('TraceInfoProxy');
+                let checker = declare('TraceInfoChecker');
+            
+                let checker_address = checker.deploy(@array![]).unwrap();
+                let proxy_address = proxy.deploy(@array![checker_address.into()]).unwrap();
+            
+                let proxy_dispatcher = ITraceInfoProxySafeDispatcher { contract_address: proxy_address };
+            
+                match proxy_dispatcher.with_panic(checker_address) {
+                    Result::Ok(_) => panic_with_felt252('shouldve panicked'),
+                    Result::Err(panic_data) => {
+                        assert(*panic_data.at(0) == 'panic', *panic_data.at(0));
+                        assert_trace_after_proxy_with_panic_call(
+                            get_last_call_trace(), proxy_address, checker_address
+                        );
+                    }
+                }
+            
+                let chcecker_dispatcher = ITraceInfoCheckerSafeDispatcher { contract_address: checker_address };
+            
+                match chcecker_dispatcher.panic() {
+                    Result::Ok(_) => panic_with_felt252('shouldve panicked'),
+                    Result::Err(panic_data) => {
+                        assert(*panic_data.at(0) == 'panic', *panic_data.at(0));
+                        assert_trace_after_checker_panic_call_from_test(get_last_call_trace(), checker_address);
+                    }
+                }
+            }
+            
+            fn assert_trace_after_checker_panic_call_from_test(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("panic"),
+                        calldata: array![],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'checker panic');
+            }
+            
+            fn assert_trace_after_proxy_with_panic_call(
+                trace: Array<CallEntryPoint>, proxy_address: ContractAddress, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("with_panic"),
+                        calldata: array![checker_address.into()],
+                        contract_address: proxy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("panic"),
+                        calldata: array![],
+                        contract_address: checker_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy with_panic');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn trace_library_call_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::{ContractAddress, ClassHash};
+            
+            #[starknet::interface]
+            trait ITraceInfoProxy<T> {
+                fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+                fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+                fn with_panic(self: @T, contract_address: ContractAddress);
+                fn call_two(self: @T, checker_address: ContractAddress, dummy_address: ContractAddress);
+            }
+            
+            #[starknet::interface]
+            trait ITraceInfoChecker<T> {
+                fn from_proxy(self: @T, data: felt252) -> felt252;
+                fn panic(self: @T);
+            }
+            
+            #[starknet::interface]
+            trait ITraceDummy<T> {
+                fn from_proxy(ref self: T);
+            }
+            
+            #[test]
+            fn test_library_call_trace_info() {
+                let proxy_hash = declare('TraceInfoProxy').class_hash;
+                let checker = declare('TraceInfoChecker');
+                let dummy = declare('TraceDummy');
+            
+                let checker_address = checker.deploy(@array![]).unwrap();
+                let dummy_address = dummy.deploy(@array![]).unwrap();
+            
+                let proxy_lib_dispatcher = ITraceInfoProxyLibraryDispatcher { class_hash: proxy_hash };
+            
+                proxy_lib_dispatcher.regular_call(checker_address);
+                assert_trace_after_proxy_regular_call(get_last_call_trace(), checker_address);
+            
+                proxy_lib_dispatcher.with_libcall(checker.class_hash);
+                assert_trace_after_proxy_call_with_libcall(get_last_call_trace(), checker.class_hash);
+            
+                proxy_lib_dispatcher.call_two(checker_address, dummy_address);
+                assert_trace_after_proxy_call_two(get_last_call_trace(), checker_address, dummy_address);
+            
+                let chcecker_lib_dispatcher = ITraceInfoCheckerLibraryDispatcher {
+                    class_hash: checker.class_hash
+                };
+            
+                chcecker_lib_dispatcher.from_proxy(4);
+                assert_trace_after_checker_call_from_test(get_last_call_trace());
+            }
+            
+            fn assert_trace_after_proxy_regular_call(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("regular_call"),
+                        calldata: array![checker_address.into()],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![2],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy libcall regular_call');
+            }
+            
+            fn assert_trace_after_proxy_call_with_libcall(
+                trace: Array<CallEntryPoint>, checker_class_hash: ClassHash
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("with_libcall"),
+                        calldata: array![checker_class_hash.into()],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![3],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy libcall with_libcall');
+            }
+            
+            fn assert_trace_after_proxy_call_two(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress, dummy_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("call_two"),
+                        calldata: array![checker_address.into(), dummy_address.into()],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![42],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy_dummy"),
+                        calldata: array![],
+                        contract_address: dummy_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy libcall call_two');
+            }
+            
+            fn assert_trace_after_checker_call_from_test(trace: Array<CallEntryPoint>) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![4],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'checker libcall from_proxy');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceDummy".to_string(),
+            Path::new("tests/data/contracts/trace_dummy.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+#[ignore]
+fn trace_failed_library_call_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::{ContractAddress, ClassHash};
+            
+            #[starknet::interface]
+            trait ITraceInfoProxy<T> {
+                fn with_libcall(self: @T, class_hash: ClassHash) -> felt252;
+                fn regular_call(self: @T, contract_address: ContractAddress) -> felt252;
+                fn with_panic(self: @T, contract_address: ContractAddress);
+            }
+            
+            #[starknet::interface]
+            trait ITraceInfoChecker<T> {
+                fn from_proxy(self: @T, data: felt252) -> felt252;
+                fn panic(self: @T);
+            }
+            
+            #[test]
+            fn test_failed_library_call_trace_info() {
+                let proxy_hash = declare('TraceInfoProxy').class_hash;
+                let checker = declare('TraceInfoChecker');
+                let checker_address = checker.deploy(@array![]).unwrap();
+            
+                let proxy_lib_dispatcher = ITraceInfoProxySafeLibraryDispatcher { class_hash: proxy_hash };
+            
+                match proxy_lib_dispatcher.with_panic(checker_address) {
+                    Result::Ok(_) => panic_with_felt252('shouldve panicked'),
+                    Result::Err(panic_data) => {
+                        assert(*panic_data.at(0) == 'panic', *panic_data.at(0));
+                        assert_trace_after_proxy_with_panic_call(get_last_call_trace(), checker_address);
+                    }
+                }
+            
+                let chcecker_lib_dispatcher = ITraceInfoCheckerSafeLibraryDispatcher {
+                    class_hash: checker.class_hash
+                };
+            
+                match chcecker_lib_dispatcher.panic() {
+                    Result::Ok(_) => panic_with_felt252('shouldve panicked'),
+                    Result::Err(panic_data) => {
+                        assert(*panic_data.at(0) == 'panic', *panic_data.at(0));
+                        assert_trace_after_checker_panic_call_from_test(get_last_call_trace(), checker_address);
+                    }
+                }
+            }
+            
+            fn assert_trace_after_proxy_with_panic_call(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("with_panic"),
+                        calldata: array![checker_address.into()],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("panic"),
+                        calldata: array![],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'proxy libcall with_panic');
+            }
+            
+            fn assert_trace_after_checker_panic_call_from_test(
+                trace: Array<CallEntryPoint>, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("panic"),
+                        calldata: array![],
+                        contract_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
+                        call_type: CallType::Delegate,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'checker libcall panic');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}
+
+#[test]
+fn trace_l1_handler() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{declare, ContractClassTrait, test_address, L1HandlerTrait,};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_last_call_trace};
+            
+            use starknet::ContractAddress;
+            
+            #[test]
+            fn test_l1_handler_call_trace_info() {
+                let proxy = declare('TraceInfoProxy');
+                let checker = declare('TraceInfoChecker');
+            
+                let checker_address = checker.deploy(@array![]).unwrap();
+                let proxy_address = proxy.deploy(@array![checker_address.into()]).unwrap();
+            
+                let mut l1_handler = L1HandlerTrait::new(checker_address, function_name: 'handle_l1_message');
+            
+                l1_handler.from_address = 123;
+                l1_handler.payload = array![proxy_address.into()].span();
+            
+                l1_handler.execute().unwrap();
+                assert_trace_after_l1_handler_call(get_last_call_trace(), proxy_address, checker_address);
+            }
+            
+            fn assert_trace_after_l1_handler_call(
+                trace: Array<CallEntryPoint>, proxy_address: ContractAddress, checker_address: ContractAddress
+            ) {
+                let expected_trace = array![
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::L1Handler,
+                        entry_point_selector: selector!("handle_l1_message"),
+                        calldata: array![123, proxy_address.into()],
+                        contract_address: checker_address,
+                        caller_address: test_address(),
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("regular_call"),
+                        calldata: array![checker_address.into()],
+                        contract_address: proxy_address,
+                        caller_address: checker_address,
+                        call_type: CallType::Call,
+                    },
+                    CallEntryPoint {
+                        entry_point_type: EntryPointType::External,
+                        entry_point_selector: selector!("from_proxy"),
+                        calldata: array![2],
+                        contract_address: checker_address,
+                        caller_address: proxy_address,
+                        call_type: CallType::Call,
+                    },
+                ];
+            
+                assert(trace == expected_trace, 'checker l1 handler');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "TraceInfoProxy".to_string(),
+            Path::new("tests/data/contracts/trace_info_proxy.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "TraceInfoChecker".to_string(),
+            Path::new("tests/data/contracts/trace_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}

--- a/crates/forge/tests/integration/trace.rs
+++ b/crates/forge/tests/integration/trace.rs
@@ -566,7 +566,6 @@ fn trace_library_call_from_test() {
 }
 
 #[test]
-#[ignore]
 fn trace_failed_library_call_from_test() {
     let test = test_case!(
         indoc!(
@@ -714,7 +713,7 @@ fn trace_l1_handler() {
                         entry_point_selector: selector!("handle_l1_message"),
                         calldata: array![123, proxy_address.into()],
                         contract_address: checker_address,
-                        caller_address: test_address(),
+                        caller_address: 0.try_into().unwrap(),
                         call_type: CallType::Call,
                     },
                     CallEntryPoint {

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -48,3 +48,5 @@ mod fs;
 mod env;
 
 mod signature;
+
+mod trace;

--- a/snforge_std/src/trace.cairo
+++ b/snforge_std/src/trace.cairo
@@ -1,0 +1,30 @@
+use core::starknet::testing::cheatcode;
+use core::starknet::ContractAddress;
+
+#[derive(Drop, Serde, PartialEq)]
+struct CallEntryPoint {
+    entry_point_type: EntryPointType,
+    entry_point_selector: felt252,
+    calldata: Array<felt252>,
+    contract_address: ContractAddress,
+    caller_address: ContractAddress,
+    call_type: CallType,
+}
+
+#[derive(Drop, Serde, PartialEq)]
+enum EntryPointType {
+    Constructor,
+    External,
+    L1Handler,
+}
+
+#[derive(Drop, Serde, PartialEq)]
+enum CallType {
+    Call,
+    Delegate,
+}
+
+fn get_last_call_trace() -> Array<CallEntryPoint> {
+    let mut output = cheatcode::<'get_last_call_trace'>(array![].span());
+    Serde::<Array<CallEntryPoint>>::deserialize(ref output).unwrap()
+}

--- a/snforge_std/src/trace.cairo
+++ b/snforge_std/src/trace.cairo
@@ -1,5 +1,6 @@
 use core::starknet::testing::cheatcode;
 use core::starknet::ContractAddress;
+use core::fmt::{Display, Debug, Formatter, Error};
 
 #[derive(Drop, Serde, PartialEq)]
 struct CallEntryPoint {
@@ -27,4 +28,60 @@ enum CallType {
 fn get_last_call_trace() -> Array<CallEntryPoint> {
     let mut output = cheatcode::<'get_last_call_trace'>(array![].span());
     Serde::<Array<CallEntryPoint>>::deserialize(ref output).unwrap()
+}
+
+impl DisplayEntryPointType of Display<EntryPointType> {
+    fn fmt(self: @EntryPointType, ref f: Formatter) -> Result<(), Error> {
+        let str: ByteArray = match self {
+            EntryPointType::Constructor => "Constructor",
+            EntryPointType::External => "External",
+            EntryPointType::L1Handler => "L1 Handler",
+        };
+        f.buffer.append(@str);
+        Result::Ok(())
+    }
+}
+
+impl DisplayCallType of Display<CallType> {
+    fn fmt(self: @CallType, ref f: Formatter) -> Result<(), Error> {
+        let str: ByteArray = match self {
+            CallType::Call => "Call",
+            CallType::Delegate => "Delegate",
+        };
+        f.buffer.append(@str);
+        Result::Ok(())
+    }
+}
+
+impl DisplayCallEntryPoint of Display<CallEntryPoint> {
+    fn fmt(self: @CallEntryPoint, ref f: Formatter) -> Result<(), Error> {
+        write!(f, "Entry point type: ")?;
+        Display::fmt(self.entry_point_type, ref f)?;
+        write!(f, "\nSelector: ")?;
+        Display::fmt(self.entry_point_selector, ref f)?;
+        write!(f, "\nCalldata: ")?;
+        Debug::fmt(self.calldata, ref f)?;
+        write!(f, "\nStorage address: ")?;
+        Debug::fmt(self.contract_address, ref f)?;
+        write!(f, "\nCaller address: ")?;
+        Debug::fmt(self.caller_address, ref f)?;
+        write!(f, "\nCall type: ")?;
+        Display::fmt(self.call_type, ref f)
+    }
+}
+
+impl DisplayArrayCallEntryPoint of Display<Array<CallEntryPoint>> {
+    fn fmt(self: @Array<CallEntryPoint>, ref f: Formatter) -> Result<(), Error> {
+        let mut i = 0;
+        loop {
+            if i == self.len() {
+                break;
+            }
+            write!(f, "\n").unwrap();
+            Display::fmt(self[i], ref f).unwrap();
+            write!(f, "\n").unwrap();
+            i += 1;
+        };
+        Result::Ok(())
+    }
 }


### PR DESCRIPTION
We have to wait with merging for 2.5.0, some of the `Debug` impls are not present in corelib in 2.4.0

## Introduced changes

- implemented `Display` trait for `CallEntryPoint` and `Array<CallEntryPoint>`

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
