### PR TITLE
Error handling for deployment scripts `call` subcommand

### DIFF
--- a/crates/sncast/tests/data/scripts/call/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/call/Scarb.toml
@@ -1,0 +1,7 @@
+[package]
+name = "call_test_scripts"
+version = "0.1.0"
+
+[dependencies]
+starknet = ">=2.3.0"
+sncast_std = { path = "../../../../../../sncast_std" }

--- a/crates/sncast/tests/data/scripts/call/src/invalid_address.cairo
+++ b/crates/sncast/tests/data/scripts/call/src/invalid_address.cairo
@@ -1,0 +1,18 @@
+use sncast_std::{call, CallResult, ScriptCommandError, ProviderError, StarknetError};
+
+fn main() {
+    let eth = 0x049;
+    let call_err: ScriptCommandError = call(
+        eth.try_into().expect('bad address'), selector!("decimals"), array![]
+    )
+        .unwrap_err();
+
+    println!("{:?}", call_err);
+
+    assert(
+        ScriptCommandError::ProviderError(
+            ProviderError::StarknetError(StarknetError::ContractNotFound)
+        ) == call_err,
+        'ohno'
+    )
+}

--- a/crates/sncast/tests/data/scripts/call/src/invalid_calldata.cairo
+++ b/crates/sncast/tests/data/scripts/call/src/invalid_calldata.cairo
@@ -1,0 +1,20 @@
+use sncast_std::{call, CallResult, ScriptCommandError, ProviderError, StarknetError, ErrorData};
+
+fn main() {
+    let eth = 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
+    let call_err: ScriptCommandError = call(
+        eth.try_into().expect('bad address'),
+        selector!("allowance"),
+        array![0x12, 0x12, 0x12, 0x12, 0x12]
+    )
+        .unwrap_err();
+
+    println!("{:?}", call_err);
+
+    let call_err: ScriptCommandError = call(
+        eth.try_into().expect('bad address'), selector!("allowance"), array![0x12]
+    )
+        .unwrap_err();
+
+    println!("{:?}", call_err);
+}

--- a/crates/sncast/tests/data/scripts/call/src/invalid_entry_point.cairo
+++ b/crates/sncast/tests/data/scripts/call/src/invalid_entry_point.cairo
@@ -1,0 +1,11 @@
+use sncast_std::{call, CallResult, ScriptCommandError, ProviderError, StarknetError, ErrorData};
+
+fn main() {
+    let eth = 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
+    let call_err: ScriptCommandError = call(
+        eth.try_into().expect('bad address'), selector!("gimme_money"), array![]
+    )
+        .unwrap_err();
+
+    println!("{:?}", call_err);
+}

--- a/crates/sncast/tests/data/scripts/call/src/lib.cairo
+++ b/crates/sncast/tests/data/scripts/call/src/lib.cairo
@@ -1,0 +1,3 @@
+mod invalid_entry_point;
+mod invalid_address;
+mod invalid_calldata;

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
@@ -45,7 +45,8 @@ fn main() {
 
     assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
 
-    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1]);
+    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1])
+        .expect('call failed');
     println!("call_result: {}", call_result);
     println!("debug call_result: {:?}", call_result);
 

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
@@ -26,7 +26,8 @@ fn second_contract() {
     );
     assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
 
-    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1]);
+    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1])
+        .expect('mapa2 call failed');
     assert(call_result.data == array![0x3], *call_result.data.at(0));
 }
 
@@ -61,7 +62,8 @@ fn main() {
     );
     assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
 
-    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1]);
+    let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1])
+        .expect('mapa call failed');
     assert(call_result.data == array![0x2], *call_result.data.at(0));
 
     second_contract();

--- a/crates/sncast/tests/data/scripts/misc/src/call_fail.cairo
+++ b/crates/sncast/tests/data/scripts/misc/src/call_fail.cairo
@@ -3,4 +3,5 @@ use sncast_std::{call, CallResult};
 fn main() {
     let eth = 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
     let call_result = call(eth.try_into().unwrap(), selector!("gimme_money"), array![]);
+    call_result.expect('call failed');
 }

