### PR TITLE
`CallResult` in trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Added
+
+- result of the call to the trace
+
 ## [0.18.0] - 2024-02-21
 
 ### Forge
@@ -48,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
-- `map_string_error` for use with dispatchers, which automatically converts string errors from the syscall result (read more [here](https://foundry-rs.github.io/starknet-foundry/testing/contracts#handling-errors))
+- `map_string_error` for use with dispatchers, which automatically converts string errors from the syscall result (read
+  more [here](https://foundry-rs.github.io/starknet-foundry/testing/contracts#handling-errors))
 
 ## [0.17.0] - 2024-02-07
 
@@ -75,23 +82,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- sncast tool configuration is now moved away from `Scarb.toml` to `snfoundry.toml` file. This file must be present in current or any parent directories in order to use profiles.
+- sncast tool configuration is now moved away from `Scarb.toml` to `snfoundry.toml` file. This file must be present in
+  current or any parent directories in order to use profiles.
 
 #### Added
 
 - `--package` flag for `declare` and `script` subcommands, that specifies scarb package to work with
-- `Debug` and `Display` impls for script subcommand responses - use `print!`, `println!` macros instead of calling `.print()`
+- `Debug` and `Display` impls for script subcommand responses - use `print!`, `println!` macros instead of
+  calling `.print()`
 
 ## [0.16.0] - 2024-01-26
 
 ### Forge
 
 #### Added
+
 - Bump to cairo 2.5.0
 
 #### Changed
 
-- `SafeDispatcher`s usages need to be tagged with `#[feature("safe_dispatcher)]` (directly before usage), see [the shamans post](https://community.starknet.io/t/cairo-v2-5-0-is-out/112807#safe-dispatchers-15)
+- `SafeDispatcher`s usages need to be tagged with `#[feature("safe_dispatcher)]` (directly before usage),
+  see [the shamans post](https://community.starknet.io/t/cairo-v2-5-0-is-out/112807#safe-dispatchers-15)
 
 ## [0.15.0] - 2024-01-24
 
@@ -128,7 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - maximum number of computational steps per call set to current Starknet limit (3M)
-- `mean` and `std deviation` fields are displayed for gas usage while running fuzzing tests 
+- `mean` and `std deviation` fields are displayed for gas usage while running fuzzing tests
 - Cairo edition in `snforge_std` and `sncast_std` set to `2023_10`
 - `snforge_std::signature` module with `stark_curve`, `secp256k1_curve` and `secp256r1_curve` submodules
 
@@ -144,7 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `assert_not_emitted` assert to check if an event was not emitted
 
-#### Changed 
+#### Changed
 
 - fields from `starknet::info::v2::TxInfo` are now part of `TxInfoMock` from `snforge_std::cheatcodes::tx_info`
 - consistent latest block numbers for each url are now used across the whole run when testing against forks
@@ -155,7 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Cast
 
-#### Added 
+#### Added
 
 - add support for sepolia network
 - `--yes` option to `account delete` command that allows to skip confirmation prompt
@@ -171,7 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - Bump cairo to 2.4.0.
-- Migrated test compilation and collection to Scarb, snforge should now be compatible with every Scarb version >= 2.4.0 unless breaking changes happen
+- Migrated test compilation and collection to Scarb, snforge should now be compatible with every Scarb version >= 2.4.0
+  unless breaking changes happen
 
 ## [0.12.0] - 2023-12-06
 
@@ -180,17 +192,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - print gas usage for each test
-- Support for test collector built-in in Scarb with the `--use-scarb-collector` flag. Requires at least `nightly-2023-12-04` version of Scarb.
+- Support for test collector built-in in Scarb with the `--use-scarb-collector` flag. Requires at
+  least `nightly-2023-12-04` version of Scarb.
 
 ### Cast
 
 #### Added
 
 - `--wait-timeout` to set timeout for waiting for tx on network using `--wait` flag (default 60s)
-- `--wait-retry-interval` to adjust the time between consecutive attempts to fetch tx from network using `--wait` flag (default 5s)
+- `--wait-retry-interval` to adjust the time between consecutive attempts to fetch tx from network using `--wait` flag (
+  default 5s)
 - allow setting nonce in declare, deploy and invoke (using `--nonce` and in deployment scripts)
 - add `get_nonce` function to cast_std
-- `--private-key-file` option to `account add` command that allows to provide a path to the file holding account private key
+- `--private-key-file` option to `account add` command that allows to provide a path to the file holding account private
+  key
 
 ## [0.11.0] - 2023-11-22
 
@@ -202,9 +217,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--rerun-failed` option to run tests that failed during the last run.
 
 #### Changed
-- `start_warp` and `stop_warp` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/start_warp.md). 
-- `start_prank` and `stop_prank` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/start_prank.md).
-- `start_roll` and `stop_roll` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/start_roll.md).
+
+- `start_warp` and `stop_warp` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read
+  more [here](./docs/src/appendix/cheatcodes/start_warp.md).
+- `start_prank` and `stop_prank` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read
+  more [here](./docs/src/appendix/cheatcodes/start_prank.md).
+- `start_roll` and `stop_roll` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read
+  more [here](./docs/src/appendix/cheatcodes/start_roll.md).
 
 PS: Credits to @bllu404 for the help with the new interfaces for cheats!
 
@@ -228,7 +247,8 @@ PS: Credits to @bllu404 for the help with the new interfaces for cheats!
 
 #### Removed
 
-- `available_gas` attribute, it didn't compute correctly gas usage. Contract functions execution cost would not be included.
+- `available_gas` attribute, it didn't compute correctly gas usage. Contract functions execution cost would not be
+  included.
 
 ## [0.10.1] - 2023-11-09
 
@@ -279,17 +299,18 @@ PS: Credits to @bllu404 for the help with the new interfaces for cheats!
 
 #### Added
 
-- `#[ignore]` attribute together with `--ignored` and `include-ignored` flags - read more [here](https://foundry-rs.github.io/starknet-foundry/testing/testing.html#ignoring-some-tests-unless-specifically-requested)
+- `#[ignore]` attribute together with `--ignored` and `include-ignored` flags - read
+  more [here](https://foundry-rs.github.io/starknet-foundry/testing/testing.html#ignoring-some-tests-unless-specifically-requested)
 - support for `deploy_syscall` directly in the test code (alternative to `deploy`)
 - `snforge_std::signature` module for performing ecdsa signatures
 
 #### Changed
 
 - updated Cairo version to 2.3.0 - compatible Scarb version is 2.3.0:
-  - tests in `src` folder now have to be in a module annotated with `#[cfg(test)]`
+    - tests in `src` folder now have to be in a module annotated with `#[cfg(test)]`
 - `snforge_std::PrintTrait` will not convert values representing ASCII control characters to strings
-- separated `snforge` to subcommands: `snforge test`, `snforge init` and `snforge clean-cache`. 
-Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.html).
+- separated `snforge` to subcommands: `snforge test`, `snforge init` and `snforge clean-cache`.
+  Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.html).
 - `starknet::get_block_info` now returns correct block info in a forked block
 
 ### Cast
@@ -301,11 +322,12 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 - `--hex-format` flag has been added
 
 #### Removed
+
 - `-i` short for `--int-format` is removed, now have to use the full form `--int-format`
 
 ## [0.8.3] - 2023-10-17
 
-### Forge 
+### Forge
 
 #### Changed
 
@@ -322,12 +344,15 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 ### Forge
 
 #### Fixed
+
 - incorrect caller address bug
 
 ## [0.8.1] - 2023-10-12
+
 ### Forge
 
 #### Fixed
+
 - significantly reduced ram usage
 
 ## [0.8.0] - 2023-10-11
@@ -339,8 +364,10 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 - `#[fuzzer(...)]` attribute allowing to specify a fuzzer configuration for a single test case
 - Support for `u8`, `u16`, `u32`, `u64`, `u128`, `u256` types to fuzzer
 - `--clean-cache` flag
-- Changed interface of `L1Handler.execute` and `L1Handler` (dropped `fee` parameter, added result handling with `RevertedTransaction`)
-- Contract now has associated state, more about it [here](https://foundry-rs.github.io/starknet-foundry/testing/testing_contract_internals.html)
+- Changed interface of `L1Handler.execute` and `L1Handler` (dropped `fee` parameter, added result handling
+  with `RevertedTransaction`)
+- Contract now has associated state, more about
+  it [here](https://foundry-rs.github.io/starknet-foundry/testing/testing_contract_internals.html)
 - cheatcodes (`prank`, `roll`, `warp`) now work on forked Cairo 0 contracts
 
 #### Changed
@@ -348,14 +375,15 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 - Spying events interface is updated to enable the use of events defined inside contracts in assertions
 - Test are executed in parallel
 - Fixed inconsistent pointers bug https://github.com/foundry-rs/starknet-foundry/issues/659
-- Fixed an issue where `deploy_at` would not trigger the constructors https://github.com/foundry-rs/starknet-foundry/issues/805
+- Fixed an issue where `deploy_at` would not trigger the
+  constructors https://github.com/foundry-rs/starknet-foundry/issues/805
 
 ### Cast
 
 #### Changed
 
-- dropped official support for cairo 1 compiled contracts. While they still should be working without any problems, 
-from now on the only officially supported cairo compiler version is 2
+- dropped official support for cairo 1 compiled contracts. While they still should be working without any problems,
+  from now on the only officially supported cairo compiler version is 2
 
 ## [0.7.1] - 2023-09-27
 
@@ -366,7 +394,8 @@ from now on the only officially supported cairo compiler version is 2
 - `var` library function for reading environmental variables
 
 #### Fixed
-- Using any concrete `block_id` when using forking mode, would lead to crashes 
+
+- Using any concrete `block_id` when using forking mode, would lead to crashes
 
 ## [0.7.0] - 2023-09-27
 
@@ -381,8 +410,10 @@ from now on the only officially supported cairo compiler version is 2
 #### Changed
 
 - Tests are collected only from a package tree (`src/lib.cairo` as an entrypoint) and `tests` folder:
-  - If there is a `lib.cairo` file in `tests` folder, then it is treated as an entrypoint to the `tests` package from which tests are collected
-  - Otherwise, all test files matching `tests/*.cairo` regex are treated as modules and added to a single virtual `lib.cairo`, which is treated as described above
+    - If there is a `lib.cairo` file in `tests` folder, then it is treated as an entrypoint to the `tests` package from
+      which tests are collected
+    - Otherwise, all test files matching `tests/*.cairo` regex are treated as modules and added to a single
+      virtual `lib.cairo`, which is treated as described above
 
 ### Cast
 
@@ -431,7 +462,8 @@ from now on the only officially supported cairo compiler version is 2
 
 - support for `keccak_syscall` syscall. It can be used directly in cairo tests
 - `l1_handler_execute` cheatcode
-- support for `roll`ing/`warp`ing/`prank`ing the constructor logic (precalculate address, prank, assert pranked state in constructor)
+- support for `roll`ing/`warp`ing/`prank`ing the constructor logic (precalculate address, prank, assert pranked state in
+  constructor)
 - `spy_events` cheatcode
 - Functions `read_json` and `FileParser<T>::parse_json` to load data from json files and deserialize it
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -138,7 +138,12 @@ pub fn execute_call_entry_point(
         resources,
         CallResult::from_execution_result(
             &result,
-            &AddressOrClassHash::build(entry_point.code_address, entry_point.class_hash),
+            &match entry_point.call_type {
+                CallType::Call => AddressOrClassHash::ContractAddress(entry_point.storage_address),
+                CallType::Delegate => {
+                    AddressOrClassHash::ClassHash(entry_point.class_hash.unwrap())
+                }
+            },
         ),
     );
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -82,9 +82,9 @@ pub fn execute_call_entry_point(
     // Hack to prevent version 0 attack on argent accounts.
     if context.account_tx_context.version() == TransactionVersion(StarkFelt::from(0_u8))
         && class_hash
-        == ClassHash(
-        StarkFelt::try_from(FAULTY_CLASS_HASH).expect("A class hash must be a felt."),
-    )
+            == ClassHash(
+                StarkFelt::try_from(FAULTY_CLASS_HASH).expect("A class hash must be a felt."),
+            )
     {
         return Err(PreExecutionError::FraudAttempt.into());
     }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -134,17 +134,13 @@ pub fn execute_call_entry_point(
         }
     });
 
+    let identifier = match entry_point.call_type {
+        CallType::Call => AddressOrClassHash::ContractAddress(entry_point.storage_address),
+        CallType::Delegate => AddressOrClassHash::ClassHash(entry_point.class_hash.unwrap()),
+    };
     runtime_state.cheatnet_state.trace_data.exit_nested_call(
         resources,
-        CallResult::from_execution_result(
-            &result,
-            &match entry_point.call_type {
-                CallType::Call => AddressOrClassHash::ContractAddress(entry_point.storage_address),
-                CallType::Delegate => {
-                    AddressOrClassHash::ClassHash(entry_point.class_hash.unwrap())
-                }
-            },
-        ),
+        CallResult::from_execution_result(&result, &identifier),
     );
 
     result

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -85,6 +85,22 @@ pub enum AddressOrClassHash {
     ClassHash(ClassHash),
 }
 
+impl AddressOrClassHash {
+    #[must_use]
+    pub fn build(
+        maybe_address: Option<ContractAddress>,
+        maybe_class_hash: Option<ClassHash>,
+    ) -> Self {
+        match maybe_address {
+            None => match maybe_class_hash {
+                None => Self::ClassHash(ClassHash::default()),
+                Some(class_hash) => Self::ClassHash(class_hash),
+            },
+            Some(address) => Self::ContractAddress(address),
+        }
+    }
+}
+
 impl CallFailure {
     /// Maps blockifier-type error, to one that can be put into memory as panic-data (or re-raised)
     #[must_use]
@@ -171,7 +187,8 @@ impl CallFailure {
 }
 
 impl CallResult {
-    fn from_execution_result(
+    #[must_use]
+    pub fn from_execution_result(
         result: &EntryPointExecutionResult<CallInfo>,
         starknet_identifier: &AddressOrClassHash,
     ) -> Self {
@@ -240,10 +257,6 @@ pub fn call_entry_point(
     );
 
     let result = CallResult::from_execution_result(&exec_result, starknet_identifier);
-    runtime_state
-        .cheatnet_state
-        .trace_data
-        .add_result_to_last_call(&result);
 
     if let Ok(call_info) = exec_result {
         syscall_handler.inner_calls.push(call_info);

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -85,22 +85,6 @@ pub enum AddressOrClassHash {
     ClassHash(ClassHash),
 }
 
-impl AddressOrClassHash {
-    #[must_use]
-    pub fn build(
-        maybe_address: Option<ContractAddress>,
-        maybe_class_hash: Option<ClassHash>,
-    ) -> Self {
-        match maybe_address {
-            None => match maybe_class_hash {
-                None => Self::ClassHash(ClassHash::default()),
-                Some(class_hash) => Self::ClassHash(class_hash),
-            },
-            Some(address) => Self::ContractAddress(address),
-        }
-    }
-}
-
 impl CallFailure {
     /// Maps blockifier-type error, to one that can be put into memory as panic-data (or re-raised)
     #[must_use]

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -525,31 +525,31 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     match curve.as_deref() {
                         Some("Secp256k1") => {
                             let Ok(signing_key) = k256::ecdsa::SigningKey::from_slice(&secret_key)
-                                else {
-                                    return Ok(handle_cheatcode_error("invalid secret_key"));
-                                };
+                            else {
+                                return Ok(handle_cheatcode_error("invalid secret_key"));
+                            };
 
                             let signature: k256::ecdsa::Signature =
                                 k256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                    .unwrap();
+                                .unwrap();
 
                             signature.split_bytes()
                         }
                         Some("Secp256r1") => {
                             let Ok(signing_key) = p256::ecdsa::SigningKey::from_slice(&secret_key)
-                                else {
-                                    return Ok(handle_cheatcode_error("invalid secret_key"));
-                                };
+                            else {
+                                return Ok(handle_cheatcode_error("invalid secret_key"));
+                            };
 
                             let signature: p256::ecdsa::Signature =
                                 p256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                    .unwrap();
+                                .unwrap();
 
                             signature.split_bytes()
                         }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -698,7 +698,7 @@ fn serialize_call_result(call_result: &CallResult) -> Vec<Felt252> {
         CallResult::Success { ret_data } => {
             output.push(Felt252::from(0));
             output.push(Felt252::from(ret_data.len()));
-            output.extend(ret_data.clone());
+            output.extend(ret_data.iter().cloned());
         }
         CallResult::Failure(call_failure) => {
             let (call_failure_variant, failure_data) = match call_failure {

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -526,31 +526,31 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     match curve.as_deref() {
                         Some("Secp256k1") => {
                             let Ok(signing_key) = k256::ecdsa::SigningKey::from_slice(&secret_key)
-                                else {
-                                    return Ok(handle_cheatcode_error("invalid secret_key"));
-                                };
+                            else {
+                                return Ok(handle_cheatcode_error("invalid secret_key"));
+                            };
 
                             let signature: k256::ecdsa::Signature =
                                 k256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                    .unwrap();
+                                .unwrap();
 
                             signature.split_bytes()
                         }
                         Some("Secp256r1") => {
                             let Ok(signing_key) = p256::ecdsa::SigningKey::from_slice(&secret_key)
-                                else {
-                                    return Ok(handle_cheatcode_error("invalid secret_key"));
-                                };
+                            else {
+                                return Ok(handle_cheatcode_error("invalid secret_key"));
+                            };
 
                             let signature: p256::ecdsa::Signature =
                                 p256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                    .unwrap();
+                                .unwrap();
 
                             signature.split_bytes()
                         }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -703,11 +703,7 @@ fn serialize_call_result(call_result: &CallResult) -> Vec<Felt252> {
         CallResult::Failure(call_failure) => {
             let (call_failure_variant, failure_data) = match call_failure {
                 CallFailure::Panic { panic_data } => (0, panic_data.clone()),
-                CallFailure::Error { msg } => {
-                    let converted_string: ByteArray = ByteArray::from(msg.clone());
-
-                    (1, converted_string.serialize())
-                }
+                CallFailure::Error { msg } => (1, ByteArray::from(msg.clone()).serialize()),
             };
 
             output.push(Felt252::from(1));

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -525,31 +525,31 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     match curve.as_deref() {
                         Some("Secp256k1") => {
                             let Ok(signing_key) = k256::ecdsa::SigningKey::from_slice(&secret_key)
-                            else {
-                                return Ok(handle_cheatcode_error("invalid secret_key"));
-                            };
+                                else {
+                                    return Ok(handle_cheatcode_error("invalid secret_key"));
+                                };
 
                             let signature: k256::ecdsa::Signature =
                                 k256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                .unwrap();
+                                    .unwrap();
 
                             signature.split_bytes()
                         }
                         Some("Secp256r1") => {
                             let Ok(signing_key) = p256::ecdsa::SigningKey::from_slice(&secret_key)
-                            else {
-                                return Ok(handle_cheatcode_error("invalid secret_key"));
-                            };
+                                else {
+                                    return Ok(handle_cheatcode_error("invalid secret_key"));
+                                };
 
                             let signature: p256::ecdsa::Signature =
                                 p256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
                                     &signing_key,
                                     &msg_hash,
                                 )
-                                .unwrap();
+                                    .unwrap();
 
                             signature.split_bytes()
                         }
@@ -653,6 +653,8 @@ fn serialize_call_trace(call_trace: &CallTrace) -> Vec<Felt252> {
         output.append(&mut serialize_call_trace(&call_trace.borrow()));
     }
 
+    output.append(&mut serialize_call_result(&call_trace.result));
+
     output
 }
 
@@ -684,6 +686,20 @@ fn serialize_call_entry_point(call_entry_point: &CallEntryPoint) -> Vec<Felt252>
     output.push(call_entry_point.storage_address.into_());
     output.push(call_entry_point.caller_address.into_());
     output.push(Felt252::from(call_type));
+
+    output
+}
+
+fn serialize_call_result(call_result: &CallResult) -> Vec<Felt252> {
+    let (call_result_variant, ret_data) = match call_result {
+        CallResult::Success { ret_data } => (0, ret_data.clone()),
+        CallResult::Failure(_) => (1, vec![]),
+    };
+
+    let mut output = vec![];
+    output.push(Felt252::from(call_result_variant));
+    output.push(Felt252::from(ret_data.len()));
+    output.extend(ret_data);
 
     output
 }

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -333,27 +333,20 @@ impl TraceData {
         current_call.borrow_mut().entry_point.class_hash = Some(class_hash);
     }
 
-    pub fn exit_nested_call(&mut self, resources_used_after_call: &ExecutionResources) {
+    pub fn exit_nested_call(
+        &mut self,
+        resources_used_after_call: &ExecutionResources,
+        call_result: CallResult,
+    ) {
         let CallStackElement {
             resources_used_before_call,
             call_trace: last_call,
         } = self.current_call_stack.pop();
 
-        last_call.borrow_mut().used_execution_resources =
+        let mut last_call = last_call.borrow_mut();
+        last_call.used_execution_resources =
             subtract_execution_resources(resources_used_after_call, &resources_used_before_call);
-    }
-
-    pub fn add_result_to_last_call(&mut self, call_result: &CallResult) {
-        let binding = self.current_call_stack.top();
-        let mut last_call = binding.borrow_mut();
-        if last_call.nested_calls.is_empty() {
-            last_call.result = call_result.clone();
-            return;
-        }
-
-        last_call.nested_calls[last_call.nested_calls.len() - 1]
-            .borrow_mut()
-            .result = call_result.clone();
+        last_call.result = call_result;
     }
 }
 

--- a/crates/forge-runner/src/trace_data.rs
+++ b/crates/forge-runner/src/trace_data.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use blockifier::execution::entry_point::{CallEntryPoint, CallType, ExecutionResources};
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use cheatnet::constants::{TEST_CONTRACT_CLASS_HASH, TEST_ENTRY_POINT_SELECTOR};
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
 use cheatnet::state::CallTrace;
 use conversions::IntoConv;
 use serde::{Deserialize, Serialize};
@@ -33,6 +34,7 @@ pub struct ProfilerCallTrace {
     // These also include resources used by internal calls
     pub used_execution_resources: ProfilerExecutionResources,
     pub nested_calls: Vec<ProfilerCallTrace>,
+    pub result: CallResult,
 }
 
 impl ProfilerCallTrace {
@@ -48,6 +50,7 @@ impl ProfilerCallTrace {
                 .into_iter()
                 .map(|c| ProfilerCallTrace::from_call_trace(c.borrow().clone(), contracts_data))
                 .collect(),
+            result: value.result,
         }
     }
 }

--- a/crates/forge-runner/src/trace_data.rs
+++ b/crates/forge-runner/src/trace_data.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 use blockifier::execution::entry_point::{CallEntryPoint, CallType, ExecutionResources};
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources as VmExecutionResources;
 use cheatnet::constants::{TEST_CONTRACT_CLASS_HASH, TEST_ENTRY_POINT_SELECTOR};
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
 use cheatnet::state::CallTrace;
 use conversions::IntoConv;
 use serde::{Deserialize, Serialize};
@@ -34,7 +33,6 @@ pub struct ProfilerCallTrace {
     // These also include resources used by internal calls
     pub used_execution_resources: ProfilerExecutionResources,
     pub nested_calls: Vec<ProfilerCallTrace>,
-    pub result: CallResult,
 }
 
 impl ProfilerCallTrace {
@@ -50,7 +48,6 @@ impl ProfilerCallTrace {
                 .into_iter()
                 .map(|c| ProfilerCallTrace::from_call_trace(c.borrow().clone(), contracts_data))
                 .collect(),
-            result: value.result,
         }
     }
 }

--- a/crates/forge/tests/data/trace/src/lib.cairo
+++ b/crates/forge/tests/data/trace/src/lib.cairo
@@ -11,6 +11,11 @@ trait RecursiveCaller<T> {
     fn execute_calls(self: @T, calls: Array<RecursiveCall>);
 }
 
+#[starknet::interface]
+trait Failing<TContractState> {
+    fn fail(self: @TContractState, data: Array<felt252>);
+}
+
 #[starknet::contract]
 mod SimpleContract {
     use core::array::ArrayTrait;
@@ -18,7 +23,8 @@ mod SimpleContract {
     use starknet::ContractAddress;
     use starknet::get_contract_address;
     use super::{
-        RecursiveCaller, RecursiveCallerDispatcher, RecursiveCallerDispatcherTrait, RecursiveCall
+        RecursiveCaller, RecursiveCallerDispatcher, RecursiveCallerDispatcherTrait, RecursiveCall,
+        Failing
     };
 
 
@@ -38,6 +44,13 @@ mod SimpleContract {
                     .execute_calls(serviced_call.payload.clone());
                 i = i + 1;
             }
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl FailingImpl of Failing<ContractState> {
+        fn fail(self: @ContractState, data: Array<felt252>) {
+            panic(data);
         }
     }
 }

--- a/crates/forge/tests/data/trace/tests/test_trace.cairo
+++ b/crates/forge/tests/data/trace/tests/test_trace.cairo
@@ -1,7 +1,10 @@
 use snforge_std::{declare, ContractClassTrait};
 use snforge_std::trace::{get_call_trace};
 
-use trace_info::{RecursiveCallerDispatcher, RecursiveCallerDispatcherTrait, RecursiveCall};
+use trace_info::{
+    RecursiveCallerDispatcher, RecursiveCallerDispatcherTrait, RecursiveCall, FailingSafeDispatcher,
+    FailingSafeDispatcherTrait
+};
 
 #[test]
 fn test_trace_print() {
@@ -23,6 +26,13 @@ fn test_trace_print() {
     ];
 
     RecursiveCallerDispatcher { contract_address: contract_address_A }.execute_calls(calls);
+
+    let failing_dispatcher = FailingSafeDispatcher { contract_address: contract_address_A };
+    #[feature("safe_dispatcher")]
+    match failing_dispatcher.fail(array![1, 2, 3, 4, 5]) {
+        Result::Ok(_) => panic_with_felt252('shouldve panicked'),
+        Result::Err(panic_data) => { assert(panic_data == array![1, 2, 3, 4, 5], ''); }
+    }
 
     println!("{}", get_call_trace());
 }

--- a/crates/forge/tests/e2e/trace_print.rs
+++ b/crates/forge/tests/e2e/trace_print.rs
@@ -76,6 +76,16 @@ fn trace_info_print() {
                     )
                 ]
                 Call Result: Success: []
+            ),
+            (
+                Entry point type: External
+                Selector: 1423007881864269398513176851135908567621420218646181695002463829511917924133
+                Calldata: [5, 1, 2, 3, 4, 5]
+                Storage address: 3447179351737797591242797233952749538061496839896319750579571119352735823363
+                Caller address: 469394814521890341860918960550914
+                Call type: Call
+                Nested Calls: []
+                Call Result: Failure: [1, 2, 3, 4, 5]
             )
         ]
         Call Result: Success: []

--- a/crates/forge/tests/e2e/trace_print.rs
+++ b/crates/forge/tests/e2e/trace_print.rs
@@ -49,6 +49,7 @@ fn trace_info_print() {
                                 Caller address: [..]
                                 Call type: Call
                                 Nested Calls: []
+                                Call Result: Success: []
                             ),
                             (
                                 Entry point type: External
@@ -58,8 +59,10 @@ fn trace_info_print() {
                                 Caller address: [..]
                                 Call type: Call
                                 Nested Calls: []
+                                Call Result: Success: []
                             )
                         ]
+                        Call Result: Success: []
                     ),
                     (
                         Entry point type: External
@@ -69,10 +72,13 @@ fn trace_info_print() {
                         Caller address: [..]
                         Call type: Call
                         Nested Calls: []
+                        Call Result: Success: []
                     )
                 ]
+                Call Result: Success: []
             )
         ]
+        Call Result: Success: []
         
         [PASS] tests::test_trace::test_trace_print (gas: [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out

--- a/crates/forge/tests/integration/trace.rs
+++ b/crates/forge/tests/integration/trace.rs
@@ -32,7 +32,7 @@ fn trace_deploy() {
                 let proxy_address_3 = proxy
                     .deploy_at(@array![checker_address.into()], 123.try_into().unwrap())
                     .unwrap();
-                                
+                    
                 assert_trace(
                     get_call_trace(), proxy_address1, proxy_address2, proxy_address_3, checker_address
                 );
@@ -75,7 +75,7 @@ fn trace_deploy() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 }
                             ],
                             result: CallResult::Success(array![])
@@ -100,7 +100,7 @@ fn trace_deploy() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 }
                             ],
                             result: CallResult::Success(array![])
@@ -125,7 +125,7 @@ fn trace_deploy() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 }
                             ],
                             result: CallResult::Success(array![])
@@ -203,7 +203,7 @@ fn trace_call() {
             
                 let chcecker_dispatcher = ITraceInfoCheckerDispatcher { contract_address: checker_address };
                 chcecker_dispatcher.from_proxy(4);
-                            
+                
                 assert_trace(
                     get_call_trace(), proxy_address, checker_address, dummy_address, checker.class_hash
                 );
@@ -246,7 +246,7 @@ fn trace_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 },
                             ],
                             result: CallResult::Success(array![])
@@ -271,7 +271,7 @@ fn trace_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![102])
                                 }
                             ],
                             result: CallResult::Success(array![102])
@@ -296,7 +296,7 @@ fn trace_call() {
                                         call_type: CallType::Delegate,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![103])
                                 }
                             ],
                             result: CallResult::Success(array![103])
@@ -321,7 +321,7 @@ fn trace_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![142])
                                 },
                                 CallTrace {
                                     entry_point: CallEntryPoint {
@@ -464,7 +464,7 @@ fn trace_failed_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 },
                             ],
                             result: CallResult::Success(array![])
