### PR TITLE
Remove lint alias from sncast config

### DIFF
--- a/crates/sncast/.cargo/config.toml
+++ b/crates/sncast/.cargo/config.toml
@@ -1,4 +1,3 @@
 [alias]
-lint = "clippy --all-targets --all-features -- --no-deps -W clippy::pedantic -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::default_trait_access"
 "test e2e" = "test --test main e2e"
 "test integration" = "test --test main integration"


### PR DESCRIPTION
- The `lint` alias in the sncast `config.toml` currently differs from the one defined in the home directory. This discrepancy is producing some warnings. By removing it here, `cargo` will always use the `lint` defined in `starknet-foundry/.cargo/config.toml`.