--- a/crates/sncast/tests/data/scripts/misc/src/call_happy.cairo
+++ b/crates/sncast/tests/data/scripts/misc/src/call_happy.cairo
@@ -3,11 +3,12 @@ use sncast_std::{call, CallResult};
 fn main() {
     let eth = 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
     let addr = 0x0089496091c660345BaA480dF76c1A900e57cf34759A899eFd1EADb362b20DB5;
-    let call_result = call(eth.try_into().unwrap(), selector!("allowance"), array![addr, addr]);
+    let call_result = call(eth.try_into().unwrap(), selector!("allowance"), array![addr, addr])
+        .unwrap();
     let call_result = *call_result.data[0];
     assert(call_result == 0, call_result);
 
-    let call_result = call(eth.try_into().unwrap(), selector!("decimals"), array![]);
+    let call_result = call(eth.try_into().unwrap(), selector!("decimals"), array![]).unwrap();
     let call_result = *call_result.data[0];
     assert(call_result == 18, call_result);
 }

--- a/crates/sncast/tests/e2e/script/call.rs
+++ b/crates/sncast/tests/e2e/script/call.rs
@@ -2,7 +2,7 @@ use crate::helpers::constants::{SCRIPTS_DIR, URL};
 use crate::helpers::fixtures::copy_script_directory_to_tempdir;
 use crate::helpers::runner::runner;
 use indoc::indoc;
-use shared::test_utils::output_assert::assert_stderr_contains;
+use shared::test_utils::output_assert::assert_stdout_contains;
 
 #[tokio::test]
 async fn test_happy_case() {
@@ -31,11 +31,82 @@ async fn test_failing() {
     let snapbox = runner(&args).current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
         indoc! {r"
         command: script run
-        error: Got an exception while executing a hint: Hint Error: An error [..]Entry point EntryPointSelector(StarkFelt[..]not found in contract[..]
+        message:[..]
+            0x63616c6c206661696c6564 ('call failed')
+
+        status: script panicked
         "},
+    );
+}
+
+#[tokio::test]
+async fn test_call_invalid_entry_point() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/call", Vec::<String>::new());
+
+    let script_name = "invalid_entry_point";
+    let args = vec!["--url", URL, "script", "run", &script_name];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Entry point EntryPointSelector(StarkFelt([..])) not found in contract." })))
+        command: script run
+        status: success
+        "#},
+    );
+}
+
+#[tokio::test]
+async fn test_call_invalid_address() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/call", Vec::<String>::new());
+
+    let script_name = "invalid_address";
+    let args = vec!["--url", URL, "script", "run", &script_name];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractNotFound(())))
+        command: script run
+        status: success
+        "},
+    );
+}
+
+#[tokio::test]
+async fn test_call_invalid_calldata() {
+    let tempdir =
+        copy_script_directory_to_tempdir(SCRIPTS_DIR.to_owned() + "/call", Vec::<String>::new());
+
+    let script_name = "invalid_calldata";
+    let args = vec!["--url", URL, "script", "run", &script_name];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Error at pc=0:1401:
+        An ASSERT_EQ instruction failed: 5:2 != 5:5.
+        " })))
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Error at pc=0:1401:
+        An ASSERT_EQ instruction failed: 5:2 != 5:1.
+        " })))
+        command: script run
+        status: success
+        "#},
     );
 }

--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -102,7 +102,7 @@ pub impl DisplayContractAddress of Display<ContractAddress> {
     }
 }
 
-#[derive(Drop, Clone, Debug)]
+#[derive(Drop, Clone, Debug, Serde)]
 pub struct CallResult {
     pub data: Array::<felt252>,
 }
@@ -115,7 +115,7 @@ impl DisplayCallResult of Display<CallResult> {
 
 pub fn call(
     contract_address: ContractAddress, function_selector: felt252, calldata: Array::<felt252>
-) -> CallResult {
+) -> Result<CallResult, ScriptCommandError> {
     let contract_address_felt: felt252 = contract_address.into();
     let mut inputs = array![contract_address_felt, function_selector];
 
@@ -126,9 +126,12 @@ pub fn call(
 
     let mut buf = cheatcode::<'call'>(inputs.span());
 
-    let result_data: Array::<felt252> = Serde::<Array<felt252>>::deserialize(ref buf).unwrap();
+    let mut result_data: Result<CallResult, ScriptCommandError> = Serde::<
+        Result<CallResult>
+    >::deserialize(ref buf)
+        .expect('call deserialize failed');
 
-    CallResult { data: result_data }
+    result_data
 }
 
 #[derive(Drop, Clone, Debug, Serde)]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Partially solves https://github.com/foundry-rs/starknet-foundry/issues/1361

## Introduced changes

<!-- A brief description of the changes -->

- `call` from `sncast_std` now returns `Result<CallResult, ScriptCommandError>`
- Added tests for `call` error handling in deployment scripts

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
