### PR TITLE
Introduce `ValidWaitParams`

### DIFF
--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -1,5 +1,5 @@
 use super::constants::{CONFIG_FILENAME, WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
-use crate::ValidWaitParams;
+use crate::ValidatedWaitParams;
 use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ pub struct CastConfig {
     pub account: String,
     pub accounts_file: Utf8PathBuf,
     pub keystore: Option<Utf8PathBuf>,
-    pub wait_params: ValidWaitParams,
+    pub wait_params: ValidatedWaitParams,
 }
 
 impl CastConfig {
@@ -28,7 +28,7 @@ impl CastConfig {
             account: get_property(&entries, "account"),
             accounts_file: get_property(&entries, "accounts-file"),
             keystore: get_property_optional(&entries, "keystore"),
-            wait_params: ValidWaitParams::new(
+            wait_params: ValidatedWaitParams::new(
                 get_property(&entries, "wait-retry-interval"),
                 get_property(&entries, "wait-timeout"),
             ),

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -1,4 +1,5 @@
 use super::constants::{CONFIG_FILENAME, WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
+use crate::ValidWaitParams;
 use anyhow::{anyhow, Result};
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
@@ -6,14 +7,13 @@ use std::fs;
 use tempfile::TempDir;
 use toml::Value;
 
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[derive(Default, Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct CastConfig {
     pub rpc_url: String,
     pub account: String,
     pub accounts_file: Utf8PathBuf,
     pub keystore: Option<Utf8PathBuf>,
-    pub wait_timeout: u16,
-    pub wait_retry_interval: u8,
+    pub wait_params: ValidWaitParams,
 }
 
 impl CastConfig {
@@ -28,22 +28,11 @@ impl CastConfig {
             account: get_property(&entries, "account"),
             accounts_file: get_property(&entries, "accounts-file"),
             keystore: get_property_optional(&entries, "keystore"),
-            wait_timeout: get_property(&entries, "wait-timeout"),
-            wait_retry_interval: get_property(&entries, "wait-retry-interval"),
+            wait_params: ValidWaitParams::new(
+                get_property(&entries, "wait-retry-interval"),
+                get_property(&entries, "wait-timeout"),
+            ),
         })
-    }
-}
-
-impl Default for CastConfig {
-    fn default() -> Self {
-        Self {
-            rpc_url: String::default(),
-            account: String::default(),
-            accounts_file: Utf8PathBuf::default(),
-            keystore: None,
-            wait_timeout: WAIT_TIMEOUT,
-            wait_retry_interval: WAIT_RETRY_INTERVAL,
-        }
     }
 }
 
@@ -289,7 +278,7 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let config = CastConfig::default();
-        assert_eq!(config.wait_timeout, WAIT_TIMEOUT);
-        assert_eq!(config.wait_retry_interval, WAIT_RETRY_INTERVAL);
+        assert_eq!(config.wait_params.get_timeout(), WAIT_TIMEOUT);
+        assert_eq!(config.wait_params.get_retry_interval(), WAIT_RETRY_INTERVAL);
     }
 }

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -30,6 +30,7 @@ use starknet::{
     signers::{LocalWallet, SigningKey},
 };
 
+use crate::helpers::constants::{WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
 use std::collections::HashMap;
 use std::thread::sleep;
 use std::time::Duration;
@@ -75,8 +76,54 @@ impl NumbersFormat {
 
 pub struct WaitForTx {
     pub wait: bool,
-    pub timeout: u16,
-    pub retry_interval: u8,
+    pub wait_params: ValidWaitParams,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, Copy, PartialEq)]
+pub struct ValidWaitParams {
+    timeout: u16,
+    retry_interval: u8,
+}
+
+impl ValidWaitParams {
+    #[must_use]
+    pub fn new(retry_interval: u8, timeout: u16) -> Self {
+        assert!(
+            !(retry_interval == 0 || timeout == 0 || u16::from(retry_interval) > timeout),
+            "Invalid values for retry_interval and/or timeout!"
+        );
+
+        Self {
+            timeout,
+            retry_interval,
+        }
+    }
+
+    #[must_use]
+    pub fn get_retries(&self) -> u16 {
+        self.timeout / u16::from(self.retry_interval)
+    }
+
+    #[must_use]
+    pub fn remaining_time(&self, steps_done: u16) -> u16 {
+        steps_done * u16::from(self.retry_interval)
+    }
+
+    #[must_use]
+    pub fn get_retry_interval(&self) -> u8 {
+        self.retry_interval
+    }
+
+    #[must_use]
+    pub fn get_timeout(&self) -> u16 {
+        self.timeout
+    }
+}
+
+impl Default for ValidWaitParams {
+    fn default() -> Self {
+        Self::new(WAIT_RETRY_INTERVAL, WAIT_TIMEOUT)
+    }
 }
 
 pub fn get_provider(url: &str) -> Result<JsonRpcClient<HttpTransport>> {
@@ -270,15 +317,11 @@ pub fn get_block_id(value: &str) -> Result<BlockId> {
 pub async fn wait_for_tx(
     provider: &JsonRpcClient<HttpTransport>,
     tx_hash: FieldElement,
-    timeout: u16,
-    retry_interval: u8,
+    wait_params: ValidWaitParams,
 ) -> Result<&str> {
     println!("Transaction hash = {tx_hash:#x}");
 
-    if retry_interval == 0 || timeout == 0 || u16::from(retry_interval) > timeout {
-        return Err(anyhow!("Invalid values for retry_interval and/or timeout!"));
-    }
-    let retries = timeout / u16::from(retry_interval);
+    let retries = wait_params.get_retries();
     for i in (1..retries).rev() {
         match provider.get_transaction_status(tx_hash).await {
             Ok(starknet::core::types::TransactionStatus::Rejected) => {
@@ -297,13 +340,13 @@ pub async fn wait_for_tx(
             },
             Ok(starknet::core::types::TransactionStatus::Received)
             | Err(StarknetError(TransactionHashNotFound)) => {
-                let remaining_time = i * u16::from(retry_interval);
+                let remaining_time = wait_params.remaining_time(i);
                 println!("Waiting for transaction to be accepted ({i} retries / {remaining_time}s left until timeout)");
             }
             Err(err) => return Err(err.into()),
         };
 
-        sleep(Duration::from_secs(retry_interval.into()));
+        sleep(Duration::from_secs(wait_params.get_retry_interval().into()));
     }
 
     Err(anyhow!(
@@ -382,14 +425,7 @@ pub async fn handle_wait_for_tx<T>(
     wait_config: WaitForTx,
 ) -> Result<T> {
     if wait_config.wait {
-        return match wait_for_tx(
-            provider,
-            transaction_hash,
-            wait_config.timeout,
-            wait_config.retry_interval,
-        )
-        .await
-        {
+        return match wait_for_tx(provider, transaction_hash, wait_config.wait_params).await {
             Ok(_) => Ok(return_value),
             Err(message) => Err(anyhow!(message)),
         };

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -76,16 +76,16 @@ impl NumbersFormat {
 
 pub struct WaitForTx {
     pub wait: bool,
-    pub wait_params: ValidWaitParams,
+    pub wait_params: ValidatedWaitParams,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Copy, PartialEq)]
-pub struct ValidWaitParams {
+pub struct ValidatedWaitParams {
     timeout: u16,
     retry_interval: u8,
 }
 
-impl ValidWaitParams {
+impl ValidatedWaitParams {
     #[must_use]
     pub fn new(retry_interval: u8, timeout: u16) -> Self {
         assert!(
@@ -120,7 +120,7 @@ impl ValidWaitParams {
     }
 }
 
-impl Default for ValidWaitParams {
+impl Default for ValidatedWaitParams {
     fn default() -> Self {
         Self::new(WAIT_RETRY_INTERVAL, WAIT_TIMEOUT)
     }
@@ -317,7 +317,7 @@ pub fn get_block_id(value: &str) -> Result<BlockId> {
 pub async fn wait_for_tx(
     provider: &JsonRpcClient<HttpTransport>,
     tx_hash: FieldElement,
-    wait_params: ValidWaitParams,
+    wait_params: ValidatedWaitParams,
 ) -> Result<&str> {
     println!("Transaction hash = {tx_hash:#x}");
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -17,7 +17,7 @@ use sncast::helpers::scarb_utils::{
 };
 use sncast::{
     chain_id_to_network_name, get_account, get_block_id, get_chain_id, get_nonce, get_provider,
-    NumbersFormat, ValidWaitParams, WaitForTx,
+    NumbersFormat, ValidatedWaitParams, WaitForTx,
 };
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
@@ -439,7 +439,7 @@ fn update_cast_config(config: &mut CastConfig, cli: &Cli) {
 
     config.accounts_file = Utf8PathBuf::from(shellexpand::tilde(&new_accounts_file).to_string());
 
-    config.wait_params = ValidWaitParams::new(
+    config.wait_params = ValidatedWaitParams::new(
         clone_or_else!(
             cli.wait_retry_interval,
             config.wait_params.get_retry_interval()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -17,7 +17,7 @@ use sncast::helpers::scarb_utils::{
 };
 use sncast::{
     chain_id_to_network_name, get_account, get_block_id, get_chain_id, get_nonce, get_provider,
-    NumbersFormat, WaitForTx,
+    NumbersFormat, ValidWaitParams, WaitForTx,
 };
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
@@ -174,9 +174,9 @@ async fn run_async_command(
 ) -> Result<()> {
     let wait_config = WaitForTx {
         wait: cli.wait,
-        timeout: config.wait_timeout,
-        retry_interval: config.wait_retry_interval,
+        wait_params: config.wait_params,
     };
+
     match cli.command {
         Commands::Declare(declare) => {
             let account = get_account(
@@ -439,7 +439,11 @@ fn update_cast_config(config: &mut CastConfig, cli: &Cli) {
 
     config.accounts_file = Utf8PathBuf::from(shellexpand::tilde(&new_accounts_file).to_string());
 
-    config.wait_timeout = clone_or_else!(cli.wait_timeout, config.wait_timeout);
-    config.wait_retry_interval =
-        clone_or_else!(cli.wait_retry_interval, config.wait_retry_interval);
+    config.wait_params = ValidWaitParams::new(
+        clone_or_else!(
+            cli.wait_retry_interval,
+            config.wait_params.get_retry_interval()
+        ),
+        clone_or_else!(cli.wait_timeout, config.wait_params.get_timeout()),
+    );
 }

--- a/crates/sncast/src/starknet_commands/script.rs
+++ b/crates/sncast/src/starknet_commands/script.rs
@@ -122,8 +122,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     self.artifacts,
                     WaitForTx {
                         wait: true,
-                        timeout: self.config.wait_timeout,
-                        retry_interval: self.config.wait_retry_interval,
+                        wait_params: self.config.wait_params,
                     },
                 ))?;
 
@@ -163,8 +162,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     nonce,
                     WaitForTx {
                         wait: true,
-                        timeout: self.config.wait_timeout,
-                        retry_interval: self.config.wait_retry_interval,
+                        wait_params: self.config.wait_params,
                     },
                 ))?;
 
@@ -203,8 +201,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     nonce,
                     WaitForTx {
                         wait: true,
-                        timeout: self.config.wait_timeout,
-                        retry_interval: self.config.wait_retry_interval,
+                        wait_params: self.config.wait_params,
                     },
                 ))?;
 

--- a/crates/sncast/src/starknet_commands/show_config.rs
+++ b/crates/sncast/src/starknet_commands/show_config.rs
@@ -27,8 +27,8 @@ pub async fn show_config(
     if keystore.is_some() {
         accounts_file_path = None;
     }
-    let wait_timeout = Some(cast_config.wait_timeout);
-    let wait_retry_interval = Some(cast_config.wait_retry_interval);
+    let wait_timeout = Some(cast_config.wait_params.get_timeout());
+    let wait_retry_interval = Some(cast_config.wait_params.get_retry_interval());
 
     Ok(ShowConfigResponse {
         profile,

--- a/crates/sncast/tests/integration/wait_for_tx.rs
+++ b/crates/sncast/tests/integration/wait_for_tx.rs
@@ -5,7 +5,7 @@ use crate::helpers::{
 use sncast::helpers::constants::UDC_ADDRESS;
 
 use camino::Utf8PathBuf;
-use sncast::{get_account, ValidWaitParams};
+use sncast::{get_account, ValidatedWaitParams};
 use sncast::{handle_wait_for_tx, parse_number, wait_for_tx, WaitForTx};
 use starknet::contract::ContractFactory;
 use starknet::core::types::FieldElement;
@@ -17,7 +17,7 @@ async fn test_happy_path() {
     let res = wait_for_tx(
         &provider,
         parse_number(&hash).unwrap(),
-        ValidWaitParams::default(),
+        ValidatedWaitParams::default(),
     )
     .await;
 
@@ -65,7 +65,7 @@ async fn test_wait_for_reverted_transaction() {
     .await
     .transaction_hash;
 
-    wait_for_tx(&provider, transaction_hash, ValidWaitParams::new(1, 3))
+    wait_for_tx(&provider, transaction_hash, ValidatedWaitParams::new(1, 3))
         .await
         .unwrap();
 }
@@ -79,7 +79,7 @@ async fn test_wait_for_nonexistent_tx() {
     wait_for_tx(
         &provider,
         parse_number("0x123456789").expect("Could not parse a number"),
-        ValidWaitParams::new(1, 3),
+        ValidatedWaitParams::new(1, 3),
     )
     .await
     .unwrap();
@@ -95,7 +95,7 @@ async fn test_happy_path_handle_wait_for_tx() {
         1,
         WaitForTx {
             wait: true,
-            wait_params: ValidWaitParams::new(5, 63),
+            wait_params: ValidatedWaitParams::new(5, 63),
         },
     )
     .await;
@@ -111,7 +111,7 @@ async fn test_wait_for_wrong_retry_values() {
     wait_for_tx(
         &provider,
         FieldElement::from_dec_str(&hash).unwrap(),
-        ValidWaitParams::new(2, 1),
+        ValidatedWaitParams::new(2, 1),
     )
     .await
     .unwrap();
@@ -125,7 +125,7 @@ async fn test_wait_for_wrong_retry_values_timeout_zero() {
     wait_for_tx(
         &provider,
         FieldElement::from_dec_str(&hash).unwrap(),
-        ValidWaitParams::new(2, 0),
+        ValidatedWaitParams::new(2, 0),
     )
     .await
     .unwrap();
@@ -139,7 +139,7 @@ async fn test_wait_for_wrong_retry_values_interval_zero() {
     wait_for_tx(
         &provider,
         FieldElement::from_dec_str(&hash).unwrap(),
-        ValidWaitParams::new(0, 1),
+        ValidatedWaitParams::new(0, 1),
     )
     .await
     .unwrap();

--- a/crates/sncast/tests/integration/wait_for_tx.rs
+++ b/crates/sncast/tests/integration/wait_for_tx.rs
@@ -5,10 +5,7 @@ use crate::helpers::{
 use sncast::helpers::constants::UDC_ADDRESS;
 
 use camino::Utf8PathBuf;
-use sncast::{
-    get_account,
-    helpers::constants::{WAIT_RETRY_INTERVAL, WAIT_TIMEOUT},
-};
+use sncast::{get_account, ValidWaitParams};
 use sncast::{handle_wait_for_tx, parse_number, wait_for_tx, WaitForTx};
 use starknet::contract::ContractFactory;
 use starknet::core::types::FieldElement;
@@ -20,8 +17,7 @@ async fn test_happy_path() {
     let res = wait_for_tx(
         &provider,
         parse_number(&hash).unwrap(),
-        WAIT_TIMEOUT,
-        WAIT_RETRY_INTERVAL,
+        ValidWaitParams::default(),
     )
     .await;
 
@@ -69,7 +65,7 @@ async fn test_wait_for_reverted_transaction() {
     .await
     .transaction_hash;
 
-    wait_for_tx(&provider, transaction_hash, 3, 1)
+    wait_for_tx(&provider, transaction_hash, ValidWaitParams::new(1, 3))
         .await
         .unwrap();
 }
@@ -83,8 +79,7 @@ async fn test_wait_for_nonexistent_tx() {
     wait_for_tx(
         &provider,
         parse_number("0x123456789").expect("Could not parse a number"),
-        3,
-        1,
+        ValidWaitParams::new(1, 3),
     )
     .await
     .unwrap();
@@ -100,8 +95,7 @@ async fn test_happy_path_handle_wait_for_tx() {
         1,
         WaitForTx {
             wait: true,
-            timeout: 63,
-            retry_interval: 5,
+            wait_params: ValidWaitParams::new(5, 63),
         },
     )
     .await;
@@ -114,9 +108,13 @@ async fn test_happy_path_handle_wait_for_tx() {
 async fn test_wait_for_wrong_retry_values() {
     let provider = create_test_provider();
     let hash = from_env("CAST_MAP_DECLARE_HASH").unwrap();
-    wait_for_tx(&provider, FieldElement::from_dec_str(&hash).unwrap(), 1, 2)
-        .await
-        .unwrap();
+    wait_for_tx(
+        &provider,
+        FieldElement::from_dec_str(&hash).unwrap(),
+        ValidWaitParams::new(2, 1),
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -124,9 +122,13 @@ async fn test_wait_for_wrong_retry_values() {
 async fn test_wait_for_wrong_retry_values_timeout_zero() {
     let provider = create_test_provider();
     let hash = from_env("CAST_MAP_DECLARE_HASH").unwrap();
-    wait_for_tx(&provider, FieldElement::from_dec_str(&hash).unwrap(), 0, 2)
-        .await
-        .unwrap();
+    wait_for_tx(
+        &provider,
+        FieldElement::from_dec_str(&hash).unwrap(),
+        ValidWaitParams::new(2, 0),
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -134,7 +136,11 @@ async fn test_wait_for_wrong_retry_values_timeout_zero() {
 async fn test_wait_for_wrong_retry_values_interval_zero() {
     let provider = create_test_provider();
     let hash = from_env("CAST_MAP_DECLARE_HASH").unwrap();
-    wait_for_tx(&provider, FieldElement::from_dec_str(&hash).unwrap(), 1, 0)
-        .await
-        .unwrap();
+    wait_for_tx(
+        &provider,
+        FieldElement::from_dec_str(&hash).unwrap(),
+        ValidWaitParams::new(0, 1),
+    )
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- ValidWaitParams::new ensures that wait_timeout and wait_retries are valid
- Created as a result of this discussion https://github.com/foundry-rs/starknet-foundry/pull/1710#discussion_r1490813951 

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
