### PR TITLE
Simplify resources calculation

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -5,17 +5,15 @@ use cairo_lang_runner::casm_run::format_next_item;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::entry_point::execute_call_entry_point;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::panic_data::try_extract_panic_data;
 use crate::runtime_extensions::common::{create_entry_point_selector, create_execute_calldata};
-use crate::state::BlockifierState;
 use blockifier::execution::call_info::CallInfo;
-use blockifier::execution::common_hints::ExecutionMode;
 use blockifier::execution::entry_point::EntryPointExecutionResult;
+use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use blockifier::execution::{
-    entry_point::{CallEntryPoint, CallType, EntryPointExecutionContext, ExecutionResources},
+    entry_point::{CallEntryPoint, CallType, ExecutionResources},
     errors::{EntryPointExecutionError, PreExecutionError},
 };
 use blockifier::state::errors::StateError;
 use cairo_felt::Felt252;
-use runtime::starknet::context::{build_block_context, build_transaction_context};
 use starknet_api::core::ClassHash;
 use starknet_api::{core::ContractAddress, deprecated_contract_class::EntryPointType};
 
@@ -175,7 +173,7 @@ impl CallResult {
 }
 
 pub fn call_l1_handler(
-    blockifier_state: &mut BlockifierState,
+    syscall_handler: &mut SyscallHintProcessor,
     runtime_state: &mut RuntimeState,
     contract_address: &ContractAddress,
     entry_point_selector: &Felt252,
@@ -197,7 +195,7 @@ pub fn call_l1_handler(
     };
 
     call_entry_point(
-        blockifier_state,
+        syscall_handler,
         runtime_state,
         entry_point,
         &AddressOrClassHash::ContractAddress(*contract_address),
@@ -205,44 +203,24 @@ pub fn call_l1_handler(
 }
 
 pub fn call_entry_point(
-    blockifier_state: &mut BlockifierState,
+    syscall_handler: &mut SyscallHintProcessor,
     runtime_state: &mut RuntimeState,
     mut entry_point: CallEntryPoint,
     starknet_identifier: &AddressOrClassHash,
 ) -> CallResult {
-    let mut resources = ExecutionResources::default();
-    let account_context = build_transaction_context();
-    let block_context = build_block_context(runtime_state.cheatnet_state.block_info);
-
-    let mut context = EntryPointExecutionContext::new(
-        &block_context,
-        &account_context,
-        ExecutionMode::Execute,
-        false,
-    )
-    .unwrap();
-
     let exec_result = execute_call_entry_point(
         &mut entry_point,
-        blockifier_state.blockifier_state,
+        syscall_handler.state,
         runtime_state,
-        &mut resources,
-        &mut context,
+        syscall_handler.resources,
+        syscall_handler.context,
     );
 
-    let call_result = CallResult::from_execution_result(&exec_result, starknet_identifier);
+    let result = CallResult::from_execution_result(&exec_result, starknet_identifier);
 
-    let used_resources = UsedResources {
-        execution_resources: resources,
-        l2_to_l1_payloads_length: exec_result.map_or(vec![], |call_info| {
-            call_info.get_sorted_l2_to_l1_payloads_length().unwrap()
-        }),
+    if let Ok(call_info) = exec_result {
+        syscall_handler.inner_calls.push(call_info);
     };
-    // add execution resources used by call contract, library call or l1 handler execution to all used resources
-    runtime_state
-        .cheatnet_state
-        .used_resources
-        .extend(&used_resources);
 
-    call_result
+    result
 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
@@ -1,20 +1,15 @@
 use crate::constants::TEST_ADDRESS;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    AddressOrClassHash, CallFailure, UsedResources,
+    AddressOrClassHash, CallFailure,
 };
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use crate::state::BlockifierState;
 use anyhow::Result;
-use blockifier::execution::common_hints::ExecutionMode;
-use blockifier::execution::entry_point::{
-    ConstructorContext, EntryPointExecutionContext, ExecutionResources,
-};
+use blockifier::execution::entry_point::ConstructorContext;
 use blockifier::execution::execution_utils::felt_to_stark_felt;
-use runtime::starknet::context::{build_block_context, build_transaction_context};
+use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use runtime::EnhancedHintError;
 use std::sync::Arc;
 
-use blockifier::state::state_api::State;
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError::CustomHint;
 use starknet_api::core::PatriciaKey;
@@ -28,29 +23,19 @@ use starknet_api::transaction::Calldata;
 use super::CheatcodeError;
 
 pub fn deploy_at(
-    blockifier_state: &mut BlockifierState,
+    syscall_handler: &mut SyscallHintProcessor,
     runtime_state: &mut RuntimeState,
     class_hash: &ClassHash,
     calldata: &[Felt252],
     contract_address: ContractAddress,
 ) -> Result<ContractAddress, CheatcodeError> {
-    let blockifier_state_raw: &mut dyn State = blockifier_state.blockifier_state;
-
-    if let Ok(class_hash) = blockifier_state_raw.get_class_hash_at(contract_address) {
+    if let Ok(class_hash) = syscall_handler.state.get_class_hash_at(contract_address) {
         if class_hash != ClassHash::default() {
             return Err(CheatcodeError::Unrecoverable(EnhancedHintError::from(
                 CustomHint(Box::from("Address is already taken")),
             )));
         }
     }
-
-    let entry_point_execution_ctx = &mut EntryPointExecutionContext::new(
-        &build_block_context(runtime_state.cheatnet_state.block_info),
-        &build_transaction_context(),
-        ExecutionMode::Execute,
-        false,
-    )
-    .unwrap();
 
     let ctor_context = ConstructorContext {
         class_hash: *class_hash,
@@ -63,40 +48,33 @@ pub fn deploy_at(
         calldata.to_vec().iter().map(felt_to_stark_felt).collect(),
     ));
 
-    let mut resources = ExecutionResources::default();
-    let result = cheated_syscalls::execute_deployment(
-        blockifier_state.blockifier_state,
+    let exec_result = cheated_syscalls::execute_deployment(
+        syscall_handler.state,
         runtime_state,
-        &mut resources,
-        entry_point_execution_ctx,
+        syscall_handler.resources,
+        syscall_handler.context,
         ctor_context,
         calldata,
         u64::MAX,
-    )
-    .map(|_call_info| contract_address)
-    .map_err(|err| {
+    );
+    runtime_state.cheatnet_state.increment_deploy_salt_base();
+
+    exec_result.as_ref().map_err(|err| {
         let call_contract_failure = CallFailure::from_execution_error(
-            &err,
+            err,
             &AddressOrClassHash::ContractAddress(contract_address),
         );
         CheatcodeError::from(call_contract_failure)
-    });
-    runtime_state.cheatnet_state.increment_deploy_salt_base();
+    })?;
 
-    // add execution resources used by deploy to all used resources
-    runtime_state
-        .cheatnet_state
-        .used_resources
-        .extend(&UsedResources {
-            execution_resources: resources,
-            l2_to_l1_payloads_length: vec![],
-        });
-
-    result
+    if let Ok(call_info) = exec_result {
+        syscall_handler.inner_calls.push(call_info);
+    }
+    Ok(contract_address)
 }
 
 pub fn deploy(
-    blockifier_state: &mut BlockifierState,
+    syscall_handler: &mut SyscallHintProcessor,
     runtime_state: &mut RuntimeState,
     class_hash: &ClassHash,
     calldata: &[Felt252],
@@ -106,7 +84,7 @@ pub fn deploy(
         .precalculate_address(class_hash, calldata);
 
     deploy_at(
-        blockifier_state,
+        syscall_handler,
         runtime_state,
         class_hash,
         calldata,

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/l1_handler_execute.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/l1_handler_execute.rs
@@ -2,31 +2,29 @@ use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
     call_l1_handler, CallResult,
 };
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use crate::state::BlockifierState;
 use blockifier::abi::abi_utils::starknet_keccak;
+use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use cairo_felt::Felt252;
 use starknet_api::core::ContractAddress;
 
-impl BlockifierState<'_> {
-    pub fn l1_handler_execute(
-        &mut self,
-        runtime_state: &mut RuntimeState,
-        contract_address: ContractAddress,
-        function_name: &Felt252,
-        from_address: &Felt252,
-        payload: &[Felt252],
-    ) -> CallResult {
-        let selector = starknet_keccak(&function_name.to_bytes_be());
+pub fn l1_handler_execute(
+    syscall_handler: &mut SyscallHintProcessor,
+    runtime_state: &mut RuntimeState,
+    contract_address: ContractAddress,
+    function_name: &Felt252,
+    from_address: &Felt252,
+    payload: &[Felt252],
+) -> CallResult {
+    let selector = starknet_keccak(&function_name.to_bytes_be());
 
-        let mut calldata = vec![from_address.clone()];
-        calldata.extend_from_slice(payload);
+    let mut calldata = vec![from_address.clone()];
+    calldata.extend_from_slice(payload);
 
-        call_l1_handler(
-            self,
-            runtime_state,
-            &contract_address,
-            &selector,
-            calldata.as_slice(),
-        )
-    }
+    call_l1_handler(
+        syscall_handler,
+        runtime_state,
+        &contract_address,
+        &selector,
+        calldata.as_slice(),
+    )
 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -275,11 +275,10 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 let class_hash = reader.read_felt().into_();
                 let calldata = reader.read_vec();
                 let cheatnet_runtime = &mut extended_runtime.extended_runtime;
-                let mut blockifier_state =
-                    BlockifierState::from(cheatnet_runtime.extended_runtime.hint_handler.state);
+                let syscall_handler = &mut cheatnet_runtime.extended_runtime.hint_handler;
 
                 handle_deploy_result(deploy(
-                    &mut blockifier_state,
+                    syscall_handler,
                     &mut RuntimeState {
                         cheatnet_state: cheatnet_runtime.extension.cheatnet_state,
                     },
@@ -292,11 +291,10 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 let calldata = reader.read_vec();
                 let contract_address = reader.read_felt().into_();
                 let cheatnet_runtime = &mut extended_runtime.extended_runtime;
-                let mut blockifier_state =
-                    BlockifierState::from(cheatnet_runtime.extended_runtime.hint_handler.state);
+                let syscall_handler = &mut cheatnet_runtime.extended_runtime.hint_handler;
 
                 handle_deploy_result(deploy_at(
-                    &mut blockifier_state,
+                    syscall_handler,
                     &mut RuntimeState {
                         cheatnet_state: cheatnet_runtime.extension.cheatnet_state,
                     },

--- a/crates/cheatnet/tests/cheatcodes/deploy.rs
+++ b/crates/cheatnet/tests/cheatcodes/deploy.rs
@@ -1,13 +1,13 @@
 use crate::assert_success;
 use crate::common::state::{build_runtime_state, create_cached_state, create_runtime_states};
-use crate::common::{call_contract, deploy_contract, felt_selector_from_name, get_contracts};
+use crate::common::{
+    call_contract, deploy_at_wrapper, deploy_contract, deploy_wrapper, felt_selector_from_name,
+    get_contracts,
+};
 use cairo_felt::Felt252;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
     CallFailure, CallResult,
-};
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::{
-    deploy, deploy_at,
 };
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::CheatcodeError;
 use conversions::felt252::FromShortString;
@@ -25,7 +25,7 @@ fn deploy_at_predefined_address() {
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    let contract_address = deploy_at(
+    let contract_address = deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -58,7 +58,7 @@ fn deploy_two_at_the_same_address() {
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    deploy_at(
+    deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -67,7 +67,7 @@ fn deploy_two_at_the_same_address() {
     )
     .unwrap();
 
-    let result = deploy_at(
+    let result = deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -92,7 +92,7 @@ fn call_predefined_contract_from_proxy_contract() {
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    let prank_checker_address = deploy_at(
+    let prank_checker_address = deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -156,7 +156,7 @@ fn deploy_contract_on_predefined_address_after_its_usage() {
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    deploy_at(
+    deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -186,7 +186,7 @@ fn try_to_deploy_at_0() {
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    let output = deploy_at(
+    let output = deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -212,7 +212,7 @@ fn deploy_calldata_no_constructor() {
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
-    let output = deploy(
+    let output = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -238,7 +238,7 @@ fn deploy_missing_arguments_in_constructor() {
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
-    let output = deploy(
+    let output = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -263,7 +263,7 @@ fn deploy_too_many_arguments_in_constructor() {
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
-    let output = deploy(
+    let output = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -287,7 +287,7 @@ fn deploy_invalid_class_hash() {
         .unwrap()
         .into_();
 
-    let output = deploy(
+    let output = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -338,7 +338,7 @@ fn deploy_at_invokes_constructor() {
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
-    let contract_address = deploy_at(
+    let contract_address = deploy_at_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,

--- a/crates/cheatnet/tests/cheatcodes/elect.rs
+++ b/crates/cheatnet/tests/cheatcodes/elect.rs
@@ -1,6 +1,6 @@
 use crate::common::assertions::assert_outputs;
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
@@ -98,7 +97,7 @@ fn elect_in_constructor() {
     );
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated_address, contract_address);
 
@@ -516,10 +515,10 @@ fn elect_multiple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let selector = felt_selector_from_name("get_sequencer_address");
 

--- a/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
+++ b/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
@@ -1,8 +1,7 @@
-use crate::common::call_contract;
 use crate::common::state::{build_runtime_state, create_cached_state};
+use crate::common::{call_contract, deploy_wrapper};
 use crate::common::{felt_selector_from_name, get_contracts, state::create_runtime_states};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
 
@@ -18,7 +17,7 @@ fn get_class_hash_simple() {
         .declare(&contract_name, &contracts)
         .unwrap();
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(
         class_hash,
@@ -38,7 +37,7 @@ fn get_class_hash_upgrade() {
         .declare(&contract_name, &contracts)
         .unwrap();
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(
         class_hash,

--- a/crates/cheatnet/tests/cheatcodes/load.rs
+++ b/crates/cheatnet/tests/cheatcodes/load.rs
@@ -1,9 +1,8 @@
 use crate::cheatcodes::{map_entry_address, variable_address};
-use crate::common::call_contract;
 use crate::common::state::{build_runtime_state, create_cached_state, create_runtime_states};
+use crate::common::{call_contract, deploy_wrapper};
 use crate::common::{felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::load;
 use conversions::felt252::FromShortString;
 
@@ -19,7 +18,7 @@ fn load_simple_state() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let selector = felt_selector_from_name("increase_balance");
 
@@ -57,7 +56,7 @@ fn load_state_map_simple_value() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let selector = felt_selector_from_name("insert");
 

--- a/crates/cheatnet/tests/cheatcodes/mock_call.rs
+++ b/crates/cheatnet/tests/cheatcodes/mock_call.rs
@@ -1,12 +1,11 @@
-use crate::common::call_contract;
 use crate::common::state::{build_runtime_state, create_cached_state};
+use crate::common::{call_contract, deploy_wrapper};
 use crate::common::{felt_selector_from_name, recover_data};
 use crate::{
     assert_success,
     common::{deploy_contract, get_contracts, state::create_runtime_states},
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
 use starknet_api::core::ContractAddress;
@@ -376,7 +375,7 @@ fn mock_call_library_call_no_effect() {
         .declare(&contract_name, &contracts)
         .unwrap();
 
-    let contract_address = deploy(
+    let contract_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -434,7 +433,7 @@ fn mock_call_before_deployment() {
         &ret_data,
     );
 
-    let contract_address = deploy(
+    let contract_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -501,7 +500,7 @@ fn mock_call_in_constructor() {
         .declare(&contract_name, &contracts)
         .unwrap();
     let balance_contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
     let ret_data = vec![Felt252::from(223)];
     runtime_state.cheatnet_state.start_mock_call(
         balance_contract_address,
@@ -513,7 +512,7 @@ fn mock_call_in_constructor() {
     let class_hash = blockifier_state
         .declare(&contract_name, &contracts)
         .unwrap();
-    let contract_address = deploy(
+    let contract_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,

--- a/crates/cheatnet/tests/cheatcodes/prank.rs
+++ b/crates/cheatnet/tests/cheatcodes/prank.rs
@@ -1,6 +1,6 @@
 use crate::common::assertions::assert_outputs;
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
@@ -99,7 +98,7 @@ fn prank_in_constructor() {
     );
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated_address, contract_address);
 
@@ -419,10 +418,10 @@ fn prank_multiple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let output = call_contract(
         &mut blockifier_state,

--- a/crates/cheatnet/tests/cheatcodes/precalculate_address.rs
+++ b/crates/cheatnet/tests/cheatcodes/precalculate_address.rs
@@ -1,9 +1,8 @@
 use crate::common::{
-    get_contracts,
+    deploy_wrapper, get_contracts,
     state::{build_runtime_state, create_cached_state, create_runtime_states},
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use conversions::felt252::FromShortString;
 
 #[test]
@@ -21,12 +20,14 @@ fn precalculate_address_simple() {
     let precalculated1 = runtime_state
         .cheatnet_state
         .precalculate_address(&class_hash, &[]);
-    let actual1 = deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+    let actual1 =
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let precalculated2 = runtime_state
         .cheatnet_state
         .precalculate_address(&class_hash, &[]);
-    let actual2 = deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+    let actual2 =
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated1, actual1);
     assert_eq!(precalculated2, actual2);
@@ -55,7 +56,7 @@ fn precalculate_address_calldata() {
         .cheatnet_state
         .precalculate_address(&class_hash, &calldata2);
 
-    let actual1 = deploy(
+    let actual1 = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -67,7 +68,7 @@ fn precalculate_address_calldata() {
         .cheatnet_state
         .precalculate_address(&class_hash, &calldata2);
 
-    let actual2 = deploy(
+    let actual2 = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,

--- a/crates/cheatnet/tests/cheatcodes/roll.rs
+++ b/crates/cheatnet/tests/cheatcodes/roll.rs
@@ -1,6 +1,6 @@
 use crate::common::assertions::assert_outputs;
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
@@ -96,7 +95,7 @@ fn roll_in_constructor() {
     );
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated_address, contract_address);
 
@@ -507,10 +506,10 @@ fn roll_multiple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let selector = felt_selector_from_name("get_block_number");
 

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -1,5 +1,5 @@
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -10,9 +10,7 @@ use crate::{
 };
 use cairo_felt::Felt252;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::{
-    deploy::deploy, spoof::TxInfoMock,
-};
+use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::spoof::TxInfoMock;
 use cheatnet::state::BlockifierState;
 use cheatnet::state::CheatTarget;
 use conversions::{felt252::FromShortString, IntoConv};
@@ -401,7 +399,7 @@ fn spoof_in_constructor() {
         .start_spoof(CheatTarget::One(precalculated_address), tx_info_mock);
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated_address, contract_address);
 
@@ -667,10 +665,10 @@ fn spoof_multiple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address_1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address_2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let tx_info_before_1 = get_tx_info(
         &mut blockifier_state,

--- a/crates/cheatnet/tests/cheatcodes/spy_events.rs
+++ b/crates/cheatnet/tests/cheatcodes/spy_events.rs
@@ -1,10 +1,9 @@
-use crate::common::call_contract;
 use crate::common::state::{build_runtime_state, create_cached_state, create_runtime_states};
+use crate::common::{call_contract, deploy_wrapper};
 use crate::common::{deploy_contract, felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
 use cairo_lang_starknet::contract::starknet_keccak;
 use cairo_vm::hint_processor::hint_processor_utils::felt_to_usize;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::spy_events::{
     Event, SpyTarget,
 };
@@ -375,9 +374,9 @@ fn check_if_there_is_no_interference() {
         .unwrap();
 
     let spy_events_checker_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
     let other_spy_events_checker_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let id1 = runtime_state
         .cheatnet_state
@@ -436,14 +435,14 @@ fn test_nested_calls() {
         .declare(&contract_name, &contracts)
         .unwrap();
 
-    let spy_events_checker_proxy_address = deploy(
+    let spy_events_checker_proxy_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
         &[spy_events_checker_address.into_()],
     )
     .unwrap();
-    let spy_events_checker_top_proxy_address = deploy(
+    let spy_events_checker_top_proxy_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
@@ -517,14 +516,14 @@ fn use_multiple_spies() {
         .declare(&contract_name, &contracts)
         .unwrap();
 
-    let spy_events_checker_proxy_address = deploy(
+    let spy_events_checker_proxy_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,
         &[spy_events_checker_address.into_()],
     )
     .unwrap();
-    let spy_events_checker_top_proxy_address = deploy(
+    let spy_events_checker_top_proxy_address = deploy_wrapper(
         &mut blockifier_state,
         &mut runtime_state,
         &class_hash,

--- a/crates/cheatnet/tests/cheatcodes/store.rs
+++ b/crates/cheatnet/tests/cheatcodes/store.rs
@@ -1,10 +1,9 @@
 use crate::assert_success;
 use crate::cheatcodes::{map_entry_address, variable_address};
-use crate::common::call_contract;
 use crate::common::state::{build_runtime_state, create_cached_state, create_runtime_states};
+use crate::common::{call_contract, deploy_wrapper};
 use crate::common::{felt_selector_from_name, get_contracts};
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::store;
 use conversions::felt252::FromShortString;
 
@@ -20,7 +19,7 @@ fn store_simple_state() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     store(
         &mut blockifier_state,
@@ -55,7 +54,7 @@ fn store_state_map_simple_value() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let map_key = Felt252::from(420);
     let inserted_value = Felt252::from(69);

--- a/crates/cheatnet/tests/cheatcodes/warp.rs
+++ b/crates/cheatnet/tests/cheatcodes/warp.rs
@@ -1,6 +1,6 @@
 use crate::common::assertions::assert_outputs;
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::CheatTarget;
 use conversions::felt252::FromShortString;
 use conversions::IntoConv;
@@ -94,7 +93,7 @@ fn warp_in_constructor() {
         .start_warp(CheatTarget::One(precalculated_address), Felt252::from(123));
 
     let contract_address =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     assert_eq!(precalculated_address, contract_address);
 
@@ -350,10 +349,10 @@ fn warp_all_simple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     runtime_state
         .cheatnet_state
@@ -514,10 +513,10 @@ fn warp_multiple() {
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
 
     let contract_address1 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let contract_address2 =
-        deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+        deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let selector = felt_selector_from_name("get_block_timestamp");
 

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -1,10 +1,10 @@
-use blockifier::execution::common_hints::ExecutionMode;
 use blockifier::execution::entry_point::{
     CallEntryPoint, CallType, EntryPointExecutionContext, ExecutionResources,
 };
 use blockifier::execution::execution_utils::ReadOnlySegments;
 use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use cairo_felt::Felt252;
+use cairo_lang_casm::hints::Hint;
 use cairo_vm::types::relocatable::Relocatable;
 use camino::Utf8PathBuf;
 use cheatnet::constants::TEST_ADDRESS;
@@ -16,15 +16,18 @@ use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
 };
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
 use cheatnet::runtime_extensions::common::{create_entry_point_selector, create_execute_calldata};
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
+use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::{
+    deploy, deploy_at,
+};
+use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::CheatcodeError;
 use cheatnet::state::BlockifierState;
 use conversions::felt252::FromShortString;
-use runtime::starknet::context::{build_block_context, build_transaction_context};
+use runtime::starknet::context::build_context;
 use scarb_api::metadata::MetadataCommandExt;
 use scarb_api::{get_contracts_map, ScarbCommand, StarknetContractArtifacts};
 use starknet::core::utils::get_selector_from_name;
-use starknet_api::core::ContractAddress;
 use starknet_api::core::PatriciaKey;
+use starknet_api::core::{ClassHash, ContractAddress};
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkHash;
 use starknet_api::patricia_key;
@@ -34,6 +37,26 @@ pub mod assertions;
 pub mod cache;
 pub mod state;
 
+fn build_syscall_hint_processor<'a>(
+    call_entry_point: CallEntryPoint,
+    blockifier_state: &'a mut BlockifierState,
+    execution_resources: &'a mut ExecutionResources,
+    entry_point_execution_context: &'a mut EntryPointExecutionContext,
+    hints: &'a HashMap<String, Hint>,
+) -> SyscallHintProcessor<'a> {
+    SyscallHintProcessor::new(
+        blockifier_state.blockifier_state,
+        execution_resources,
+        entry_point_execution_context,
+        Relocatable {
+            segment_index: 0,
+            offset: 0,
+        },
+        call_entry_point,
+        hints,
+        ReadOnlySegments::default(),
+    )
+}
 pub fn recover_data(output: CallResult) -> Vec<Felt252> {
     match output {
         CallResult::Success { ret_data, .. } => ret_data,
@@ -65,7 +88,80 @@ pub fn deploy_contract(
     let contracts = get_contracts();
 
     let class_hash = blockifier_state.declare(&contract, &contracts).unwrap();
-    deploy(blockifier_state, runtime_state, &class_hash, calldata).unwrap()
+
+    let mut execution_resources = ExecutionResources::default();
+    let mut entry_point_execution_context = build_context(runtime_state.cheatnet_state.block_info);
+    let hints = HashMap::new();
+
+    let mut syscall_hint_processor = build_syscall_hint_processor(
+        CallEntryPoint::default(),
+        blockifier_state,
+        &mut execution_resources,
+        &mut entry_point_execution_context,
+        &hints,
+    );
+
+    deploy(
+        &mut syscall_hint_processor,
+        runtime_state,
+        &class_hash,
+        calldata,
+    )
+    .unwrap()
+}
+
+pub fn deploy_wrapper(
+    blockifier_state: &mut BlockifierState,
+    runtime_state: &mut RuntimeState,
+    class_hash: &ClassHash,
+    calldata: &[Felt252],
+) -> Result<ContractAddress, CheatcodeError> {
+    let mut execution_resources = ExecutionResources::default();
+    let mut entry_point_execution_context = build_context(runtime_state.cheatnet_state.block_info);
+    let hints = HashMap::new();
+
+    let mut syscall_hint_processor = build_syscall_hint_processor(
+        CallEntryPoint::default(),
+        blockifier_state,
+        &mut execution_resources,
+        &mut entry_point_execution_context,
+        &hints,
+    );
+
+    deploy(
+        &mut syscall_hint_processor,
+        runtime_state,
+        class_hash,
+        calldata,
+    )
+}
+
+pub fn deploy_at_wrapper(
+    blockifier_state: &mut BlockifierState,
+    runtime_state: &mut RuntimeState,
+    class_hash: &ClassHash,
+    calldata: &[Felt252],
+    contract_address: ContractAddress,
+) -> Result<ContractAddress, CheatcodeError> {
+    let mut execution_resources = ExecutionResources::default();
+    let mut entry_point_execution_context = build_context(runtime_state.cheatnet_state.block_info);
+    let hints = HashMap::new();
+
+    let mut syscall_hint_processor = build_syscall_hint_processor(
+        CallEntryPoint::default(),
+        blockifier_state,
+        &mut execution_resources,
+        &mut entry_point_execution_context,
+        &hints,
+    );
+
+    deploy_at(
+        &mut syscall_hint_processor,
+        runtime_state,
+        class_hash,
+        calldata,
+        contract_address,
+    )
 }
 
 pub fn call_contract_getter_by_name(
@@ -111,26 +207,15 @@ pub fn call_contract(
     };
 
     let mut execution_resources = ExecutionResources::default();
-    let mut entry_point_execution_context = EntryPointExecutionContext::new(
-        &build_block_context(runtime_state.cheatnet_state.block_info),
-        &build_transaction_context(),
-        ExecutionMode::Execute,
-        false,
-    )
-    .unwrap();
+    let mut entry_point_execution_context = build_context(runtime_state.cheatnet_state.block_info);
     let hints = HashMap::new();
 
-    let mut syscall_hint_processor = SyscallHintProcessor::new(
-        blockifier_state.blockifier_state,
+    let mut syscall_hint_processor = build_syscall_hint_processor(
+        entry_point.clone(),
+        blockifier_state,
         &mut execution_resources,
         &mut entry_point_execution_context,
-        Relocatable {
-            segment_index: 0,
-            offset: 0,
-        },
-        entry_point.clone(),
         &hints,
-        ReadOnlySegments::default(),
     );
 
     call_entry_point(

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -3,7 +3,7 @@ use crate::common::state::{
     build_runtime_state, create_fork_cached_state, create_fork_cached_state_at,
     create_runtime_states,
 };
-use crate::common::{call_contract, deploy_contract, felt_selector_from_name};
+use crate::common::{call_contract, deploy_contract, deploy_wrapper, felt_selector_from_name};
 use crate::{assert_error, assert_success};
 use blockifier::state::cached_state::{CachedState, GlobalContractCache};
 use cairo_felt::Felt252;
@@ -11,7 +11,6 @@ use cairo_vm::vm::errors::hint_errors::HintError;
 use cheatnet::constants::build_testing_state;
 use cheatnet::forking::state::ForkStateReader;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::CheatcodeError;
 use cheatnet::state::{BlockInfoReader, BlockifierState, CheatnetState, ExtendedStateReader};
 use conversions::{IntoConv, TryIntoConv};
@@ -108,7 +107,7 @@ fn try_deploying_undeclared_class() {
     let class_hash = "1".to_owned().try_into_().unwrap();
 
     assert!(
-        match deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]) {
+        match deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]) {
             Err(CheatcodeError::Unrecoverable(EnhancedHintError::Hint(HintError::CustomHint(
                 msg,
             )))) => msg.as_ref().contains(class_hash.to_string().as_str()),

--- a/crates/cheatnet/tests/starknet/nonce.rs
+++ b/crates/cheatnet/tests/starknet/nonce.rs
@@ -1,5 +1,5 @@
-use crate::common::call_contract;
 use crate::common::state::build_runtime_state;
+use crate::common::{call_contract, deploy_wrapper};
 use crate::{
     assert_success,
     common::{
@@ -9,7 +9,6 @@ use crate::{
 };
 use cairo_felt::Felt252;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::deploy;
 use cheatnet::state::BlockifierState;
 use conversions::felt252::FromShortString;
 use starknet_api::core::ContractAddress;
@@ -82,7 +81,7 @@ fn nonce_declare_deploy() {
 
     let nonce2 = check_nonce(&mut blockifier_state, &mut runtime_state, &contract_address);
 
-    deploy(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
+    deploy_wrapper(&mut blockifier_state, &mut runtime_state, &class_hash, &[]).unwrap();
 
     let nonce3 = check_nonce(&mut blockifier_state, &mut runtime_state, &contract_address);
 

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -10,7 +10,6 @@ use crate::gas::calculate_used_gas;
 use crate::test_case_summary::{Single, TestCaseSummary};
 use crate::{RunnerConfig, RunnerParams, TestCaseRunnable, CACHE_DIR};
 use anyhow::{bail, ensure, Result};
-use blockifier::execution::common_hints::ExecutionMode;
 use blockifier::execution::entry_point::{EntryPointExecutionContext, ExecutionResources};
 use blockifier::execution::execution_utils::ReadOnlySegments;
 use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
@@ -40,8 +39,7 @@ use cheatnet::runtime_extensions::forge_runtime_extension::{
 };
 use cheatnet::state::{BlockInfoReader, CallTrace, CheatnetState, ExtendedStateReader};
 use itertools::chain;
-use runtime::starknet::context;
-use runtime::starknet::context::BlockInfo;
+use runtime::starknet::context::build_context;
 use runtime::{ExtendedRuntime, StarknetRuntime};
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -118,19 +116,6 @@ pub(crate) fn run_fuzz_test(
 
         extract_test_case_summary(run_result, &case, args)
     })
-}
-
-fn build_context(block_info: BlockInfo) -> EntryPointExecutionContext {
-    let block_context = context::build_block_context(block_info);
-    let account_context = context::build_transaction_context();
-
-    EntryPointExecutionContext::new(
-        &block_context,
-        &account_context,
-        ExecutionMode::Execute,
-        false,
-    )
-    .unwrap()
 }
 
 fn get_syscall_segment_index(test_param_types: &[(GenericTypeId, i16)]) -> isize {

--- a/crates/runtime/src/starknet/context.rs
+++ b/crates/runtime/src/starknet/context.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use blockifier::block_context::{FeeTokenAddresses, GasPrices};
 
+use blockifier::execution::common_hints::ExecutionMode;
+use blockifier::execution::entry_point::EntryPointExecutionContext;
 use blockifier::transaction::objects::{CommonAccountFields, CurrentAccountTransactionContext};
 use blockifier::{
     abi::constants, block_context::BlockContext, transaction::objects::AccountTransactionContext,
@@ -32,11 +34,6 @@ pub const STEP_RESOURCE_COST: f64 = 0.005_f64;
 
 // HOW TO FIND:
 // 1. https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/#calculation_of_computation_costs
-#[must_use]
-pub fn build_default_block_context() -> BlockContext {
-    build_block_context(BlockInfo::default())
-}
-
 #[must_use]
 pub fn build_block_context(block_info: BlockInfo) -> BlockContext {
     // blockifier::test_utils::create_for_account_testing
@@ -127,6 +124,20 @@ pub fn build_transaction_context() -> AccountTransactionContext {
         paymaster_data: Default::default(),
         account_deployment_data: Default::default(),
     })
+}
+
+#[must_use]
+pub fn build_context(block_info: BlockInfo) -> EntryPointExecutionContext {
+    let block_context = build_block_context(block_info);
+    let account_context = build_transaction_context();
+
+    EntryPointExecutionContext::new(
+        &block_context,
+        &account_context,
+        ExecutionMode::Execute,
+        false,
+    )
+    .unwrap()
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug)]

--- a/crates/sncast/src/starknet_commands/script.rs
+++ b/crates/sncast/src/starknet_commands/script.rs
@@ -4,11 +4,8 @@ use std::fs;
 use crate::starknet_commands::{call, declare, deploy, invoke};
 use crate::{get_account, get_nonce, WaitForTx};
 use anyhow::{anyhow, Context, Result};
-use blockifier::execution::common_hints::ExecutionMode;
 use blockifier::execution::deprecated_syscalls::DeprecatedSyscallSelector;
-use blockifier::execution::entry_point::{
-    CallEntryPoint, EntryPointExecutionContext, ExecutionResources,
-};
+use blockifier::execution::entry_point::{CallEntryPoint, ExecutionResources};
 use blockifier::execution::execution_utils::ReadOnlySegments;
 use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use blockifier::state::cached_state::CachedState;
@@ -26,7 +23,7 @@ use clap::command;
 use clap::Args;
 use conversions::{FromConv, IntoConv};
 use itertools::chain;
-use runtime::starknet::context::{build_default_block_context, build_transaction_context};
+use runtime::starknet::context::{build_context, BlockInfo};
 use runtime::starknet::state::DictStateReader;
 use runtime::utils::BufferReader;
 use runtime::{
@@ -300,15 +297,7 @@ pub fn run(
         .assemble_ex(&entry_code, &footer);
 
     // hint processor
-    let block_context = build_default_block_context();
-    let account_context = build_transaction_context();
-    let mut context = EntryPointExecutionContext::new(
-        &block_context.clone(),
-        &account_context,
-        ExecutionMode::Execute,
-        false,
-    )
-    .unwrap();
+    let mut context = build_context(BlockInfo::default());
 
     let mut blockifier_state = CachedState::from(DictStateReader::default());
     let mut execution_resources = ExecutionResources::default();


### PR DESCRIPTION
## Introduced changes

- mutable reference to used resources from `SyscallHintProcessor` used in `StarknetRuntime` for test execution are now passed to `call_entry_point` function, providing automatic resource calculation (lower layers handle it for us, we don't have to manually append resources for: call, library call and l1 handler)

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
