### PR TITLE
Fold appendix in docs by default

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,3 +12,7 @@ edit-url-template = "https://github.com/foundry-rs/starknet-foundry/edit/master/
 
 [output.html.playground]
 runnable = false
+
+[output.html.fold]
+enable = true
+level = 0


### PR DESCRIPTION
## Introduced changes
Resulting menu fold:
![image](https://github.com/foundry-rs/starknet-foundry/assets/34059895/1e53598a-86c4-4bde-b3f9-95672aa54322)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
