### PR TITLE
Fix `SerializeAsFelt252Vec` for `Vec`

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_info.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_info.rs
@@ -91,7 +91,7 @@ fn get_cheated_tx_info_ptr(
     };
     if let Some(resource_bounds) = resource_bounds {
         let (resource_bounds_start_ptr, resource_bounds_end_ptr) =
-            add_vec_memory_segment(&resource_bounds.serialize_as_felt252_vec(), vm);
+            add_vec_memory_segment(&resource_bounds.serialize_as_felt252_vec()[1..], vm);
         new_tx_info[8] = resource_bounds_start_ptr.into();
         new_tx_info[9] = resource_bounds_end_ptr.into();
     }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_info.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_info.rs
@@ -3,7 +3,10 @@ use cairo_vm::{
     types::relocatable::{MaybeRelocatable, Relocatable},
     vm::vm_core::VirtualMachine,
 };
-use conversions::{felt252::SerializeAsFelt252Vec, FromConv, IntoConv};
+use conversions::{
+    felt252::{RawFeltVec, SerializeAsFelt252Vec},
+    FromConv, IntoConv,
+};
 
 use crate::{
     runtime_extensions::forge_runtime_extension::cheatcodes::spoof::TxInfoMock, state::CheatedData,
@@ -90,8 +93,10 @@ fn get_cheated_tx_info_ptr(
         new_tx_info[7] = MaybeRelocatable::Int(nonce);
     };
     if let Some(resource_bounds) = resource_bounds {
-        let (resource_bounds_start_ptr, resource_bounds_end_ptr) =
-            add_vec_memory_segment(&resource_bounds.serialize_as_felt252_vec()[1..], vm);
+        let (resource_bounds_start_ptr, resource_bounds_end_ptr) = add_vec_memory_segment(
+            &RawFeltVec::new(resource_bounds).serialize_as_felt252_vec(),
+            vm,
+        );
         new_tx_info[8] = resource_bounds_start_ptr.into();
         new_tx_info[9] = resource_bounds_end_ptr.into();
     }

--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -129,6 +129,33 @@ pub trait SerializeAsFelt252Vec: Sized {
     }
 }
 
+/// use this wrapper to NOT add extra length felt
+/// useful e.g. when you need to pass an already serialized value
+pub struct RawFeltVec<T>(Vec<T>)
+where
+    T: SerializeAsFelt252Vec;
+
+impl<T> RawFeltVec<T>
+where
+    T: SerializeAsFelt252Vec,
+{
+    #[must_use]
+    pub fn new(vec: Vec<T>) -> Self {
+        Self(vec)
+    }
+}
+
+impl<T> SerializeAsFelt252Vec for RawFeltVec<T>
+where
+    T: SerializeAsFelt252Vec,
+{
+    fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
+        for e in self.0 {
+            e.serialize_into_felt252_vec(output);
+        }
+    }
+}
+
 impl<T> SerializeAsFelt252Vec for Vec<T>
 where
     T: SerializeAsFelt252Vec,

--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -134,6 +134,10 @@ where
     T: SerializeAsFelt252Vec,
 {
     fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
+        let len: Felt252 = self.len().into();
+
+        len.serialize_into_felt252_vec(output);
+
         for e in self {
             e.serialize_into_felt252_vec(output);
         }

--- a/crates/sncast/src/response/structs.rs
+++ b/crates/sncast/src/response/structs.rs
@@ -1,7 +1,7 @@
 use cairo_felt::Felt252;
 use camino::Utf8PathBuf;
-use conversions::felt252::SerializeAsFelt252Vec;
 use conversions::FromConv;
+use conversions::{felt252::SerializeAsFelt252Vec, IntoConv};
 use serde::{Deserialize, Serialize, Serializer};
 use starknet::core::types::FieldElement;
 
@@ -9,6 +9,12 @@ pub struct Decimal(pub u64);
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct Felt(pub FieldElement);
+
+impl FromConv<Felt> for Felt252 {
+    fn from_(value: Felt) -> Self {
+        value.0.into_()
+    }
+}
 
 impl Serialize for Decimal {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -47,8 +53,7 @@ impl CommandResponse for CallResponse {}
 
 impl SerializeAsFelt252Vec for CallResponse {
     fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
-        output.push(Felt252::from(self.response.len()));
-        output.extend(self.response.iter().map(|el| Felt252::from_(el.0)));
+        self.response.serialize_into_felt252_vec(output);
     }
 }
 
@@ -60,7 +65,7 @@ impl CommandResponse for InvokeResponse {}
 
 impl SerializeAsFelt252Vec for InvokeResponse {
     fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
-        output.push(Felt252::from_(self.transaction_hash.0));
+        self.transaction_hash.serialize_into_felt252_vec(output);
     }
 }
 

--- a/crates/sncast/src/state/state_file.rs
+++ b/crates/sncast/src/state/state_file.rs
@@ -204,15 +204,20 @@ impl From<DeployResponse> for ScriptTransactionOutput {
 
 #[must_use]
 pub fn serialize_as_script_function_result(output: ScriptTransactionOutput) -> Vec<Felt252> {
-    let res = match output {
-        ScriptTransactionOutput::InvokeResponse(val) => val.serialize_as_felt252_vec(),
-        ScriptTransactionOutput::DeclareResponse(val) => val.serialize_as_felt252_vec(),
-        ScriptTransactionOutput::DeployResponse(val) => val.serialize_as_felt252_vec(),
+    match output {
+        ScriptTransactionOutput::InvokeResponse(val) => {
+            Ok::<_, StarknetCommandError>(val).serialize_as_felt252_vec()
+        }
+        ScriptTransactionOutput::DeclareResponse(val) => {
+            Ok::<_, StarknetCommandError>(val).serialize_as_felt252_vec()
+        }
+        ScriptTransactionOutput::DeployResponse(val) => {
+            Ok::<_, StarknetCommandError>(val).serialize_as_felt252_vec()
+        }
         ScriptTransactionOutput::ErrorResponse(_) => {
             panic!("Cannot return ErrorResponse as script function response")
         }
-    };
-    Ok::<Vec<Felt252>, StarknetCommandError>(res).serialize_as_felt252_vec()
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Fix `SerializeAsFelt252Vec` for `Vec`. There was missing length serialization in `Vec` implementation