@@ -489,7 +489,7 @@ fn trace_failed_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                                 }
                             ],
                             result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
@@ -621,7 +621,7 @@ fn trace_library_call_from_test() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![102])
                                 }
                             ],
                             result: CallResult::Success(array![102])
@@ -646,7 +646,7 @@ fn trace_library_call_from_test() {
                                         call_type: CallType::Delegate,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![103])
                                 }
                             ],
                             result: CallResult::Success(array![103])
@@ -671,7 +671,7 @@ fn trace_library_call_from_test() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![142])
                                 },
                                 CallTrace {
                                     entry_point: CallEntryPoint {
@@ -814,7 +814,7 @@ fn trace_failed_library_call_from_test() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 },
                             ],
                             result: CallResult::Success(array![])
@@ -839,7 +839,7 @@ fn trace_failed_library_call_from_test() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                                 }
                             ],
                             result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
@@ -942,7 +942,7 @@ fn trace_l1_handler() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![101])
                                 }
                             ],
                             result: CallResult::Success(array![])
@@ -977,10 +977,10 @@ fn trace_l1_handler() {
                                                 call_type: CallType::Call,
                                             },
                                             nested_calls: array![],
-                                            result: CallResult::Success(array![])
+                                            result: CallResult::Success(array![102])
                                         }
                                     ],
