### PR TITLE
Move test helpers to test_utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6035,10 +6035,12 @@ dependencies = [
  "forge_runner",
  "indoc 2.0.4",
  "project-root",
+ "regex",
  "scarb-api",
  "scarb-metadata",
  "serde",
  "serde_json",
+ "snapbox",
  "tempfile",
  "tokio",
 ]

--- a/crates/forge/src/warn.rs
+++ b/crates/forge/src/warn.rs
@@ -103,6 +103,7 @@ mod tests {
     use serde_json::{json, Value};
     use serial_test::serial;
     use std::{io::read_to_string, sync::Once, time::Duration};
+    use test_utils::output_assert::assert_stdout_contains;
 
     /**
      * all tests using [`BufferRedirect`] must be run with --nocapture
@@ -183,7 +184,14 @@ mod tests {
 
         let stdout = read_to_string(buffer.into_inner()).unwrap();
 
-        assert!(stdout == "[WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0\n");
+        assert_stdout_contains(
+            stdout,
+            indoc!(
+                r"
+                    [WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
+                "
+            ),
+        );
     }
 
     // must be run with --nocapture or will fail
@@ -201,7 +209,14 @@ mod tests {
 
         let stdout = read_to_string(buffer.into_inner()).unwrap();
 
-        assert!(stdout == "[WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0\n");
+        assert_stdout_contains(
+            stdout,
+            indoc!(
+                r"
+                    [WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
+                "
+            ),
+        );
     }
 
     // must be run with --nocapture or will fail
@@ -220,22 +235,14 @@ mod tests {
 
         let stdout = read_to_string(buffer.into_inner()).unwrap();
 
-        //TODO use assert_stdout_contains!()
-        assert!(
-            stdout
-                == indoc!(
-                    r"
+        assert_stdout_contains(
+            stdout,
+            indoc!(
+                r"
                     [WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
                     [WARNING] The RPC node with url = http://127.0.0.1:3035/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
-                    "
-                )
-                || stdout
-                    == indoc!(
-                        r"
-                    [WARNING] The RPC node with url = http://127.0.0.1:3035/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
-                    [WARNING] The RPC node with url = http://127.0.0.1:3030/rpc has unsupported version = (0.5.0), use node supporting RPC version 0.6.0
-                    "
-                    )
+                "
+            ),
         );
     }
 

--- a/crates/forge/test_utils/Cargo.toml
+++ b/crates/forge/test_utils/Cargo.toml
@@ -24,6 +24,8 @@ serde.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 project-root.workspace = true
+regex.workspace = true
+snapbox.workspace = true
 forge = { path = "../../forge" }
 scarb-api = { path = "../../scarb-api" }
 forge_runner = { path = "../../forge-runner" }

--- a/crates/forge/test_utils/src/lib.rs
+++ b/crates/forge/test_utils/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod output_assert;
 pub mod runner;
 pub mod running_tests;
 

--- a/crates/forge/test_utils/src/output_assert.rs
+++ b/crates/forge/test_utils/src/output_assert.rs
@@ -1,0 +1,87 @@
+use std::borrow::Cow;
+
+use regex::Regex;
+use snapbox::cmd::OutputAssert;
+
+pub trait IntoOutput {
+    fn into_stdout<'a>(&'a self) -> Cow<'a, str>;
+    fn into_stderr<'a>(&'a self) -> Cow<'a, str>;
+}
+
+impl IntoOutput for OutputAssert {
+    fn into_stdout<'a>(&'a self) -> Cow<'a, str> {
+        String::from_utf8(self.get_output().stdout.clone())
+            .unwrap()
+            .into()
+    }
+    fn into_stderr<'a>(&'a self) -> Cow<'a, str> {
+        String::from_utf8(self.get_output().stderr.clone())
+            .unwrap()
+            .into()
+    }
+}
+
+impl IntoOutput for String {
+    fn into_stdout<'a>(&'a self) -> Cow<'a, str> {
+        self.into()
+    }
+    fn into_stderr<'a>(&'a self) -> Cow<'a, str> {
+        self.into()
+    }
+}
+
+fn find_with_wildcard(line: &str, actual: &Vec<String>) -> Option<usize> {
+    let escaped = regex::escape(line);
+    let replaced = escaped.replace("\\[\\.\\.\\]", ".*");
+    let wrapped = format!("^{replaced}$");
+    let re = Regex::new(wrapped.as_str()).unwrap();
+
+    actual.iter().position(|other| re.is_match(other))
+}
+
+fn is_present(line: &str, actual: &mut Vec<String>) -> bool {
+    let position = find_with_wildcard(line, actual);
+    if let Some(position) = position {
+        actual.remove(position);
+        return true;
+    }
+    false
+}
+
+fn assert_output_contains(output: &str, lines: &str) {
+    let asserted_lines: Vec<String> = lines.lines().map(std::convert::Into::into).collect();
+    let mut actual_lines: Vec<String> = output.lines().map(std::convert::Into::into).collect();
+
+    let mut matches = true;
+    let mut out = String::new();
+
+    for line in &asserted_lines {
+        if is_present(line, &mut actual_lines) {
+            out.push_str("| ");
+        } else {
+            matches = false;
+            out.push_str("- ");
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    for remaining_line in actual_lines {
+        matches = false;
+        out.push_str("+ ");
+        out.push_str(&remaining_line);
+        out.push('\n');
+    }
+
+    assert!(matches, "Stdout does not match:\n\n{out}");
+}
+
+pub fn assert_stdout_contains(output: impl IntoOutput, lines: impl AsRef<str>) {
+    let stdout = output.into_stdout();
+
+    assert_output_contains(&stdout, lines.as_ref());
+}
+pub fn assert_stderr_contains(output: impl IntoOutput, lines: impl AsRef<str>) {
+    let stderr = output.into_stderr();
+
+    assert_output_contains(&stderr, lines.as_ref());
+}

--- a/crates/forge/test_utils/src/output_assert.rs
+++ b/crates/forge/test_utils/src/output_assert.rs
@@ -1,36 +1,35 @@
-use std::borrow::Cow;
-
 use regex::Regex;
 use snapbox::cmd::OutputAssert;
+use std::borrow::Cow;
 
-pub trait IntoOutput {
-    fn into_stdout<'a>(&'a self) -> Cow<'a, str>;
-    fn into_stderr<'a>(&'a self) -> Cow<'a, str>;
+pub trait AsOutput {
+    fn as_stdout(&self) -> Cow<'_, str>;
+    fn as_stderr(&self) -> Cow<'_, str>;
 }
 
-impl IntoOutput for OutputAssert {
-    fn into_stdout<'a>(&'a self) -> Cow<'a, str> {
+impl AsOutput for OutputAssert {
+    fn as_stdout(&self) -> Cow<'_, str> {
         String::from_utf8(self.get_output().stdout.clone())
             .unwrap()
             .into()
     }
-    fn into_stderr<'a>(&'a self) -> Cow<'a, str> {
+    fn as_stderr(&self) -> Cow<'_, str> {
         String::from_utf8(self.get_output().stderr.clone())
             .unwrap()
             .into()
     }
 }
 
-impl IntoOutput for String {
-    fn into_stdout<'a>(&'a self) -> Cow<'a, str> {
+impl AsOutput for String {
+    fn as_stdout(&self) -> Cow<'_, str> {
         self.into()
     }
-    fn into_stderr<'a>(&'a self) -> Cow<'a, str> {
+    fn as_stderr(&self) -> Cow<'_, str> {
         self.into()
     }
 }
 
-fn find_with_wildcard(line: &str, actual: &Vec<String>) -> Option<usize> {
+fn find_with_wildcard(line: &str, actual: &[String]) -> Option<usize> {
     let escaped = regex::escape(line);
     let replaced = escaped.replace("\\[\\.\\.\\]", ".*");
     let wrapped = format!("^{replaced}$");
@@ -75,13 +74,13 @@ fn assert_output_contains(output: &str, lines: &str) {
     assert!(matches, "Stdout does not match:\n\n{out}");
 }
 
-pub fn assert_stdout_contains(output: impl IntoOutput, lines: impl AsRef<str>) {
-    let stdout = output.into_stdout();
+pub fn assert_stdout_contains(output: impl AsOutput, lines: impl AsRef<str>) {
+    let stdout = output.as_stdout();
 
     assert_output_contains(&stdout, lines.as_ref());
 }
-pub fn assert_stderr_contains(output: impl IntoOutput, lines: impl AsRef<str>) {
-    let stderr = output.into_stderr();
+pub fn assert_stderr_contains(output: impl AsOutput, lines: impl AsRef<str>) {
+    let stderr = output.as_stderr();
 
     assert_output_contains(&stderr, lines.as_ref());
 }

--- a/crates/forge/test_utils/src/output_assert.rs
+++ b/crates/forge/test_utils/src/output_assert.rs
@@ -74,11 +74,14 @@ fn assert_output_contains(output: &str, lines: &str) {
     assert!(matches, "Stdout does not match:\n\n{out}");
 }
 
+#[allow(clippy::needless_pass_by_value)]
 pub fn assert_stdout_contains(output: impl AsOutput, lines: impl AsRef<str>) {
     let stdout = output.as_stdout();
 
     assert_output_contains(&stdout, lines.as_ref());
 }
+
+#[allow(clippy::needless_pass_by_value)]
 pub fn assert_stderr_contains(output: impl AsOutput, lines: impl AsRef<str>) {
     let stderr = output.as_stderr();
 

--- a/crates/forge/tests/e2e/collection.rs
+++ b/crates/forge/tests/e2e/collection.rs
@@ -1,7 +1,6 @@
-use crate::{assert_stdout_contains, e2e::common::runner::setup_package};
+use crate::e2e::common::runner::{setup_package, test_runner};
 use indoc::indoc;
-
-use crate::e2e::common::runner::test_runner;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 fn collection_with_lib() {
@@ -15,7 +14,7 @@ fn collection_with_lib() {
         .assert()
         .success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -43,7 +42,7 @@ fn collection_with_lib() {
         [PASS] tests::fibfabfob::test_fib [..]
         [PASS] tests::fibfabfob::test_fab [..]
         Tests: 17 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }
 
@@ -59,7 +58,7 @@ fn collection_without_lib() {
         .assert()
         .success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -87,6 +86,6 @@ fn collection_without_lib() {
         [PASS] tests::fibfabfob::test_fob [..]
         [PASS] tests::fibfabfob::test_fib [..]
         Tests: 17 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/common/runner.rs
+++ b/crates/forge/tests/e2e/common/runner.rs
@@ -1,9 +1,7 @@
-use ark_std::iterable::Iterable;
 use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
 use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
-use regex::Regex;
 use snapbox::cmd::{cargo_bin, Command as SnapboxCommand};
 use std::process::Command;
 use std::str::FromStr;
@@ -202,73 +200,4 @@ pub(crate) fn get_current_branch() -> String {
 
         String::from_utf8(output.stdout).unwrap().trim().to_string()
     }
-}
-
-pub(crate) fn find_with_wildcard(line: &str, actual: &Vec<String>) -> Option<usize> {
-    let escaped = regex::escape(line);
-    let replaced = escaped.replace("\\[\\.\\.\\]", ".*");
-    let wrapped = format!("^{replaced}$");
-    let re = Regex::new(wrapped.as_str()).unwrap();
-
-    actual.iter().position(|other| re.is_match(other))
-}
-
-pub(crate) fn is_present(line: &str, actual: &mut Vec<String>) -> bool {
-    let position = find_with_wildcard(line, actual);
-    if let Some(position) = position {
-        actual.remove(position);
-        return true;
-    }
-    false
-}
-
-pub(crate) fn assert_output_contains(output: &str, lines: &str) {
-    let asserted_lines: Vec<String> = lines.lines().map(std::convert::Into::into).collect();
-    let mut actual_lines: Vec<String> = output.lines().map(std::convert::Into::into).collect();
-
-    let mut matches = true;
-    let mut out = String::new();
-
-    for line in &asserted_lines {
-        if is_present(line, &mut actual_lines) {
-            out.push_str("| ");
-        } else {
-            matches = false;
-            out.push_str("- ");
-        }
-        out.push_str(line);
-        out.push('\n');
-    }
-    for remaining_line in actual_lines {
-        matches = false;
-        out.push_str("+ ");
-        out.push_str(&remaining_line);
-        out.push('\n');
-    }
-
-    assert!(matches, "Stdout does not match:\n\n{out}");
-}
-
-#[macro_export]
-macro_rules! assert_stdout_contains {
-    ( $output:expr, $lines:expr ) => {{
-        use $crate::e2e::common::runner::assert_output_contains;
-
-        let output = $output.get_output();
-        let stdout = String::from_utf8(output.stdout.clone()).unwrap();
-
-        assert_output_contains(&stdout, $lines);
-    }};
-}
-
-#[macro_export]
-macro_rules! assert_stderr_contains {
-    ( $output:expr, $lines:expr ) => {{
-        use $crate::e2e::common::runner::assert_output_contains;
-
-        let output = $output.get_output();
-        let stderr = String::from_utf8(output.stderr.clone()).unwrap();
-
-        assert_output_contains(&stderr, $lines);
-    }};
 }

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -13,7 +13,7 @@ fn print_error_if_attributes_incorrect() {
     let output = snapbox.current_dir(&mock_tests_dir).assert().code(2);
     assert_stderr_contains(
         output,
-        &formatdoc! {r#"
+        formatdoc! {r#"
         error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
          --> {mock_tests_dir_path_str}/src/lib.cairo:4:11
             #[fork(url: "https://lib.com")]

--- a/crates/forge/tests/e2e/diagnostics_and_plugins.rs
+++ b/crates/forge/tests/e2e/diagnostics_and_plugins.rs
@@ -1,7 +1,6 @@
-use crate::assert_stderr_contains;
-use indoc::formatdoc;
-
 use crate::e2e::common::runner::{setup_package, test_runner};
+use indoc::formatdoc;
+use test_utils::output_assert::assert_stderr_contains;
 
 #[test]
 fn print_error_if_attributes_incorrect() {
@@ -12,7 +11,7 @@ fn print_error_if_attributes_incorrect() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(&mock_tests_dir).assert().code(2);
-    assert_stderr_contains!(
+    assert_stderr_contains(
         output,
         &formatdoc! {r#"
         error: Plugin diagnostic: Expected fork config must be of the form `url: <double quote string>, block_id: <snforge_std::BlockId>`.
@@ -126,6 +125,6 @@ fn print_error_if_attributes_incorrect() {
          --> {mock_tests_dir_path_str}/tests/test_fork.cairo:95:7
         #[fork(url: "http://188.34.188.184:9545/rpc/v0_6", block_id: BlockId::Tag(sumting::Latest))]
               ^***********************************************************************************^
-    "#}
+    "#},
     );
 }

--- a/crates/forge/tests/e2e/env.rs
+++ b/crates/forge/tests/e2e/env.rs
@@ -1,6 +1,6 @@
-use crate::assert_stdout_contains;
 use crate::e2e::common::runner::{setup_package, test_runner};
 use indoc::indoc;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 fn env_var_reading() {
@@ -13,7 +13,7 @@ fn env_var_reading() {
         .env("STRING_ENV_VAR", "'abcde'")
         .assert()
         .code(0);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -24,6 +24,6 @@ fn env_var_reading() {
         Running 1 test(s) from src/
         [PASS] env::tests::reading_env_vars [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/forking.rs
+++ b/crates/forge/tests/e2e/forking.rs
@@ -1,9 +1,9 @@
-use crate::assert_stdout_contains;
 use crate::e2e::common::runner::{
     runner, setup_package, setup_package_with_file_patterns, test_runner, BASE_FILE_PATTERNS,
 };
 use forge::shared_cache::CACHE_DIR;
 use indoc::indoc;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 fn without_cache() {
@@ -15,7 +15,7 @@ fn without_cache() {
         .args(["forking::tests::test_fork_simple"])
         .assert()
         .code(0);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -29,7 +29,7 @@ fn without_cache() {
         [PASS] forking::tests::test_fork_simple_hash_hex [..]
         [PASS] forking::tests::test_fork_simple_hash_number [..]
         Tests: 4 passed, 0 failed, 0 skipped, 0 ignored, 1 filtered out
-        "}
+        "},
     );
 }
 
@@ -51,7 +51,7 @@ fn with_cache() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -69,7 +69,7 @@ fn with_cache() {
 
         Failures:
             forking::tests::test_fork_simple
-        "}
+        "},
     );
 }
 
@@ -92,7 +92,7 @@ fn with_clean_cache() {
         .assert()
         .code(0);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -103,7 +103,7 @@ fn with_clean_cache() {
         Running 1 test(s) from src/
         [PASS] forking::tests::test_fork_simple [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 4 filtered out
-        "}
+        "},
     );
 }
 
@@ -121,7 +121,7 @@ fn printing_latest_block_number() {
         .assert()
         .code(0);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -134,6 +134,6 @@ fn printing_latest_block_number() {
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 4 filtered out
 
         Latest block number = [..] for url = http://188.34.188.184:9545/rpc/v0_6
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/fuzzing.rs
+++ b/crates/forge/tests/e2e/fuzzing.rs
@@ -1,6 +1,6 @@
 use crate::e2e::common::runner::{setup_package, test_runner};
-use crate::{assert_stderr_contains, assert_stdout_contains};
 use indoc::indoc;
+use test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains};
 
 #[test]
 fn fuzzing() {
@@ -8,7 +8,7 @@ fn fuzzing() {
     let snapbox = test_runner().arg("fuzzing");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -40,7 +40,7 @@ fn fuzzing() {
 
         Failures:
             fuzzing::tests::failing_fuzz
-        "}
+        "},
     );
 }
 
@@ -54,7 +54,7 @@ fn fuzzing_set_runs() {
         .args(["--fuzzer-runs", "10"])
         .assert()
         .code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -86,7 +86,7 @@ fn fuzzing_set_runs() {
 
         Failures:
             fuzzing::tests::failing_fuzz
-        "}
+        "},
     );
 }
 
@@ -100,7 +100,7 @@ fn fuzzing_set_seed() {
         .args(["--fuzzer-seed", "1234"])
         .assert()
         .code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -132,7 +132,7 @@ fn fuzzing_set_seed() {
 
         Failures:
             fuzzing::tests::failing_fuzz
-        "}
+        "},
     );
 }
 
@@ -146,13 +146,13 @@ fn fuzzing_incorrect_runs() {
         .args(["--fuzzer-runs", "0"])
         .assert()
         .code(2);
-    assert_stderr_contains!(
+    assert_stderr_contains(
         output,
         indoc! {r"
         error: invalid value '0' for '--fuzzer-runs <FUZZER_RUNS>': Number of fuzzer runs must be greater than or equal to 3
 
         For more information, try '--help'.
-        "}
+        "},
     );
 }
 
@@ -162,7 +162,7 @@ fn fuzzing_incorrect_function_args() {
     let snapbox = test_runner().arg("incorrect_args");
 
     let output = snapbox.current_dir(&temp).assert().code(2);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -173,7 +173,7 @@ fn fuzzing_incorrect_function_args() {
         Running 0 test(s) from src/
         Running 2 test(s) from tests/
         [ERROR] Tried to use incorrect type for fuzzing. Type = tests::incorrect_args::MyStruct is not supported
-        "}
+        "},
     );
 }
 
@@ -183,7 +183,7 @@ fn fuzzing_exit_first() {
     let snapbox = test_runner().arg("exit_first_fuzz").arg("-x");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -203,7 +203,7 @@ fn fuzzing_exit_first() {
         Fuzzer seed: [..]
         Failures:
             tests::exit_first_fuzz::exit_first_fails_test
-        "}
+        "},
     );
 }
 
@@ -213,7 +213,7 @@ fn fuzzing_exit_first_single_fail() {
     let snapbox = test_runner().arg("exit_first_single_fail").arg("-x");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -232,6 +232,6 @@ fn fuzzing_exit_first_single_fail() {
             tests::exit_first_single_fail::exit_first_fails_test
 
         Tests: 0 passed, 1 failed, 1 skipped, 0 ignored, 17 filtered out
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/io_operations.rs
+++ b/crates/forge/tests/e2e/io_operations.rs
@@ -1,10 +1,9 @@
-use crate::assert_stdout_contains;
-use assert_fs::fixture::PathChild;
-use indoc::indoc;
-
 use crate::e2e::common::runner::{
     setup_package_with_file_patterns, test_runner, BASE_FILE_PATTERNS,
 };
+use assert_fs::fixture::PathChild;
+use indoc::indoc;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 #[allow(clippy::too_many_lines)]
@@ -123,13 +122,13 @@ fn file_reading() {
     // run from different directories to make sure cwd is always set to package directory
     let snapbox = test_runner();
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(output, expected);
+    assert_stdout_contains(output, expected);
 
     let snapbox = test_runner();
     let output = snapbox.current_dir(temp.child("src")).assert().code(1);
-    assert_stdout_contains!(output, expected);
+    assert_stdout_contains(output, expected);
 
     let snapbox = test_runner();
     let output = snapbox.current_dir(temp.child("data")).assert().code(1);
-    assert_stdout_contains!(output, expected);
+    assert_stdout_contains(output, expected);
 }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1,16 +1,15 @@
-use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
-use camino::Utf8PathBuf;
-use indoc::{formatdoc, indoc};
-use test_utils::tempdir_with_tool_versions;
-use toml_edit::{value, Document, Item};
-
-use crate::assert_stdout_contains;
 use crate::e2e::common::runner::{
     get_current_branch, get_remote_url, runner, setup_package, test_runner,
 };
+use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
+use camino::Utf8PathBuf;
+use indoc::{formatdoc, indoc};
 use std::fs;
 use std::{path::Path, str::FromStr};
 use tempfile::TempDir;
+use test_utils::output_assert::assert_stdout_contains;
+use test_utils::tempdir_with_tool_versions;
+use toml_edit::{value, Document, Item};
 
 #[test]
 fn simple_package() {
@@ -18,7 +17,7 @@ fn simple_package() {
     let snapbox = test_runner();
     let output = snapbox.current_dir(&temp).assert().code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
     [..]Compiling[..]
@@ -54,7 +53,7 @@ fn simple_package() {
     Failures:
         tests::test_simple::test_failing
         tests::test_simple::test_another_failing
-    "}
+    "},
     );
 }
 
@@ -95,7 +94,7 @@ fn simple_package_with_git_dependency() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Updating git repository https://github.com/foundry-rs/starknet-foundry
@@ -132,7 +131,7 @@ fn simple_package_with_git_dependency() {
         Failures:
             tests::test_simple::test_failing
             tests::test_simple::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -165,7 +164,7 @@ fn with_filter() {
 
     let output = snapbox.current_dir(&temp).arg("two").assert().success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -178,7 +177,7 @@ fn with_filter() {
         [PASS] tests::test_simple::test_two [..]
         [PASS] tests::test_simple::test_two_and_two [..]
         Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 11 filtered out
-        "}
+        "},
     );
 }
 
@@ -193,7 +192,7 @@ fn with_filter_matching_module() {
         .assert()
         .success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -207,7 +206,7 @@ fn with_filter_matching_module() {
         [IGNORE] tests::ext_function_test::ignored_test
         [PASS] tests::ext_function_test::test_simple [..]
         Tests: 2 passed, 0 failed, 0 skipped, 1 ignored, 10 filtered out
-        "}
+        "},
     );
 }
 
@@ -223,7 +222,7 @@ fn with_exact_filter() {
         .assert()
         .success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -235,7 +234,7 @@ fn with_exact_filter() {
         Running 1 test(s) from tests/
         [PASS] tests::test_simple::test_two [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 12 filtered out
-        "}
+        "},
     );
 }
 #[test]
@@ -250,7 +249,7 @@ fn with_gas_usage() {
         .assert()
         .success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -262,7 +261,7 @@ fn with_gas_usage() {
         Running 1 test(s) from tests/
         [PASS] tests::test_simple::test_two (gas: ~1)
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 12 filtered out
-        "}
+        "},
     );
 }
 
@@ -273,7 +272,7 @@ fn with_non_matching_filter() {
 
     let output = snapbox.current_dir(&temp).arg("qwerty").assert().success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -284,7 +283,7 @@ fn with_non_matching_filter() {
         Running 0 test(s) from src/
         Running 0 test(s) from tests/
         Tests: 0 passed, 0 failed, 0 skipped, 0 ignored, 13 filtered out
-        "}
+        "},
     );
 }
 
@@ -295,7 +294,7 @@ fn with_ignored_flag() {
 
     let output = snapbox.current_dir(&temp).arg("--ignored").assert().code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -315,7 +314,7 @@ fn with_ignored_flag() {
         
         Failures:
             tests::ext_function_test::ignored_test
-        "}
+        "},
     );
 }
 
@@ -330,7 +329,7 @@ fn with_include_ignored_flag() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -371,7 +370,7 @@ fn with_include_ignored_flag() {
             tests::ext_function_test::ignored_test
             tests::test_simple::test_failing
             tests::test_simple::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -387,7 +386,7 @@ fn with_ignored_flag_and_filter() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -406,7 +405,7 @@ fn with_ignored_flag_and_filter() {
         
         Failures:
             tests::ext_function_test::ignored_test
-        "}
+        "},
     );
 }
 
@@ -422,7 +421,7 @@ fn with_include_ignored_flag_and_filter() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -442,7 +441,7 @@ fn with_include_ignored_flag_and_filter() {
         
         Failures:
             tests::ext_function_test::ignored_test
-        "}
+        "},
     );
 }
 
@@ -457,7 +456,7 @@ fn with_rerun_failed_flag_without_cache() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -493,7 +492,7 @@ fn with_rerun_failed_flag_without_cache() {
         Failure data:
             0x6661696c696e6720636865636b ('failing check')
 
-        "}
+        "},
     );
 }
 
@@ -511,7 +510,7 @@ fn with_rerun_failed_flag_and_name_filter() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -530,7 +529,7 @@ fn with_rerun_failed_flag_and_name_filter() {
         Failures:
             tests::test_simple::test_another_failing
 
-        "}
+        "},
     );
 }
 
@@ -547,7 +546,7 @@ fn with_rerun_failed_flag() {
         .assert()
         .code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -572,7 +571,7 @@ fn with_rerun_failed_flag() {
             tests::test_simple::test_another_failing
             tests::test_simple::test_failing
 
-        "}
+        "},
     );
 }
 
@@ -583,7 +582,7 @@ fn with_panic_data_decoding() {
 
     let output = snapbox.current_dir(&temp).assert().code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r#"
         [..]Compiling[..]
@@ -638,7 +637,7 @@ fn with_panic_data_decoding() {
             tests::test_panic_decoding::test_assert_eq
             tests::test_panic_decoding::test_assert_message
             tests::test_panic_decoding::test_assert_eq_message
-        "#}
+        "#},
     );
 }
 
@@ -677,7 +676,7 @@ fn with_exit_first() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -696,7 +695,7 @@ fn with_exit_first() {
 
         Failures:
             tests::ext_function_test::simple_test
-        "}
+        "},
     );
 }
 
@@ -706,7 +705,7 @@ fn with_exit_first_flag() {
     let snapbox = test_runner().arg("--exit-first");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -725,7 +724,7 @@ fn with_exit_first_flag() {
 
         Failures:
             tests::ext_function_test::simple_test
-        "}
+        "},
     );
 }
 
@@ -793,7 +792,7 @@ fn init_new_project_test() {
         .current_dir(temp.child(Path::new("test_name")))
         .assert()
         .success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Updating git repository https://github.com/foundry-rs/starknet-foundry
@@ -807,7 +806,7 @@ fn init_new_project_test() {
         [PASS] tests::test_contract::test_increase_balance [..]
         [PASS] tests::test_contract::test_cannot_increase_balance_with_zero_value [..]
         Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-    "}
+    "},
     );
 }
 
@@ -821,7 +820,7 @@ fn should_panic() {
 
     let output = snapbox.current_dir(&temp).assert().code(1);
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! { r"
         [..]Compiling[..]
@@ -875,7 +874,7 @@ fn should_panic() {
             tests::should_panic_test::expected_panic_but_didnt_with_expected
             tests::should_panic_test::expected_panic_but_didnt_with_expected_multiple
             tests::should_panic_test::didnt_expect_panic
-        "}
+        "},
     );
 }
 
@@ -885,7 +884,7 @@ fn printing_in_contracts() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(&temp).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r#"
         [..]Compiling[..]
@@ -906,7 +905,7 @@ fn printing_in_contracts() {
         [PASS] tests::test_contract::test_increase_balance [..]
         [PASS] tests::test_contract::test_cannot_increase_balance_with_zero_value [..]
         Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "#}
+        "#},
     );
 }
 
@@ -934,7 +933,7 @@ fn incompatible_snforge_std_version_warning() {
         .assert()
         .failure();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Updating git repository https://github.com/foundry-rs/starknet-foundry
@@ -972,7 +971,7 @@ fn incompatible_snforge_std_version_warning() {
         Failures:
             tests::test_simple::test_failing
             tests::test_simple::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -982,7 +981,7 @@ fn detailed_resources_flag() {
     let snapbox = test_runner().arg("--detailed-resources");
     let output = snapbox.current_dir(&temp).assert().success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -999,6 +998,6 @@ fn detailed_resources_flag() {
                 syscalls: ([..])
                 
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/trace.rs
+++ b/crates/forge/tests/e2e/trace.rs
@@ -1,6 +1,6 @@
-use crate::assert_stdout_contains;
 use crate::e2e::common::runner::{setup_package, test_runner};
 use indoc::indoc;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 fn trace_info_print() {
@@ -9,7 +9,7 @@ fn trace_info_print() {
 
     let output = snapbox.current_dir(&temp).assert().success();
 
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -76,6 +76,6 @@ fn trace_info_print() {
         
         [PASS] tests::test_trace::test_trace_print (gas: [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }

--- a/crates/forge/tests/e2e/workspaces.rs
+++ b/crates/forge/tests/e2e/workspaces.rs
@@ -1,9 +1,7 @@
-use std::path::PathBuf;
-
-use crate::assert_stdout_contains;
-use indoc::indoc;
-
 use crate::e2e::common::runner::{setup_hello_workspace, setup_virtual_workspace, test_runner};
+use indoc::indoc;
+use std::path::PathBuf;
+use test_utils::output_assert::assert_stdout_contains;
 
 #[test]
 fn root_workspace_without_arguments() {
@@ -11,7 +9,7 @@ fn root_workspace_without_arguments() {
 
     let snapbox = test_runner();
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -37,7 +35,7 @@ fn root_workspace_without_arguments() {
         Failures:
             tests::test_failing::test_failing
             tests::test_failing::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -47,7 +45,7 @@ fn root_workspace_specific_package() {
     let snapbox = test_runner().arg("--package").arg("addition");
 
     let output = snapbox.current_dir(&temp).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -64,7 +62,7 @@ fn root_workspace_specific_package() {
         [PASS] tests::nested::test_nested::test_two [..]
         [PASS] tests::nested::test_nested::test_two_and_two [..]
         Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }
 
@@ -74,7 +72,7 @@ fn root_workspace_specific_package2() {
     let snapbox = test_runner().arg("--package").arg("fibonacci");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -99,7 +97,7 @@ fn root_workspace_specific_package2() {
         
         Failures:
             tests::abc::efg::failing_test
-        "}
+        "},
     );
 }
 
@@ -109,7 +107,7 @@ fn root_workspace_specific_package_and_name() {
     let snapbox = test_runner().arg("simple").arg("--package").arg("addition");
 
     let output = snapbox.current_dir(&temp).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -122,7 +120,7 @@ fn root_workspace_specific_package_and_name() {
         Running 1 test(s) from tests/
         [PASS] tests::nested::simple_case [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 4 filtered out
-        "}
+        "},
     );
 }
 
@@ -132,7 +130,7 @@ fn root_workspace_specify_root_package() {
     let snapbox = test_runner().arg("--package").arg("hello_workspaces");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -158,7 +156,7 @@ fn root_workspace_specify_root_package() {
         Failures:
             tests::test_failing::test_failing
             tests::test_failing::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -170,7 +168,7 @@ fn root_workspace_inside_nested_package() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(package_dir).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -187,7 +185,7 @@ fn root_workspace_inside_nested_package() {
         [PASS] tests::nested::test_nested::test_two [..]
         [PASS] tests::nested::test_nested::test_two_and_two [..]
         Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }
 
@@ -197,7 +195,7 @@ fn root_workspace_for_entire_workspace() {
     let snapbox = test_runner().arg("--workspace");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -255,7 +253,7 @@ fn root_workspace_for_entire_workspace() {
             tests::abc::efg::failing_test
             tests::test_failing::test_failing
             tests::test_failing::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -266,7 +264,7 @@ fn root_workspace_for_entire_workspace_inside_package() {
 
     let snapbox = test_runner().arg("--workspace");
     let output = snapbox.current_dir(package_dir).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -324,7 +322,7 @@ fn root_workspace_for_entire_workspace_inside_package() {
             tests::abc::efg::failing_test
             tests::test_failing::test_failing
             tests::test_failing::test_another_failing
-        "}
+        "},
     );
 }
 
@@ -361,7 +359,7 @@ fn virtual_workspace_without_arguments() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -398,7 +396,7 @@ fn virtual_workspace_without_arguments() {
         
         Failures:
             tests::abc::efg::failing_test
-        "}
+        "},
     );
 }
 
@@ -408,7 +406,7 @@ fn virtual_workspace_specify_package() {
     let snapbox = test_runner().arg("--package").arg("subtraction");
 
     let output = snapbox.current_dir(&temp).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -425,7 +423,7 @@ fn virtual_workspace_specify_package() {
         [PASS] tests::nested::test_nested::test_two [..]
         [PASS] tests::nested::test_nested::test_two_and_two [..]
         Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }
 
@@ -435,7 +433,7 @@ fn virtual_workspace_specific_package2() {
     let snapbox = test_runner().arg("--package").arg("fibonacci2");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -459,7 +457,7 @@ fn virtual_workspace_specific_package2() {
         
         Failures:
             tests::abc::efg::failing_test
-        "}
+        "},
     );
 }
 
@@ -472,7 +470,7 @@ fn virtual_workspace_specific_package_and_name() {
         .arg("subtraction");
 
     let output = snapbox.current_dir(&temp).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -485,7 +483,7 @@ fn virtual_workspace_specific_package_and_name() {
         Running 1 test(s) from tests/
         [PASS] tests::nested::simple_case [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 4 filtered out
-        "}
+        "},
     );
 }
 
@@ -497,7 +495,7 @@ fn virtual_workspace_inside_nested_package() {
     let snapbox = test_runner();
 
     let output = snapbox.current_dir(package_dir).assert().success();
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -514,7 +512,7 @@ fn virtual_workspace_inside_nested_package() {
         [PASS] tests::nested::test_nested::test_two [..]
         [PASS] tests::nested::test_nested::test_two_and_two [..]
         Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
-        "}
+        "},
     );
 }
 
@@ -524,7 +522,7 @@ fn virtual_workspace_for_entire_workspace() {
     let snapbox = test_runner().arg("--workspace");
 
     let output = snapbox.current_dir(&temp).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -561,7 +559,7 @@ fn virtual_workspace_for_entire_workspace() {
         
         Failures:
             tests::abc::efg::failing_test
-        "}
+        "},
     );
 }
 
@@ -572,7 +570,7 @@ fn virtual_workspace_for_entire_workspace_inside_package() {
 
     let snapbox = test_runner().arg("--workspace");
     let output = snapbox.current_dir(package_dir).assert().code(1);
-    assert_stdout_contains!(
+    assert_stdout_contains(
         output,
         indoc! {r"
         [..]Compiling[..]
@@ -609,7 +607,7 @@ fn virtual_workspace_for_entire_workspace_inside_package() {
         
         Failures:
             tests::abc::efg::failing_test
-        "}
+        "},
     );
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1666

## Introduced changes

<!-- A brief description of the changes -->

- Moved test helpers (`assert_stdout_contains`, `assert_stderr_contains`) to test_utils so it can be used in unit tests

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
