### PR TITLE
Enable using Cairo 1 accounts in sncast

### DIFF
--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -346,18 +346,11 @@ fn get_account_data_from_accounts_file(
     let accounts: HashMap<String, HashMap<String, AccountData>> = read_and_parse_json_file(path)?;
     let network_name = chain_id_to_network_name(chain_id);
 
-    let account = accounts
+    accounts
         .get(&network_name)
         .and_then(|accounts_map| accounts_map.get(name))
-        .cloned();
-
-    account.ok_or_else(|| {
-        anyhow!(
-            "Account = {} not found under network = {}",
-            name,
-            network_name
-        )
-    })
+        .cloned()
+        .ok_or_else(|| anyhow!("Account = {name} not found under network = {network_name}"))
 }
 
 fn read_and_parse_json_file<T: DeserializeOwned>(path: &Utf8PathBuf) -> Result<T> {

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -15,7 +15,7 @@ use starknet::providers::{JsonRpcClient, Provider};
 use starknet::signers::{LocalWallet, SigningKey};
 
 use sncast::{
-    account_file_exists, chain_id_to_network_name, get_keystore_password,
+    chain_id_to_network_name, check_account_file_exists, get_keystore_password,
     handle_account_factory_error, handle_rpc_error, handle_wait_for_tx, parse_number, WaitForTx,
 };
 
@@ -64,7 +64,7 @@ pub async fn deploy(
         if name == String::default() {
             bail!("No --name value passed")
         }
-        account_file_exists(&accounts_file)?;
+        check_account_file_exists(&accounts_file)?;
         deploy_from_accounts_file(
             provider,
             accounts_file,

--- a/crates/sncast/tests/data/accounts/faulty_accounts.json
+++ b/crates/sncast/tests/data/accounts/faulty_accounts.json
@@ -7,6 +7,12 @@
             "address": "0x76e7ce6466e353a00b614ee763f1bc93dba01a57925784a7682efa6b1879c3d",
             "deployed": true
         },
+        "with_wrong_class_hash": {
+            "private_key": "0x88ecc06581d81c76cef06d6f4f0c1b28",
+            "public_key": "0x8cdbe26bc82084b04eccb3c6f8a76f12ad6c4015b3dc8ab90dc840d42cac29",
+            "address": "0x691a61b12a7105b1372cc377f135213c11e8400a546f6b0e7ea0296046690ce",
+            "class_hash": "class_hash"
+        },
         "with_wrong_address": {
             "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
             "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",

--- a/crates/sncast/tests/data/keystore/my_account.json
+++ b/crates/sncast/tests/data/keystore/my_account.json
@@ -3,7 +3,8 @@
     "variant": {
         "type": "open_zeppelin",
         "version": 1,
-        "public_key": "0xe2d3d7080bfc665e0060a06e8e95c3db3ff78a1fec4cc81ddc87e49a12e0a"
+        "public_key": "0xe2d3d7080bfc665e0060a06e8e95c3db3ff78a1fec4cc81ddc87e49a12e0a",
+        "legacy": true
     },
     "deployment": {
         "status": "deployed",

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -142,7 +142,10 @@ async fn test_nonexistent_account_address() {
     let snapbox = runner(&args).current_dir(contract_path.path());
     let output = snapbox.assert().failure();
 
-    assert_stderr_contains(output, "Error: Invalid account address");
+    assert_stderr_contains(
+        output,
+        "Error: No account exists with the provided address 0x1010101010011aaabbcc",
+    );
 }
 
 #[tokio::test]

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -144,7 +144,7 @@ async fn test_nonexistent_account_address() {
 
     assert_stderr_contains(
         output,
-        "Error: No account exists with the provided address 0x1010101010011aaabbcc",
+        "Error: Account with address 0x1010101010011aaabbcc not found on network SN_GOERLI",
     );
 }
 

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -265,7 +265,7 @@ async fn test_nonexistent_account_address() {
         output,
         indoc! {r"
         command: script run
-        error: Invalid account address
+        error: Account with address 0x1010101010011aaabbcc not found on network SN_GOERLI
         "},
     );
 }

--- a/crates/sncast/tests/integration/lib_tests.rs
+++ b/crates/sncast/tests/integration/lib_tests.rs
@@ -125,7 +125,7 @@ async fn test_get_account_failed_to_convert_field_elements() {
     let err1 = account1.unwrap_err();
     assert!(err1
         .to_string()
-        .contains("Failed to convert private key = privatekey to FieldElement"));
+        .contains("Failed to convert private key to FieldElement"));
 
     let account2 = get_account(
         "with_wrong_address",
@@ -138,6 +138,18 @@ async fn test_get_account_failed_to_convert_field_elements() {
     assert!(err2
         .to_string()
         .contains("Failed to convert account address = address to FieldElement"));
+
+    let account3 = get_account(
+        "with_wrong_class_hash",
+        &Utf8PathBuf::from("tests/data/accounts/faulty_accounts.json"),
+        &provider,
+        None,
+    )
+    .await;
+    let err3 = account3.unwrap_err();
+    assert!(err3
+        .to_string()
+        .contains("Failed to convert class hash = class_hash to FieldElement"));
 }
 
 // TODO (#1690): Move this test to the shared crate and execute it for a real node


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

#1202 

This PR is part of the stack:

-- Write legacy information to accounts file (#1849)
-> Enable using Cairo 1 accounts in sncast (#1850)
-- Use Cairo 1 accounts in sncast tests (#1851)
-- Update documentation and default class hash (#1900)

## Introduced changes

<!-- A brief description of the changes -->

- Modify logic in `get_account` function to enable using Cairo >=1 accounts

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [ ] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
