### PR TITLE
Add functions to retrieve `SEPOLIA_RPC_URL`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+SEPOLIA_RPC_URL=https://example.com/rpc/v0_7

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Scarb.lock
 .spr.yml
 .snfoundry_cache/
 .snfoundry_trace/
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4376,6 +4376,7 @@ dependencies = [
  "cairo-felt",
  "cairo-lang-runner",
  "console",
+ "dotenv",
  "regex",
  "semver",
  "snapbox",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -8,6 +8,7 @@ anyhow.workspace = true
 cairo-felt.workspace = true
 cairo-lang-runner.workspace = true
 console.workspace = true
+dotenv.workspace = true
 semver.workspace = true
 starknet.workspace = true
 url.workspace = true

--- a/crates/shared/src/consts.rs
+++ b/crates/shared/src/consts.rs
@@ -1,1 +1,2 @@
 pub const EXPECTED_RPC_VERSION: &str = "0.7.0";
+pub const RPC_URL_VERSION: &str = "v0_7";

--- a/crates/shared/src/test_utils/mod.rs
+++ b/crates/shared/src/test_utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod node_url;
 pub mod output_assert;

--- a/crates/shared/src/test_utils/node_url.rs
+++ b/crates/shared/src/test_utils/node_url.rs
@@ -1,0 +1,29 @@
+use anyhow::{Context, Result};
+use std::env;
+use url::Url;
+
+/// Loads node RPC URL from `SEPOLIA_RPC_URL` environmental variable set in dotenv.
+///
+/// #### Note:
+/// - `node_rpc_url()` -> <https://example.com/rpc/v0_7>
+/// - `node_url()` -> <https://example.com/>
+pub fn node_rpc_url() -> Result<Url> {
+    dotenv::dotenv().ok();
+    let node_rpc_url = env::var("SEPOLIA_RPC_URL")
+        .context("The required environmental variable `SEPOLIA_RPC_URL` is not set. Please set it manually or in .env file"
+    )?;
+
+    Url::parse(&node_rpc_url).with_context(|| {
+        format!("Failed to parse the URL from the `SEPOLIA_RPC_URL` environmental variable: {node_rpc_url}")
+    })
+}
+
+/// Loads node URL from `SEPOLIA_RPC_URL` environmental variable and parses it,
+/// returning URL with no slug (`rpc/v0_7` suffix).
+pub fn node_url() -> Result<Url> {
+    let mut node_url = node_rpc_url()?;
+    node_url.set_path("");
+    node_url.set_query(None);
+
+    Ok(node_url)
+}


### PR DESCRIPTION
commit-id:918e569e

Fix cargo lint errors

Change implementation of rpc_url()

rpc_url() -> node_url() (to rebase)

Apply review suggestions (to rebase)

Envs from dotenv (to rebase)

Add .env.template file, rename functions once again (to rebase)

---

**Stack**:
- #2006
- #2004
- #2003 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*