### PR TITLE
docs: correct l1_handler_execute.md's link path

### DIFF
--- a/docs/src/appendix/cheatcodes/l1_handler_execute.md
+++ b/docs/src/appendix/cheatcodes/l1_handler_execute.md
@@ -11,7 +11,7 @@ arriving from Ethereum.
 > Execution of the `#[l1_handler]` function may panic like any other function.
 > If you'd like to assert the panic data, use `RevertedTransaction` returned by the function.
 > It works like a regular `SafeDispatcher` would with a function call.
-> For more info check out [handling panic errors](../../testing/contracts.html#handling-errors)
+> For more info check out [handling panic errors](../../testing/contracts.md#handling-errors)
 
 
 ```rust


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

walk through this doc, found `contracts.html` actually is md file, so original link jump will fail

<img width="1102" alt="image" src="https://github.com/foundry-rs/starknet-foundry/assets/153156292/7cff207d-5e28-47b0-8a08-167bb268f27e">

<!-- A brief description of the changes -->


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
