### PR TITLE
Use functions from blockifier to calculate used gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Changed
+
+- Gas estimation is now aligned with the Starknet v0.13
+
 ## [0.16.0] - 2024-01-26
 
 ### Forge

--- a/crates/forge-runner/src/gas.rs
+++ b/crates/forge-runner/src/gas.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use crate::test_case_summary::{Single, TestCaseSummary};
-use blockifier::fee::eth_gas_constants;
 use blockifier::fee::fee_utils::calculate_tx_l1_gas_usage;
-use blockifier::fee::gas_usage::get_message_segment_length;
+use blockifier::fee::gas_usage::calculate_tx_gas_usage;
 use blockifier::fee::os_resources::OS_RESOURCES;
 use blockifier::fee::os_usage::get_additional_os_resources;
 use blockifier::state::cached_state::{CachedState, StateChangesCount};
@@ -33,12 +32,14 @@ pub fn calculate_used_gas(
     // which we don't want to include in gas cost
     state_changes.compiled_class_hash_updates.clear();
 
-    let l1_gas_usage = get_l1_gas_usage(
+    let l1_gas_usage = calculate_tx_gas_usage(
         &resources.l2_to_l1_payloads_length,
         StateChangesCount::from(&state_changes),
+        None,
     );
 
     let resource_mapping = used_resources_to_resource_mapping(&total_vm_usage, l1_gas_usage);
+
     calculate_tx_l1_gas_usage(&resource_mapping, block_context)
         .expect("Calculating gas failed, some resources were not included.")
 }
@@ -75,35 +76,6 @@ fn get_total_vm_usage(resources: &ExecutionResources) -> VmExecutionResources {
         .unwrap()
             - unnecessary_added_resources);
     total_vm_usage.filter_unused_builtins()
-}
-
-fn get_l1_gas_usage(
-    l2_to_l1_payloads_length: &[usize],
-    state_changes_count: StateChangesCount,
-) -> usize {
-    let message_segment_length = get_message_segment_length(l2_to_l1_payloads_length, None);
-    let onchain_data_segment_length = get_onchain_data_segment_length(state_changes_count);
-
-    message_segment_length * eth_gas_constants::SHARP_GAS_PER_MEMORY_WORD
-        + onchain_data_segment_length * eth_gas_constants::SHARP_GAS_PER_MEMORY_WORD
-}
-
-// TODO::copied from blockifier, because it became private
-fn get_onchain_data_segment_length(state_changes_count: StateChangesCount) -> usize {
-    // For each newly modified contract:
-    // contract address (1 word).
-    // + 1 word with the following info: A flag indicating whether the class hash was updated, the
-    // number of entry updates, and the new nonce.
-    let mut onchain_data_segment_length = state_changes_count.n_modified_contracts * 2;
-    // For each class updated (through a deploy or a class replacement).
-    onchain_data_segment_length +=
-        state_changes_count.n_class_hash_updates * constants::CLASS_UPDATE_SIZE;
-    // For each modified storage cell: key, new value.
-    onchain_data_segment_length += state_changes_count.n_storage_updates * 2;
-    // For each compiled class updated (through declare): class_hash, compiled_class_hash
-    onchain_data_segment_length += state_changes_count.n_compiled_class_hash_updates * 2;
-
-    onchain_data_segment_length
 }
 
 pub fn check_available_gas(

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -4,7 +4,9 @@ use test_utils::runner::Contract;
 use test_utils::running_tests::run_test_case;
 use test_utils::{assert_gas, assert_passed, test_case};
 
-// gas values comes from https://book.starknet.io/ch03-01-02-fee-mechanism.html#computation
+// all calculations are based on formula from
+// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/#overall_fee
+
 #[test]
 fn declare_cost_is_omitted() {
     let test = test_case!(
@@ -32,7 +34,6 @@ fn declare_cost_is_omitted() {
     assert_gas!(result, "declare_cost_is_omitted", 1);
 }
 
-// FIXME(#1596): Code (steps) was added but the cost did not change
 #[test]
 fn deploy_syscall_cost() {
     let test = test_case!(
@@ -59,10 +60,39 @@ fn deploy_syscall_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1224 = 2 * cost per 32-byte word (contract_address and contract modification info)
-    // 612 = updated class_hash (through deploy)
     // 6 = gas cost from steps
-    assert_gas!(result, "deploy_syscall_cost", 1224 + 612 + 6);
+    // 1101 = gas cost of onchain data (deploy cost)
+    assert_gas!(result, "deploy_syscall_cost", 6 + 1101);
+}
+
+#[test]
+fn snforge_std_deploy_cost() {
+    let test = test_case!(
+        indoc!(
+            r"
+            use snforge_std::{ declare, ContractClassTrait };
+            
+            #[test]
+            fn deploy_cost() {
+                let contract = declare('GasChecker');
+                let address = contract.deploy(@array![]).unwrap();
+                assert(address != 0.try_into().unwrap(), 'wrong deployed addr');
+            }
+        "
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+    // 2 = gas cost from steps
+    // 1101 = gas cost of onchain data (deploy cost)
+    assert_gas!(result, "deploy_cost", 2 + 1101);
 }
 
 #[test]
@@ -114,9 +144,9 @@ fn contract_keccak_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 11 = cost of single keccak builtin
-    assert_gas!(result, "contract_keccak_cost", 1836 + 11);
+    assert_gas!(result, "contract_keccak_cost", 1101 + 11);
 }
 
 #[test]
@@ -172,9 +202,9 @@ fn contract_range_check_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 2 = cost of 22 range check builtins
-    assert_gas!(result, "contract_range_check_cost", 1836 + 2);
+    assert_gas!(result, "contract_range_check_cost", 1101 + 2);
 }
 
 #[test]
@@ -228,9 +258,9 @@ fn contract_bitwise_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 2 = cost of 6 bitwise builtins
-    assert_gas!(result, "contract_bitwise_cost", 1836 + 2);
+    assert_gas!(result, "contract_bitwise_cost", 1101 + 2);
 }
 
 #[test]
@@ -284,9 +314,9 @@ fn contract_pedersen_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 2 = cost of 12 pedersen builtins
-    assert_gas!(result, "contract_pedersen_cost", 1836 + 2);
+    assert_gas!(result, "contract_pedersen_cost", 1101 + 2);
 }
 
 #[test]
@@ -340,9 +370,9 @@ fn contract_poseidon_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 2 = cost of 12 poseidon builtins
-    assert_gas!(result, "contract_poseidon_cost", 1836 + 2);
+    assert_gas!(result, "contract_poseidon_cost", 1101 + 2);
 }
 
 #[test]
@@ -397,9 +427,9 @@ fn contract_ec_op_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
+    // 1101 = cost of deploy (see snforge_std_deploy_cost test)
     // 6 = cost of single ec_op builtin
-    assert_gas!(result, "contract_ec_op_cost", 1836 + 6);
+    assert_gas!(result, "contract_ec_op_cost", 1101 + 6);
 }
 
 #[test]