-                                    result: CallResult::Success(array![])
+                                    result: CallResult::Success(array![102])
                                 }
                             ],
                             result: CallResult::Success(array![102])

--- a/crates/forge/tests/integration/trace.rs
+++ b/crates/forge/tests/integration/trace.rs
@@ -11,7 +11,7 @@ fn trace_deploy() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
             
             use starknet::{SyscallResultTrait, deploy_syscall, ContractAddress};
             
@@ -32,7 +32,7 @@ fn trace_deploy() {
                 let proxy_address_3 = proxy
                     .deploy_at(@array![checker_address.into()], 123.try_into().unwrap())
                     .unwrap();
-            
+                                
                 assert_trace(
                     get_call_trace(), proxy_address1, proxy_address2, proxy_address_3, checker_address
                 );
@@ -74,9 +74,11 @@ fn trace_deploy() {
                                         caller_address: proxy_address1,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
                             ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -97,9 +99,11 @@ fn trace_deploy() {
                                         caller_address: proxy_address2,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
                             ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -120,11 +124,14 @@ fn trace_deploy() {
                                         caller_address: proxy_address3,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
                             ],
+                            result: CallResult::Success(array![])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(trace == expected_trace, '');
@@ -155,7 +162,7 @@ fn trace_call() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector, start_prank, CheatTarget};
-            use snforge_std::trace::{CallTrace, CallEntryPoint, CallType, EntryPointType, get_call_trace};
+            use snforge_std::trace::{CallTrace, CallEntryPoint, CallType, EntryPointType, get_call_trace, CallResult};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -196,7 +203,7 @@ fn trace_call() {
             
                 let chcecker_dispatcher = ITraceInfoCheckerDispatcher { contract_address: checker_address };
                 chcecker_dispatcher.from_proxy(4);
-            
+                            
                 assert_trace(
                     get_call_trace(), proxy_address, checker_address, dummy_address, checker.class_hash
                 );
@@ -239,8 +246,10 @@ fn trace_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 },
-                            ]
+                            ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -261,9 +270,11 @@ fn trace_call() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![102])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -284,9 +295,11 @@ fn trace_call() {
                                         caller_address: test_address(),
                                         call_type: CallType::Delegate,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![103])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -307,7 +320,8 @@ fn trace_call() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 },
                                 CallTrace {
                                     entry_point: CallEntryPoint {
@@ -318,9 +332,11 @@ fn trace_call() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -331,9 +347,11 @@ fn trace_call() {
                                 caller_address: test_address(),
                                 call_type: CallType::Call,
                             },
-                            nested_calls: array![]
+                            nested_calls: array![],
+                            result: CallResult::Success(array![104])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(expected == trace, '');
@@ -369,7 +387,7 @@ fn trace_failed_call() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -409,7 +427,7 @@ fn trace_failed_call() {
                     Result::Ok(_) => panic_with_felt252('shouldve panicked'),
                     Result::Err(panic_data) => { assert(*panic_data.at(0) == 'panic', *panic_data.at(0)); }
                 }
-            
+                
                 assert_trace(get_call_trace(), proxy_address, checker_address);
             }
             
@@ -446,8 +464,10 @@ fn trace_failed_call() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 },
-                            ]
+                            ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -468,9 +488,11 @@ fn trace_failed_call() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Failure(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -481,9 +503,11 @@ fn trace_failed_call() {
                                 caller_address: test_address(),
                                 call_type: CallType::Call,
                             },
-                            nested_calls: array![]
+                            nested_calls: array![],
+                            result: CallResult::Failure(array![])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(expected == trace, '');
@@ -514,7 +538,7 @@ fn trace_library_call_from_test() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -557,7 +581,7 @@ fn trace_library_call_from_test() {
                 };
             
                 chcecker_lib_dispatcher.from_proxy(4);
-            
+                
                 assert_trace(get_call_trace(), checker_address, dummy_address, checker.class_hash);
             }
             
