### PR TITLE
Add `EntryPointSelector` to `conversions`

### DIFF
--- a/crates/cheatnet/src/constants.rs
+++ b/crates/cheatnet/src/constants.rs
@@ -6,7 +6,6 @@ use blockifier::execution::contract_class::{ContractClassV1, ContractClassV1Inne
 use blockifier::execution::contract_class::ContractClass;
 use cairo_vm::types::program::Program;
 
-use crate::runtime_extensions::common::create_entry_point_selector;
 use blockifier::execution::entry_point::{CallEntryPoint, CallType};
 use conversions::IntoConv;
 use starknet::core::utils::get_selector_from_name;
@@ -82,10 +81,8 @@ pub fn build_testing_state() -> DictStateReader {
 
 #[must_use]
 pub fn build_test_entry_point() -> CallEntryPoint {
-    let test_selector = get_selector_from_name(TEST_ENTRY_POINT_SELECTOR)
-        .unwrap()
-        .into_();
-    let entry_point_selector = create_entry_point_selector(&test_selector);
+    let test_selector = get_selector_from_name(TEST_ENTRY_POINT_SELECTOR).unwrap();
+    let entry_point_selector = test_selector.into_();
     CallEntryPoint {
         class_hash: None,
         code_address: Some(contract_address!(TEST_ADDRESS)),

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -3,7 +3,7 @@ use crate::runtime_extensions::{
     call_to_blockifier_runtime_extension::{
         execution::entry_point::execute_call_entry_point, panic_data::try_extract_panic_data,
     },
-    common::{create_entry_point_selector, create_execute_calldata},
+    common::create_execute_calldata,
 };
 use blockifier::execution::{
     call_info::CallInfo,
@@ -15,7 +15,7 @@ use blockifier::execution::{
 use blockifier::state::errors::StateError;
 use cairo_felt::Felt252;
 use cairo_lang_runner::casm_run::format_next_item;
-use conversions::byte_array::ByteArray;
+use conversions::{byte_array::ByteArray, IntoConv};
 use serde::{Deserialize, Serialize};
 use starknet_api::{
     core::{ClassHash, ContractAddress},
@@ -206,14 +206,13 @@ pub fn call_l1_handler(
     entry_point_selector: &Felt252,
     calldata: &[Felt252],
 ) -> CallResult {
-    let entry_point_selector = create_entry_point_selector(entry_point_selector);
     let calldata = create_execute_calldata(calldata);
 
     let entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(*contract_address),
         entry_point_type: EntryPointType::L1Handler,
-        entry_point_selector,
+        entry_point_selector: entry_point_selector.clone().into_(),
         calldata,
         storage_address: *contract_address,
         caller_address: ContractAddress::default(),

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -1,16 +1,9 @@
 use blockifier::execution::execution_utils::felt_to_stark_felt;
 use cairo_felt::Felt252;
-use conversions::IntoConv;
-use starknet_api::core::EntryPointSelector;
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::Calldata;
 
 pub fn create_execute_calldata(calldata: &[Felt252]) -> Calldata {
     let calldata: Vec<StarkFelt> = calldata.iter().map(felt_to_stark_felt).collect();
     Calldata(calldata.into())
-}
-
-#[must_use]
-pub fn create_entry_point_selector(entry_point_selector: &Felt252) -> EntryPointSelector {
-    EntryPointSelector(entry_point_selector.clone().into_()) //FIXME: remove clone and take `entry_point_selector` by value
 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mock_call.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mock_call.rs
@@ -2,7 +2,7 @@ use crate::CheatnetState;
 use blockifier::execution::execution_utils::felt_to_stark_felt;
 use cairo_felt::Felt252;
 use conversions::IntoConv;
-use starknet_api::core::{ContractAddress, EntryPointSelector};
+use starknet_api::core::ContractAddress;
 use starknet_api::hash::StarkFelt;
 use std::collections::hash_map::Entry;
 
@@ -17,7 +17,7 @@ impl CheatnetState {
 
         let contract_mocked_functions = self.mocked_functions.entry(contract_address).or_default();
 
-        contract_mocked_functions.insert(EntryPointSelector(function_selector.into_()), ret_data);
+        contract_mocked_functions.insert(function_selector.into_(), ret_data);
     }
 
     pub fn stop_mock_call(
@@ -27,7 +27,7 @@ impl CheatnetState {
     ) {
         if let Entry::Occupied(mut e) = self.mocked_functions.entry(contract_address) {
             let contract_mocked_functions = e.get_mut();
-            contract_mocked_functions.remove(&EntryPointSelector(function_selector.into_()));
+            contract_mocked_functions.remove(&function_selector.into_());
         }
     }
 }

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -16,12 +16,13 @@ use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
     CallFailure, CallResult,
 };
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use cheatnet::runtime_extensions::common::{create_entry_point_selector, create_execute_calldata};
+use cheatnet::runtime_extensions::common::create_execute_calldata;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::declare::declare;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::deploy::{
     deploy, deploy_at,
 };
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::CheatcodeError;
+use conversions::IntoConv;
 use runtime::starknet::context::build_context;
 use scarb_api::metadata::MetadataCommandExt;
 use scarb_api::{get_contracts_map, ScarbCommand, StarknetContractArtifacts};
@@ -190,14 +191,13 @@ pub fn call_contract(
     entry_point_selector: &Felt252,
     calldata: &[Felt252],
 ) -> CallResult {
-    let entry_point_selector = create_entry_point_selector(entry_point_selector);
     let calldata = create_execute_calldata(calldata);
 
     let entry_point = CallEntryPoint {
         class_hash: None,
         code_address: Some(*contract_address),
         entry_point_type: EntryPointType::External,
-        entry_point_selector,
+        entry_point_selector: entry_point_selector.clone().into_(),
         calldata,
         storage_address: *contract_address,
         caller_address: ContractAddress(patricia_key!(TEST_ADDRESS)),

--- a/crates/conversions/src/class_hash.rs
+++ b/crates/conversions/src/class_hash.rs
@@ -1,7 +1,7 @@
 use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, IntoConv, TryFromConv};
 use cairo_felt::{Felt252, ParseFeltError};
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::hash::StarkFelt;
 
 impl FromConv<Felt252> for ClassHash {
@@ -14,5 +14,6 @@ from_thru_felt252!(FieldElement, ClassHash);
 from_thru_felt252!(StarkFelt, ClassHash);
 from_thru_felt252!(ContractAddress, ClassHash);
 from_thru_felt252!(Nonce, ClassHash);
+from_thru_felt252!(EntryPointSelector, ClassHash);
 
 try_from_thru_felt252!(String, ClassHash);

--- a/crates/conversions/src/contract_address.rs
+++ b/crates/conversions/src/contract_address.rs
@@ -1,7 +1,7 @@
 use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, TryFromConv};
 use cairo_felt::{Felt252, ParseFeltError};
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce, PatriciaKey};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
 
 impl FromConv<Felt252> for ContractAddress {
@@ -14,5 +14,6 @@ from_thru_felt252!(FieldElement, ContractAddress);
 from_thru_felt252!(ClassHash, ContractAddress);
 from_thru_felt252!(StarkFelt, ContractAddress);
 from_thru_felt252!(Nonce, ContractAddress);
+from_thru_felt252!(EntryPointSelector, ContractAddress);
 
 try_from_thru_felt252!(String, ContractAddress);

--- a/crates/conversions/src/dec_string.rs
+++ b/crates/conversions/src/dec_string.rs
@@ -1,7 +1,7 @@
 use crate::{from_thru_felt252, FromConv};
 use cairo_felt::Felt252;
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::hash::StarkFelt;
 
 impl FromConv<Felt252> for String {
@@ -16,3 +16,4 @@ from_thru_felt252!(StarkFelt, String);
 from_thru_felt252!(ClassHash, String);
 from_thru_felt252!(ContractAddress, String);
 from_thru_felt252!(Nonce, String);
+from_thru_felt252!(EntryPointSelector, String);

--- a/crates/conversions/src/entrypoint_selector.rs
+++ b/crates/conversions/src/entrypoint_selector.rs
@@ -1,0 +1,19 @@
+use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, IntoConv, TryFromConv};
+use cairo_felt::{Felt252, ParseFeltError};
+use starknet::core::types::FieldElement;
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
+use starknet_api::hash::StarkFelt;
+
+impl FromConv<Felt252> for EntryPointSelector {
+    fn from_(value: Felt252) -> EntryPointSelector {
+        EntryPointSelector(value.into_())
+    }
+}
+
+from_thru_felt252!(FieldElement, EntryPointSelector);
+from_thru_felt252!(StarkFelt, EntryPointSelector);
+from_thru_felt252!(ContractAddress, EntryPointSelector);
+from_thru_felt252!(Nonce, EntryPointSelector);
+from_thru_felt252!(ClassHash, EntryPointSelector);
+
+try_from_thru_felt252!(String, EntryPointSelector);

--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -1,9 +1,9 @@
-use crate::{FromConv, TryFromConv};
+use crate::{FromConv, IntoConv, TryFromConv};
 use blockifier::execution::execution_utils::stark_felt_to_felt;
 use cairo_felt::{Felt252, ParseFeltError};
 use num_traits::Num;
 use starknet::core::types::FieldElement;
-use starknet_api::core::Nonce;
+use starknet_api::core::{EntryPointSelector, Nonce};
 use starknet_api::{
     core::{ClassHash, ContractAddress},
     hash::StarkFelt,
@@ -36,6 +36,12 @@ impl FromConv<ContractAddress> for Felt252 {
 impl FromConv<Nonce> for Felt252 {
     fn from_(value: Nonce) -> Felt252 {
         stark_felt_to_felt(value.0)
+    }
+}
+
+impl FromConv<EntryPointSelector> for Felt252 {
+    fn from_(value: EntryPointSelector) -> Felt252 {
+        value.0.into_()
     }
 }
 

--- a/crates/conversions/src/field_element.rs
+++ b/crates/conversions/src/field_element.rs
@@ -1,7 +1,7 @@
 use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, TryFromConv};
 use cairo_felt::{Felt252, ParseFeltError};
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::hash::StarkFelt;
 
 impl FromConv<Felt252> for FieldElement {
@@ -14,5 +14,6 @@ from_thru_felt252!(ContractAddress, FieldElement);
 from_thru_felt252!(StarkFelt, FieldElement);
 from_thru_felt252!(ClassHash, FieldElement);
 from_thru_felt252!(Nonce, FieldElement);
+from_thru_felt252!(EntryPointSelector, FieldElement);
 
 try_from_thru_felt252!(String, FieldElement);

--- a/crates/conversions/src/lib.rs
+++ b/crates/conversions/src/lib.rs
@@ -4,6 +4,7 @@ pub mod byte_array;
 pub mod class_hash;
 pub mod contract_address;
 pub mod dec_string;
+pub mod entrypoint_selector;
 pub mod felt252;
 pub mod field_element;
 pub mod nonce;

--- a/crates/conversions/src/nonce.rs
+++ b/crates/conversions/src/nonce.rs
@@ -1,7 +1,7 @@
 use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, IntoConv, TryFromConv};
 use cairo_felt::{Felt252, ParseFeltError};
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::hash::StarkFelt;
 
 impl FromConv<Felt252> for Nonce {
@@ -14,5 +14,6 @@ from_thru_felt252!(FieldElement, Nonce);
 from_thru_felt252!(StarkFelt, Nonce);
 from_thru_felt252!(ClassHash, Nonce);
 from_thru_felt252!(ContractAddress, Nonce);
+from_thru_felt252!(EntryPointSelector, Nonce);
 
 try_from_thru_felt252!(String, Nonce);

--- a/crates/conversions/src/stark_felt.rs
+++ b/crates/conversions/src/stark_felt.rs
@@ -2,7 +2,7 @@ use crate::{from_thru_felt252, try_from_thru_felt252, FromConv, TryFromConv};
 use blockifier::execution::execution_utils::felt_to_stark_felt;
 use cairo_felt::{Felt252, ParseFeltError};
 use starknet::core::types::FieldElement;
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::hash::StarkFelt;
 
 impl FromConv<Felt252> for StarkFelt {
@@ -15,5 +15,6 @@ from_thru_felt252!(FieldElement, StarkFelt);
 from_thru_felt252!(ClassHash, StarkFelt);
 from_thru_felt252!(ContractAddress, StarkFelt);
 from_thru_felt252!(Nonce, StarkFelt);
+from_thru_felt252!(EntryPointSelector, StarkFelt);
 
 try_from_thru_felt252!(String, StarkFelt);

--- a/crates/forge-runner/src/contracts_data.rs
+++ b/crates/forge-runner/src/contracts_data.rs
@@ -65,17 +65,15 @@ fn add_simple_abi_entry_to_mapping(
     match abi_entry {
         AbiEntry::Function(abi_function) | AbiEntry::L1Handler(abi_function) => {
             selector_map.insert(
-                EntryPointSelector(get_selector_from_name(&abi_function.name).unwrap().into_()),
+                get_selector_from_name(&abi_function.name).unwrap().into_(),
                 abi_function.name,
             );
         }
         AbiEntry::Constructor(abi_constructor) => {
             selector_map.insert(
-                EntryPointSelector(
-                    get_selector_from_name(&abi_constructor.name)
-                        .unwrap()
-                        .into_(),
-                ),
+                get_selector_from_name(&abi_constructor.name)
+                    .unwrap()
+                    .into_(),
                 abi_constructor.name,
             );
         }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Add `EntryPointSelector` to `conversions`
- Remove `create_entry_point_selector` in favour of `.into_()`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
