### PR TITLE
Use `append_span` in forge_std + remove unnecessary imports

### DIFF
--- a/crates/forge/tests/integration/spoof.rs
+++ b/crates/forge/tests/integration/spoof.rs
@@ -15,7 +15,7 @@ fn start_and_stop_spoof_single_attribute() {
             use serde::Serde;
             use starknet::ContractAddress;
             use array::SpanTrait;
-            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget, cheatcodes::tx_info::extend_array };
+            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget };
             use starknet::info::v2::ResourceBounds;
 
             #[starknet::interface]
@@ -252,7 +252,7 @@ fn start_spoof_cancel_mock_by_setting_attribute_to_none() {
             use serde::Serde;
             use starknet::ContractAddress;
             use array::SpanTrait;
-            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget, cheatcodes::tx_info::extend_array };
+            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget };
             use starknet::info::v2::ResourceBounds;
 
             #[starknet::interface]
@@ -352,7 +352,7 @@ fn start_spoof_no_attributes_mocked() {
             use starknet::ContractAddress;
             use starknet::ContractAddressIntoFelt252;
             use array::SpanTrait;
-            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget, cheatcodes::tx_info::extend_array };
+            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget };
             use starknet::info::v2::ResourceBounds;
 
             #[starknet::interface]
@@ -504,7 +504,7 @@ fn start_spoof_all() {
             use starknet::ContractAddress;
             use starknet::ContractAddressIntoFelt252;
             use array::SpanTrait;
-            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget, cheatcodes::tx_info::extend_array };
+            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget };
             use starknet::info::v2::ResourceBounds;
 
             #[starknet::interface]

--- a/crates/forge/tests/integration/spoof.rs
+++ b/crates/forge/tests/integration/spoof.rs
@@ -137,7 +137,7 @@ fn start_spoof_all_attributes_mocked() {
             use starknet::ContractAddressIntoFelt252;
             use starknet::Felt252TryIntoContractAddress;
             use array::SpanTrait;
-            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget, cheatcodes::tx_info::extend_array };
+            use snforge_std::{ declare, ContractClassTrait, start_spoof, stop_spoof, TxInfoMock, TxInfoMockTrait, CheatTarget };
             use starknet::info::v2::ResourceBounds;
 
             #[starknet::interface]

--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -1,5 +1,3 @@
-use core::array::ArrayTrait;
-use core::serde::Serde;
 use starknet::{testing::cheatcode, ContractAddress, ClassHash};
 
 #[derive(Drop, Clone)]

--- a/snforge_std/src/cheatcodes.cairo
+++ b/snforge_std/src/cheatcodes.cairo
@@ -1,14 +1,4 @@
-use array::ArrayTrait;
-use array::SpanTrait;
-use traits::Into;
-use traits::TryInto;
-use serde::Serde;
-
-use starknet::{
-    testing::cheatcode, ClassHash, ContractAddress, ClassHashIntoFelt252,
-    ContractAddressIntoFelt252, Felt252TryIntoClassHash, Felt252TryIntoContractAddress,
-    contract_address_const
-};
+use starknet::{testing::cheatcode, ContractAddress, contract_address_const};
 
 
 mod events;

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -1,8 +1,4 @@
 use starknet::{ContractAddress, ClassHash, testing::cheatcode};
