### PR TITLE
Use `ByteArray`s instead of `felt252`s in our own library assertions

### DIFF
--- a/sncast_std/src/lib.cairo
+++ b/sncast_std/src/lib.cairo
@@ -126,10 +126,11 @@ pub fn call(
 
     let mut buf = cheatcode::<'call'>(inputs.span());
 
-    let mut result_data: Result<CallResult, ScriptCommandError> = Serde::<
-        Result<CallResult>
-    >::deserialize(ref buf)
-        .expect('call deserialize failed');
+    let mut result_data: Result<CallResult, ScriptCommandError> =
+        match Serde::<Result<CallResult>>::deserialize(ref buf) {
+        Option::Some(result_data) => result_data,
+        Option::None => panic!("call deserialize failed")
+    };
 
     result_data
 }
@@ -165,10 +166,11 @@ pub fn declare(
 
     let mut buf = cheatcode::<'declare'>(inputs.span());
 
-    let mut result_data: Result<DeclareResult, ScriptCommandError> = Serde::<
-        Result<DeclareResult>
-    >::deserialize(ref buf)
-        .expect('declare deserialize failed');
+    let mut result_data: Result<DeclareResult, ScriptCommandError> =
+        match Serde::<Result<DeclareResult>>::deserialize(ref buf) {
+        Option::Some(result_data) => result_data,
+        Option::None => panic!("declare deserialize failed"),
+    };
 
     result_data
 }
@@ -221,10 +223,11 @@ pub fn deploy(
 
     let mut buf = cheatcode::<'deploy'>(inputs.span());
 
-    let mut result_data: Result<DeployResult, ScriptCommandError> = Serde::<
-        Result<DeployResult>
-    >::deserialize(ref buf)
-        .expect('deploy deserialize failed');
+    let mut result_data: Result<DeployResult, ScriptCommandError> =
+        match Serde::<Result<DeployResult>>::deserialize(ref buf) {
+        Option::Some(result_data) => result_data,
+        Option::None => panic!("deploy deserialize failed")
+    };
 
     result_data
 }
@@ -265,10 +268,11 @@ pub fn invoke(
 
     let mut buf = cheatcode::<'invoke'>(inputs.span());
 
-    let mut result_data: Result<InvokeResult, ScriptCommandError> = Serde::<
-        Result<InvokeResult>
-    >::deserialize(ref buf)
-        .expect('invoke deserialize failed');
+    let mut result_data: Result<InvokeResult, ScriptCommandError> =
+        match Serde::<Result<InvokeResult>>::deserialize(ref buf) {
+        Option::Some(result_data) => result_data,
+        Option::None => panic!("invoke deserialize failed")
+    };
 
     result_data
 }

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -172,7 +172,10 @@ fn get_class_hash(contract_address: ContractAddress) -> ClassHash {
 
     // Expecting a buffer with one felt252, being the class hash.
     let buf = cheatcode::<'get_class_hash'>(array![contract_address_felt].span());
-    (*buf[0]).try_into().expect('Invalid class hash value')
+    match (*buf[0]).try_into() {
+        Option::Some(hash) => hash,
+        Option::None => panic!("Invalid class hash value")
+    }
 }
 
 fn _prepare_calldata(

--- a/snforge_std/src/cheatcodes/events.cairo
+++ b/snforge_std/src/cheatcodes/events.cairo
@@ -1,3 +1,4 @@
+use core::option::OptionTrait;
 use starknet::testing::cheatcode;
 use starknet::ContractAddress;
 
@@ -75,11 +76,8 @@ impl EventAssertionsImpl<
             let emitted = is_emitted(ref self, from, event);
 
             if !emitted {
-                panic(
-                    array![
-                        'Event with matching data and', 'keys was not emitted from', (*from).into()
-                    ]
-                );
+                let from: felt252 = (*from).into();
+                panic!("Event with matching data and keys was not emitted from {}", from);
             }
 
             i += 1;
@@ -99,9 +97,8 @@ impl EventAssertionsImpl<
             let emitted = is_emitted(ref self, from, event);
 
             if emitted {
-                panic(
-                    array!['Event with matching data and', 'keys was emitted from', (*from).into()]
-                );
+                let from: felt252 = (*from).into();
+                panic!("Event with matching data and keys was emitted from {}", from);
             }
 
             i += 1;

--- a/snforge_std/src/cheatcodes/storage.cairo
+++ b/snforge_std/src/cheatcodes/storage.cairo
@@ -9,7 +9,7 @@ fn validate_storage_address_felt(storage_address_felt: felt252) {
     match storage_address_try_from_felt252(storage_address_felt) {
         Option::Some(_) => {},
         // Panics in order not to leave inconsistencies in the state
-        Option::None(()) => panic(array!['storage_address out of range', storage_address_felt]),
+        Option::None(()) => panic!("storage_address out of range {}", storage_address_felt),
     }
 }
 

--- a/snforge_std/src/errors.cairo
+++ b/snforge_std/src/errors.cairo
@@ -20,8 +20,10 @@ impl SyscallResultStringErrorTraitImpl<T> of SyscallResultStringErrorTrait<T> {
             Result::Err(panic_data) => {
                 if panic_data.len() > 0 && *panic_data.at(0) == BYTE_ARRAY_MAGIC {
                     let mut panic_data_span = panic_data.span().slice(1, panic_data.len() - 1);
-                    let deserialized = Serde::<ByteArray>::deserialize(ref panic_data_span)
-                        .expect('panic string not deserializable');
+                    let deserialized = match Serde::<ByteArray>::deserialize(ref panic_data_span) {
+                        Option::Some(str) => str,
+                        Option::None => panic!("panic string not deserializable")
+                    };
                     return Result::Err(PanicDataOrString::String(deserialized));
                 }
                 Result::Err(PanicDataOrString::PanicData(panic_data))


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1892

## Introduced changes

<!-- A brief description of the changes -->

- Use `ByteArray`s instead of `felt252`s in our own library assertions

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
