### PR TITLE
Ignore tests which are using the integration node URL

### DIFF
--- a/crates/cheatnet/tests/cheatcodes/prank.rs
+++ b/crates/cheatnet/tests/cheatcodes/prank.rs
@@ -293,6 +293,7 @@ fn prank_one_then_all() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn prank_cairo0_callback() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
+++ b/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
@@ -42,6 +42,7 @@ impl ReplaceBytecodeTrait for TestEnvironment<'_> {
     }
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork() {
     let cache_dir = TempDir::new().unwrap();

--- a/crates/cheatnet/tests/cheatcodes/spy_events.rs
+++ b/crates/cheatnet/tests/cheatcodes/spy_events.rs
@@ -476,6 +476,8 @@ fn test_emitted_by_emit_events_syscall() {
         "Wrong spy_events_checker event"
     );
 }
+
+#[ignore] // TODO (#1916)
 #[test]
 fn capture_cairo0_event() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/cheatnet/tests/starknet/cheat_fork.rs
+++ b/crates/cheatnet/tests/starknet/cheat_fork.rs
@@ -13,6 +13,7 @@ use test_case::test_case;
 const CAIRO0_TESTER_ADDRESS: &str =
     "1825832089891106126806210124294467331434544162488231781791271899226056323189";
 