@@ -596,9 +620,11 @@ fn trace_library_call_from_test() {
                                         caller_address: test_address(),
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![102])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -619,9 +645,11 @@ fn trace_library_call_from_test() {
                                         caller_address: 0.try_into().unwrap(),
                                         call_type: CallType::Delegate,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![103])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -642,7 +670,8 @@ fn trace_library_call_from_test() {
                                         caller_address: test_address(),
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 },
                                 CallTrace {
                                     entry_point: CallEntryPoint {
@@ -653,9 +682,11 @@ fn trace_library_call_from_test() {
                                         caller_address: test_address(),
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -666,9 +697,11 @@ fn trace_library_call_from_test() {
                                 caller_address: 0.try_into().unwrap(),
                                 call_type: CallType::Delegate,
                             },
-                            nested_calls: array![]
+                            nested_calls: array![],
+                            result: CallResult::Success(array![104])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(expected == trace, '');
@@ -704,7 +737,7 @@ fn trace_failed_library_call_from_test() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -744,7 +777,7 @@ fn trace_failed_library_call_from_test() {
                     Result::Ok(_) => panic_with_felt252('shouldve panicked'),
                     Result::Err(panic_data) => { assert(*panic_data.at(0) == 'panic', *panic_data.at(0)); }
                 }
-            
+                            
                 assert_trace(get_call_trace(), proxy_address, checker_address);
             }
             
@@ -781,8 +814,10 @@ fn trace_failed_library_call_from_test() {
                                         call_type: CallType::Call,
                                     },
                                     nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 },
-                            ]
+                            ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -803,9 +838,11 @@ fn trace_failed_library_call_from_test() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Failure(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -816,9 +853,11 @@ fn trace_failed_library_call_from_test() {
                                 caller_address: test_address(),
                                 call_type: CallType::Call,
                             },
-                            nested_calls: array![]
+                            nested_calls: array![],
+                            result: CallResult::Failure(array![])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(expected == trace, '');
@@ -849,7 +888,7 @@ fn trace_l1_handler() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector, L1HandlerTrait,};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
             
             use starknet::ContractAddress;
             
