### PR TITLE
Add work item issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/work_item.yml
+++ b/.github/ISSUE_TEMPLATE/work_item.yml
@@ -13,7 +13,7 @@ body:
       required: true
 
   - type: textarea
-    id: what-happened
+    id: description
     attributes:
       label: Description
       description: Describe the issue here.

--- a/.github/ISSUE_TEMPLATE/work_item.yml
+++ b/.github/ISSUE_TEMPLATE/work_item.yml
@@ -15,7 +15,7 @@ body:
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened
+      label: Description
       description: Describe the issue here.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/work_item.yml
+++ b/.github/ISSUE_TEMPLATE/work_item.yml
@@ -1,0 +1,21 @@
+name: Work item
+description: Submit an actionable task
+body:
+  - type: dropdown
+    id: tool-name
+    attributes:
+      label: Which components does the task require to be changed?
+      multiple: true
+      options:
+        - snforge
+        - sncast
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the issue here.
+    validations:
+      required: true


### PR DESCRIPTION

## Introduced changes

<!-- A brief description of the changes -->

Adds a template for generic issues we want to work on. 
The target is to put the information about the components that should be considered for changes in the issue description, and avoid having blurred responsibility when 2 teams are assigned to the same issue.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
