### PR TITLE
Error handling for deployment scripts `deploy` subcommand

### DIFF
--- a/crates/sncast/tests/data/scripts/deploy/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/deploy/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-name = "deploy_script"
+name = "deploy_test_scripts"
 version = "0.1.0"
 
 [dependencies]

--- a/crates/sncast/tests/data/scripts/deploy/src/invalid_calldata.cairo
+++ b/crates/sncast/tests/data/scripts/deploy/src/invalid_calldata.cairo
@@ -1,24 +1,25 @@
-use sncast_std::{deploy, DeployResult};
+use sncast_std::{get_nonce, deploy, DeployResult, ScriptCommandError, ProviderError, StarknetError};
 use starknet::{ClassHash, Felt252TryIntoClassHash};
 use traits::Into;
 
 fn main() {
     let max_fee = 99999999999999999;
     let salt = 0x3;
+
     let class_hash: ClassHash = 0x059426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded
         .try_into()
         .expect('Invalid class hash value');
 
+    let deploy_nonce = get_nonce('pending');
     let deploy_result = deploy(
         class_hash,
-        array![0x2, 0x2, 0x0],
+        array![0x2],
         Option::Some(salt),
         true,
         Option::Some(max_fee),
-        Option::None
+        Option::Some(deploy_nonce)
     )
-        .expect('deploy failed');
+        .unwrap_err();
 
-    assert(deploy_result.transaction_hash != 0, deploy_result.transaction_hash);
+    println!("{:?}", deploy_result);
 }
-

--- a/crates/sncast/tests/data/scripts/deploy/src/invalid_class_hash.cairo
+++ b/crates/sncast/tests/data/scripts/deploy/src/invalid_class_hash.cairo
@@ -1,0 +1,23 @@
+use sncast_std::{get_nonce, deploy, DeployResult, ScriptCommandError, ProviderError, StarknetError};
+use starknet::{ClassHash, Felt252TryIntoClassHash};
+use traits::Into;
+
+fn main() {
+    let max_fee = 99999999999999999;
+    let salt = 0x3;
+
+    let class_hash: ClassHash = 0xdddd.try_into().expect('Invalid class hash value');
+
+    let deploy_nonce = get_nonce('pending');
+    let deploy_result = deploy(
+        class_hash,
+        array![0x2, 0x2, 0x0],
+        Option::Some(salt),
+        true,
+        Option::Some(max_fee),
+        Option::Some(deploy_nonce)
+    )
+        .unwrap_err();
+
+    println!("{:?}", deploy_result);
+}

--- a/crates/sncast/tests/data/scripts/deploy/src/invalid_nonce.cairo
+++ b/crates/sncast/tests/data/scripts/deploy/src/invalid_nonce.cairo
@@ -1,24 +1,33 @@
-use sncast_std::{deploy, DeployResult};
+use sncast_std::{get_nonce, deploy, DeployResult, ScriptCommandError, ProviderError, StarknetError};
+
 use starknet::{ClassHash, Felt252TryIntoClassHash};
 use traits::Into;
 
 fn main() {
     let max_fee = 99999999999999999;
     let salt = 0x3;
+
     let class_hash: ClassHash = 0x059426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded
         .try_into()
         .expect('Invalid class hash value');
 
+    let deploy_nonce = get_nonce('pending') + 100;
     let deploy_result = deploy(
         class_hash,
         array![0x2, 0x2, 0x0],
         Option::Some(salt),
         true,
         Option::Some(max_fee),
-        Option::None
+        Option::Some(deploy_nonce)
     )
-        .expect('deploy failed');
+        .unwrap_err();
 
-    assert(deploy_result.transaction_hash != 0, deploy_result.transaction_hash);
+    println!("{:?}", deploy_result);
+
+    assert(
+        ScriptCommandError::ProviderError(
+            ProviderError::StarknetError(StarknetError::InvalidTransactionNonce)
+        ) == deploy_result,
+        'ohno'
+    )
 }
-

--- a/crates/sncast/tests/data/scripts/deploy/src/lib.cairo
+++ b/crates/sncast/tests/data/scripts/deploy/src/lib.cairo
@@ -1,2 +1,5 @@
 mod with_calldata;