@@ -902,9 +941,11 @@ fn trace_l1_handler() {
                                         caller_address: proxy_address,
                                         call_type: CallType::Call,
                                     },
-                                    nested_calls: array![]
+                                    nested_calls: array![],
+                                    result: CallResult::Success(array![])
                                 }
                             ],
+                            result: CallResult::Success(array![])
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -935,13 +976,17 @@ fn trace_l1_handler() {
                                                 caller_address: proxy_address,
                                                 call_type: CallType::Call,
                                             },
-                                            nested_calls: array![]
+                                            nested_calls: array![],
+                                            result: CallResult::Success(array![])
                                         }
-                                    ]
+                                    ],
+                                    result: CallResult::Success(array![])
                                 }
-                            ]
+                            ],
+                            result: CallResult::Success(array![102])
                         }
-                    ]
+                    ],
+                    result: CallResult::Success(array![])
                 };
             
                 assert(trace == expected_trace, '');

--- a/crates/forge/tests/integration/trace.rs
+++ b/crates/forge/tests/integration/trace.rs
@@ -387,7 +387,7 @@ fn trace_failed_call() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult, CallFailure};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -492,7 +492,7 @@ fn trace_failed_call() {
                                     result: CallResult::Success(array![])
                                 }
                             ],
-                            result: CallResult::Failure(array![])
+                            result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -504,7 +504,7 @@ fn trace_failed_call() {
                                 call_type: CallType::Call,
                             },
                             nested_calls: array![],