+#[ignore] // TODO (#1916)
 #[test_case("return_caller_address"; "when common call")]
 #[test_case("return_proxied_caller_address"; "when library call")]
 fn prank_cairo0_contract(selector: &str) {
@@ -73,6 +74,7 @@ fn prank_cairo0_contract(selector: &str) {
     assert_eq!(unpranked_caller, caller);
 }
 
+#[ignore] // TODO (#1916)
 #[test_case("return_block_number"; "when common call")]
 #[test_case("return_proxied_block_number"; "when library call")]
 fn roll_cairo0_contract(selector: &str) {
@@ -132,6 +134,7 @@ fn roll_cairo0_contract(selector: &str) {
     assert_eq!(unrolled_block_number, block_number);
 }
 
+#[ignore] // TODO (#1916)
 #[test_case("return_block_timestamp"; "when common call")]
 #[test_case("return_proxied_block_timestamp"; "when library call")]
 fn warp_cairo0_contract(selector: &str) {

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -27,6 +27,7 @@ use std::str::FromStr;
 use tempfile::TempDir;
 use url::Url;
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_simple() {
     let cache_dir = TempDir::new().unwrap();
@@ -72,6 +73,7 @@ fn fork_simple() {
     assert_success(output, &[Felt252::from(102)]);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn try_calling_nonexistent_contract() {
     let cache_dir = TempDir::new().unwrap();
@@ -114,6 +116,7 @@ fn try_deploying_undeclared_class() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn test_forking_at_block_number() {
     let node_url: Url = "http://188.34.188.184:9545/rpc/v0_7".parse().unwrap();
@@ -185,6 +188,7 @@ fn test_forking_at_block_number() {
     purge_cache(cache_dir.path().to_str().unwrap());
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn call_forked_contract_from_other_contract() {
     let cache_dir = TempDir::new().unwrap();
@@ -217,6 +221,7 @@ fn call_forked_contract_from_other_contract() {
     assert_success(output, &[Felt252::from(2)]);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn library_call_on_forked_class_hash() {
     let cache_dir = TempDir::new().unwrap();
@@ -266,6 +271,7 @@ fn library_call_on_forked_class_hash() {
     assert_success(output, &[Felt252::from(100)]);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn call_forked_contract_from_constructor() {
     let cache_dir = TempDir::new().unwrap();
@@ -305,6 +311,7 @@ fn call_forked_contract_from_constructor() {
     assert_success(output, &[Felt252::from(2)]);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn call_forked_contract_get_block_info_via_proxy() {
     let cache_dir = TempDir::new().unwrap();
@@ -369,6 +376,7 @@ fn call_forked_contract_get_block_info_via_proxy() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn call_forked_contract_get_block_info_via_libcall() {
     let cache_dir = TempDir::new().unwrap();
@@ -434,6 +442,7 @@ fn call_forked_contract_get_block_info_via_libcall() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn using_specified_block_nb_is_cached() {
     let cache_dir = TempDir::new().unwrap();
@@ -521,6 +530,7 @@ fn using_specified_block_nb_is_cached() {
     purge_cache(cache_dir.path().to_str().unwrap());
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn test_cache_merging() {
     fn run_test(cache_dir: &str, contract_address: &str, balance: u64) {
@@ -633,6 +643,7 @@ fn test_cache_merging() {
     assert_cache();
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn test_cached_block_info_merging() {
     fn run_test(cache_dir: &str, contract_address: &str, balance: u64, call_get_block_info: bool) {
@@ -700,6 +711,7 @@ fn test_cached_block_info_merging() {
     assert_cached_block_info(true);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn test_calling_nonexistent_url() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/forge/tests/e2e/forking.rs
+++ b/crates/forge/tests/e2e/forking.rs
@@ -5,6 +5,7 @@ use forge::shared_cache::CACHE_DIR;
 use indoc::indoc;
 use shared::test_utils::output_assert::assert_stdout_contains;
 
+#[ignore] // TODO (#1916)
 #[test]
 fn without_cache() {
     let temp = setup_package("forking");
@@ -32,6 +33,7 @@ fn without_cache() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 /// The cache file at `forking/$CACHE_DIR` was modified to have different value stored
 /// that this from the real network. We use it to verify that values from cache are actually used.
@@ -71,6 +73,7 @@ fn with_cache() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn with_clean_cache() {
     let temp = setup_package_with_file_patterns(
@@ -100,6 +103,7 @@ fn with_clean_cache() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn printing_latest_block_number() {
     let temp = setup_package_with_file_patterns(

--- a/crates/forge/tests/integration/cheat_fork.rs
+++ b/crates/forge/tests/integration/cheat_fork.rs
@@ -4,7 +4,7 @@ use test_utils::running_tests::run_test_case;
 use test_utils::test_case;
 
 static CHEATNET_RPC_URL: &str = "http://188.34.188.184:9545/rpc/v0_7";
-
+#[ignore] // TODO (#1916)
 #[test]
 fn prank_cairo0_contract() {
     let test = test_case!(formatdoc!(
@@ -53,6 +53,7 @@ fn prank_cairo0_contract() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn roll_cairo0_contract() {
     let test = test_case!(formatdoc!(
@@ -101,6 +102,7 @@ fn roll_cairo0_contract() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn warp_cairo0_contract() {
     let test = test_case!(formatdoc!(
@@ -151,6 +153,7 @@ fn warp_cairo0_contract() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn mock_call_cairo0_contract() {
     let test = test_case!(formatdoc!(
@@ -192,6 +195,7 @@ fn mock_call_cairo0_contract() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn store_load_cairo0_contract() {
     let test = test_case!(formatdoc!(

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -284,6 +284,7 @@ fn fork_get_block_info_fails() {
     );
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 // found in: https://github.com/foundry-rs/starknet-foundry/issues/1175
 fn incompatible_abi() {

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -23,6 +23,7 @@ use test_utils::test_case;
 static INTEGRATION_RPC_URL: &str = "http://188.34.188.184:9545/rpc/v0_7";
 static TESTNET_RPC_URL: &str = "http://188.34.188.184:6060/rpc";
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_simple_decorator() {
     let test = test_case!(formatdoc!(
@@ -66,6 +67,7 @@ fn fork_simple_decorator() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_aliased_decorator() {
     let test = test_case!(formatdoc!(
@@ -147,6 +149,7 @@ fn fork_aliased_decorator() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_cairo0_contract() {
     let test = test_case!(formatdoc!(
@@ -177,6 +180,7 @@ fn fork_cairo0_contract() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn get_block_info_in_forked_block() {
     let test = test_case!(formatdoc!(
@@ -256,6 +260,7 @@ fn get_block_info_in_forked_block() {
     assert_passed(&result);
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_get_block_info_fails() {
     let test = test_case!(formatdoc!(

--- a/crates/forge/tests/integration/spy_events.rs
+++ b/crates/forge/tests/integration/spy_events.rs
@@ -618,6 +618,7 @@ fn assert_not_emitted_fails() {
     assert_case_output_contains(&result, "assert_not_emitted_fails", "keys was emitted");
 }
 
+#[ignore] // TODO (#1916)
 #[test]
 fn capture_cairo0_event() {
     let test = test_case!(

--- a/crates/forge/tests/integration/store_load.rs
+++ b/crates/forge/tests/integration/store_load.rs
@@ -555,6 +555,7 @@ fn store_load_felt_to_felt() {
     assert_passed(&result);
 }
 static INTEGRATION_RPC_URL: &str = "http://188.34.188.184:9545/rpc/v0_7";
+#[ignore] // TODO (#1916)
 #[test]
 fn fork_store_load() {
     let test = test_utils::test_case!(formatdoc!(


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

- Disables the tests which are going to crash soon enough because of goerli integration shutdown