### PR TITLE
Clippy error fix

### DIFF
--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -98,6 +98,7 @@ impl ForkCache {
                 .write(true)
                 .read(true)
                 .create(true)
+                .truncate(false)
                 .open(&cache_file_path)
                 .unwrap();
 
@@ -129,6 +130,7 @@ impl ForkCache {
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(cache_file)
             .unwrap();
 


### PR DESCRIPTION
## Introduced changes

Fixes the error on CI introduced with stable rust being bumped to 1.77.0
