### PR TITLE
Fix error message when creating account without correct class_hash

### DIFF
--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -32,7 +32,8 @@ use starknet::{
 
 use crate::helpers::constants::{WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
 use shared::rpc::create_rpc_client;
-use starknet::accounts::ConnectedAccount;
+use starknet::accounts::{AccountFactoryError, ConnectedAccount};
+use starknet::signers::local_wallet::SignError;
 use std::collections::HashMap;
 use std::thread::sleep;
 use std::time::Duration;
@@ -479,6 +480,14 @@ pub fn handle_rpc_error(error: ProviderError) -> Error {
             anyhow!("Unsupported contract class version")
         }
         _ => anyhow!("Unknown RPC error"),
+    }
+}
+
+#[must_use]
+pub fn handle_account_factory_error(err: AccountFactoryError<SignError>) -> anyhow::Error {
+    match err {
+        AccountFactoryError::Provider(error) => handle_rpc_error(error),
+        error => anyhow!(error),
     }
 }
 

--- a/crates/sncast/src/starknet_commands/account/add.rs
+++ b/crates/sncast/src/starknet_commands/account/add.rs
@@ -6,7 +6,7 @@ use camino::Utf8PathBuf;
 use clap::Args;
 use sncast::helpers::configuration::CastConfig;
 use sncast::response::structs::AccountAddResponse;
-use sncast::{get_chain_id, parse_number};
+use sncast::{check_class_hash_exists, get_chain_id, parse_number};
 use starknet::core::types::BlockTag::Pending;
 use starknet::core::types::{BlockId, FieldElement};
 use starknet::providers::{
@@ -77,6 +77,10 @@ pub async fn add(
             public_key == &private_key.verifying_key().scalar(),
             "The private key does not match the public key"
         );
+    }
+
+    if let Some(class_hash) = add.class_hash {
+        check_class_hash_exists(provider, class_hash).await?;
     }
 
     let deployed = add.deployed

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -9,14 +9,14 @@ use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::{CREATE_KEYSTORE_PASSWORD_ENV_VAR, OZ_CLASS_HASH};
 use sncast::response::structs::{AccountCreateResponse, Felt};
 use sncast::{
-    extract_or_generate_salt, get_chain_id, get_keystore_password, handle_account_factory_error,
-    handle_rpc_error, parse_number,
+    check_class_hash_exists, extract_or_generate_salt, get_chain_id, get_keystore_password,
+    handle_account_factory_error, parse_number,
 };
 use starknet::accounts::{AccountFactory, OpenZeppelinAccountFactory};
-use starknet::core::types::{BlockId, BlockTag, FeeEstimate, FieldElement, StarknetError};
+use starknet::core::types::{FeeEstimate, FieldElement};
 use starknet::core::utils::get_contract_address;
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider, ProviderError};
+use starknet::providers::JsonRpcClient;
 use starknet::signers::{LocalWallet, SigningKey};
 
 #[derive(Args, Debug)]
@@ -108,19 +108,6 @@ pub async fn create(
             "Account already deployed".to_string()
         },
     })
