### PR TITLE
Parsing arguments from memory now fail single test only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "cairo-lang-starknet",
  "cairo-lang-utils",
  "cairo-vm",
+ "indoc",
  "num-bigint",
  "num-traits 0.2.18",
  "serde",

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -32,7 +32,7 @@ use crate::runtime_extensions::forge_runtime_extension::cheatcodes::storage::{
 use crate::runtime_extensions::forge_runtime_extension::file_operations::string_into_felt;
 use cairo_lang_starknet::contract::starknet_keccak;
 use conversions::byte_array::ByteArray;
-use runtime::utils::BufferReader;
+use runtime::utils::{BufferReadResult, BufferReader};
 use runtime::{
     CheatcodeHandlingResult, EnhancedHintError, ExtendedRuntime, ExtensionLogic,
     SyscallHandlingResult,
@@ -54,25 +54,26 @@ pub struct ForgeExtension<'a> {
 }
 
 trait BufferReaderExt {
-    fn read_cheat_target(&mut self) -> CheatTarget;
+    fn read_cheat_target(&mut self) -> BufferReadResult<CheatTarget>;
 }
 
 impl BufferReaderExt for BufferReader<'_> {
-    fn read_cheat_target(&mut self) -> CheatTarget {
-        let cheat_target_variant = self.read_felt().to_u8();
-        match cheat_target_variant {
+    fn read_cheat_target(&mut self) -> BufferReadResult<CheatTarget> {
+        let cheat_target_variant = self.read_felt()?.to_u8();
+
+        Ok(match cheat_target_variant {
             Some(0) => CheatTarget::All,
-            Some(1) => CheatTarget::One(self.read_felt().into_()),
+            Some(1) => CheatTarget::One(self.read_felt()?.into_()),
             Some(2) => {
                 let contract_addresses: Vec<_> = self
-                    .read_vec()
+                    .read_vec()?
                     .iter()
                     .map(|el| ContractAddress::from_(el.clone()))
                     .collect();
                 CheatTarget::Multiple(contract_addresses)
             }
             _ => unreachable!("Invalid CheatTarget variant"),
-        }
+        })
     }
 }
 
@@ -89,8 +90,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
     ) -> Result<CheatcodeHandlingResult, EnhancedHintError> {
         match selector {
             "start_roll" => {
-                let target = input_reader.read_cheat_target();
-                let block_number = input_reader.read_felt();
+                let target = input_reader.read_cheat_target()?;
+                let block_number = input_reader.read_felt()?;
                 extended_runtime
                     .extended_runtime
                     .extension
@@ -99,7 +100,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_roll" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
                 extended_runtime
                     .extended_runtime
@@ -109,8 +110,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "start_warp" => {
-                let target = input_reader.read_cheat_target();
-                let warp_timestamp = input_reader.read_felt();
+                let target = input_reader.read_cheat_target()?;
+                let warp_timestamp = input_reader.read_felt()?;
 
                 extended_runtime
                     .extended_runtime
@@ -121,7 +122,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_warp" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
                 extended_runtime
                     .extended_runtime
@@ -131,8 +132,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "start_elect" => {
-                let target = input_reader.read_cheat_target();
-                let sequencer_address = input_reader.read_felt().into_();
+                let target = input_reader.read_cheat_target()?;
+                let sequencer_address = input_reader.read_felt()?.into_();
 
                 extended_runtime
                     .extended_runtime
@@ -142,7 +143,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_elect" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
                 extended_runtime
                     .extended_runtime
                     .extension
@@ -151,9 +152,9 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "start_prank" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
-                let caller_address = input_reader.read_felt().into_();
+                let caller_address = input_reader.read_felt()?.into_();
 
                 extended_runtime
                     .extended_runtime
@@ -163,7 +164,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_prank" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
                 extended_runtime
                     .extended_runtime
@@ -173,10 +174,10 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "start_mock_call" => {
-                let contract_address = input_reader.read_felt().into_();
-                let function_selector = input_reader.read_felt();
+                let contract_address = input_reader.read_felt()?.into_();
+                let function_selector = input_reader.read_felt()?;
 
-                let ret_data = input_reader.read_vec();
+                let ret_data = input_reader.read_vec()?;
 
                 extended_runtime
                     .extended_runtime
@@ -186,8 +187,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_mock_call" => {
-                let contract_address = input_reader.read_felt().into_();
-                let function_selector = input_reader.read_felt();
+                let contract_address = input_reader.read_felt()?.into_();
+                let function_selector = input_reader.read_felt()?;
 
                 extended_runtime
                     .extended_runtime
@@ -197,25 +198,26 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "start_spoof" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
-                let version = input_reader.read_option_felt();
-                let account_contract_address = input_reader.read_option_felt();
-                let max_fee = input_reader.read_option_felt();
-                let signature = input_reader.read_option_vec();
-                let transaction_hash = input_reader.read_option_felt();
-                let chain_id = input_reader.read_option_felt();
-                let nonce = input_reader.read_option_felt();
-                let resource_bounds = input_reader.read_option_felt().map(|resource_bounds_len| {
-                    input_reader.read_vec_body(
+                let version = input_reader.read_option_felt()?;
+                let account_contract_address = input_reader.read_option_felt()?;
+                let max_fee = input_reader.read_option_felt()?;
+                let signature = input_reader.read_option_vec()?;
+                let transaction_hash = input_reader.read_option_felt()?;
+                let chain_id = input_reader.read_option_felt()?;
+                let nonce = input_reader.read_option_felt()?;
+                let resource_bounds = match input_reader.read_option_felt()? {
+                    Some(resource_bounds_len) => Some(input_reader.read_vec_body(
                         3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
-                    )
-                });
-                let tip = input_reader.read_option_felt();
-                let paymaster_data = input_reader.read_option_vec();
-                let nonce_data_availability_mode = input_reader.read_option_felt();
-                let fee_data_availability_mode = input_reader.read_option_felt();
-                let account_deployment_data = input_reader.read_option_vec();
+                    )?),
+                    None => None,
+                };
+                let tip = input_reader.read_option_felt()?;
+                let paymaster_data = input_reader.read_option_vec()?;
+                let nonce_data_availability_mode = input_reader.read_option_felt()?;
+                let fee_data_availability_mode = input_reader.read_option_felt()?;
+                let account_deployment_data = input_reader.read_option_vec()?;
 
                 let tx_info_mock = cheatcodes::spoof::TxInfoMock {
                     version,
@@ -241,7 +243,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "stop_spoof" => {
-                let target = input_reader.read_cheat_target();
+                let target = input_reader.read_cheat_target()?;
 
                 extended_runtime
                     .extended_runtime
@@ -251,8 +253,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
             "replace_bytecode" => {
-                let contract = input_reader.read_felt().into_();
-                let class = input_reader.read_felt().into_();
+                let contract = input_reader.read_felt()?.into_();
+                let class = input_reader.read_felt()?.into_();
 
                 extended_runtime
                     .extended_runtime
@@ -268,7 +270,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .hint_handler
                     .state;
 
-                let contract_name = input_reader.read_string();
+                let contract_name = input_reader.read_string()?;
                 let contracts = self.contracts;
                 match declare(*state, &contract_name, contracts) {
                     Ok(class_hash) => {
@@ -283,8 +285,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 }
             }
             "deploy" => {
-                let class_hash = input_reader.read_felt().into_();
-                let calldata = input_reader.read_vec();
+                let class_hash = input_reader.read_felt()?.into_();
+                let calldata = input_reader.read_vec()?;
                 let cheatnet_runtime = &mut extended_runtime.extended_runtime;
                 let syscall_handler = &mut cheatnet_runtime.extended_runtime.hint_handler;
 
@@ -300,9 +302,9 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 ))
             }
             "deploy_at" => {
-                let class_hash = input_reader.read_felt().into_();
-                let calldata = input_reader.read_vec();
-                let contract_address = input_reader.read_felt().into_();
+                let class_hash = input_reader.read_felt()?.into_();
+                let calldata = input_reader.read_vec()?;
+                let contract_address = input_reader.read_felt()?.into_();
                 let cheatnet_runtime = &mut extended_runtime.extended_runtime;
                 let syscall_handler = &mut cheatnet_runtime.extended_runtime.hint_handler;
 
@@ -319,8 +321,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 ))
             }
             "precalculate_address" => {
-                let class_hash = input_reader.read_felt().into_();
-                let calldata = input_reader.read_vec();
+                let class_hash = input_reader.read_felt()?.into_();
+                let calldata = input_reader.read_vec()?;
 
                 let contract_address = extended_runtime
                     .extended_runtime
@@ -335,7 +337,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 ]))
             }
             "var" => {
-                let name = input_reader.read_string();
+                let name = input_reader.read_string()?;
 
                 let env_var = self
                     .environment_variables
@@ -348,7 +350,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![parsed_env_var]))
             }
             "get_class_hash" => {
-                let contract_address = input_reader.read_felt().into_();
+                let contract_address = input_reader.read_felt()?.into_();
 
                 let state = &mut extended_runtime
                     .extended_runtime
@@ -367,11 +369,11 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 }
             }
             "l1_handler_execute" => {
-                let contract_address = input_reader.read_felt().into_();
-                let function_selector = input_reader.read_felt();
-                let from_address = input_reader.read_felt();
+                let contract_address = input_reader.read_felt()?.into_();
+                let function_selector = input_reader.read_felt()?;
+                let from_address = input_reader.read_felt()?;
 
-                let payload = input_reader.read_vec();
+                let payload = input_reader.read_vec()?;
 
                 let cheatnet_runtime = &mut extended_runtime.extended_runtime;
 
@@ -399,27 +401,27 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 }
             }
             "read_txt" => {
-                let file_path = input_reader.read_string();
+                let file_path = input_reader.read_string()?;
                 let parsed_content = file_operations::read_txt(file_path)?;
                 Ok(CheatcodeHandlingResult::Handled(parsed_content))
             }
             "read_json" => {
-                let file_path = input_reader.read_string();
+                let file_path = input_reader.read_string()?;
                 let parsed_content = file_operations::read_json(file_path)?;
 
                 Ok(CheatcodeHandlingResult::Handled(parsed_content))
             }
             "spy_events" => {
                 let spy_target_variant = input_reader
-                    .read_felt()
+                    .read_felt()?
                     .to_u8()
                     .expect("Invalid spy_target length");
                 let spy_on = match spy_target_variant {
                     0 => SpyTarget::All,
-                    1 => SpyTarget::One(input_reader.read_felt().into_()),
+                    1 => SpyTarget::One(input_reader.read_felt()?.into_()),
                     _ => {
                         let addresses = input_reader
-                            .read_vec()
+                            .read_vec()?
                             .iter()
                             .map(|el| ContractAddress::from_(el.clone()))
                             .collect();
@@ -436,7 +438,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(vec![Felt252::from(id)]))
             }
             "fetch_events" => {
-                let id = &input_reader.read_felt();
+                let id = &input_reader.read_felt()?;
                 let (emitted_events_len, serialized_events) = extended_runtime
                     .extended_runtime
                     .extension
@@ -447,7 +449,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::Handled(result))
             }
             "event_name_hash" => {
-                let name = input_reader.read_felt();
+                let name = input_reader.read_felt()?;
                 let hash = starknet_keccak(as_cairo_short_string(&name).unwrap().as_bytes());
 
                 Ok(CheatcodeHandlingResult::Handled(vec![Felt252::from(hash)]))
@@ -461,8 +463,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 ]))
             }
             "stark_sign_message" => {
-                let private_key = input_reader.read_felt();
-                let message_hash = input_reader.read_felt();
+                let private_key = input_reader.read_felt()?;
+                let message_hash = input_reader.read_felt()?;
 
                 if private_key == Felt252::from(0) {
                     return Ok(handle_cheatcode_error("invalid secret_key"));
@@ -481,7 +483,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 }
             }
             "generate_ecdsa_keys" => {
-                let curve = as_cairo_short_string(&input_reader.read_felt());
+                let curve = as_cairo_short_string(&input_reader.read_felt()?);
 
                 let (signing_key_bytes, verifying_key_bytes) = {
                     match curve.as_deref() {
@@ -519,11 +521,11 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 ]))
             }
             "ecdsa_sign_message" => {
-                let curve = as_cairo_short_string(&input_reader.read_felt());
-                let sk_low = input_reader.read_felt();
-                let sk_high = input_reader.read_felt();
-                let msg_hash_low = input_reader.read_felt();
-                let msg_hash_high = input_reader.read_felt();
+                let curve = as_cairo_short_string(&input_reader.read_felt()?);
+                let sk_low = input_reader.read_felt()?;
+                let sk_high = input_reader.read_felt()?;
+                let msg_hash_low = input_reader.read_felt()?;
+                let msg_hash_high = input_reader.read_felt()?;
 
                 let secret_key = concat_u128_bytes(&sk_low.to_be_bytes(), &sk_high.to_be_bytes());
                 let msg_hash =
@@ -593,9 +595,9 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .extended_runtime
                     .hint_handler
                     .state;
-                let target = ContractAddress::from_(input_reader.read_felt());
-                let storage_address = input_reader.read_felt();
-                store(*state, target, &storage_address, input_reader.read_felt())
+                let target = ContractAddress::from_(input_reader.read_felt()?);
+                let storage_address = input_reader.read_felt()?;
+                store(*state, target, &storage_address, input_reader.read_felt()?)
                     .expect("Failed to store");
                 Ok(CheatcodeHandlingResult::Handled(vec![]))
             }
