### PR TITLE
Write legacy information to accounts file

### DIFF
--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use starknet::core::types::{
     BlockId, BlockTag,
     BlockTag::{Latest, Pending},
-    ContractErrorData, FieldElement,
+    ContractClass, ContractErrorData, FieldElement,
     StarknetError::{ClassHashNotFound, ContractNotFound, TransactionHashNotFound},
 };
 use starknet::core::utils::UdcUniqueness::{NotUnique, Unique};
@@ -48,6 +48,7 @@ struct Account {
     salt: Option<String>,
     deployed: Option<bool>,
     class_hash: Option<String>,
+    legacy: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -331,6 +332,54 @@ fn get_account_from_accounts_file<'a>(
     );
 
     Ok(account)
+}
+
+pub async fn check_if_legacy_contract(
+    class_hash: Option<FieldElement>,
+    address: FieldElement,
+    provider: &JsonRpcClient<HttpTransport>,
+) -> Result<bool> {
+    let class_hash = extract_class_hash_or_fetch(class_hash, address, provider).await?;
+    let contract_class = provider
+        .get_class(BlockId::Tag(Pending), class_hash)
+        .await?;
+
+    Ok(is_legacy_contract(&contract_class))
+}
+
+async fn extract_class_hash_or_fetch(
+    class_hash: Option<FieldElement>,
+    address: FieldElement,
+    provider: &JsonRpcClient<HttpTransport>,
+) -> Result<FieldElement> {
+    match class_hash {
+        Some(class_hash) => Ok(class_hash),
+        None => get_class_hash_by_address(provider, address)
+            .await?
+            .ok_or_else(|| anyhow!("No class hash exists for the provided address {address:#x}")),
+    }
+}
+
+pub async fn get_class_hash_by_address(
+    provider: &JsonRpcClient<HttpTransport>,
+    address: FieldElement,
+) -> Result<Option<FieldElement>> {
+    match provider
+        .get_class_hash_at(BlockId::Tag(Pending), address)
+        .await
+    {
+        Ok(class_hash) => Ok(Some(class_hash)),
+        Err(StarknetError(ContractNotFound)) => Ok(None),
+        Err(err) => Err(handle_rpc_error(err)),
+    }
+}
+
+#[must_use]
+pub fn is_legacy_contract(contract_class: &ContractClass) -> bool {
+    match contract_class {
+        ContractClass::Legacy(_) => true,
+        ContractClass::Sierra(_) => false,
+    }
 }
 
 pub fn get_block_id(value: &str) -> Result<BlockId> {

--- a/crates/sncast/src/starknet_commands/account/add.rs
+++ b/crates/sncast/src/starknet_commands/account/add.rs
@@ -4,16 +4,12 @@ use crate::starknet_commands::account::{
 use anyhow::{ensure, Context, Result};
 use camino::Utf8PathBuf;
 use clap::Args;
-use sncast::handle_rpc_error;
 use sncast::helpers::configuration::CastConfig;
 use sncast::response::structs::AccountAddResponse;
 use sncast::{check_class_hash_exists, get_chain_id, parse_number};
-use starknet::core::types::BlockTag::Pending;
-use starknet::core::types::{BlockId, FieldElement, StarknetError};
-use starknet::providers::{
-    jsonrpc::{HttpTransport, JsonRpcClient},
-    Provider, ProviderError,
-};
+use sncast::{check_if_legacy_contract, get_class_hash_by_address};
+use starknet::core::types::FieldElement;
+use starknet::providers::jsonrpc::{HttpTransport, JsonRpcClient};
 use starknet::signers::SigningKey;
 
 #[derive(Args, Debug)]
@@ -76,7 +72,7 @@ pub async fn add(
     }
 
     let fetched_class_hash = get_class_hash_by_address(provider, add.address).await?;
-    let is_deployed = fetched_class_hash.is_some();
+    let deployed = fetched_class_hash.is_some();
     let class_hash = match (fetched_class_hash, add.class_hash) {
         (Some(from_provider), Some(from_user)) => {
             ensure!(
@@ -94,8 +90,16 @@ pub async fn add(
         _ => fetched_class_hash,
     };
 
-    let account_json =
-        prepare_account_json(private_key, add.address, is_deployed, class_hash, add.salt);
+    let legacy = check_if_legacy_contract(class_hash, add.address, provider).await?;
+
+    let account_json = prepare_account_json(
+        private_key,
+        add.address,
+        deployed,
+        legacy,
+        class_hash,
+        add.salt,
+    );
 
     let chain_id = get_chain_id(provider).await?;
     write_account_to_accounts_file(account, accounts_file, chain_id, account_json.clone())?;
@@ -125,18 +129,4 @@ pub async fn add(
 fn get_private_key_from_file(file_path: &Utf8PathBuf) -> Result<FieldElement> {
     let private_key_string = std::fs::read_to_string(file_path.clone())?;
     parse_number(&private_key_string)
-}
-
-async fn get_class_hash_by_address(
-    provider: &JsonRpcClient<HttpTransport>,
-    address: FieldElement,
-) -> Result<Option<FieldElement>> {
-    match provider
-        .get_class_hash_at(BlockId::Tag(Pending), address)
-        .await
-    {
-        Ok(class_hash) => Ok(Some(class_hash)),
-        Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(None),
-        Err(err) => Err(handle_rpc_error(err)),
-    }
 }

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -38,6 +38,7 @@ pub fn prepare_account_json(
     private_key: &SigningKey,
     address: FieldElement,
     deployed: bool,
+    legacy: bool,
     class_hash: Option<FieldElement>,
     salt: Option<FieldElement>,
 ) -> serde_json::Value {
@@ -46,6 +47,7 @@ pub fn prepare_account_json(
         "public_key": format!("{:#x}", private_key.verifying_key().scalar()),
         "address": format!("{address:#x}"),
         "deployed": deployed,
+        "legacy": legacy,
     });
 
     if let Some(salt) = salt {

--- a/crates/sncast/tests/e2e/account/add.rs
+++ b/crates/sncast/tests/e2e/account/add.rs
@@ -189,7 +189,7 @@ pub async fn test_nonexistent_account_address() {
 
     snapbox.assert().stderr_matches(indoc! {r"
         command: account add
-        error: No class hash exists for the provided address 0x123
+        error: There is no contract at the specified address
     "});
 }
 

--- a/crates/sncast/tests/e2e/account/add.rs
+++ b/crates/sncast/tests/e2e/account/add.rs
@@ -1,5 +1,6 @@
 use crate::helpers::constants::{
-    DEVNET_OZ_CLASS_HASH, DEVNET_OZ_CLASS_HASH_CAIRO_1, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS, URL,
+    DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_OZ_CLASS_HASH_CAIRO_1, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
+    URL,
 };
 use crate::helpers::runner::runner;
 use camino::Utf8PathBuf;
@@ -28,7 +29,7 @@ pub async fn test_happy_case() {
         "--private-key",
         "0x456",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -48,7 +49,7 @@ pub async fn test_happy_case() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": "0x123",
-                    "class_hash": DEVNET_OZ_CLASS_HASH,
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0,
                     "deployed": false,
                     "legacy": true,
                     "private_key": "0x456",
@@ -92,7 +93,7 @@ pub async fn test_existent_account_address() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
-                    "class_hash": DEVNET_OZ_CLASS_HASH,
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0,
                     "deployed": true,
                     "legacy": true,
                     "private_key": "0x456",
@@ -215,7 +216,7 @@ pub async fn test_happy_case_add_profile() {
         "--salt",
         "0x3",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
         "--add-profile",
         "my_account_add",
     ];
@@ -238,7 +239,7 @@ pub async fn test_happy_case_add_profile() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": "0x1",
-                    "class_hash": DEVNET_OZ_CLASS_HASH,
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0,
                     "deployed": false,
                     "private_key": "0x2",
                     "public_key": "0x759ca09377679ecd535a81e83039658bf40959283187c654c5416f439403cf5",
@@ -293,7 +294,7 @@ pub async fn test_detect_deployed() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
-                    "class_hash": DEVNET_OZ_CLASS_HASH,
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0,
                     "deployed": true,
                     "private_key": "0x5",
                     "public_key": "0x788435d61046d3eec54d77d25bd194525f4fa26ebe6575536bc6f656656b74c",
@@ -373,7 +374,7 @@ pub async fn test_private_key_from_file() {
         "--private-key-file",
         private_key_file,
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -397,7 +398,7 @@ pub async fn test_private_key_from_file() {
                     "legacy": true,
                     "private_key": "0x456",
                     "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
-                    "class_hash": DEVNET_OZ_CLASS_HASH,
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0,
                   }
                 }
             }
@@ -536,7 +537,7 @@ pub async fn test_private_key_as_int_in_file() {
                     "legacy": true,
                     "private_key": "0x456",
                     "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
-                    "class_hash": DEVNET_OZ_CLASS_HASH
+                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_0
                   }
                 }
             }

--- a/crates/sncast/tests/e2e/account/add.rs
+++ b/crates/sncast/tests/e2e/account/add.rs
@@ -27,6 +27,8 @@ pub async fn test_happy_case() {
         "0x123",
         "--private-key",
         "0x456",
+        "--class-hash",
+        DEVNET_OZ_CLASS_HASH,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -46,9 +48,11 @@ pub async fn test_happy_case() {
                 "alpha-goerli": {
                   "my_account_add": {
                     "address": "0x123",
+                    "class_hash": DEVNET_OZ_CLASS_HASH,
                     "deployed": false,
+                    "legacy": true,
                     "private_key": "0x456",
-                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063"
+                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
                   }
                 }
             }
@@ -90,6 +94,7 @@ pub async fn test_existent_account_address() {
                     "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
                     "class_hash": DEVNET_OZ_CLASS_HASH,
                     "deployed": true,
+                    "legacy": true,
                     "private_key": "0x456",
                     "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063"
                   }
@@ -160,6 +165,34 @@ pub async fn test_nonexistent_account_address_and_nonexistent_class_hash() {
 }
 
 #[tokio::test]
+pub async fn test_nonexistent_account_address() {
+    let tempdir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "accounts.json";
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "add",
+        "--name",
+        "my_account_add",
+        "--address",
+        "0x123",
+        "--private-key",
+        "0x456",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+
+    snapbox.assert().stderr_matches(indoc! {r"
+        command: account add
+        error: No class hash exists for the provided address 0x123
+    "});
+}
+
+#[tokio::test]
 pub async fn test_happy_case_add_profile() {
     let tempdir = tempdir().expect("Failed to create a temporary directory");
     let accounts_file = "accounts.json";
@@ -210,6 +243,7 @@ pub async fn test_happy_case_add_profile() {
                     "private_key": "0x2",
                     "public_key": "0x759ca09377679ecd535a81e83039658bf40959283187c654c5416f439403cf5",
                     "salt": "0x3",
+                    "legacy": true
                   }
                 }
             }
@@ -262,7 +296,8 @@ pub async fn test_detect_deployed() {
                     "class_hash": DEVNET_OZ_CLASS_HASH,
                     "deployed": true,
                     "private_key": "0x5",
-                    "public_key": "0x788435d61046d3eec54d77d25bd194525f4fa26ebe6575536bc6f656656b74c"
+                    "public_key": "0x788435d61046d3eec54d77d25bd194525f4fa26ebe6575536bc6f656656b74c",
+                    "legacy": true
                   }
                 }
             }
@@ -337,6 +372,8 @@ pub async fn test_private_key_from_file() {
         "0x123",
         "--private-key-file",
         private_key_file,
+        "--class-hash",
+        DEVNET_OZ_CLASS_HASH,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -357,8 +394,10 @@ pub async fn test_private_key_from_file() {
                   "my_account_add": {
                     "address": "0x123",
                     "deployed": false,
+                    "legacy": true,
                     "private_key": "0x456",
-                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063"
+                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
+                    "class_hash": DEVNET_OZ_CLASS_HASH,
                   }
                 }
             }
@@ -473,7 +512,7 @@ pub async fn test_private_key_as_int_in_file() {
         "--name",
         "my_account_add",
         "--address",
-        "0x123",
+        DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
         "--private-key-file",
         private_key_file,
     ];
@@ -492,10 +531,12 @@ pub async fn test_private_key_as_int_in_file() {
             {
                 "alpha-goerli": {
                   "my_account_add": {
-                    "address": "0x123",
-                    "deployed": false,
+                    "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
+                    "deployed": true,
+                    "legacy": true,
                     "private_key": "0x456",
-                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063"
+                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
+                    "class_hash": DEVNET_OZ_CLASS_HASH
                   }
                 }
             }

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -50,6 +50,7 @@ pub async fn test_happy_case() {
     assert!(contents.contains("address"));
     assert!(contents.contains("salt"));
     assert!(contents.contains("class_hash"));
+    assert!(contents.contains("legacy"));
 }
 
 #[tokio::test]
@@ -121,6 +122,7 @@ pub async fn test_happy_case_generate_salt() {
     assert!(contents.contains("address"));
     assert!(contents.contains("salt"));
     assert!(contents.contains("class_hash"));
+    assert!(contents.contains("legacy"));
 }
 
 #[tokio::test]
@@ -195,6 +197,7 @@ pub async fn test_happy_case_accounts_file_already_exists() {
         .expect("Unable to read created file");
     assert!(contents.contains("my_account"));
     assert!(contents.contains("deployed"));
+    assert!(contents.contains("legacy"));
 }
 
 #[tokio::test]
@@ -290,6 +293,7 @@ pub async fn test_happy_case_keystore() {
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
+    assert!(contents.contains("\"legacy\": true"));
 }
 
 #[tokio::test]
@@ -329,6 +333,7 @@ pub async fn test_happy_case_keystore_add_profile() {
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
+    assert!(contents.contains("\"legacy\": true"));
 
     let contents = fs::read_to_string(tempdir.path().join("snfoundry.toml"))
         .expect("Unable to read snfoundry.toml");
@@ -483,6 +488,7 @@ pub async fn test_happy_case_keystore_int_format() {
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
+    assert!(contents.contains("\"legacy\": true"));
 }
 
 #[tokio::test]
@@ -522,4 +528,5 @@ pub async fn test_happy_case_keystore_hex_format() {
     assert!(contents.contains("\"deployment\": {"));
     assert!(contents.contains("\"variant\": {"));
     assert!(contents.contains("\"version\": 1"));
+    assert!(contents.contains("\"legacy\": true"));
 }

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -1,4 +1,4 @@
-use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH, URL};
+use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
 use crate::helpers::fixtures::{copy_file, default_cli_args};
 use crate::helpers::runner::runner;
 use configuration::copy_config_to_tempdir;
@@ -26,7 +26,7 @@ pub async fn test_happy_case() {
         "--salt",
         "0x1",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -100,7 +100,7 @@ pub async fn test_happy_case_generate_salt() {
         "--name",
         "my_account",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -142,7 +142,7 @@ pub async fn test_happy_case_add_profile() {
         "--add-profile",
         "my_account",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -180,7 +180,7 @@ pub async fn test_happy_case_accounts_file_already_exists() {
         "--salt",
         "0x1",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -217,7 +217,7 @@ pub async fn test_profile_already_exists() {
         "--add-profile",
         "default",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -243,7 +243,7 @@ pub async fn test_account_already_exists() {
         "--salt",
         "0x1",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ]);
 
     let snapbox = runner(&args);
@@ -275,7 +275,7 @@ pub async fn test_happy_case_keystore() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -316,7 +316,7 @@ pub async fn test_happy_case_keystore_add_profile() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
         "--add-profile",
         "with_keystore",
     ];
@@ -359,7 +359,7 @@ pub async fn test_keystore_without_account() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -397,7 +397,7 @@ pub async fn test_keystore_file_already_exists() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -436,7 +436,7 @@ pub async fn test_keystore_account_file_already_exists() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -470,7 +470,7 @@ pub async fn test_happy_case_keystore_int_format() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
@@ -510,7 +510,7 @@ pub async fn test_happy_case_keystore_hex_format() {
         "account",
         "create",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -1,4 +1,4 @@
-use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH, URL};
+use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
 use crate::helpers::fixtures::{convert_to_hex, copy_file};
 use crate::helpers::fixtures::{
     get_address_from_keystore, get_transaction_hash, get_transaction_receipt, mint_token,
@@ -32,7 +32,7 @@ pub async fn test_happy_case() {
         "--max-fee",
         "99999999999999999",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -71,7 +71,7 @@ pub async fn test_happy_case_add_profile() {
         "--max-fee",
         "99999999999999999",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -134,7 +134,7 @@ async fn test_too_low_max_fee() {
         "--max-fee",
         "1",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -247,7 +247,7 @@ pub async fn create_account(add_profile: bool) -> TempDir {
         "--name",
         "my_account",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
     if add_profile {
         args.push("--add-profile");
@@ -311,7 +311,7 @@ pub async fn test_happy_case_keystore() {
         "--max-fee",
         "99999999999999999",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -358,7 +358,7 @@ pub async fn test_keystore_already_deployed() {
         "--max-fee",
         "10000000000000000",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -403,7 +403,7 @@ pub async fn test_keystore_key_mismatch() {
         "--max-fee",
         "10000000000000000",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -443,7 +443,7 @@ pub async fn test_deploy_keystore_inexistent_keystore_file() {
         "--max-fee",
         "10000000000000000",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -483,7 +483,7 @@ pub async fn test_deploy_keystore_inexistent_account_file() {
         "--max-fee",
         "10000000000000000",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -527,7 +527,7 @@ pub async fn test_deploy_keystore_no_status() {
         "--max-fee",
         "10000000000000000",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
@@ -587,7 +587,7 @@ pub async fn test_deploy_keystore_other_args() {
         "--max-fee",
         "99999999999999999",
         "--class-hash",
-        DEVNET_OZ_CLASS_HASH,
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());

--- a/crates/sncast/tests/helpers/constants.rs
+++ b/crates/sncast/tests/helpers/constants.rs
@@ -10,7 +10,7 @@ pub const SCRIPTS_DIR: &str = "tests/data/scripts";
 pub const DEVNET_ENV_FILE: &str = ".env.devnet_hashes_and_addresses";
 pub const MULTICALL_CONFIGS_DIR: &str = "crates/sncast/tests/data/multicall_configs";
 
-pub const DEVNET_OZ_CLASS_HASH: &str =
+pub const DEVNET_OZ_CLASS_HASH_CAIRO_0: &str =
     "0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f";
 pub const DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS: &str =
     "0x691a61b12a7105b1372cc377f135213c11e8400a546f6b0e7ea0296046690ce";

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -1,5 +1,5 @@
 use crate::helpers::constants::{
-    ACCOUNT_FILE_PATH, CONTRACTS_DIR, DEVNET_ENV_FILE, DEVNET_OZ_CLASS_HASH, URL,
+    ACCOUNT_FILE_PATH, CONTRACTS_DIR, DEVNET_ENV_FILE, DEVNET_OZ_CLASS_HASH_CAIRO_0, URL,
 };
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -92,7 +92,8 @@ pub async fn deploy_keystore_account() {
         .unwrap_or_else(|_| panic!("Failed to parse keystore account file at = {account_path}"));
 
     let factory = OpenZeppelinAccountFactory::new(
-        parse_number(DEVNET_OZ_CLASS_HASH).expect("Could not parse DEVNET_OZ_CLASS_HASH"),
+        parse_number(DEVNET_OZ_CLASS_HASH_CAIRO_0)
+            .expect("Could not parse DEVNET_OZ_CLASS_HASH_CAIRO_0"),
         chain_id,
         LocalWallet::from_signing_key(private_key),
         provider,

--- a/crates/sncast/tests/integration/lib_tests.rs
+++ b/crates/sncast/tests/integration/lib_tests.rs
@@ -1,9 +1,11 @@
-use crate::helpers::constants::URL;
+use crate::helpers::constants::{
+    DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS, URL,
+};
 use crate::helpers::fixtures::create_test_provider;
 
 use camino::Utf8PathBuf;
 use shared::rpc::{get_rpc_version, is_expected_version};
-use sncast::{get_account, get_provider};
+use sncast::{check_if_legacy_contract, get_account, get_provider, parse_number};
 use std::fs;
 use url::ParseError;
 
@@ -144,4 +146,27 @@ async fn test_supported_rpc_version_matches_devnet_version() {
     let provider = create_test_provider();
     let devnet_spec_version = get_rpc_version(&provider).await.unwrap();
     assert!(is_expected_version(&devnet_spec_version));
+}
+
+#[tokio::test]
+async fn test_check_if_legacy_contract_by_class_hash() {
+    let provider = create_test_provider();
+    let class_hash = parse_number(DEVNET_OZ_CLASS_HASH_CAIRO_0)
+        .expect("Failed to parse DEVNET_OZ_CLASS_HASH_CAIRO_0");
+    let mock_address = parse_number("0x1").unwrap();
+    let is_legacy = check_if_legacy_contract(Some(class_hash), mock_address, &provider)
+        .await
+        .unwrap();
+    assert!(is_legacy);
+}
+
+#[tokio::test]
+async fn test_check_if_legacy_contract_by_address() {
+    let provider = create_test_provider();
+    let address = parse_number(DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS)
+        .expect("Failed to parse DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS");
+    let is_legacy = check_if_legacy_contract(None, address, &provider)
+        .await
+        .unwrap();
+    assert!(is_legacy);
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

#1202 

This PR is part of the stack:

-> Write legacy information to accounts file (#1849)
-- Enable using Cairo 1 accounts in sncast (#1850)
-- Use Cairo 1 accounts in sncast tests (#1851)
-- Update documentation and default class hash (#1900)

## Introduced changes

<!-- A brief description of the changes -->

- Write `legacy` information to accounts file in `account create` and `account add` to distinguish between Cairo 0 and Cairo >=1 accounts
- Rename `DEVNET_OZ_CLASS_HASH` -> `DEVNET_OZ_CLASS_HASH_CAIRO_0`

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [ ] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
