### PR TITLE
Remove useless code related to `UsedResources`

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -1,4 +1,3 @@
-use blockifier::execution::deprecated_syscalls::hint_processor::SyscallCounter;
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_lang_runner::casm_run::format_next_item;
 
@@ -23,27 +22,6 @@ use super::RuntimeState;
 pub struct UsedResources {
     pub execution_resources: ExecutionResources,
     pub l2_to_l1_payloads_length: Vec<usize>,
-}
-
-impl UsedResources {
-    pub fn extend(self: &mut UsedResources, other: &UsedResources) {
-        self.execution_resources.vm_resources += &other.execution_resources.vm_resources;
-
-        self.update_syscall_counter(&other.execution_resources.syscall_counter);
-
-        self.l2_to_l1_payloads_length
-            .extend(&other.l2_to_l1_payloads_length);
-    }
-
-    fn update_syscall_counter(self: &mut UsedResources, syscall_counter: &SyscallCounter) {
-        for (syscall, count) in syscall_counter {
-            *self
-                .execution_resources
-                .syscall_counter
-                .entry(*syscall)
-                .or_insert(0) += count;
-        }
-    }
 }
 
 /// Enum representing possible call execution result, along with the data

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -725,18 +725,8 @@ pub fn get_all_execution_resources(runtime: ForgeRuntime) -> UsedResources {
         .get_sorted_l2_to_l1_payloads_length()
         .unwrap();
 
-    let mut all_resources = UsedResources {
+    UsedResources {
         execution_resources: runtime_execution_resources,
         l2_to_l1_payloads_length: runtime_l2_to_l1_payloads_length,
-    };
-
-    let cheatnet_used_resources = &runtime
-        .extended_runtime
-        .extended_runtime
-        .extension
-        .cheatnet_state
-        .used_resources;
-    all_resources.extend(cheatnet_used_resources);
-
-    all_resources
+    }
 }

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -1,5 +1,4 @@
 use crate::forking::state::ForkStateReader;
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::UsedResources;
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spoof::TxInfoMock;
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spy_events::{
     Event, SpyTarget,
@@ -181,9 +180,6 @@ pub struct CheatnetState {
     pub detected_events: Vec<Event>,
     pub deploy_salt_base: u32,
     pub block_info: BlockInfo,
-    // execution resources used by all contract calls
-    pub used_resources: UsedResources,
-
     pub trace_data: TraceData,
 }
 
@@ -209,7 +205,6 @@ impl Default for CheatnetState {
             detected_events: vec![],
             deploy_salt_base: 0,
             block_info: Default::default(),
-            used_resources: Default::default(),
             trace_data: TraceData {
                 current_call_stack: NotEmptyCallStack::from(test_call),
             },


### PR DESCRIPTION
Not needed anymore after #1673 and #1669 