-
+mod same_class_hash_and_salt;
+mod invalid_class_hash;
+mod invalid_calldata;
+mod invalid_nonce;

--- a/crates/sncast/tests/data/scripts/deploy/src/same_class_hash_and_salt.cairo
+++ b/crates/sncast/tests/data/scripts/deploy/src/same_class_hash_and_salt.cairo
@@ -1,0 +1,40 @@
+use sncast_std::{get_nonce, deploy, DeployResult, ScriptCommandError, ProviderError, StarknetError};
+use starknet::{ClassHash, Felt252TryIntoClassHash};
+use traits::Into;
+
+fn main() {
+    let max_fee = 99999999999999999;
+    let salt = 0x34542;
+
+    let class_hash: ClassHash = 0x059426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded
+        .try_into()
+        .expect('Invalid class hash value');
+
+    let deploy_nonce = get_nonce('pending');
+    let deploy_result = deploy(
+        class_hash,
+        array![0x2, 0x2, 0x0],
+        Option::Some(salt),
+        true,
+        Option::Some(max_fee),
+        Option::Some(deploy_nonce)
+    )
+        .expect('1st deploy failed');
+
+    let class_hash: ClassHash = 0x059426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded
+        .try_into()
+        .expect('Invalid class hash value');
+
+    let deploy_nonce = get_nonce('pending');
+    let deploy_result = deploy(
+        class_hash,
+        array![0x2, 0x2, 0x0],
+        Option::Some(salt),
+        true,
+        Option::Some(max_fee),
+        Option::Some(deploy_nonce)
+    )
+        .unwrap_err();
+
+    println!("{:?}", deploy_result);
+}

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
@@ -25,7 +25,8 @@ fn main() {
         true,
         Option::Some(max_fee),
         Option::Some(deploy_nonce)
-    );
+    )
+        .expect('deploy failed');
     println!("deploy_result: {}", deploy_result);
     println!("debug deploy_result: {:?}", deploy_result);
 

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
@@ -13,7 +13,8 @@ fn second_contract() {
         false,
         Option::None,
         Option::None
-    );
+    )
+        .expect('mapa deploy failed');
     assert(deploy_result.transaction_hash != 0, deploy_result.transaction_hash);
 
     let invoke_result = invoke(
@@ -42,7 +43,8 @@ fn main() {
         true,
         Option::Some(max_fee),
         Option::Some(deploy_nonce)
-    );
+    )
+        .expect('mapa deploy failed');
     assert(deploy_result.transaction_hash != 0, deploy_result.transaction_hash);
 
     let invoke_nonce = get_nonce('pending');

--- a/crates/sncast/tests/e2e/script/deploy.rs
+++ b/crates/sncast/tests/e2e/script/deploy.rs
@@ -2,6 +2,7 @@ use crate::helpers::constants::{ACCOUNT_FILE_PATH, SCRIPTS_DIR, URL};
 use crate::helpers::fixtures::{copy_script_directory_to_tempdir, get_accounts_path};
 use crate::helpers::runner::runner;
 use indoc::indoc;
