### PR TITLE
Error handling for deployment scripts `invoke` subcommand

### DIFF
--- a/crates/sncast/tests/data/scripts/invoke/src/contract_does_not_exist.cairo
+++ b/crates/sncast/tests/data/scripts/invoke/src/contract_does_not_exist.cairo
@@ -1,9 +1,14 @@
-use sncast_std::{invoke, InvokeResult};
+use sncast_std::{invoke, InvokeResult, ScriptCommandError, ProviderError, StarknetError};
 use starknet::{ContractAddress, Felt252TryIntoContractAddress};
 use traits::Into;
 
 fn main() {
     let map_contract_address = 0x123.try_into().expect('Invalid contract address value');
-    invoke(map_contract_address, selector!("put"), array![0x10, 0x1], Option::None, Option::None);
+
+    let invoke_result = invoke(
+        map_contract_address, selector!("put"), array![0x10, 0x1], Option::None, Option::None
+    )
+        .unwrap_err();
+    println!("{:?}", invoke_result);
 }
 

--- a/crates/sncast/tests/data/scripts/invoke/src/max_fee_too_low.cairo
+++ b/crates/sncast/tests/data/scripts/invoke/src/max_fee_too_low.cairo
@@ -1,4 +1,4 @@
-use sncast_std::{invoke, InvokeResult};
+use sncast_std::{invoke, InvokeResult, ScriptCommandError, ProviderError, StarknetError};
 use starknet::{ContractAddress, Felt252TryIntoContractAddress};
 use traits::Into;
 
@@ -7,8 +7,10 @@ fn main() {
         .try_into()
         .expect('Invalid contract address value');
 
-    invoke(
+    let invoke_result = invoke(
         map_contract_address, selector!("put"), array![0x10, 0x1], Option::Some(1), Option::None
-    );
+    )
+        .unwrap_err();
+    println!("{:?}", invoke_result);
 }
 

--- a/crates/sncast/tests/data/scripts/invoke/src/wrong_calldata.cairo
+++ b/crates/sncast/tests/data/scripts/invoke/src/wrong_calldata.cairo
@@ -1,4 +1,4 @@
-use sncast_std::{invoke, InvokeResult};
+use sncast_std::{invoke, InvokeResult, ScriptCommandError, ProviderError, StarknetError};
 use starknet::{ContractAddress, Felt252TryIntoContractAddress};
 use traits::Into;
 
@@ -7,6 +7,10 @@ fn main() {
         .try_into()
         .expect('Invalid contract address value');
 
-    invoke(map_contract_address, selector!("put"), array![0x10], Option::None, Option::None);
+    let invoke_result = invoke(
+        map_contract_address, selector!("put"), array![0x10], Option::None, Option::None
+    )
+        .unwrap_err();
+    println!("{:?}", invoke_result);
 }
 

--- a/crates/sncast/tests/data/scripts/invoke/src/wrong_function_name.cairo
+++ b/crates/sncast/tests/data/scripts/invoke/src/wrong_function_name.cairo
@@ -1,4 +1,4 @@
-use sncast_std::{invoke, InvokeResult};
+use sncast_std::{invoke, InvokeResult, ScriptCommandError, ProviderError, StarknetError};
 use starknet::{ContractAddress, Felt252TryIntoContractAddress};
 use traits::Into;
 
@@ -7,8 +7,10 @@ fn main() {
         .try_into()
         .expect('Invalid contract address value');
 
-    invoke(
+    let invoke_result = invoke(
         map_contract_address, selector!("mariusz"), array![0x10, 0x1], Option::None, Option::None
-    );
+    )
+        .unwrap_err();
+    println!("{:?}", invoke_result);
 }
 

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/display_debug_traits_for_subcommand_responses.cairo
@@ -39,7 +39,8 @@ fn main() {
         array![0x1, 0x2],
         Option::Some(max_fee),
         Option::Some(invoke_nonce)
-    );
+    )
+        .expect('invoke failed');
     println!("invoke_result: {}", invoke_result);
     println!("debug invoke_result: {:?}", invoke_result);
 

