### PR TITLE
Add `Debug` and `Display` impls for script subcommand responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - `--package` flag for `declare` and `script` subcommands, that specifies scarb package to work with
+- `Debug` and `Display` impls for script subcommand responses
 
 ## [0.16.0] - 2024-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - `--package` flag for `declare` and `script` subcommands, that specifies scarb package to work with
-- `Debug` and `Display` impls for script subcommand responses
+- `Debug` and `Display` impls for script subcommand responses - use `print!`, `println!` macros instead of calling `.print()`
 
 ## [0.16.0] - 2024-01-26
 

--- a/crates/sncast/tests/data/scripts/map_script/contracts/src/lib.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/contracts/src/lib.cairo
@@ -2,6 +2,7 @@
 trait IMap<TMapState> {
     fn put(ref self: TMapState, key: felt252, value: felt252);
     fn get(self: @TMapState, key: felt252) -> felt252;
+    fn dummy(self: @TMapState) -> felt252;
 }
 
 
@@ -12,7 +13,7 @@ mod Mapa {
         storage: LegacyMap::<felt252, felt252>,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Map of super::IMap<ContractState> {
         fn put(ref self: ContractState, key: felt252, value: felt252) {
             self.storage.write(key, value);
@@ -20,6 +21,10 @@ mod Mapa {
 
         fn get(self: @ContractState, key: felt252) -> felt252 {
             self.storage.read(key)
+        }
+
+        fn dummy(self: @ContractState) -> felt252 {
+            1
         }
     }
 }
@@ -31,7 +36,7 @@ mod Mapa2 {
         storage: LegacyMap::<felt252, felt252>,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl Map of super::IMap<ContractState> {
         fn put(ref self: ContractState, key: felt252, value: felt252) {
             self.storage.write(key, value);
@@ -39,6 +44,10 @@ mod Mapa2 {
 
         fn get(self: @ContractState, key: felt252) -> felt252 {
             self.storage.read(key)
+        }
+
+        fn dummy(self: @ContractState) -> felt252 {
+            1
         }
     }
 }

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
@@ -3,6 +3,7 @@ use sncast_std::{
 };
 
 fn main() {
+    println!("test");
     let max_fee = 99999999999999999;
     let salt = 0x3;
 

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
@@ -1,0 +1,50 @@
+use sncast_std::{
+    declare, deploy, invoke, call, DeclareResult, DeployResult, InvokeResult, CallResult, get_nonce
+};
+
+fn main() {
+    let max_fee = 99999999999999999;
+    let salt = 0x3;
+
+    let declare_nonce = get_nonce('latest');
+    println!("declare_nonce: {}", declare_nonce);
+    println!("debug declare_nonce: {:?}", declare_nonce);
+
+    let declare_result = declare('Mapa', Option::Some(max_fee), Option::Some(declare_nonce));
+    println!("declare_result: {}", declare_result);
+    println!("debug declare_result: {:?}", declare_result);
+
+    let class_hash = declare_result.class_hash;
+    let deploy_nonce = get_nonce('pending');
+    let deploy_result = deploy(
+        class_hash,
+        ArrayTrait::new(),
+        Option::Some(salt),
+        true,
+        Option::Some(max_fee),
+        Option::Some(deploy_nonce)
+    );
+    println!("deploy_result: {}", deploy_result);
+    println!("debug deploy_result: {:?}", deploy_result);
+
+    assert(deploy_result.transaction_hash != 0, deploy_result.transaction_hash);
+
+    let invoke_nonce = get_nonce('pending');
+    let invoke_result = invoke(
+        deploy_result.contract_address,
+        'put',
+        array![0x1, 0x2],
+        Option::Some(max_fee),
+        Option::Some(invoke_nonce)
+    );
+    println!("invoke_result: {}", invoke_result);
+    println!("debug invoke_result: {:?}", invoke_result);
+
+    assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
+
+    let call_result = call(deploy_result.contract_address, 'get', array![0x1]);
+    println!("call_result: {}", call_result);
+    println!("debug call_result: {:?}", call_result);
+
+    assert(call_result.data == array![0x2], *call_result.data.at(0));
+}

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/lib.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/lib.cairo
@@ -1,2 +1,2 @@
 mod map_script;
-
+mod display_debug_traits_for_subcommand_responses;

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -1,6 +1,6 @@
 use crate::helpers::constants::{CONTRACTS_DIR, URL};
 use crate::helpers::fixtures::{
-    copy_directory_to_tempdir, duplicate_directory_with_salt, get_accounts_path,
+    copy_directory_to_tempdir, duplicate_contract_directory_with_salt, get_accounts_path,
     get_transaction_hash, get_transaction_receipt,
 };
 use indoc::indoc;
@@ -10,7 +10,7 @@ use starknet::core::types::TransactionReceipt::Declare;
 #[tokio::test]
 async fn test_happy_case() {
     let contract_path =
-        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "1");
+        duplicate_contract_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "1");
     let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
     let args = vec![
         "--url",
@@ -193,7 +193,7 @@ fn scarb_build_fails_manifest_does_not_exist() {
 #[test]
 fn test_too_low_max_fee() {
     let contract_path =
-        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "2");
+        duplicate_contract_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "2");
     let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
 
     let args = vec![

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -1,5 +1,7 @@
 use crate::helpers::constants::{ACCOUNT, ACCOUNT_FILE_PATH, CONTRACTS_DIR, URL};
-use crate::helpers::fixtures::{duplicate_directory_with_salt, from_env, get_keystores_path};
+use crate::helpers::fixtures::{
+    duplicate_contract_directory_with_salt, from_env, get_keystores_path,
+};
 use crate::helpers::runner::runner;
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
@@ -213,7 +215,7 @@ async fn test_keystore_inexistent_account() {
 #[tokio::test]
 async fn test_keystore_undeployed_account() {
     let contract_path =
-        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "8");
+        duplicate_contract_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "8");
     let my_key_path = get_keystores_path("tests/data/keystore/my_key.json");
     let my_account_undeployed_path =
         get_keystores_path("tests/data/keystore/my_account_undeployed.json");
@@ -245,7 +247,7 @@ async fn test_keystore_undeployed_account() {
 #[tokio::test]
 async fn test_keystore_declare() {
     let contract_path =
-        duplicate_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "999");
+        duplicate_contract_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "999");
     let my_key_path = get_keystores_path("tests/data/keystore/predeployed_key.json");
     let my_account_path = get_keystores_path("tests/data/keystore/predeployed_account.json");
     let args = vec![

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -175,3 +175,41 @@ async fn test_multiple_packages_happy_case() {
         status: success
     "});
 }
+
+#[tokio::test]
+async fn test_run_script_display_debug_traits() {
+    let script_name = "display_debug_traits_for_subcommand_responses";
+    let args = vec![
+        "--accounts-file",
+        "../../../accounts/accounts.json",
+        "--account",
+        "user4",
+        "--url",
+        URL,
+        "script",
+        &script_name,
+    ];
+
+    let snapbox = Command::new(cargo_bin!("sncast"))
+        .current_dir(SCRIPTS_DIR.to_owned() + "/map_script/scripts")
+        .args(args);
+
+    snapbox.assert().success().stdout_matches(indoc! {r#"
+        ...
+        declare_nonce: 1
+        debug declare_nonce: 1
+        Transaction hash = 0x[..]
+        declare_result: class_hash: [..], transaction_hash: [..]
+        debug declare_result: DeclareResult { class_hash: [..], transaction_hash: [..] }
+        Transaction hash = 0x[..]
+        deploy_result: contract_address: [..], transaction_hash: [..]
+        debug deploy_result: DeployResult { contract_address: [..], transaction_hash: [..] }
+        Transaction hash = 0x[..]
+        invoke_result: [..]
+        debug invoke_result: InvokeResult { transaction_hash: [..] }
+        call_result: [2]
+        debug call_result: CallResult { data: [2] }
+        command: script
+        status: success
+    "#});
+}

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -1,4 +1,5 @@
 use crate::helpers::constants::{SCRIPTS_DIR, URL};
+use crate::helpers::fixtures::duplicate_directory_and_salt_file;
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
 
@@ -178,12 +179,20 @@ async fn test_multiple_packages_happy_case() {
 
 #[tokio::test]
 async fn test_run_script_display_debug_traits() {
+    let current_dir = duplicate_directory_and_salt_file(
+        SCRIPTS_DIR.to_owned() + "/map_script",
+        Some(SCRIPTS_DIR.to_owned()),
+        "dummy",
+        "contracts/src/lib.cairo",
+        "45",
+    );
+
     let script_name = "display_debug_traits_for_subcommand_responses";
     let args = vec![
         "--accounts-file",
         "../../../accounts/accounts.json",
         "--account",
-        "user4",
+        "user6",
         "--url",
         URL,
         "script",
@@ -191,7 +200,7 @@ async fn test_run_script_display_debug_traits() {
     ];
 
     let snapbox = Command::new(cargo_bin!("sncast"))
-        .current_dir(SCRIPTS_DIR.to_owned() + "/map_script/scripts")
+        .current_dir(current_dir.path().join("scripts"))
         .args(args);
 
     snapbox.assert().success().stdout_matches(indoc! {r"

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -1,7 +1,6 @@
 use crate::helpers::constants::{SCRIPTS_DIR, URL};
 use crate::helpers::fixtures::{
     duplicate_contract_directory_with_salt, duplicate_script_directory, get_accounts_path,
-    get_deps_map_from_paths,
 };
 use indoc::indoc;
 use snapbox::cmd::{cargo_bin, Command};
@@ -187,9 +186,10 @@ async fn test_run_script_display_debug_traits() {
         "dummy",
         "45",
     );
-    let mut deps = get_deps_map_from_paths(vec![contract_dir.as_ref()]);
-    let script_dir =
-        duplicate_script_directory(SCRIPTS_DIR.to_owned() + "/map_script/scripts/", &mut deps);
+    let script_dir = duplicate_script_directory(
+        SCRIPTS_DIR.to_owned() + "/map_script/scripts/",
+        vec![contract_dir.as_ref()],
+    );
 
     let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
 

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -196,8 +196,9 @@ async fn test_run_script_display_debug_traits() {
 
     snapbox.assert().success().stdout_matches(indoc! {r"
         ...
-        declare_nonce: 1
-        debug declare_nonce: 1
+        test
+        declare_nonce: [..]
+        debug declare_nonce: [..]
         Transaction hash = 0x[..]
         declare_result: class_hash: [..], transaction_hash: [..]
         debug declare_result: DeclareResult { class_hash: [..], transaction_hash: [..] }

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -194,7 +194,7 @@ async fn test_run_script_display_debug_traits() {
         .current_dir(SCRIPTS_DIR.to_owned() + "/map_script/scripts")
         .args(args);
 
-    snapbox.assert().success().stdout_matches(indoc! {r#"
+    snapbox.assert().success().stdout_matches(indoc! {r"
         ...
         declare_nonce: 1
         debug declare_nonce: 1
@@ -211,5 +211,5 @@ async fn test_run_script_display_debug_traits() {
         debug call_result: CallResult { data: [2] }
         command: script
         status: success
-    "#});
+    "});
 }

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -293,17 +293,12 @@ pub fn duplicate_directory_and_salt_file(
     let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("Failed to create Utf8PathBuf from PathBuf");
 
-    let paths = fs::read_dir(src_dir.clone())
-        .unwrap()
-        .filter_map(Result::ok)
-        .map(|dir_entry| dir_entry.path())
-        .collect::<Vec<_>>();
-    fs_extra::copy_items(
-        &paths,
+    fs_extra::dir::copy(
+        &src_dir,
         &dest_dir,
-        &fs_extra::dir::CopyOptions::new().overwrite(true),
+        &fs_extra::dir::CopyOptions::new().content_only(true),
     )
-    .unwrap();
+    .expect("Unable to copy directory");
 
     let contract_code =
         fs::read_to_string(src_dir.join(file_to_be_salted)).expect("Unable to get contract code");

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -273,12 +273,9 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
 fn copy_dir_into_temp_dir(src_dir: &Utf8PathBuf) -> TempDir {
     let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
 
-    let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
-        .expect("Failed to create Utf8PathBuf from PathBuf");
-
     fs_extra::dir::copy(
         src_dir,
-        dest_dir,
+        temp_dir.as_ref(),
         &fs_extra::dir::CopyOptions::new().content_only(true),
     )
     .expect("Unable to copy directory content");

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -349,19 +349,19 @@ pub fn duplicate_script_directory(
         .as_table_mut()
         .unwrap();
 
-    if let Some(sncast_std) = deps_toml.get_mut("sncast_std") {
-        if let Some(sncast_std_path) = sncast_std.get_mut("path") {
-            let sncast_std_path =
-                Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
-            if sncast_std_path.is_relative() {
-                let sncast_std_path = src_dir.join(sncast_std_path);
-                let sncast_std_path_absolute = sncast_std_path
-                    .canonicalize_utf8()
-                    .expect("Failed to canonicalize sncast_std path");
-                deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
-            }
+    let sncast_std = deps_toml.get_mut("sncast_std").expect("sncast_std not found");
+    if let Some(sncast_std_path) = sncast_std.get_mut("path") {
+        let sncast_std_path =
+            Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
+        if sncast_std_path.is_relative() {
+            let sncast_std_path = src_dir.join(sncast_std_path);
+            let sncast_std_path_absolute = sncast_std_path
+                .canonicalize_utf8()
+                .expect("Failed to canonicalize sncast_std path");
+            deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
         }
     }
+
 
     for (key, value) in deps {
         let pkg = deps_toml.get_mut(&key).unwrap().as_table_mut().unwrap();

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -351,10 +351,13 @@ pub fn duplicate_script_directory(
 
     if let Some(sncast_std) = deps_toml.get_mut("sncast_std") {
         if let Some(sncast_std_path) = sncast_std.get_mut("path") {
-            let sncast_std_path = Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
+            let sncast_std_path =
+                Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
             if sncast_std_path.is_relative() {
                 let sncast_std_path = src_dir.join(sncast_std_path);
-                let sncast_std_path_absolute = sncast_std_path.canonicalize_utf8().expect("Failed to canonicalize sncast_std path");
+                let sncast_std_path_absolute = sncast_std_path
+                    .canonicalize_utf8()
+                    .expect("Failed to canonicalize sncast_std path");
                 deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
             }
         }

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -298,7 +298,7 @@ pub fn duplicate_directory_and_salt_file(
         &dest_dir,
         &fs_extra::dir::CopyOptions::new().content_only(true),
     )
-    .expect("Unable to copy directory");
+    .expect("Unable to copy directory content");
 
     let contract_code =
         fs::read_to_string(src_dir.join(file_to_be_salted)).expect("Unable to get contract code");

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -285,10 +285,9 @@ pub fn duplicate_directory_and_salt_file(
 ) -> TempDir {
     let src_dir = Utf8PathBuf::from(src_path);
     let temp_dir = match dst_path {
-        Some(dst_path) => TempDir::new_in(dst_path),
-        None => TempDir::new(),
+        Some(dst_path) => TempDir::new_in(dst_path).expect("Unable to create a temporary directory in the specified path"),
+        None => TempDir::new().expect("Unable to create a temporary directory"),
     };
-    let temp_dir = temp_dir.expect("Unable to create a temporary directory");
 
     let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("Failed to create Utf8PathBuf from PathBuf");

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -285,7 +285,8 @@ pub fn duplicate_directory_and_salt_file(
 ) -> TempDir {
     let src_dir = Utf8PathBuf::from(src_path);
     let temp_dir = match dst_path {
-        Some(dst_path) => TempDir::new_in(dst_path).expect("Unable to create a temporary directory in the specified path"),
+        Some(dst_path) => TempDir::new_in(dst_path)
+            .expect("Unable to create a temporary directory in the specified path"),
         None => TempDir::new().expect("Unable to create a temporary directory"),
     };
 

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -338,17 +338,16 @@ pub fn duplicate_script_directory(
     let sncast_std = deps_toml
         .get_mut("sncast_std")
         .expect("sncast_std not found");
-    if let Some(sncast_std_path) = sncast_std.get_mut("path") {
-        let sncast_std_path =
-            Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
-        if sncast_std_path.is_relative() {
-            let sncast_std_path = src_dir.join(sncast_std_path);
-            let sncast_std_path_absolute = sncast_std_path
-                .canonicalize_utf8()
-                .expect("Failed to canonicalize sncast_std path");
-            deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
-        }
-    }
+
+    let sncast_std_path = sncast_std.get_mut("path").expect("No path to sncast_std");
+    let sncast_std_path =
+        Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
+
+    let sncast_std_path = src_dir.join(sncast_std_path);
+    let sncast_std_path_absolute = sncast_std_path
+        .canonicalize_utf8()
+        .expect("Failed to canonicalize sncast_std path");
+    deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
 
     for (key, value) in deps {
         let pkg = deps_toml.get_mut(&key).unwrap().as_table_mut().unwrap();

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -270,19 +270,6 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(parsed_url))
 }
 
-fn copy_dir_to_temp_dir(src_dir: impl AsRef<Utf8Path>) -> TempDir {
-    let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
-
-    fs_extra::dir::copy(
-        src_dir.as_ref(),
-        temp_dir.as_ref(),
-        &fs_extra::dir::CopyOptions::new().content_only(true),
-    )
-    .expect("Failed to copy directory content");
-
-    temp_dir
-}
-
 #[must_use]
 pub fn duplicate_contract_directory_with_salt(
     src_dir: impl AsRef<Utf8Path>,
@@ -291,7 +278,7 @@ pub fn duplicate_contract_directory_with_salt(
 ) -> TempDir {
     let src_dir = Utf8PathBuf::from(src_dir.as_ref());
 
-    let temp_dir = copy_dir_to_temp_dir(&src_dir);
+    let temp_dir = copy_directory_to_tempdir(&src_dir);
 
     let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("Failed to create Utf8PathBuf from PathBuf");
@@ -308,13 +295,12 @@ pub fn duplicate_contract_directory_with_salt(
 }
 
 #[must_use]
-pub fn copy_directory_to_tempdir(src_path: String) -> TempDir {
-    let src_dir = Utf8PathBuf::from(src_path);
-    let temp_dir = TempDir::new().expect("Failed to create a temporary directory");
+pub fn copy_directory_to_tempdir(src_dir: impl AsRef<Utf8Path>) -> TempDir {
+    let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
 
     fs_extra::dir::copy(
-        src_dir,
-        &temp_dir,
+        src_dir.as_ref(),
+        temp_dir.as_ref(),
         &fs_extra::dir::CopyOptions::new()
             .overwrite(true)
             .content_only(true),
@@ -332,7 +318,7 @@ pub fn duplicate_script_directory(
 
     let src_dir = Utf8PathBuf::from(src_dir.as_ref());
 
-    let temp_dir = copy_dir_to_temp_dir(&src_dir);
+    let temp_dir = copy_directory_to_tempdir(&src_dir);
 
     let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("Failed to create Utf8PathBuf from PathBuf");

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -7,7 +7,7 @@ use primitive_types::U256;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
-use sncast::helpers::scarb_utils::{get_package_metadata, get_scarb_metadata};
+use sncast::helpers::scarb_utils::get_package_metadata;
 use sncast::{apply_optional, get_chain_id, get_keystore_password};
 use sncast::{get_account, get_provider, parse_number};
 use starknet::accounts::{Account, AccountFactory, Call, Execution, OpenZeppelinAccountFactory};
@@ -349,7 +349,9 @@ pub fn duplicate_script_directory(
         .as_table_mut()
         .unwrap();
 
-    let sncast_std = deps_toml.get_mut("sncast_std").expect("sncast_std not found");
+    let sncast_std = deps_toml
+        .get_mut("sncast_std")
+        .expect("sncast_std not found");
     if let Some(sncast_std_path) = sncast_std.get_mut("path") {
         let sncast_std_path =
             Utf8PathBuf::from(sncast_std_path.as_str().expect("Failed to extract string"));
@@ -361,7 +363,6 @@ pub fn duplicate_script_directory(
             deps.insert(String::from("sncast_std"), sncast_std_path_absolute);
         }
     }
-
 
     for (key, value) in deps {
         let pkg = deps_toml.get_mut(&key).unwrap().as_table_mut().unwrap();
@@ -387,9 +388,8 @@ pub fn get_deps_map_from_paths(
         let path = Utf8PathBuf::from_path_buf(path.as_ref().to_path_buf())
             .expect("Failed to create Utf8PathBuf from PathBuf");
         let manifest_path = path.join("Scarb.toml");
-        let metadata = get_scarb_metadata(&manifest_path).expect("Failed to get scarb metadata");
-        let package = get_package_metadata(&metadata, &manifest_path)
-            .expect("Failed to get package metadata");
+        let package =
+            get_package_metadata(&manifest_path, &None).expect("Failed to get package metadata");
         deps.insert(package.name.clone(), path);
     }
 

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -2,7 +2,7 @@ use crate::helpers::constants::{
     ACCOUNT_FILE_PATH, CONTRACTS_DIR, DEVNET_ENV_FILE, DEVNET_OZ_CLASS_HASH, URL,
 };
 use anyhow::Context;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use primitive_types::U256;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -270,11 +270,11 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
     JsonRpcClient::new(HttpTransport::new(parsed_url))
 }
 
-fn copy_dir_to_temp_dir(src_dir: &Utf8PathBuf) -> TempDir {
+fn copy_dir_to_temp_dir(src_dir: impl AsRef<Utf8Path>) -> TempDir {
     let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
 
     fs_extra::dir::copy(
-        src_dir,
+        src_dir.as_ref(),
         temp_dir.as_ref(),
         &fs_extra::dir::CopyOptions::new().content_only(true),
     )
@@ -285,11 +285,11 @@ fn copy_dir_to_temp_dir(src_dir: &Utf8PathBuf) -> TempDir {
 
 #[must_use]
 pub fn duplicate_contract_directory_with_salt(
-    src_dir: String,
+    src_dir: impl AsRef<Utf8Path>,
     code_to_be_salted: &str,
     salt: &str,
 ) -> TempDir {
-    let src_dir = Utf8PathBuf::from(src_dir);
+    let src_dir = Utf8PathBuf::from(src_dir.as_ref());
 
     let temp_dir = copy_dir_to_temp_dir(&src_dir);
 
@@ -325,12 +325,12 @@ pub fn copy_directory_to_tempdir(src_path: String) -> TempDir {
 }
 
 pub fn duplicate_script_directory(
-    src_dir: String,
+    src_dir: impl AsRef<Utf8Path>,
     deps: Vec<impl AsRef<std::path::Path>>,
 ) -> TempDir {
     let mut deps = get_deps_map_from_paths(deps);
 
-    let src_dir = Utf8PathBuf::from(src_dir);
+    let src_dir = Utf8PathBuf::from(src_dir.as_ref());
 
     let temp_dir = copy_dir_to_temp_dir(&src_dir);
 

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -267,29 +267,49 @@ pub fn create_test_provider() -> JsonRpcClient<HttpTransport> {
 }
 
 #[must_use]
-pub fn duplicate_directory_with_salt(src_path: String, to_be_salted: &str, salt: &str) -> TempDir {
+pub fn duplicate_contract_directory_with_salt(
+    src_path: String,
+    to_be_salted: &str,
+    salt: &str,
+) -> TempDir {
+    duplicate_directory_and_salt_file(src_path, None, to_be_salted, "src/lib.cairo", salt)
+}
+
+#[must_use]
+pub fn duplicate_directory_and_salt_file(
+    src_path: String,
+    dst_path: Option<String>,
+    code_to_be_salted: &str,
+    file_to_be_salted: &str,
+    salt: &str,
+) -> TempDir {
     let src_dir = Utf8PathBuf::from(src_path);
-    let temp_dir = TempDir::new().expect("Unable to create a temporary directory");
+    let temp_dir = match dst_path {
+        Some(dst_path) => TempDir::new_in(dst_path),
+        None => TempDir::new(),
+    };
+    let temp_dir = temp_dir.expect("Unable to create a temporary directory");
+
     let dest_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf())
         .expect("Failed to create Utf8PathBuf from PathBuf");
 
-    fs_extra::dir::copy(
-        src_dir.join("src"),
+    let paths = fs::read_dir(src_dir.clone())
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|dir_entry| dir_entry.path())
+        .collect::<Vec<_>>();
+    fs_extra::copy_items(
+        &paths,
         &dest_dir,
         &fs_extra::dir::CopyOptions::new().overwrite(true),
     )
-    .expect("Unable to copy the src directory");
-    fs_extra::file::copy(
-        src_dir.join("Scarb.toml"),
-        dest_dir.join("Scarb.toml"),
-        &fs_extra::file::CopyOptions::new().overwrite(true),
-    )
-    .expect("Unable to copy Scarb.toml");
+    .unwrap();
 
     let contract_code =
-        fs::read_to_string(src_dir.join("src/lib.cairo")).expect("Unable to get contract code");
-    let updated_code = contract_code.replace(to_be_salted, &(to_be_salted.to_string() + salt));
-    fs::write(dest_dir.join("src/lib.cairo"), updated_code)
+        fs::read_to_string(src_dir.join(file_to_be_salted)).expect("Unable to get contract code");
+    let updated_code =
+        contract_code.replace(code_to_be_salted, &(code_to_be_salted.to_string() + salt));
+    fs::write(dest_dir.join(file_to_be_salted), updated_code)
         .expect("Unable to change contract code");
 
     temp_dir

--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -1,9 +1,9 @@
-use starknet::{testing::cheatcode, ContractAddress, ClassHash, class_hash_to_felt252};
-use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
+use starknet::{testing::cheatcode, ContractAddress, ClassHash};
+use core::fmt::{Debug, Display, Error, Formatter};
 
 impl DisplayClassHash of Display<ClassHash> {
     fn fmt(self: @ClassHash, ref f: Formatter) -> Result<(), Error> {
-        let class_hash: felt252 = class_hash_to_felt252(*self);
+        let class_hash: felt252 = (*self).into();
         Display::fmt(@class_hash, ref f)
     }
 }

--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -1,8 +1,29 @@
-use starknet::{testing::cheatcode, ContractAddress, ClassHash};
+use starknet::{testing::cheatcode, ContractAddress, ClassHash, class_hash_to_felt252};
+use core::fmt::{Debug, Display, DisplayInteger, Error, Formatter};
 
-#[derive(Drop, Clone)]
+impl DisplayClassHash of Display<ClassHash> {
+    fn fmt(self: @ClassHash, ref f: Formatter) -> Result<(), Error> {
+        let class_hash: felt252 = class_hash_to_felt252(*self);
+        Display::fmt(@class_hash, ref f)
+    }
+}
+
+impl DisplayContractAddress of Display<ContractAddress> {
+    fn fmt(self: @ContractAddress, ref f: Formatter) -> Result<(), Error> {
+        let addr: felt252 = (*self).into();
+        Display::fmt(@addr, ref f)
+    }
+}
+
+#[derive(Drop, Clone, Debug)]
 pub struct CallResult {
     pub data: Array::<felt252>,
+}
+
+impl DisplayCallResult of Display<CallResult> {
+    fn fmt(self: @CallResult, ref f: Formatter) -> Result<(), Error> {
+        Debug::fmt(self.data, ref f)
+    }
 }
 
 pub fn call(
@@ -23,10 +44,16 @@ pub fn call(
     CallResult { data: result_data }
 }
 
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Debug)]
 pub struct DeclareResult {
     pub class_hash: ClassHash,
     pub transaction_hash: felt252,
+}
+
+impl DisplayDeclareResult of Display<DeclareResult> {
+    fn fmt(self: @DeclareResult, ref f: Formatter) -> Result<(), Error> {
+        write!(f, "class_hash: {}, transaction_hash: {}", *self.class_hash, *self.transaction_hash)
+    }
 }
 
 pub fn declare(
@@ -51,10 +78,21 @@ pub fn declare(
     DeclareResult { class_hash, transaction_hash }
 }
 
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Debug)]
 pub struct DeployResult {
     pub contract_address: ContractAddress,
     pub transaction_hash: felt252,
+}
+
+impl DisplayDeployResult of Display<DeployResult> {
+    fn fmt(self: @DeployResult, ref f: Formatter) -> Result<(), Error> {
+        write!(
+            f,
+            "contract_address: {}, transaction_hash: {}",
+            *self.contract_address,
+            *self.transaction_hash
+        )
+    }
 }
 
 pub fn deploy(
@@ -96,9 +134,15 @@ pub fn deploy(
     DeployResult { contract_address, transaction_hash }
 }
 
-#[derive(Drop, Clone)]
+#[derive(Drop, Clone, Debug)]
 pub struct InvokeResult {
     pub transaction_hash: felt252,
+}
+
+impl DisplayInvokeResult of Display<InvokeResult> {
+    fn fmt(self: @InvokeResult, ref f: Formatter) -> Result<(), Error> {
+        write!(f, "{}", *self.transaction_hash)
+    }
 }
 
 pub fn invoke(


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1616 

## Introduced changes

<!-- A brief description of the changes -->

- Add `Debug` and `Display` impls for script subcommand responses -> Cairo `println!` now works for them

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