+use shared::test_utils::output_assert::assert_stdout_contains;
 
 #[tokio::test]
 async fn test_with_calldata() {
@@ -23,9 +24,190 @@ async fn test_with_calldata() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    snapbox.assert().success().stdout_matches(indoc! {r"
-        ...
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
         command: script run
         status: success
-    "});
+        "},
+    );
+}
+
+#[tokio::test]
+async fn test_same_salt_and_class_hash_deployed_twice() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/deploy", Vec::<String>::new());
+    let accounts_json_path = get_accounts_path(ACCOUNT_FILE_PATH);
+
+    let script_name = "same_class_hash_and_salt";
+    let args = vec![
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user3",
+        "--url",
+        URL,
+        "script",
+        "run",
+        &script_name,
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+        ScriptCommandError::WaitForTransactionError(WaitForTransactionError::TransactionError(TransactionError::Reverted(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+
+        Error in the called contract ([..]):
+        Error at pc=0:32:
+        Got an exception while executing a hint: Custom Hint Error: Requested ContractAddress(PatriciaKey(StarkFelt("[..]"))) is unavailable for deployment.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:174)
+        Unknown location (pc=0:127)
+        " })))
+        command: script run
+        status: success
+        "#},
+    );
+}
+
+#[tokio::test]
+async fn test_invalid_class_hash() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/deploy", Vec::<String>::new());
+    let accounts_json_path = get_accounts_path(ACCOUNT_FILE_PATH);
+
+    let script_name = "invalid_class_hash";
+    let args = vec![
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user2",
+        "--url",
+        URL,
+        "script",
+        "run",
+        &script_name,
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+        ScriptCommandError::WaitForTransactionError(WaitForTransactionError::TransactionError(TransactionError::Reverted(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+
+        Error in the called contract ([..]):
+        Error at pc=0:32:
+        Got an exception while executing a hint: Custom Hint Error: Class with hash ClassHash(
+            StarkFelt(
+                "[..]",
+            ),
+        ) is not declared.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:174)
+        Unknown location (pc=0:127)
+        " })))
+        command: script run
+        status: success
+        "#},
+    );
+}
+
+#[tokio::test]
+async fn test_invalid_call_data() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/deploy", Vec::<String>::new());
+    let accounts_json_path = get_accounts_path(ACCOUNT_FILE_PATH);
+
+    let script_name = "invalid_calldata";
+    let args = vec![
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user5",
+        "--url",
+        URL,
+        "script",
+        "run",
+        &script_name,
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+        ScriptCommandError::WaitForTransactionError(WaitForTransactionError::TransactionError(TransactionError::Reverted(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+
+        Error in the called contract ([..]):
+        Error at pc=0:32:
+        Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: [..] ('Failed to deserialize param #2').
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:174)
+        Unknown location (pc=0:127)
+        " })))
+        command: script run
+        status: success
+        "#},
+    );
+}
+
+#[tokio::test]
+async fn test_invalid_nonce() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/deploy", Vec::<String>::new());
+    let accounts_json_path = get_accounts_path(ACCOUNT_FILE_PATH);
+
+    let script_name = "invalid_nonce";
+    let args = vec![
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user5",
+        "--url",
+        URL,
+        "script",
+        "run",
+        &script_name,
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::InvalidTransactionNonce(())))
+        command: script run
+        status: success
+        "},
+    );
 }

--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -170,7 +170,7 @@ pub fn declare(
     result_data
 }
 
-#[derive(Drop, Clone, Debug)]
+#[derive(Drop, Clone, Debug, Serde)]
 pub struct DeployResult {
     pub contract_address: ContractAddress,
     pub transaction_hash: felt252,
@@ -194,7 +194,7 @@ pub fn deploy(
     unique: bool,
     max_fee: Option<felt252>,
     nonce: Option<felt252>
-) -> DeployResult {
+) -> Result<DeployResult, ScriptCommandError> {
     let class_hash_felt: felt252 = class_hash.into();
     let mut inputs = array![class_hash_felt];
 
@@ -216,14 +216,14 @@ pub fn deploy(
     inputs.append_span(max_fee_serialized.span());
     inputs.append_span(nonce_serialized.span());
 
-    let buf = cheatcode::<'deploy'>(inputs.span());
+    let mut buf = cheatcode::<'deploy'>(inputs.span());
 
-    let contract_address: ContractAddress = (*buf[0])
-        .try_into()
-        .expect('Invalid contract address value');
-    let transaction_hash = *buf[1];
+    let mut result_data: Result<DeployResult, ScriptCommandError> = Serde::<
+        Result<DeployResult>
+    >::deserialize(ref buf)
+        .expect('deploy deserialize failed');
 
-    DeployResult { contract_address, transaction_hash }
+    result_data
 }
 
 #[derive(Drop, Clone, Debug)]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Partially solves #1361




## Introduced changes

<!-- A brief description of the changes -->

- `deploy` from `sncast_std` now returns `Result<DeployResult, ScriptCommandError>`
- Added tests for `deploy` error handling in deployment scripts

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