@@ -434,10 +464,9 @@ fn storage_write_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
-    // 1224 = 2 * cost per 32-byte word (storage write)
     // 3 = gas cost of steps
-    assert_gas!(result, "storage_write_cost", 1836 + 1224 + 3);
+    // 2203 = gas cost of onchain data
+    assert_gas!(result, "storage_write_cost", 3 + 2203);
 }
 
 #[test]
@@ -465,10 +494,9 @@ fn storage_write_from_test_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1224 = 2 * cost per 32-byte word (modified contract)
-    // 1224 = 2 * cost per 32-byte word (storage write)
     // 1 = gas cost of steps
-    assert_gas!(result, "storage_write_from_test_cost", 1224 + 1224 + 1);
+    // 1652 = gas cost of onchain data
+    assert_gas!(result, "storage_write_from_test_cost", 1 + 1652);
 }
 
 #[test]
@@ -504,10 +532,9 @@ fn multiple_storage_writes_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
-    // 1224 = 2 * cost per 32-byte word (storage write)
     // 3 = gas cost of steps
-    assert_gas!(result, "multiple_storage_writes_cost", 1836 + 1224 + 3);
+    // 2203 = gas cost of onchain data
+    assert_gas!(result, "multiple_storage_writes_cost", 3 + 2203);
 }
 
 #[test]
@@ -542,10 +569,9 @@ fn l1_message_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
-    // 2448 = 4 * cost per 32-byte word (l2_l1_message, header is of length 3 and payload size is 1)
     // 3 = gas cost of steps
-    assert_gas!(result, "l1_message_cost", 1836 + 2448 + 3);
+    // 27865 = gas cost of onchain data
+    assert_gas!(result, "l1_message_cost", 3 + 27865);
 }
 
 #[test]
@@ -562,9 +588,9 @@ fn l1_message_from_test_cost() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 2448 = 4 * cost per 32-byte word (l2_l1_message, header is of length 3 and payload size is 1)
     // 1 = gas cost of steps
-    assert_gas!(result, "l1_message_from_test_cost", 2448 + 1);
+    // 26764 = gas cost of onchain data
+    assert_gas!(result, "l1_message_from_test_cost", 1 + 26764);
 }
 
 #[test]
@@ -611,9 +637,7 @@ fn l1_message_cost_for_proxy() {
     let result = run_test_case(&test);
 
     assert_passed!(result);
-    // 1836 = 3 * cost per 32-byte word (deploy)
-    // 1836 = 3 * cost per 32-byte word (deploy)
-    // 2448 = 4 * cost per 32-byte word (l2_l1_message, header is of length 3 and payload size is 1)
     // 8 = gas cost of steps
-    assert_gas!(result, "l1_message_cost_for_proxy", 1836 + 1836 + 2448 + 8);
+    // 29206 = gas cost of onchain data
+    assert_gas!(result, "l1_message_cost_for_proxy", 8 + 29206);
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1445

## Introduced changes

<!-- A brief description of the changes -->

- `calculate_tx_gas_usage` function is used to calculate onchain gas usage

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
