### PR TITLE
Install devnet from release to speed CI up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,6 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
-        with:
-          cache-directories: crates/sncast/tests/utils/devnet
       - name: Install starknet-devnet-rs
         run: ./scripts/install_devnet.sh
       - uses: software-mansion/setup-scarb@v1.3.2

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -119,7 +119,7 @@ fn test_too_low_max_fee() {
     let mut args = default_cli_args();
     args.append(&mut vec![
         "--account",
-        "user8",
+        "user11",
         "--wait",
         "invoke",
         "--contract-address",

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -36,7 +36,7 @@ fn start_devnet() {
     let sepolia_rpc_url =
         from_env("SEPOLIA_RPC_URL").expect("Failed to get SEPOLIA_RPC_URL environment variable");
 
-    Command::new("tests/utils/devnet/bin/starknet-devnet")
+    Command::new("tests/utils/devnet/starknet-devnet")
         .args([
             "--port",
             &port,

--- a/scripts/install_devnet.sh
+++ b/scripts/install_devnet.sh
@@ -2,10 +2,70 @@
 set -e
 
 DEVNET_INSTALL_DIR="$(git rev-parse --show-toplevel)/crates/sncast/tests/utils/devnet"
-DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs.git"
-DEVNET_REV="0a0d6ec"
+DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs"
+DEVNET_VER="v0.0.5"
 
-cargo install --locked --git "$DEVNET_REPO" --rev "$DEVNET_REV" --root "$DEVNET_INSTALL_DIR" --force
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+      echo "$1 is not available"
+      echo "Please install $1 and run the script again"
+      exit 1
+  fi
+}
+
+get_architecture() {
+  local _ostype _cputype _arch _clibtype
+  _ostype="$(uname -s)"
+  _cputype="$(uname -m)"
+  _clibtype="gnu"
+
+  if [ "$_ostype" = Linux ] && ldd --_requested_version 2>&1 | grep -q 'musl'; then
+    _clibtype="musl"
+  fi
+
+  if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ] && sysctl hw.optional.x86_64 | grep -q ': 1'; then
+    _cputype=x86_64
+  fi
+
+  case "$_ostype" in
+  Linux)
+    _ostype=unknown-linux-$_clibtype
+    ;;
+
+  Darwin)
+    _ostype=apple-darwin
+    ;;
+  *)
+    err "unsupported OS type: $_ostype"
+    ;;
+  esac
+
+  case "$_cputype" in
+  aarch64 | arm64)
+    _cputype=aarch64
+    ;;
+
+  x86_64 | x86-64 | x64 | amd64)
+    _cputype=x86_64
+    ;;
+  *)
+    err "unknown CPU type: $_cputype"
+    ;;
+  esac
+
+  _arch="${_cputype}-${_ostype}"
+
+  RETVAL="$_arch"
+}
+
+require_cmd curl
+require_cmd tar
+
+get_architecture
+SYSTEM_TRIPLET="$RETVAL"
+
+mkdir -p "${DEVNET_INSTALL_DIR}"
+curl -L "${DEVNET_REPO}/releases/download/${DEVNET_VER}/starknet-devnet-${SYSTEM_TRIPLET}.tar.gz" | tar -xz -C "${DEVNET_INSTALL_DIR}" || exit 1
 
 echo "All done!"
 exit 0


### PR DESCRIPTION

## Introduced changes

<!-- A brief description of the changes -->

I have noticed sncast test on CI take the longest time to complete, from all the jobs. This PR aims to reduce the time needed to complete sncast CI job. The main issue was with devnet installation and its caching, since about a week devnet is available as ready binary, so we start to use that. 

Before:
<img width="275" alt="obraz" src="https://github.com/foundry-rs/starknet-foundry/assets/9470712/121d6fbb-8ebd-4b37-9ce8-8f9d34f57e8d">

Now:
<img width="275" alt="obraz" src="https://github.com/foundry-rs/starknet-foundry/assets/9470712/3bb7a78b-b723-4692-960c-3bd678fd80f9">


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