@@ -605,14 +607,14 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .extended_runtime
                     .hint_handler
                     .state;
-                let target = ContractAddress::from_(input_reader.read_felt());
-                let storage_address = &input_reader.read_felt();
+                let target = ContractAddress::from_(input_reader.read_felt()?);
+                let storage_address = &input_reader.read_felt()?;
                 let loaded = load(*state, target, storage_address).expect("Failed to load");
                 Ok(CheatcodeHandlingResult::Handled(vec![loaded]))
             }
             "map_entry_address" => {
-                let map_selector = &input_reader.read_felt();
-                let keys = &input_reader.read_vec();
+                let map_selector = &input_reader.read_felt()?;
+                let keys = &input_reader.read_vec()?;
                 let map_entry_address = calculate_variable_address(map_selector, Some(keys));
                 Ok(CheatcodeHandlingResult::Handled(vec![map_entry_address]))
             }

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -64,7 +64,7 @@ impl<'a> TxInfoTrait for TestEnvironment<'a> {
 }
 
 #[derive(Clone, Default, Debug, PartialEq)]
-pub struct TxInfo {
+struct TxInfo {
     pub version: Felt252,
     pub account_contract_address: Felt252,
     pub max_fee: Felt252,

--- a/crates/cheatnet/tests/cheatcodes/spoof.rs
+++ b/crates/cheatnet/tests/cheatcodes/spoof.rs
@@ -1,25 +1,23 @@
-use crate::common::state::build_runtime_state;
-use crate::common::{call_contract, deploy_wrapper};
-use crate::{
-    common::assertions::assert_success,
-    common::{
-        call_contract_getter_by_name, deploy_contract, felt_selector_from_name, get_contracts,
-        recover_data, state::create_cached_state,
-    },
+use super::test_environment::TestEnvironment;
+use crate::common::{
+    assertions::assert_success,
+    call_contract, call_contract_getter_by_name, deploy_contract, deploy_wrapper,
+    felt_selector_from_name, get_contracts, recover_data,
+    state::{build_runtime_state, create_cached_state},
 };
 use blockifier::state::state_api::State;
 use cairo_felt::Felt252;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::RuntimeState;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::declare::declare;
-use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::spoof::TxInfoMock;
-use cheatnet::state::{CheatSpan, CheatTarget, CheatnetState};
+use cheatnet::{
+    runtime_extensions::{
+        call_to_blockifier_runtime_extension::RuntimeState,
+        forge_runtime_extension::cheatcodes::{declare::declare, spoof::TxInfoMock},
+    },
+    state::{CheatSpan, CheatTarget, CheatnetState},
+};
 use conversions::IntoConv;
 use num_traits::ToPrimitive;
 use runtime::utils::BufferReader;
-use starknet_api::core::ContractAddress;
-use starknet_api::transaction::TransactionHash;
-
-use super::test_environment::TestEnvironment;
+use starknet_api::{core::ContractAddress, transaction::TransactionHash};
 
 trait SpoofTrait {
     fn spoof(&mut self, target: CheatTarget, tx_info_mock: TxInfoMock, span: CheatSpan);
@@ -113,22 +111,24 @@ impl TxInfo {
     fn deserialize(data: &[Felt252]) -> Self {
         let mut reader = BufferReader::new(data);
 
-        let version = reader.read_felt();
-        let account_contract_address = reader.read_felt();
-        let max_fee = reader.read_felt();
-        let signature = reader.read_vec();
-        let transaction_hash = reader.read_felt();
-        let chain_id = reader.read_felt();
-        let nonce = reader.read_felt();
-        let resource_bounds_len = reader.read_felt();
-        let resource_bounds = reader.read_vec_body(
-            3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
-        );
-        let tip = reader.read_felt();
-        let paymaster_data = reader.read_vec();
-        let nonce_data_availability_mode = reader.read_felt();
-        let fee_data_availability_mode = reader.read_felt();
-        let account_deployment_data = reader.read_vec();
+        let version = reader.read_felt().unwrap();
+        let account_contract_address = reader.read_felt().unwrap();
+        let max_fee = reader.read_felt().unwrap();
+        let signature = reader.read_vec().unwrap();
+        let transaction_hash = reader.read_felt().unwrap();
+        let chain_id = reader.read_felt().unwrap();
+        let nonce = reader.read_felt().unwrap();
+        let resource_bounds_len = reader.read_felt().unwrap();
+        let resource_bounds = reader
+            .read_vec_body(
+                3 * resource_bounds_len.to_usize().unwrap(), // ResourceBounds struct has 3 fields
+            )
+            .unwrap();
+        let tip = reader.read_felt().unwrap();
+        let paymaster_data = reader.read_vec().unwrap();
+        let nonce_data_availability_mode = reader.read_felt().unwrap();
+        let fee_data_availability_mode = reader.read_felt().unwrap();
+        let account_deployment_data = reader.read_vec().unwrap();
 
         Self {
             version,

--- a/crates/forge/tests/integration/runtime.rs
+++ b/crates/forge/tests/integration/runtime.rs
@@ -27,3 +27,31 @@ fn missing_cheatcode_error() {
         "Cheatcode `not_existing123` is not supported in this runtime",
     );
 }
+
+#[test]
+fn cheatcode_invalid_args() {
+    let test = test_utils::test_case!(indoc!(
+        r"
+            use starknet::testing::cheatcode;
+
+            #[test]
+            fn cheatcode_invalid_args() {
+                cheatcode::<'replace_bytecode'>(array![].span());
+                assert(true,'');
+            }
+        "
+    ));
+
+    let result = run_test_case(&test);
+    assert_case_output_contains(
+        &result,
+        "cheatcode_invalid_args",
+        indoc!(
+            r"
+                Got an exception while executing a hint: Hint Error: Reading from buffer failed, this can be caused by calling starknet::testing::cheatcode with invalid arguments.
+                Probably snforge_std version is incompatible, check above for incompatibility warning.
+            "
+        ),
+    );
+    assert_failed(&result);
+}

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 testing = []
 
 [dependencies]
+indoc.workspace = true
 anyhow.workspace = true
 cairo-lang-runner.workspace = true
 cairo-lang-casm.workspace = true

--- a/crates/runtime/src/utils.rs
+++ b/crates/runtime/src/utils.rs
@@ -1,12 +1,39 @@
+use crate::EnhancedHintError;
 use cairo_felt::{felt_str, Felt252};
 use cairo_lang_runner::short_string::{as_cairo_short_string, as_cairo_short_string_ex};
 use cairo_lang_utils::byte_array::{BYTES_IN_WORD, BYTE_ARRAY_MAGIC};
+use indoc::indoc;
 use num_traits::{cast::ToPrimitive, identities::One};
+use thiserror::Error;
 
 pub struct BufferReader<'a> {
     pub buffer: &'a [Felt252],
     pub idx: usize,
 }
+
+#[derive(Error, Debug)]
+pub enum BufferReadError {
+    #[error("Read out of bounds")]
+    EndOfBuffer,
+    #[error("Failed to parse while reading")]
+    ParseFailed,
+}
+
+impl From<BufferReadError> for EnhancedHintError {
+    fn from(value: BufferReadError) -> Self {
+        EnhancedHintError::Anyhow(
+            anyhow::Error::from(value)
+                .context(
+                    indoc!(r"
+                        Reading from buffer failed, this can be caused by calling starknet::testing::cheatcode with invalid arguments.
+                        Probably snforge_std version is incompatible, check above for incompatibility warning.
+                    ")
+                )
+        )
+    }
+}
+
+pub type BufferReadResult<T> = core::result::Result<T, BufferReadError>;
 
 impl BufferReader<'_> {
     #[must_use]
@@ -14,46 +41,64 @@ impl BufferReader<'_> {
         BufferReader::<'a> { buffer, idx: 0 }
     }
 
-    pub fn read_felt(&mut self) -> Felt252 {
+    pub fn read_felt(&mut self) -> BufferReadResult<Felt252> {
+        let felt = self.buffer.get(self.idx).cloned();
+
         self.idx += 1;
-        self.buffer[self.idx - 1].clone()
+
+        felt.ok_or(BufferReadError::EndOfBuffer)
     }
 
-    pub fn read_vec_body(&mut self, count: usize) -> Vec<Felt252> {
+    pub fn read_vec_body(&mut self, count: usize) -> BufferReadResult<Vec<Felt252>> {
+        let start = self.idx;
+
         self.idx += count;
-        self.buffer[self.idx - count..self.idx].to_vec()
+
+        Ok(self
+            .buffer
+            .get(start..self.idx)
+            .ok_or(BufferReadError::EndOfBuffer)?
+            .to_vec())
     }
 
-    pub fn read_vec(&mut self) -> Vec<Felt252> {
-        let count = felt252_to_vec_length(&self.read_felt());
+    pub fn read_vec(&mut self) -> BufferReadResult<Vec<Felt252>> {
+        let count = felt252_to_vec_length(&self.read_felt()?);
         self.read_vec_body(count)
     }
 
-    pub fn read_option_felt(&mut self) -> Option<Felt252> {
-        self.idx += 1;
-        (!self.buffer[self.idx - 1].is_one()).then(|| self.read_felt())
+    pub fn read_option_felt(&mut self) -> BufferReadResult<Option<Felt252>> {
+        match self.read_felt() {
+            Ok(felt) if !felt.is_one() => Ok(Some(self.read_felt()?)),
+            _ => Ok(None),
+        }
     }
 
-    pub fn read_option_vec(&mut self) -> Option<Vec<Felt252>> {
-        self.read_option_felt()
-            .map(|count| self.read_vec_body(felt252_to_vec_length(&count)))
+    pub fn read_option_vec(&mut self) -> BufferReadResult<Option<Vec<Felt252>>> {
+        Ok(match self.read_option_felt()? {
+            Some(count) => Some(self.read_vec_body(felt252_to_vec_length(&count))?),
+            None => None,
+        })
     }
 
-    pub fn read_bool(&mut self) -> bool {
-        self.idx += 1;
-        self.buffer[self.idx - 1] == 1.into()
+    pub fn read_bool(&mut self) -> BufferReadResult<bool> {
+        self.read_felt().map(|felt| felt == 1.into())
     }
 
-    pub fn read_short_string(&mut self) -> Option<String> {
-        as_cairo_short_string(&self.read_felt())
+    pub fn read_short_string(&mut self) -> BufferReadResult<Option<String>> {
+        self.read_felt().map(|felt| as_cairo_short_string(&felt))
     }
 
-    pub fn read_string(&mut self) -> String {
-        let (result, idx_increment) = try_format_string(&self.buffer[self.idx..]).unwrap();
+    pub fn read_string(&mut self) -> BufferReadResult<String> {
+        let (result, idx_increment) = try_format_string(
+            self.buffer
+                .get(self.idx..)
+                .ok_or(BufferReadError::EndOfBuffer)?,
+        )
+        .ok_or(BufferReadError::ParseFailed)?;
 
         self.idx += idx_increment;
 
-        result
+        Ok(result)
     }
 }
 

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -76,9 +76,9 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
     ) -> Result<CheatcodeHandlingResult, EnhancedHintError> {
         let res = match selector {
             "call" => {
-                let contract_address = input_reader.read_felt().into_();
-                let function_selector = input_reader.read_felt().into_();
-                let calldata = input_reader.read_vec();
+                let contract_address = input_reader.read_felt()?.into_();
+                let function_selector = input_reader.read_felt()?.into_();
+                let calldata = input_reader.read_vec()?;
                 let calldata_felts: Vec<FieldElement> = calldata
                     .iter()
                     .map(|el| FieldElement::from_(el.clone()))
@@ -96,12 +96,12 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 ))
             }
             "declare" => {
-                let contract_name = input_reader.read_string();
+                let contract_name = input_reader.read_string()?;
                 let max_fee = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
                 let nonce = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
 
                 let account = self.tokio_runtime.block_on(get_account(
@@ -127,22 +127,22 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 ))
             }
             "deploy" => {
-                let class_hash = input_reader.read_felt().into_();
+                let class_hash = input_reader.read_felt()?.into_();
                 let constructor_calldata: Vec<FieldElement> = input_reader
-                    .read_vec()
+                    .read_vec()?
                     .iter()
                     .map(|el| FieldElement::from_(el.clone()))
                     .collect();
 
                 let salt = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
-                let unique = input_reader.read_bool();
+                let unique = input_reader.read_bool()?;
                 let max_fee = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
                 let nonce = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
 
                 let account = self.tokio_runtime.block_on(get_account(
@@ -170,18 +170,18 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 ))
             }
             "invoke" => {
-                let contract_address = input_reader.read_felt().into_();
-                let function_selector = input_reader.read_felt().into_();
+                let contract_address = input_reader.read_felt()?.into_();
+                let function_selector = input_reader.read_felt()?.into_();
                 let calldata: Vec<FieldElement> = input_reader
-                    .read_vec()
+                    .read_vec()?
                     .iter()
                     .map(|el| FieldElement::from_(el.clone()))
                     .collect();
                 let max_fee = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
                 let nonce = input_reader
-                    .read_option_felt()
+                    .read_option_felt()?
                     .map(conversions::IntoConv::into_);
 
                 let account = self.tokio_runtime.block_on(get_account(
@@ -209,7 +209,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
             }
             "get_nonce" => {
                 let block_id = input_reader
-                    .read_short_string()
+                    .read_short_string()?
                     .expect("Failed to convert entry point name to short string");
                 let account = self.tokio_runtime.block_on(get_account(
                     &self.config.account,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1469

## Introduced changes

<!-- A brief description of the changes -->

- Parsing arguments from memory now fail single test with message, instead of stoping execution

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
