### PR TITLE
Workaround missing function debug name info in release artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cast
+
+#### Fixed
+- scripts built with release profile are now properly recognized and ran 
+
 ## [0.22.0] - 2024-04-17
 
 ### Forge

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -465,7 +465,7 @@ fn run_script_command(
                 },
             )
             .expect("Failed to build artifacts");
-            // todo #2042: remove duplicated compilation
+            // TODO(#2042): remove duplicated compilation
             build(
                 &package_metadata,
                 &BuildConfig {

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -14,7 +14,7 @@ use shared::verify_and_warn_if_incompatible_rpc_version;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::{DEFAULT_ACCOUNTS_FILE, DEFAULT_MULTICALL_CONTENTS};
 use sncast::helpers::scarb_utils::{
-    assert_manifest_path_exists, build_and_load_artifacts, get_package_metadata,
+    assert_manifest_path_exists, build, build_and_load_artifacts, get_package_metadata,
     get_scarb_metadata_with_deps, BuildConfig,
 };
 use sncast::response::errors::handle_starknet_command_error;
@@ -462,6 +462,16 @@ fn run_script_command(
                     scarb_toml_path: manifest_path.clone(),
                     json: cli.json,
                     profile: cli.profile.clone().unwrap_or("dev".to_string()),
+                },
+            )
+            .expect("Failed to build artifacts");
+            // todo #2042: remove duplicated compilation
+            build(
+                &package_metadata,
+                &BuildConfig {
+                    scarb_toml_path: manifest_path.clone(),
+                    json: cli.json,
+                    profile: "dev".to_string(),
                 },
             )
             .expect("Failed to build script");

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -33,7 +33,7 @@ pub struct Create {
     /// If passed, a profile with provided name and corresponding data will be created in snfoundry.toml
     #[clap(long)]
     pub add_profile: Option<String>,
-    // TODO (#253): think about supporting different account providers
+    // TODO(#1855, #1854): think about supporting different account providers
     /// Custom open zeppelin contract class hash of declared contract
     #[clap(short, long)]
     pub class_hash: Option<FieldElement>,

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -454,6 +454,7 @@ fn inject_lib_artifact(
         .target_dir
         .clone()
         .unwrap_or_else(|| metadata.workspace.root.join("target"));
+    // TODO(#2042)
     let sierra_path = &target_dir.join("dev").join(sierra_filename);
 
     let lib_artifacts = ScriptStarknetContractArtifacts {

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -326,7 +326,8 @@ pub fn run(
     .with_context(|| "Failed to set up runner")?;
 
     let name_suffix = module_name.to_string() + "::main";
-    let func = runner.find_function(name_suffix.as_str())?;
+    let func = runner.find_function(name_suffix.as_str())
+        .context("Failed to find main function in script - please make sure `sierra-replace-ids` is not set to `false` for `dev` profile in script's Scarb.toml")?;
 
     let (entry_code, builtins) = runner.create_entry_code(func, &Vec::new(), usize::MAX)?;
     let footer = SierraCasmRunner::create_code_footer();

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -454,9 +454,7 @@ fn inject_lib_artifact(
         .target_dir
         .clone()
         .unwrap_or_else(|| metadata.workspace.root.join("target"));
-    let sierra_path = &target_dir
-        .join(&metadata.current_profile)
-        .join(sierra_filename);
+    let sierra_path = &target_dir.join("dev").join(sierra_filename);
 
     let lib_artifacts = ScriptStarknetContractArtifacts {
         sierra: fs::read_to_string(sierra_path)?,

--- a/crates/sncast/src/state/state_file.rs
+++ b/crates/sncast/src/state/state_file.rs
@@ -259,7 +259,7 @@ pub fn load_or_create_state_file(path: &Utf8PathBuf) -> Result<ScriptTransaction
     }
 }
 
-// todo (1233): remove must_use attribute when it's no longer needed
+// TODO(#1233): remove must_use attribute when it's no longer needed
 #[must_use]
 pub fn generate_transaction_entry_with_id(
     tx_entry: ScriptTransactionEntry,

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -506,3 +506,41 @@ async fn test_state_file_rerun_failed_tx() {
     let invoke_tx_entry = tx_entries_after_first_run.get(map_invoke_tx_id).unwrap();
     assert_tx_entry_success(invoke_tx_entry, "invoke");
 }
+
+#[tokio::test]
+async fn test_using_release_profile() {
+    let contract_dir = duplicate_contract_directory_with_salt(
+        SCRIPTS_DIR.to_owned() + "/map_script/contracts/",
+        "dummy",
+        "69420",
+    );
+    let script_dir = copy_script_directory_to_tempdir(
+        SCRIPTS_DIR.to_owned() + "/map_script/scripts/",
+        vec![contract_dir.as_ref()],
+    );
+
+    let accounts_json_path = get_accounts_path(ACCOUNT_FILE_PATH);
+
+    let script_name = "map_script";
+    let args = vec![
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user5",
+        "--url",
+        URL,
+        "--profile",
+        "release",
+        "script",
+        "run",
+        &script_name,
+    ];
+
+    let snapbox = runner(&args).current_dir(script_dir.path());
+
+    snapbox.assert().success().stdout_matches(indoc! {r"
+        ...
+        command: script run
+        status: success
+    "});
+}


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

- Works around an issue, where there are no function debug name info in release artifacts. The issue will be fully fixed by https://github.com/foundry-rs/starknet-foundry/issues/2042

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