-use array::ArrayTrait;
-use traits::Into;
-use clone::Clone;
-
 
 #[derive(Drop, Clone)]
 struct RevertedTransaction {

--- a/snforge_std/src/cheatcodes/events.cairo
+++ b/snforge_std/src/cheatcodes/events.cairo
@@ -1,10 +1,3 @@
-use array::ArrayTrait;
-use array::SpanTrait;
-use clone::Clone;
-use serde::Serde;
-use option::OptionTrait;
-use traits::Into;
-
 use starknet::testing::cheatcode;
 use starknet::ContractAddress;
 

--- a/snforge_std/src/cheatcodes/fork.cairo
+++ b/snforge_std/src/cheatcodes/fork.cairo
@@ -1,6 +1,3 @@
-use serde::Serde;
-
-
 #[derive(Drop, Copy, Serde)]
 enum BlockTag {
     Latest,

--- a/snforge_std/src/cheatcodes/l1_handler.cairo
+++ b/snforge_std/src/cheatcodes/l1_handler.cairo
@@ -1,5 +1,4 @@
 use starknet::{ContractAddress, testing::cheatcode};
-use traits::Into;
 use snforge_std::cheatcodes::contract_class::RevertedTransaction;
 
 #[derive(Drop, Clone)]

--- a/snforge_std/src/cheatcodes/tx_info.cairo
+++ b/snforge_std/src/cheatcodes/tx_info.cairo
@@ -1,11 +1,6 @@
-use core::clone::Clone;
 use starknet::{ContractAddress, testing::cheatcode, contract_address_const};
 use starknet::info::v2::ResourceBounds;
-use option::OptionTrait;
-use array::ArrayTrait;
-use array::SpanTrait;
 use snforge_std::CheatTarget;
-use serde::Serde;
 
 #[derive(Copy, Drop, Serde)]
 struct TxInfoMock {
@@ -70,10 +65,5 @@ fn stop_spoof(target: CheatTarget) {
 }
 
 fn extend_array(ref array: Array<felt252>, mut span: Span<felt252>) {
-    loop {
-        match span.pop_front() {
-            Option::Some(x) => { array.append(x.clone()); },
-            Option::None => { break; }
-        };
-    };
+    ArrayTrait::append_span(ref array, span);
 }

--- a/snforge_std/src/cheatcodes/tx_info.cairo
+++ b/snforge_std/src/cheatcodes/tx_info.cairo
@@ -1,4 +1,3 @@
-use core::array::ArrayTrait;
 use starknet::{ContractAddress, testing::cheatcode, contract_address_const};
 use starknet::info::v2::ResourceBounds;
 use snforge_std::CheatTarget;

--- a/snforge_std/src/cheatcodes/tx_info.cairo
+++ b/snforge_std/src/cheatcodes/tx_info.cairo
@@ -1,3 +1,4 @@
+use core::array::ArrayTrait;
 use starknet::{ContractAddress, testing::cheatcode, contract_address_const};
 use starknet::info::v2::ResourceBounds;
 use snforge_std::CheatTarget;
@@ -52,8 +53,8 @@ fn start_spoof(target: CheatTarget, tx_info_mock: TxInfoMock) {
     tx_info_mock.serialize(ref tx_info_serialized);
 
     let mut inputs: Array<felt252> = array![];
-    extend_array(ref inputs, cheat_target_serialized.span());
-    extend_array(ref inputs, tx_info_serialized.span());
+    inputs.append_span(cheat_target_serialized.span());
+    inputs.append_span(tx_info_serialized.span());
 
     cheatcode::<'start_spoof'>(inputs.span());
 }
@@ -64,6 +65,3 @@ fn stop_spoof(target: CheatTarget) {
     cheatcode::<'stop_spoof'>(inputs.span());
 }
 
-fn extend_array(ref array: Array<felt252>, mut span: Span<felt252>) {
-    array.append_span(span);
-}

--- a/snforge_std/src/cheatcodes/tx_info.cairo
+++ b/snforge_std/src/cheatcodes/tx_info.cairo
@@ -65,5 +65,5 @@ fn stop_spoof(target: CheatTarget) {
 }
 
 fn extend_array(ref array: Array<felt252>, mut span: Span<felt252>) {
-    ArrayTrait::append_span(ref array, span);
+    array.append_span(span);
 }

--- a/snforge_std/src/env/env_vars.cairo
+++ b/snforge_std/src/env/env_vars.cairo
@@ -1,9 +1,3 @@
-use array::ArrayTrait;
-use array::SpanTrait;
-use clone::Clone;
-use option::OptionTrait;
-use serde::Serde;
-
 use starknet::testing::cheatcode;
 
 fn var(name: felt252) -> felt252 {

--- a/snforge_std/src/fs/file_operations.cairo
+++ b/snforge_std/src/fs/file_operations.cairo
@@ -1,9 +1,3 @@
-use array::ArrayTrait;
-use array::SpanTrait;
-use clone::Clone;
-use option::OptionTrait;
-use serde::Serde;
-
 use starknet::testing::cheatcode;
 
 #[derive(Drop, Copy)]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1379 

## Introduced changes

This PR uses `append_span` where its is needed in forge_std, i.e. directly instead  of `extend_array` function in tx_info.cairo.

I also removed unnecessary imports, not needed with prelude `2023_10` used by default with `scarb >= 2.4.0`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
