### PR TITLE
Introduce `SerializeAsFelt252Vec` trait to conversions

### DIFF
--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -1,3 +1,4 @@
+use crate::byte_array::ByteArray;
 use crate::{FromConv, TryFromConv};
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_felt::{Felt252, ParseFeltError};
@@ -59,5 +60,32 @@ impl FromShortString<Felt252> for Felt252 {
         } else {
             Err(ParseFeltError)
         }
+    }
+}
+
+pub trait SerializeAsFelt252Vec {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252>;
+}
+
+impl<T: SerializeAsFelt252Vec, E: SerializeAsFelt252Vec> SerializeAsFelt252Vec for Result<T, E> {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        match self {
+            Ok(val) => {
+                let mut res = vec![Felt252::from(0)];
+                res.extend(val.serialize_as_felt252_vec());
+                res
+            }
+            Err(err) => {
+                let mut res = vec![Felt252::from(1)];
+                res.extend(err.serialize_as_felt252_vec());
+                res
+            }
+        }
+    }
+}
+
+impl SerializeAsFelt252Vec for &str {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        ByteArray::from(*self).serialize_no_magic()
     }
 }

--- a/crates/conversions/tests/e2e/felt252.rs
+++ b/crates/conversions/tests/e2e/felt252.rs
@@ -3,8 +3,10 @@ mod tests_felt252 {
     use crate::helpers::hex::str_hex_to_felt252;
     use cairo_felt::{Felt252, PRIME_STR};
     use cairo_lang_runner::short_string::as_cairo_short_string;
-    use conversions::felt252::FromShortString;
+    use conversions::byte_array::ByteArray;
+    use conversions::felt252::{FromShortString, SerializeAsFelt252Vec};
     use conversions::{FromConv, IntoConv, TryFromConv, TryIntoConv};
+    use itertools::chain;
     use starknet::core::types::FieldElement;
     use starknet_api::core::{ClassHash, ContractAddress, Nonce};
     use starknet_api::hash::{StarkFelt, StarkHash};
@@ -89,5 +91,29 @@ mod tests_felt252 {
         let shortstring = String::from("1234567890123456789012345678901a");
 
         assert!(Felt252::from_short_string(&shortstring).is_err());
+    }
+
+    #[test]
+    fn test_result_to_felt252_vec() {
+        let val = "a";
+        let serialised_val = vec![Felt252::from(0), Felt252::from(97), Felt252::from(1)];
+
+        let res: Result<&str, &str> = Ok(val);
+        let expected: Vec<Felt252> =
+            chain!(vec![Felt252::from(0)], serialised_val.clone()).collect();
+        assert_eq!(res.serialize_as_felt252_vec(), expected);
+
+        let res: Result<&str, &str> = Err(val);
+        let expected: Vec<Felt252> = chain!(vec![Felt252::from(1)], serialised_val).collect();
+        assert_eq!(res.serialize_as_felt252_vec(), expected);
+    }
+
+    #[test]
+    fn test_str_to_felt252_vec() {
+        let val = "abc";
+        assert_eq!(
+            val.serialize_as_felt252_vec(),
+            ByteArray::from(val).serialize_no_magic()
+        );
     }
 }

--- a/crates/sncast/src/response/structs.rs
+++ b/crates/sncast/src/response/structs.rs
@@ -1,4 +1,7 @@
+use cairo_felt::Felt252;
 use camino::Utf8PathBuf;
+use conversions::felt252::SerializeAsFelt252Vec;
+use conversions::FromConv;
 use serde::{Deserialize, Serialize, Serializer};
 use starknet::core::types::FieldElement;
 
@@ -42,11 +45,25 @@ pub struct CallResponse {
 }
 impl CommandResponse for CallResponse {}
 