-                            result: CallResult::Failure(array![])
+                            result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                         }
                     ],
                     result: CallResult::Success(array![])
@@ -737,7 +737,7 @@ fn trace_failed_library_call_from_test() {
         indoc!(
             r#"
             use snforge_std::{declare, ContractClassTrait, test_address, test_selector};
-            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult};
+            use snforge_std::trace::{CallEntryPoint, CallType, EntryPointType, get_call_trace, CallTrace, CallResult, CallFailure};
             
             use starknet::{ContractAddress, ClassHash};
             
@@ -777,7 +777,7 @@ fn trace_failed_library_call_from_test() {
                     Result::Ok(_) => panic_with_felt252('shouldve panicked'),
                     Result::Err(panic_data) => { assert(*panic_data.at(0) == 'panic', *panic_data.at(0)); }
                 }
-                            
+                
                 assert_trace(get_call_trace(), proxy_address, checker_address);
             }
             
@@ -842,7 +842,7 @@ fn trace_failed_library_call_from_test() {
                                     result: CallResult::Success(array![])
                                 }
                             ],
-                            result: CallResult::Failure(array![])
+                            result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                         },
                         CallTrace {
                             entry_point: CallEntryPoint {
@@ -854,7 +854,7 @@ fn trace_failed_library_call_from_test() {
                                 call_type: CallType::Call,
                             },
                             nested_calls: array![],
-                            result: CallResult::Failure(array![])
+                            result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
                         }
                     ],
                     result: CallResult::Success(array![])

