### PR TITLE
`syscall_ptr` with `SegmentArena` fix 

### DIFF
--- a/crates/forge/tests/data/contracts/dict_using_contract.cairo
+++ b/crates/forge/tests/data/contracts/dict_using_contract.cairo
@@ -1,0 +1,44 @@
+#[starknet::contract]
+mod DictUsingContract {
+    use core::num::traits::{One};
+
+    fn unique_count(mut ary: Array<felt252>) -> u32 {
+        let mut dict: Felt252Dict<felt252> = Default::default();
+        let mut counter = 0;
+        loop {
+            match ary.pop_front() {
+                Option::Some(value) => {
+                    if dict.get(value).is_one() {
+                        continue;
+                    }
+                    dict.insert(value, One::one());
+                    counter += 1;
+                },
+                Option::None => { break; }
+            }
+        };
+        counter
+    }
+
+    #[storage]
+    struct Storage {
+        unique_count: u32
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, values: Array<felt252>) {
+        self.unique_count.write(unique_count(values.clone()));  // 2 invocations for 2 dict allocations
+        self.unique_count.write(unique_count(values));
+    }
+
+    #[external(v0)]
+    fn get_unique(self: @ContractState) -> u32 {
+        self.unique_count.read()
+    }
+
+    #[external(v0)]
+    fn write_unique(ref self: ContractState, values: Array<felt252>) {
+        self.unique_count.write(unique_count(values.clone()));  // 2 invocations for 2 dict allocations
+        self.unique_count.write(unique_count(values));
+    }
+}

--- a/crates/forge/tests/integration/dict.rs
+++ b/crates/forge/tests/integration/dict.rs
@@ -1,0 +1,53 @@
+use indoc::indoc;
+use std::path::Path;
+use test_utils::assert_passed;
+use test_utils::runner::Contract;
+use test_utils::running_tests::run_test_case;
+
+#[test]
+fn using_dict() {
+    let test = test_utils::test_case!(
+        indoc!(
+            r"
+        use result::ResultTrait;
+        use snforge_std::{ declare, ContractClass, ContractClassTrait };
+        use array::ArrayTrait;
+        
+        #[starknet::interface]
+        trait IDictUsingContract<TContractState> {
+            fn get_unique(self: @TContractState) -> u8; 
+            fn write_unique(self: @TContractState, values: Array<felt252>); 
+        }
+        
+        #[test]
+        fn using_dict() {
+            let contract = declare('DictUsingContract');
+            let numbers = array![1, 2, 3, 3, 3, 3 ,3, 4, 4, 4, 4, 4, 5, 5, 5, 5];
+            let mut inputs: Array<felt252> = array![];
+            numbers.serialize(ref inputs);
+            
+            let contract_address = contract.deploy(@inputs).unwrap();
+            let dispatcher = IDictUsingContractDispatcher { contract_address };
+            
+            let unq = dispatcher.get_unique();
+            assert(unq == 5, 'wrong unique count');
+
+            numbers.serialize(ref inputs);
+            dispatcher.write_unique(array![1, 2, 3, 3, 3, 3 ,3, 4, 4, 4, 4, 4]);
+            
+            let unq = dispatcher.get_unique();
+            assert(unq == 4, 'wrong unique count');
+        }
+        "
+        ),
+        Contract::from_code_path(
+            "DictUsingContract".to_string(),
+            Path::new("tests/data/contracts/dict_using_contract.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}

--- a/crates/forge/tests/integration/mod.rs
+++ b/crates/forge/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod cheat_fork;
 mod declare;
 mod deploy;
 mod deploy_at;
+mod dict;
 mod dispatchers;
 mod elect;
 mod env;

--- a/crates/forge/tests/integration/test_state.rs
+++ b/crates/forge/tests/integration/test_state.rs
@@ -794,3 +794,74 @@ fn caller_address_in_called_contract() {
 
     assert_passed!(result);
 }
+
+#[test]
+fn felt252_dict_usage() {
+    let test = test_case!(indoc!(
+        r"
+        #[starknet::contract]
+        mod DictUsingContract {
+            use core::num::traits::{One};
+            
+            fn unique_count(mut ary: Array<felt252>) -> u32 {
+                let mut dict: Felt252Dict<felt252> = Default::default();
+                let mut counter = 0;
+                loop {
+                    match ary.pop_front() {
+                        Option::Some(value) => {
+                            if dict.get(value).is_one() {
+                                continue;
+                            }
+                            dict.insert(value, One::one());
+                            counter += 1;
+                        },
+                        Option::None => { break; }
+                    }
+                };
+                counter
+            }
+
+            #[storage]
+            struct Storage {
+                unique_count: u32
+            }
+        
+            #[constructor]
+            fn constructor(ref self: ContractState, values: Array<felt252>) {
+                self.unique_count.write(unique_count(values));
+            }
+        
+            #[external(v0)]
+            fn get_unique(self: @ContractState) -> u32 {
+                self.unique_count.read()
+            }
+            #[external(v0)]
+            fn write_unique(ref self: ContractState, values: Array<felt252>) {
+                self.unique_count.write(unique_count(values));
+            }
+        }
+        
+        #[test]
+        fn test_dict_in_constructor() {
+            let mut testing_state = DictUsingContract::contract_state_for_testing();
+            DictUsingContract::constructor(
+                ref testing_state, 
+                array![1, 2, 3, 3, 3, 3 ,3, 4, 4, 4, 4, 4, 5, 5, 5, 5]
+            );
+            
+            assert(DictUsingContract::get_unique(@testing_state) == 5_u32, 'wrong unq ctor');
+            
+            DictUsingContract::write_unique(
+                ref testing_state, 
+                array![1, 2, 3, 3, 3, 3 ,3, 4, 4, 4, 4, 4]
+            );
+            
+            assert(DictUsingContract::get_unique(@testing_state) == 4_u32, ' wrote wrong unq');
+        }
+        "
+    ));
+
+    let result = run_test_case(&test);
+
+    assert_passed!(result);
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1614 

## Introduced changes

<!-- A brief description of the changes -->

- Fixes inconsistency which is generated because of inconsistent syscall pointer when syscall_arena builtin is allocated in the segments (done only if it is required, on CASM generation level)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