-}
-
-async fn check_class_hash_exists(
-    provider: &JsonRpcClient<HttpTransport>,
-    class_hash: FieldElement,
-) -> Result<()> {
-    match provider.get_class(BlockId::Tag(BlockTag::Latest), class_hash).await {
-        Ok(_) => Ok(()),
-        Err(err) => match err {
-            ProviderError::StarknetError(StarknetError::ClassHashNotFound) => Err(anyhow!("Class with hash {class_hash:#x} is not declared, try using --class-hash with a hash of the declared class")),
-            _ => Err(handle_rpc_error(err))
-        }
-    }
 }
 
 async fn generate_account(

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -117,7 +117,7 @@ async fn check_class_hash_exists(
     match provider.get_class(BlockId::Tag(BlockTag::Latest), class_hash).await {
         Ok(_) => Ok(()),
         Err(err) => match err {
-            ProviderError::StarknetError(StarknetError::ClassHashNotFound) => Err(anyhow!("The class {class_hash:#x} is undeclared, try using --class-hash with a class hash that is already declared")),
+            ProviderError::StarknetError(StarknetError::ClassHashNotFound) => Err(anyhow!("Class with hash {class_hash:#x} is not declared, try using --class-hash with a hash of the declared class")),
             _ => Err(handle_rpc_error(err))
         }
     }

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -15,8 +15,8 @@ use starknet::providers::{JsonRpcClient, Provider};
 use starknet::signers::{LocalWallet, SigningKey};
 
 use sncast::{
-    account_file_exists, chain_id_to_network_name, get_keystore_password, handle_rpc_error,
-    handle_wait_for_tx, parse_number, WaitForTx,
+    account_file_exists, chain_id_to_network_name, get_keystore_password,
+    handle_account_factory_error, handle_rpc_error, handle_wait_for_tx, parse_number, WaitForTx,
 };
 
 #[derive(Args, Debug)]
@@ -274,8 +274,7 @@ async fn deploy_oz_account(
     } else {
         match deployment.estimate_fee().await {
             Ok(max_fee) => max_fee.overall_fee,
-            Err(AccountFactoryError::Provider(error)) => return Err(handle_rpc_error(error)),
-            Err(error) => bail!(error),
+            Err(error) => return Err(handle_account_factory_error(error)),
         }
     };
     let result = deployment.max_fee(deploy_max_fee).send().await;

--- a/crates/sncast/tests/e2e/account/add.rs
+++ b/crates/sncast/tests/e2e/account/add.rs
@@ -1,4 +1,4 @@
-use crate::helpers::constants::{DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS, URL};
+use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS, URL};
 use crate::helpers::runner::runner;
 use camino::Utf8PathBuf;
 use indoc::indoc;
@@ -77,7 +77,7 @@ pub async fn test_happy_case_add_profile() {
         "--salt",
         "0x3",
         "--class-hash",
-        "0x4",
+        DEVNET_OZ_CLASS_HASH,
         "--add-profile",
         "my_account_add",
     ];
@@ -100,7 +100,7 @@ pub async fn test_happy_case_add_profile() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": "0x1",
-                    "class_hash": "0x4",
+                    "class_hash": DEVNET_OZ_CLASS_HASH,
                     "deployed": false,
                     "private_key": "0x2",
                     "public_key": "0x759ca09377679ecd535a81e83039658bf40959283187c654c5416f439403cf5",

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -77,7 +77,7 @@ pub async fn test_invalid_class_hash() {
 
     snapbox.assert().stderr_matches(indoc! {r"
         command: account create
-        error: The class 0x10101 is undeclared, try using --class-hash with a class hash that is already declared
+        error: Class with hash 0x10101 is not declared, try using --class-hash with a hash of the declared class
     "});
 }
 

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -54,6 +54,32 @@ pub async fn test_happy_case() {
 }
 
 #[tokio::test]
+pub async fn test_no_class_hash() {
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "accounts.json";
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--name",
+        "my_account_create_happy",
+        "--salt",
+        "0x1",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+
+    snapbox.assert().stderr_matches(indoc! {r"
+        command: account create
+        error: The class 0x58d97f7d76e78f44905cc30cb65b91ea49a4b908a76703c54197bca90f81773 is undeclared, try using --class-hash with a class hash that is already declared
+    "});
+}
+
+#[tokio::test]
 pub async fn test_happy_case_generate_salt() {
     let temp_dir = tempdir().expect("Unable to create a temporary directory");
     let accounts_file = "accounts.json";

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -54,7 +54,7 @@ pub async fn test_happy_case() {
 }
 
 #[tokio::test]
-pub async fn test_no_class_hash() {
+pub async fn test_invalid_class_hash() {
     let temp_dir = tempdir().expect("Unable to create a temporary directory");
     let accounts_file = "accounts.json";
 
@@ -65,6 +65,8 @@ pub async fn test_no_class_hash() {
         accounts_file,
         "account",
         "create",
+        "--class-hash",
+        "0x10101",
         "--name",
         "my_account_create_happy",
         "--salt",
@@ -75,7 +77,7 @@ pub async fn test_no_class_hash() {
 
     snapbox.assert().stderr_matches(indoc! {r"
         command: account create
-        error: The class 0x58d97f7d76e78f44905cc30cb65b91ea49a4b908a76703c54197bca90f81773 is undeclared, try using --class-hash with a class hash that is already declared
+        error: The class 0x10101 is undeclared, try using --class-hash with a class hash that is already declared
     "});
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

As a part of #1542

## Introduced changes

<!-- A brief description of the changes -->

- Return proper error message when undeclared account class hash is used
- Return proper error message when fee estimation fails in account create

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