--- a/docs/src/appendix/snforge-library/get_call_trace.md
+++ b/docs/src/appendix/snforge-library/get_call_trace.md
@@ -4,11 +4,13 @@
 fn get_call_trace() -> CallTrace;
 ```
 
-(For whole structure definition, please refer to [`snforge-std` source](https://github.com/foundry-rs/starknet-foundry/tree/v0.16.0/snforge_std))
+(For whole structure definition, please refer
+to [`snforge-std` source](https://github.com/foundry-rs/starknet-foundry/tree/v0.16.0/snforge_std))
 
 Gets current call trace of the test, up to the last call made to a contract.
 
 ## Example call trace
+
 ```cairo
 use snforge_std::trace::{CallTrace, CallEntryPoint, CallType, EntryPointType, get_call_trace};
 ...
@@ -42,9 +44,11 @@ let ctrace = CallTrace {
                         caller_address: 123.try_into().unwrap(),
                         call_type: CallType::Call,
                     },
-                    nested_calls: array![]
+                    nested_calls: array![],
+                    result: CallResult::Success(array![101])
                 }
             ],
+            result: CallResult::Success(array![])
         },
         CallTrace {
             entry_point: CallEntryPoint {
@@ -55,7 +59,8 @@ let ctrace = CallTrace {
                 caller_address: 0.try_into().unwrap(),
                 call_type: CallType::Call,
             },
-            nested_calls: array![]
+            nested_calls: array![],
+            result: CallResult::Failure(CallFailure::Panic(array![482670963043]))
         }
     ]
 };