--- a/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/src/map_script.cairo
@@ -23,7 +23,8 @@ fn second_contract() {
         array![0x1, 0x3],
         Option::None,
         Option::None
-    );
+    )
+        .expect('mapa2 invoke failed');
     assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
 
     let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1])
@@ -59,7 +60,8 @@ fn main() {
         array![0x1, 0x2],
         Option::Some(max_fee),
         Option::Some(invoke_nonce)
-    );
+    )
+        .expect('mapa invoke failed');
     assert(invoke_result.transaction_hash != 0, invoke_result.transaction_hash);
 
     let call_result = call(deploy_result.contract_address, selector!("get"), array![0x1])

--- a/crates/sncast/tests/e2e/script/invoke.rs
+++ b/crates/sncast/tests/e2e/script/invoke.rs
@@ -2,7 +2,7 @@ use crate::helpers::constants::{ACCOUNT_FILE_PATH, SCRIPTS_DIR, URL};
 use crate::helpers::fixtures::{copy_script_directory_to_tempdir, get_accounts_path};
 use crate::helpers::runner::runner;
 use indoc::indoc;
-use shared::test_utils::output_assert::assert_stderr_contains;
+use shared::test_utils::output_assert::assert_stdout_contains;
 
 #[tokio::test]
 async fn test_max_fee_too_low() {
@@ -26,11 +26,12 @@ async fn test_max_fee_too_low() {
     let snapbox = runner(&args).current_dir(script_dir.path());
     let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
         indoc! {r"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::InsufficientMaxFee(())))
         command: script run
-        error: Got an exception while executing a hint: Hint Error: Max fee is smaller than the minimal transaction cost
+        status: success
         "},
     );
 }
@@ -57,12 +58,21 @@ async fn test_contract_does_not_exist() {
     let snapbox = runner(&args).current_dir(script_dir.path());
     let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
-        indoc! {r"
+        indoc! {r#"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint: Custom Hint Error: Requested contract address ContractAddress(PatriciaKey(StarkFelt("[..]"))) is not deployed.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+        " })))
         command: script run
-        error: Got an exception while executing a hint: Hint Error: An error [..]Requested contract address[..]is not deployed[..]
-        "},
+        status: success
+        "#},
     );
 }
 
@@ -88,12 +98,21 @@ fn test_wrong_function_name() {
     let snapbox = runner(&args).current_dir(script_dir.path());
     let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
-        indoc! {r"
+        indoc! {r#"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint: Custom Hint Error: Entry point EntryPointSelector(StarkFelt("[..]")) not found in contract.
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+        " })))
         command: script run
-        error: Got an exception while executing a hint: Hint Error: An error [..] Entry point EntryPointSelector(StarkFelt[..]not found in contract[..]
-        "},
+        status: success
+        "#},
     );
 }
 
@@ -119,11 +138,20 @@ fn test_wrong_calldata() {
     let snapbox = runner(&args).current_dir(script_dir.path());
     let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
-        indoc! {r"
+        indoc! {r#"
+        ScriptCommandError::ProviderError(ProviderError::StarknetError(StarknetError::ContractError(ErrorData { msg: "Error in the called contract ([..]):
+        Error at pc=0:81:
+        Got an exception while executing a hint: Custom Hint Error: Execution failed. Failure reason: [..] ('Failed to deserialize param #2').
+        Cairo traceback (most recent call last):
+        Unknown location (pc=0:731)
+        Unknown location (pc=0:677)
+        Unknown location (pc=0:291)
+        Unknown location (pc=0:314)
+        " })))
         command: script run
-        error: Got an exception while executing a hint: Hint Error: An error [..]Failed to deserialize param #2[..]
-        "},
+        status: success
+        "#},
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Partially solves #1361


## Introduced changes

<!-- A brief description of the changes -->

- `invoke` from `sncast_std` now returns `Result<InvokeResult, ScriptCommandError>`
- Added tests for `invoke` error handling in deployment scripts

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
