### PR TITLE
Call `get_account` once in `script run`

### DIFF
--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -265,7 +265,24 @@ async fn test_nonexistent_account_address() {
         output,
         indoc! {r"
         command: script run
-        error: Got an exception while executing a hint: Hint Error: Invalid account address
+        error: Invalid account address
+        "},
+    );
+}
+
+#[tokio::test]
+async fn test_no_account_passed() {
+    let script_name = "map_script";
+    let args = vec!["--url", URL, "script", "run", &script_name];
+
+    let snapbox = runner(&args).current_dir(SCRIPTS_DIR.to_owned() + "/map_script/scripts");
+    let output = snapbox.assert().success();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+        command: script run
+        error: [..] Account not defined. Please ensure the correct account is passed to `script run` command
         "},
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1901 

## Introduced changes

<!-- A brief description of the changes -->

- Move `get_account` calls out of the `handle_cheatcode` function. Instead of calling it multiple times for every single operation in a script, call it just once within the `run` function.

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [ ] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