+impl SerializeAsFelt252Vec for CallResponse {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        let mut res = vec![Felt252::from(self.response.len())];
+        res.extend(self.response.iter().map(|el| Felt252::from_(el.0)));
+        res
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct InvokeResponse {
     pub transaction_hash: Felt,
 }
 impl CommandResponse for InvokeResponse {}
+
+impl SerializeAsFelt252Vec for InvokeResponse {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        vec![Felt252::from_(self.transaction_hash.0)]
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct DeployResponse {
@@ -55,12 +72,30 @@ pub struct DeployResponse {
 }
 impl CommandResponse for DeployResponse {}
 
+impl SerializeAsFelt252Vec for DeployResponse {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        vec![
+            Felt252::from_(self.contract_address.0),
+            Felt252::from_(self.transaction_hash.0),
+        ]
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct DeclareResponse {
     pub class_hash: Felt,
     pub transaction_hash: Felt,
 }
 impl CommandResponse for DeclareResponse {}
+
+impl SerializeAsFelt252Vec for DeclareResponse {
+    fn serialize_as_felt252_vec(&self) -> Vec<Felt252> {
+        vec![
+            Felt252::from_(self.class_hash.0),
+            Felt252::from_(self.transaction_hash.0),
+        ]
+    }
+}
 
 #[derive(Serialize)]
 pub struct AccountCreateResponse {

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -19,7 +19,7 @@ use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::errors::hint_errors::HintError;
 use cairo_vm::vm::vm_core::VirtualMachine;
 use clap::Args;
-use conversions::byte_array::ByteArray;
+use conversions::felt252::SerializeAsFelt252Vec;
 use conversions::{FromConv, IntoConv};
 use itertools::chain;
 use runtime::starknet::context::{build_context, BlockInfo};
@@ -36,9 +36,7 @@ use shared::print::print_as_warning;
 use shared::utils::build_readable_text;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::SCRIPT_LIB_ARTIFACT_NAME;
-use sncast::response::errors::{SNCastProviderError, SNCastStarknetError, StarknetCommandError};
 use sncast::response::structs::ScriptRunResponse;
-use sncast::{TransactionError, WaitForTransactionError};
 use starknet::accounts::Account;
 use starknet::core::types::{BlockId, BlockTag::Pending, FieldElement};
 use starknet::providers::jsonrpc::HttpTransport;
@@ -46,139 +44,6 @@ use starknet::providers::JsonRpcClient;
 use tokio::runtime::Runtime;
 
 type ScriptStarknetContractArtifacts = StarknetContractArtifacts;
-
-pub trait SerializeAsFelt252 {
-    fn serialize_as_felt252(&self) -> Vec<Felt252>;
-}
-
-impl SerializeAsFelt252 for StarknetCommandError {
-    fn serialize_as_felt252(&self) -> Vec<Felt252> {
-        match self {
-            StarknetCommandError::UnknownError(err) => {
-                let mut res = vec![Felt252::from(0)];
-                res.extend(ByteArray::from(err.to_string().as_str()).serialize_no_magic());
-                res
-            }
-            StarknetCommandError::ContractArtifactsNotFound(err) => {
-                let mut res = vec![Felt252::from(1)];
-                res.extend(ByteArray::from(err.data.as_str()).serialize_no_magic());
-                res
-            }
-            StarknetCommandError::WaitForTransactionError(err) => {
-                let mut res = vec![Felt252::from(2)];
-                res.extend(err.serialize_as_felt252());
-                res
-            }
-            StarknetCommandError::ProviderError(err) => {
-                let mut res = vec![Felt252::from(3)];
-                res.extend(err.serialize_as_felt252());
-                res
-            }
-        }
-    }
-}
-
-impl SerializeAsFelt252 for SNCastProviderError {
-    fn serialize_as_felt252(&self) -> Vec<Felt252> {
-        match self {
-            SNCastProviderError::StarknetError(err) => {
-                let mut res = vec![Felt252::from(0)];
-                res.extend(err.serialize_as_felt252());
-                res
-            }
-            SNCastProviderError::RateLimited => {
-                vec![Felt252::from(1)]
-            }
-            SNCastProviderError::UnknownError(err) => {
-                let mut res = vec![Felt252::from(2)];
-                res.extend(ByteArray::from(err.to_string().as_str()).serialize_no_magic());
-                res
-            }
-        }
-    }
-}
-
-impl SerializeAsFelt252 for SNCastStarknetError {
-    fn serialize_as_felt252(&self) -> Vec<Felt252> {
-        match self {
-            SNCastStarknetError::FailedToReceiveTransaction => vec![Felt252::from(0)],
-            SNCastStarknetError::ContractNotFound => vec![Felt252::from(1)],
-            SNCastStarknetError::BlockNotFound => vec![Felt252::from(2)],
-            SNCastStarknetError::InvalidTransactionIndex => vec![Felt252::from(3)],
-            SNCastStarknetError::ClassHashNotFound => vec![Felt252::from(4)],
-            SNCastStarknetError::TransactionHashNotFound => vec![Felt252::from(5)],
-            SNCastStarknetError::ContractError(err) => {
-                let mut res = vec![Felt252::from(6)];
-                res.extend(ByteArray::from(err.revert_error.as_str()).serialize_no_magic());
-                res
-            }
-            SNCastStarknetError::TransactionExecutionError(err) => {
-                let mut res = vec![Felt252::from(7), Felt252::from(err.transaction_index)];
-                res.extend(ByteArray::from(err.execution_error.as_str()).serialize_no_magic());
-                res
-            }
-            SNCastStarknetError::ClassAlreadyDeclared => vec![Felt252::from(8)],
-            SNCastStarknetError::InvalidTransactionNonce => vec![Felt252::from(9)],
-            SNCastStarknetError::InsufficientMaxFee => vec![Felt252::from(10)],
-            SNCastStarknetError::InsufficientAccountBalance => vec![Felt252::from(11)],
-            SNCastStarknetError::ValidationFailure(err) => {
-                let mut res = vec![Felt252::from(12)];
-                res.extend(ByteArray::from(err.as_str()).serialize_no_magic());
-                res
-            }
-            SNCastStarknetError::CompilationFailed => vec![Felt252::from(13)],
-            SNCastStarknetError::ContractClassSizeIsTooLarge => vec![Felt252::from(14)],
-            SNCastStarknetError::NonAccount => vec![Felt252::from(15)],
-            SNCastStarknetError::DuplicateTx => vec![Felt252::from(16)],
-            SNCastStarknetError::CompiledClassHashMismatch => vec![Felt252::from(17)],
-            SNCastStarknetError::UnsupportedTxVersion => vec![Felt252::from(18)],
-            SNCastStarknetError::UnsupportedContractClassVersion => vec![Felt252::from(19)],
-            SNCastStarknetError::UnexpectedError(err) => {
-                let mut res = vec![Felt252::from(20)];
-                res.extend(ByteArray::from(err.to_string().as_str()).serialize_no_magic());
-                res
-            }
-        }
-    }
-}
-
-impl SerializeAsFelt252 for WaitForTransactionError {
-    fn serialize_as_felt252(&self) -> Vec<Felt252> {
-        match self {
-            WaitForTransactionError::TransactionError(err) => {
-                let mut res = vec![Felt252::from(0)];
-                res.extend(err.serialize_as_felt252());
-                res
-            }
-            WaitForTransactionError::TimedOut => vec![Felt252::from(1)],
-            WaitForTransactionError::ProviderError(err) => {
-                let mut res = vec![Felt252::from(2)];
-                res.extend(err.serialize_as_felt252());
-                res
-            }
-        }
-    }
-}
-
-impl SerializeAsFelt252 for TransactionError {
-    fn serialize_as_felt252(&self) -> Vec<Felt252> {
-        match self {
-            TransactionError::Rejected => vec![Felt252::from(0)],
-            TransactionError::Reverted(err) => {
-                let mut res = vec![Felt252::from(1)];
-                res.extend(ByteArray::from(err.data.as_str()).serialize_no_magic());
-                res
-            }
-        }
-    }
-}
-
-fn handle_starknet_command_error_in_script(err: &StarknetCommandError) -> Vec<Felt252> {
-    let error_msg_serialized = err.serialize_as_felt252();
-    let mut res: Vec<Felt252> = vec![Felt252::from(1)];
-    res.extend(error_msg_serialized);
-    res
-}
 
 #[derive(Args, Debug)]
 #[command(about = "Execute a deployment script")]
@@ -219,26 +84,16 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     .map(|el| FieldElement::from_(el.clone()))
                     .collect();
 
-                match self.tokio_runtime.block_on(call::call(
+                let call_result = self.tokio_runtime.block_on(call::call(
                     contract_address,
                     function_selector,
                     calldata_felts,
                     self.provider,
                     &BlockId::Tag(Pending),
-                )) {
-                    Ok(call_response) => {
-                        let mut res: Vec<Felt252> = vec![
-                            Felt252::from(0),
-                            Felt252::from(call_response.response.len()),
-                        ];
-                        res.extend(call_response.response.iter().map(|el| Felt252::from_(el.0)));
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                    Err(err) => {
-                        let res = handle_starknet_command_error_in_script(&err);
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                }
+                ));
+                Ok(CheatcodeHandlingResult::Handled(
+                    call_result.serialize_as_felt252_vec(),
+                ))
             }
             "declare" => {
                 let contract_name = input_reader.read_string();
@@ -256,7 +111,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     self.config.keystore.clone(),
                 ))?;
 
-                match self.tokio_runtime.block_on(declare::declare(
+                let declare_result = self.tokio_runtime.block_on(declare::declare(
                     &contract_name,
                     max_fee,
                     &account,
@@ -266,20 +121,10 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                         wait: true,
                         wait_params: self.config.wait_params,
                     },
-                )) {
-                    Ok(declare_response) => {
-                        let res: Vec<Felt252> = vec![
-                            Felt252::from(0),
-                            Felt252::from_(declare_response.class_hash.0),
-                            Felt252::from_(declare_response.transaction_hash.0),
-                        ];
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                    Err(err) => {
-                        let res = handle_starknet_command_error_in_script(&err);
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                }
+                ));
+                Ok(CheatcodeHandlingResult::Handled(
+                    declare_result.serialize_as_felt252_vec(),
+                ))
             }
             "deploy" => {
                 let class_hash = input_reader.read_felt().into_();
@@ -307,7 +152,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     self.config.keystore.clone(),
                 ))?;
 
-                match self.tokio_runtime.block_on(deploy::deploy(
+                let deploy_result = self.tokio_runtime.block_on(deploy::deploy(
                     class_hash,
                     constructor_calldata,
                     salt,
@@ -319,20 +164,10 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                         wait: true,
                         wait_params: self.config.wait_params,
                     },
-                )) {
-                    Ok(deploy_response) => {
-                        let res: Vec<Felt252> = vec![
-                            Felt252::from(0),
-                            Felt252::from_(deploy_response.contract_address.0),
-                            Felt252::from_(deploy_response.transaction_hash.0),
-                        ];
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                    Err(err) => {
-                        let res = handle_starknet_command_error_in_script(&err);
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                }
+                ));
+                Ok(CheatcodeHandlingResult::Handled(
+                    deploy_result.serialize_as_felt252_vec(),
+                ))
             }
             "invoke" => {
                 let contract_address = input_reader.read_felt().into_();
@@ -356,7 +191,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                     self.config.keystore.clone(),
                 ))?;
 
-                match self.tokio_runtime.block_on(invoke::invoke(
+                let invoke_result = self.tokio_runtime.block_on(invoke::invoke(
                     contract_address,
                     function_selector,
                     calldata,
@@ -367,19 +202,10 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                         wait: true,
                         wait_params: self.config.wait_params,
                     },
-                )) {
-                    Ok(invoke_response) => {
-                        let res: Vec<Felt252> = vec![
-                            Felt252::from(0),
-                            Felt252::from_(invoke_response.transaction_hash.0),
-                        ];
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                    Err(err) => {
-                        let res = handle_starknet_command_error_in_script(&err);
-                        Ok(CheatcodeHandlingResult::Handled(res))
-                    }
-                }
+                ));
+                Ok(CheatcodeHandlingResult::Handled(
+                    invoke_result.serialize_as_felt252_vec(),
+                ))
             }
             "get_nonce" => {
                 let block_id = input_reader


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1721

## Introduced changes

<!-- A brief description of the changes -->

- Introduce `SerializeAsFelt252Vec` trait to conversions with impls for Result and str
- Implement `SerializeAsFelt252Vec` for sncast error types and some response structs (those that are used in deployment scripts)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