@@ -64,7 +69,9 @@ let ctrace = CallTrace {
 The topmost-call is representing the test call, which will always be present if you're running a test.
 It can have nested `CallTrace` - it's an array of subsequent traces made in scope of the call.
 
-The whole structure is represented as a tree of calls, in which each contract interaction (`constructor` call, `l1_handler` call, library or a regular contract `call` via dispatcher) is a new execution scope - thus resulting in a new nested trace.
+The whole structure is represented as a tree of calls, in which each contract interaction (`constructor`
+call, `l1_handler` call, library or a regular contract `call` via dispatcher) is a new execution scope - thus resulting
+in a new nested trace.
 
 ## Displaying the trace
 
@@ -96,8 +103,10 @@ println!("{}", get_call_trace());
 //                   Caller address: [..]
 //                   Call type: Call
 //                   Nested Calls: []
+//                   Call Result: Success: [101]
 //               )
 //           ]
+//           Call Result: Success: []
 //       )
 //   ]
 ```

--- a/snforge_std/src/trace.cairo
+++ b/snforge_std/src/trace.cairo
@@ -35,7 +35,13 @@ enum CallType {
 #[derive(Drop, Serde, PartialEq)]
 enum CallResult {
     Success: Array<felt252>,
-    Failure: Array<felt252>
+    Failure: CallFailure
+}
+
+#[derive(Drop, Serde, PartialEq)]
+enum CallFailure {
+    Panic: Array<felt252>,
+    Error: ByteArray
 }
 
 fn get_call_trace() -> CallTrace {
@@ -52,9 +58,17 @@ impl DisplayCallResult of Display<CallResult> {
                 write!(f, "Success: ")?;
                 Debug::fmt(val, ref f)?;
             },
-            CallResult::Failure(val) => {
+            CallResult::Failure(call_failure) => {
                 write!(f, "Failure: ")?;
-                Debug::fmt(val, ref f)?;
+
+                match call_failure {
+                    CallFailure::Panic(val) => {
+                        Debug::fmt(val, ref f)?;
+                    },
+                    CallFailure::Error(msg) => {
+                        Display::fmt(msg, ref f)?;
+                    },
+                };
             },
         };
         Result::Ok(())

--- a/snforge_std/src/trace.cairo
+++ b/snforge_std/src/trace.cairo
@@ -62,12 +62,8 @@ impl DisplayCallResult of Display<CallResult> {
                 write!(f, "Failure: ")?;
 
                 match call_failure {
-                    CallFailure::Panic(val) => {
-                        Debug::fmt(val, ref f)?;
-                    },
-                    CallFailure::Error(msg) => {
-                        Display::fmt(msg, ref f)?;
-                    },
+                    CallFailure::Panic(val) => { Debug::fmt(val, ref f)?; },
+                    CallFailure::Error(msg) => { Display::fmt(msg, ref f)?; },
                 };
             },
         };
@@ -141,7 +137,7 @@ impl DisplayIndentedCallTrace of Display<Indented<CallTrace>> {
                 .unwrap();
             write!(f, "\n").unwrap();
             write_indents_to_formatter(*self.base_indents, ref f);
-        }        
+        }
         write!(f, "]").unwrap();
 
         write!(f, "\n").unwrap();


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1428 

## Introduced changes

<!-- A brief description of the changes -->

- `CallResult` is available in `CallTrace` and `ProfilerCallTrace`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
