### PR TITLE
Return `Result` in `stark_sign_message` and `ecdsa_sign_message` cheatcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
+- `SignerTrait::sign` now returns `Result` instead of failing the test
+
 - `L1HandlerTrait::execute()` takes source address and payloads as arguments [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes/l1_handler.html)
 
 - When calling to an address which does not exists, error is forwarded to cairo runtime instead of failing the test

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -36,11 +36,9 @@ use cairo_vm::vm::{
     errors::hint_errors::HintError, runners::cairo_runner::ExecutionResources,
     vm_core::VirtualMachine,
 };
-use conversions::{
-    byte_array::ByteArray,
-    felt252::{FromShortString, TryInferFormat},
-    FromConv, IntoConv,
-};
+use conversions::felt252::SerializeAsFelt252Vec;
+use conversions::{byte_array::ByteArray, felt252::TryInferFormat, IntoConv};
+use runtime::FromReader;
 use runtime::{
     utils::buffer_reader::BufferReader, CheatcodeHandlingResult, EnhancedHintError,
     ExtendedRuntime, ExtensionLogic, SyscallHandlingResult,
@@ -276,30 +274,30 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
             "generate_stark_keys" => {
                 let key_pair = SigningKey::from_random();
 
-                Ok(CheatcodeHandlingResult::Handled(vec![
-                    key_pair.secret_scalar().into_(),
-                    key_pair.verifying_key().scalar().into_(),
-                ]))
+                Ok(CheatcodeHandlingResult::from_serializable((
+                    key_pair.secret_scalar(),
+                    key_pair.verifying_key().scalar(),
+                )))
             }
             "stark_sign_message" => {
                 let private_key = input_reader.read()?;
                 let message_hash = input_reader.read()?;
 
                 if private_key == FieldElement::from(0_u8) {
-                    return Ok(handle_cheatcode_error("invalid secret_key"));
+                    return Ok(CheatcodeHandlingResult::from_serializable(Err::<(), _>(
+                        SignError::InvalidSecretKey,
+                    )));
                 }
 
                 let key_pair = SigningKey::from_secret_scalar(private_key);
 
-                if let Ok(signature) = key_pair.sign(&message_hash) {
-                    Ok(CheatcodeHandlingResult::Handled(vec![
-                        Felt252::from(0),
-                        Felt252::from_(signature.r),
-                        Felt252::from_(signature.s),
-                    ]))
+                let result = if let Ok(signature) = key_pair.sign(&message_hash) {
+                    Ok((signature.r, signature.s))
                 } else {
-                    Ok(handle_cheatcode_error("message_hash out of range"))
-                }
+                    Err(SignError::HashOutOfRange)
+                };
+
+                Ok(CheatcodeHandlingResult::from_serializable(result))
             }
             "generate_ecdsa_keys" => {
                 let curve = as_cairo_short_string(&input_reader.read()?);
@@ -330,69 +328,63 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     }
                 };
 
-                Ok(CheatcodeHandlingResult::Handled(vec![
-                    Felt252::from_bytes_be(&signing_key_bytes[16..32]), // 16 low  bytes of secret_key
-                    Felt252::from_bytes_be(&signing_key_bytes[0..16]), // 16 high bytes of secret_key
-                    Felt252::from_bytes_be(&verifying_key_bytes[17..33]), // 16 low  bytes of public_key's x-coordinate
-                    Felt252::from_bytes_be(&verifying_key_bytes[1..17]), // 16 high bytes of public_key's x-coordinate
-                    Felt252::from_bytes_be(&verifying_key_bytes[49..65]), // 16 low  bytes of public_key's y-coordinate
-                    Felt252::from_bytes_be(&verifying_key_bytes[33..49]), // 16 high bytes of public_key's y-coordinate
-                ]))
+                Ok(CheatcodeHandlingResult::from_serializable((
+                    CairoU256::from_bytes(&signing_key_bytes),
+                    CairoU256::from_bytes(&verifying_key_bytes[1..]), // bytes of public_key's x-coordinate
+                    CairoU256::from_bytes(&verifying_key_bytes[33..]), // bytes of public_key's y-coordinate
+                )))
             }
             "ecdsa_sign_message" => {
-                let curve = as_cairo_short_string(&input_reader.read()?);
-                let sk_low: Felt252 = input_reader.read()?;
-                let sk_high: Felt252 = input_reader.read()?;
-                let msg_hash_low: Felt252 = input_reader.read()?;
-                let msg_hash_high: Felt252 = input_reader.read()?;
+                let curve = input_reader.read_short_string()?;
+                let secret_key: CairoU256 = input_reader.read()?;
+                let msg_hash: CairoU256 = input_reader.read()?;
 
-                let secret_key = concat_u128_bytes(&sk_low.to_be_bytes(), &sk_high.to_be_bytes());
-                let msg_hash =
-                    concat_u128_bytes(&msg_hash_low.to_be_bytes(), &msg_hash_high.to_be_bytes());
-
-                let (r_bytes, s_bytes) = {
+                let result = {
                     match curve.as_deref() {
                         Some("Secp256k1") => {
-                            let Ok(signing_key) = k256::ecdsa::SigningKey::from_slice(&secret_key)
-                            else {
-                                return Ok(handle_cheatcode_error("invalid secret_key"));
-                            };
+                            if let Ok(signing_key) =
+                                k256::ecdsa::SigningKey::from_slice(&secret_key.to_be_bytes())
+                            {
+                                let signature: k256::ecdsa::Signature =
+                                    k256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
+                                        &signing_key,
+                                        &msg_hash.to_be_bytes(),
+                                    )
+                                    .unwrap();
 
-                            let signature: k256::ecdsa::Signature =
-                                k256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
-                                    &signing_key,
-                                    &msg_hash,
-                                )
-                                .unwrap();
-
-                            signature.split_bytes()
+                                Ok(signature.split_bytes())
+                            } else {
+                                Err(SignError::InvalidSecretKey)
+                            }
                         }
                         Some("Secp256r1") => {
-                            let Ok(signing_key) = p256::ecdsa::SigningKey::from_slice(&secret_key)
-                            else {
-                                return Ok(handle_cheatcode_error("invalid secret_key"));
-                            };
+                            if let Ok(signing_key) =
+                                p256::ecdsa::SigningKey::from_slice(&secret_key.to_be_bytes())
+                            {
+                                let signature: p256::ecdsa::Signature =
+                                    p256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
+                                        &signing_key,
+                                        &msg_hash.to_be_bytes(),
+                                    )
+                                    .unwrap();
 
-                            let signature: p256::ecdsa::Signature =
-                                p256::ecdsa::signature::hazmat::PrehashSigner::sign_prehash(
-                                    &signing_key,
-                                    &msg_hash,
-                                )
-                                .unwrap();
-
-                            signature.split_bytes()
+                                Ok(signature.split_bytes())
+                            } else {
+                                Err(SignError::InvalidSecretKey)
+                            }
                         }
                         _ => return Ok(CheatcodeHandlingResult::Forwarded),
                     }
                 };
 
-                Ok(CheatcodeHandlingResult::Handled(vec![
-                    Felt252::from(0),
-                    Felt252::from_bytes_be(&r_bytes[16..32]), // 16 low  bytes of r
-                    Felt252::from_bytes_be(&r_bytes[0..16]),  // 16 high bytes of r
-                    Felt252::from_bytes_be(&s_bytes[16..32]), // 16 low  bytes of s
-                    Felt252::from_bytes_be(&s_bytes[0..16]),  // 16 high bytes of s
-                ]))
+                let result = result.map(|(r_bytes, s_bytes)| {
+                    (
+                        CairoU256::from_bytes(&r_bytes),
+                        CairoU256::from_bytes(&s_bytes),
+                    )
+                });
+
+                Ok(CheatcodeHandlingResult::from_serializable(result))
             }
             "get_call_trace" => {
                 let call_trace = &extended_runtime
@@ -453,6 +445,54 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
             ))),
             _ => Ok(SyscallHandlingResult::Forwarded),
         }
+    }
+}
+
+#[derive(FromReader)]
+struct CairoU256 {
+    low: u128,
+    high: u128,
+}
+
+impl CairoU256 {
+    fn from_bytes(bytes: &[u8]) -> Self {
+        Self {
+            low: u128::from_be_bytes(bytes[16..32].try_into().unwrap()),
+            high: u128::from_be_bytes(bytes[0..16].try_into().unwrap()),
+        }
+    }
+
+    fn to_be_bytes(&self) -> [u8; 32] {
+        let mut result = [0; 32];
+
+        result[16..].copy_from_slice(&self.low.to_be_bytes());
+        result[..16].copy_from_slice(&self.high.to_be_bytes());
+
+        result
+    }
+}
+
+impl SerializeAsFelt252Vec for CairoU256 {
+    fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
+        let low: Felt252 = self.low.into();
+        let high: Felt252 = self.high.into();
+
+        output.push(low);
+        output.push(high);
+    }
+}
+
+enum SignError {
+    InvalidSecretKey,
+    HashOutOfRange,
+}
+
+impl SerializeAsFelt252Vec for SignError {
+    fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
+        match self {
+            Self::InvalidSecretKey => output.push(0.into()),
+            Self::HashOutOfRange => output.push(1.into()),
+        };
     }
 }
 
@@ -581,22 +621,6 @@ pub fn cheatcode_panic_result(panic_data: Vec<Felt252>) -> Vec<Felt252> {
     result.push(Felt252::from(panic_data.len()));
 
     result.extend(panic_data);
-    result
-}
-
-fn handle_cheatcode_error(error_short_string: &str) -> CheatcodeHandlingResult {
-    CheatcodeHandlingResult::Handled(vec![
-        Felt252::from(1),
-        Felt252::from_short_string(error_short_string)
-            .expect("Should convert shortstring to Felt252"),
-    ])
-}
-
-fn concat_u128_bytes(low: &[u8; 32], high: &[u8; 32]) -> [u8; 32] {
-    let mut result = [0; 32];
-    // the values of u128 are contained in the last 16 bytes
-    result[..16].copy_from_slice(&high[16..32]);
-    result[16..].copy_from_slice(&low[16..32]);
     result
 }
 

--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -186,10 +186,6 @@ impl<T: SerializeAsFelt252Vec, E: SerializeAsFelt252Vec> SerializeAsFelt252Vec f
     }
 }
 
-impl SerializeAsFelt252Vec for () {
-    fn serialize_into_felt252_vec(self, _output: &mut Vec<Felt252>) {}
-}
-
 impl<T> SerializeAsFelt252Vec for T
 where
     T: IntoConv<Felt252>,

--- a/crates/conversions/src/felt252.rs
+++ b/crates/conversions/src/felt252.rs
@@ -218,3 +218,26 @@ impl SerializeAsFelt252Vec for String {
         self.as_str().serialize_as_felt252_vec()
     }
 }
+
+macro_rules! impl_serialize_for_tuple {
+    ($($ty:ident),*) => {
+        impl<$( $ty ),*> SerializeAsFelt252Vec for ( $( $ty, )* )
+        where
+        $( $ty: SerializeAsFelt252Vec, )*
+        {
+            #[allow(non_snake_case)]
+            #[allow(unused_variables)]
+            fn serialize_into_felt252_vec(self, output: &mut Vec<Felt252>) {
+                let ( $( $ty, )* ) = self;
+
+                $( $ty.serialize_into_felt252_vec(output); )*
+            }
+        }
+    };
+}
+
+impl_serialize_for_tuple!();
+impl_serialize_for_tuple!(A);
+impl_serialize_for_tuple!(A, B);
+impl_serialize_for_tuple!(A, B, C);
+impl_serialize_for_tuple!(A, B, C, D); // cairo serde supports tuples in range 0 - 4 only

--- a/crates/forge/tests/integration/signing.rs
+++ b/crates/forge/tests/integration/signing.rs
@@ -6,7 +6,7 @@ use test_utils::{runner::assert_passed, test_case};
 fn test_stark_sign_msg_hash_range() {
     let test = test_case!(indoc!(
         r"
-            use snforge_std::signature::KeyPairTrait;
+            use snforge_std::signature::{KeyPairTrait, SignError};
             use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl, StarkCurveVerifierImpl};
             
             const UPPER_BOUND: felt252 = 0x800000000000000000000000000000000000000000000000000000000000000;
@@ -16,21 +16,20 @@ fn test_stark_sign_msg_hash_range() {
                 let key_pair = KeyPairTrait::<felt252, felt252>::generate();
                 
                 let msg_hash = UPPER_BOUND - 1;
-                let (r, s): (felt252, felt252) = key_pair.sign(msg_hash);
+                let (r, s): (felt252, felt252) = key_pair.sign(msg_hash).unwrap();
             
                 let is_valid = key_pair.verify(msg_hash, (r, s));
                 assert(is_valid, 'Signature should be valid');
             }
 
             #[test]
-            #[should_panic(expected: ('message_hash out of range', ))]
             fn invalid_range() {
                 let key_pair = KeyPairTrait::<felt252, felt252>::generate();
                 
                 // message_hash should be smaller than UPPER_BOUND
                 // https://github.com/starkware-libs/crypto-cpp/blob/78e3ed8dc7a0901fe6d62f4e99becc6e7936adfd/src/starkware/crypto/ecdsa.cc#L65
                 let msg_hash = UPPER_BOUND;
-                key_pair.sign(msg_hash);
+                assert(key_pair.sign(msg_hash).unwrap_err() == SignError::HashOutOfRange, '');
             }
         "
     ));
@@ -52,7 +51,7 @@ fn test_stark_curve() {
             let key_pair = KeyPairTrait::<felt252, felt252>::generate();
             
             let msg_hash = 0xbadc0ffee;
-            let (r, s): (felt252, felt252) = key_pair.sign(msg_hash);
+            let (r, s): (felt252, felt252) = key_pair.sign(msg_hash).unwrap();
         
             let is_valid = key_pair.verify(msg_hash, (r, s));
             assert(is_valid, 'Signature should be valid');
@@ -83,7 +82,7 @@ fn test_secp256k1_curve() {
                 let key_pair = KeyPairTrait::<u256, Secp256k1Point>::generate();
                 
                 let msg_hash = 0xbadc0ffee;
-                let (r, s): (u256, u256) = key_pair.sign(msg_hash);
+                let (r, s): (u256, u256) = key_pair.sign(msg_hash).unwrap();
             
                 let is_valid = key_pair.verify(msg_hash, (r, s));
                 assert(is_valid, 'Signature should be valid');
@@ -114,7 +113,7 @@ fn test_secp256r1_curve() {
                 let key_pair = KeyPairTrait::<u256, Secp256r1Point>::generate();
                 
                 let msg_hash = 0xbadc0ffee;
-                let (r, s): (u256, u256) = key_pair.sign(msg_hash);
+                let (r, s): (u256, u256) = key_pair.sign(msg_hash).unwrap();
             
                 let is_valid = key_pair.verify(msg_hash, (r, s));
                 assert(is_valid, 'Signature should be valid');
@@ -154,8 +153,8 @@ fn test_secp256_curves() {
 
                 let msg_hash: u256 = 0xbadc0ffee;
 
-                let sig_k1 = key_pair_k1.sign(msg_hash);
-                let sig_r1 = key_pair_r1.sign(msg_hash);
+                let sig_k1 = key_pair_k1.sign(msg_hash).unwrap();
+                let sig_r1 = key_pair_r1.sign(msg_hash).unwrap();
                 
                 assert(sig_k1 != sig_r1, 'Signatures should be different');
 
@@ -198,8 +197,8 @@ fn test_stark_secp256k1_curves() {
             
                 let msg_hash = 0xbadc0ffee;
             
-                let (r_stark, s_stark): (felt252, felt252) = key_pair_stark.sign(msg_hash);
-                let (r_secp256k1, s_secp256k1): (u256, u256) = key_pair_secp256k1.sign(msg_hash.into());
+                let (r_stark, s_stark): (felt252, felt252) = key_pair_stark.sign(msg_hash).unwrap();
+                let (r_secp256k1, s_secp256k1): (u256, u256) = key_pair_secp256k1.sign(msg_hash.into()).unwrap();
                 
                 assert(r_stark.into() != r_secp256k1, 'Signatures should be different');
                 assert(s_stark.into() != s_secp256k1, 'Signatures should be different');
@@ -221,7 +220,7 @@ fn test_stark_secp256k1_curves() {
 fn test_invalid_secret_key() {
     let test = test_case!(indoc!(
         r"
-            use snforge_std::signature::{KeyPair, KeyPairTrait};
+            use snforge_std::signature::{KeyPair, KeyPairTrait, SignError};
             use snforge_std::signature::stark_curve::{StarkCurveKeyPairImpl, StarkCurveSignerImpl};
             use snforge_std::signature::secp256k1_curve::{Secp256k1CurveKeyPairImpl, Secp256k1CurveSignerImpl};
             use snforge_std::signature::secp256r1_curve::{Secp256r1CurveKeyPairImpl, Secp256r1CurveSignerImpl};
@@ -247,26 +246,23 @@ fn test_invalid_secret_key() {
             }
             
             #[test]
-            #[should_panic(expected: ('invalid secret_key', ))]
             fn sign_stark() {
                 let key_pair = KeyPair { secret_key: 0, public_key: 0x321 } ;
-                key_pair.sign(123);
+                assert(key_pair.sign(123).unwrap_err() == SignError::InvalidSecretKey, '');
             }
             
             #[test]
-            #[should_panic(expected: ('invalid secret_key', ))]
             fn sign_secp256k1() {
                 let generator = Secp256k1Impl::get_generator_point();
                 let key_pair = KeyPair { secret_key: 0, public_key: generator } ;
-                key_pair.sign(123);
+                assert(key_pair.sign(123).unwrap_err() == SignError::InvalidSecretKey, '');
             }
             
             #[test]
-            #[should_panic(expected: ('invalid secret_key', ))]
             fn sign_secp256r1() {
                 let generator = Secp256r1Impl::get_generator_point();
                 let key_pair = KeyPair { secret_key: 0, public_key: generator } ;
-                key_pair.sign(123);
+                assert(key_pair.sign(123).unwrap_err() == SignError::InvalidSecretKey, '');
             }
         "
     ));

--- a/docs/src/appendix/snforge-library/signature.md
+++ b/docs/src/appendix/snforge-library/signature.md
@@ -37,8 +37,8 @@ trait KeyPairTrait<SK, PK> {
 ## `SignerTrait`
 
 ```rust
-trait SignerTrait<T, H, U, E> {
-    fn sign(self: T, message_hash: H) -> Result<U, E> ;
+trait SignerTrait<T, H, U> {
+    fn sign(self: T, message_hash: H) -> Result<U, SignError> ;
 }
 ```
 

--- a/docs/src/appendix/snforge-library/signature.md
+++ b/docs/src/appendix/snforge-library/signature.md
@@ -37,8 +37,8 @@ trait KeyPairTrait<SK, PK> {
 ## `SignerTrait`
 
 ```rust
-trait SignerTrait<T, H, U> {
-    fn sign(self: T, message_hash: H) -> U;
+trait SignerTrait<T, H, U, E> {
+    fn sign(self: T, message_hash: H) -> Result<U, E> ;
 }
 ```
 
@@ -68,17 +68,17 @@ use core::starknet::SyscallResultTrait;
 fn test_using_curves() {
     // Secp256r1
     let key_pair = KeyPairTrait::<u256, Secp256r1Point>::generate();
-    let (r, s): (u256, u256) = key_pair.sign(msg_hash);
+    let (r, s): (u256, u256) = key_pair.sign(msg_hash).unwrap();
     let is_valid = key_pair.verify(msg_hash, (r, s));
     
     // Secp256k1
     let key_pair = KeyPairTrait::<u256, Secp256k1Point>::generate();
-    let (r, s): (u256, u256) = key_pair.sign(msg_hash);
+    let (r, s): (u256, u256) = key_pair.sign(msg_hash).unwrap();
     let is_valid = key_pair.verify(msg_hash, (r, s));
     
     // StarkCurve
     let key_pair = KeyPairTrait::<felt252, felt252>::generate();
-    let (r, s): (felt252, felt252) = key_pair.sign(msg_hash);
+    let (r, s): (felt252, felt252) = key_pair.sign(msg_hash).unwrap();
     let is_valid = key_pair.verify(msg_hash, (r, s));
 }
 ```

--- a/snforge_std/src/signature.cairo
+++ b/snforge_std/src/signature.cairo
@@ -17,13 +17,13 @@ trait KeyPairTrait<SK, PK> {
     fn from_secret_key(secret_key: SK) -> KeyPair<SK, PK>;
 }
 
-trait SignerTrait<T, H, U> {
+trait SignerTrait<T, H, U, E> {
     /// Signs given message hash
     /// `self` - KeyPair used for signing
     /// `message_hash` - input to sign bounded by the curve type (u256 for 256bit curves, felt252
     /// for StarkCurve)
-    /// Returns the signature components (usually r,s tuple)
-    fn sign(self: T, message_hash: H) -> U;
+    /// Returns the signature components (usually r,s tuple) or error
+    fn sign(self: T, message_hash: H) -> Result<U, E>;
 }
 
 trait VerifierTrait<T, H, U> {
@@ -35,10 +35,8 @@ trait VerifierTrait<T, H, U> {
     fn verify(self: T, message_hash: H, signature: U) -> bool;
 }
 
-fn to_u256(low: felt252, high: felt252) -> u256 {
-    u256 { low: low.try_into().unwrap(), high: high.try_into().unwrap() }
-}
-
-fn from_u256(x: u256) -> (felt252, felt252) {
-    (x.low.into(), x.high.into())
+#[derive(Copy, Drop, Serde, PartialEq)]
+enum SignError {
+    InvalidSecretKey,
+    HashOutOfRange
 }

--- a/snforge_std/src/signature.cairo
+++ b/snforge_std/src/signature.cairo
@@ -17,13 +17,13 @@ trait KeyPairTrait<SK, PK> {
     fn from_secret_key(secret_key: SK) -> KeyPair<SK, PK>;
 }
 
-trait SignerTrait<T, H, U, E> {
+trait SignerTrait<T, H, U> {
     /// Signs given message hash
     /// `self` - KeyPair used for signing
     /// `message_hash` - input to sign bounded by the curve type (u256 for 256bit curves, felt252
     /// for StarkCurve)
     /// Returns the signature components (usually r,s tuple) or error
-    fn sign(self: T, message_hash: H) -> Result<U, E>;
+    fn sign(self: T, message_hash: H) -> Result<U, SignError>;
 }
 
 trait VerifierTrait<T, H, U> {

--- a/snforge_std/src/signature/secp256k1_curve.cairo
+++ b/snforge_std/src/signature/secp256k1_curve.cairo
@@ -37,9 +37,7 @@ impl Secp256k1CurveKeyPairImpl of KeyPairTrait<u256, Secp256k1Point> {
     }
 }
 
-impl Secp256k1CurveSignerImpl of SignerTrait<
-    KeyPair<u256, Secp256k1Point>, u256, (u256, u256), SignError
-> {
+impl Secp256k1CurveSignerImpl of SignerTrait<KeyPair<u256, Secp256k1Point>, u256, (u256, u256)> {
     fn sign(
         self: KeyPair<u256, Secp256k1Point>, message_hash: u256
     ) -> Result<(u256, u256), SignError> {

--- a/snforge_std/src/signature/secp256k1_curve.cairo
+++ b/snforge_std/src/signature/secp256k1_curve.cairo
@@ -1,20 +1,21 @@
+use core::serde::Serde;
+use core::option::OptionTrait;
 use starknet::secp256_trait::{is_valid_signature};
 use starknet::secp256k1::{Secp256k1Point, Secp256k1Impl, Secp256k1PointImpl};
 use starknet::{SyscallResultTrait};
 use starknet::testing::cheatcode;
 use super::super::_cheatcode::handle_cheatcode;
+use super::SignError;
 
-use snforge_std::signature::{KeyPair, KeyPairTrait, SignerTrait, VerifierTrait, to_u256, from_u256};
+use snforge_std::signature::{KeyPair, KeyPairTrait, SignerTrait, VerifierTrait};
 
 impl Secp256k1CurveKeyPairImpl of KeyPairTrait<u256, Secp256k1Point> {
     fn generate() -> KeyPair<u256, Secp256k1Point> {
-        let output = handle_cheatcode(
+        let mut output = handle_cheatcode(
             cheatcode::<'generate_ecdsa_keys'>(array!['Secp256k1'].span())
         );
 
-        let secret_key = to_u256(*output[0], *output[1]);
-        let pk_x = to_u256(*output[2], *output[3]);
-        let pk_y = to_u256(*output[4], *output[5]);
+        let (secret_key, pk_x, pk_y): (u256, u256, u256) = Serde::deserialize(ref output).unwrap();
 
         let public_key = Secp256k1Impl::secp256_ec_new_syscall(pk_x, pk_y)
             .unwrap_syscall()
@@ -36,25 +37,19 @@ impl Secp256k1CurveKeyPairImpl of KeyPairTrait<u256, Secp256k1Point> {
     }
 }
 
-impl Secp256k1CurveSignerImpl of SignerTrait<KeyPair<u256, Secp256k1Point>, u256, (u256, u256)> {
-    fn sign(self: KeyPair<u256, Secp256k1Point>, message_hash: u256) -> (u256, u256) {
-        let (sk_low, sk_high) = from_u256(self.secret_key);
-        let (msg_hash_low, msg_hash_high) = from_u256(message_hash);
+impl Secp256k1CurveSignerImpl of SignerTrait<
+    KeyPair<u256, Secp256k1Point>, u256, (u256, u256), SignError
+> {
+    fn sign(
+        self: KeyPair<u256, Secp256k1Point>, message_hash: u256
+    ) -> Result<(u256, u256), SignError> {
+        let mut input = array!['Secp256k1'];
+        self.secret_key.serialize(ref input);
+        message_hash.serialize(ref input);
 
-        let output = handle_cheatcode(
-            cheatcode::<
-                'ecdsa_sign_message'
-            >(array!['Secp256k1', sk_low, sk_high, msg_hash_low, msg_hash_high].span())
-        );
+        let mut output = handle_cheatcode(cheatcode::<'ecdsa_sign_message'>(input.span()));
 
-        if *output[0] == 1 {
-            core::panic_with_felt252(*output[1]);
-        }
-
-        let r = to_u256(*output[1], *output[2]);
-        let s = to_u256(*output[3], *output[4]);
-
-        (r, s)
+        Serde::deserialize(ref output).unwrap()
     }
 }
 

--- a/snforge_std/src/signature/secp256r1_curve.cairo
+++ b/snforge_std/src/signature/secp256r1_curve.cairo
@@ -3,17 +3,16 @@ use starknet::secp256r1::{Secp256r1Point, Secp256r1Impl, Secp256r1PointImpl};
 use starknet::{SyscallResultTrait};
 use starknet::testing::cheatcode;
 use super::super::_cheatcode::handle_cheatcode;
-use snforge_std::signature::{KeyPair, KeyPairTrait, SignerTrait, VerifierTrait, to_u256, from_u256};
+use super::SignError;
+use snforge_std::signature::{KeyPair, KeyPairTrait, SignerTrait, VerifierTrait};
 
 impl Secp256r1CurveKeyPairImpl of KeyPairTrait<u256, Secp256r1Point> {
     fn generate() -> KeyPair<u256, Secp256r1Point> {
-        let output = handle_cheatcode(
+        let mut output = handle_cheatcode(
             cheatcode::<'generate_ecdsa_keys'>(array!['Secp256r1'].span())
         );
 
-        let secret_key = to_u256(*output[0], *output[1]);
-        let pk_x = to_u256(*output[2], *output[3]);
-        let pk_y = to_u256(*output[4], *output[5]);
+        let (secret_key, pk_x, pk_y): (u256, u256, u256) = Serde::deserialize(ref output).unwrap();
 
         let public_key = Secp256r1Impl::secp256_ec_new_syscall(pk_x, pk_y)
             .unwrap_syscall()
@@ -35,25 +34,19 @@ impl Secp256r1CurveKeyPairImpl of KeyPairTrait<u256, Secp256r1Point> {
     }
 }
 
-impl Secp256r1CurveSignerImpl of SignerTrait<KeyPair<u256, Secp256r1Point>, u256, (u256, u256)> {
-    fn sign(self: KeyPair<u256, Secp256r1Point>, message_hash: u256) -> (u256, u256) {
-        let (sk_low, sk_high) = from_u256(self.secret_key);
-        let (msg_hash_low, msg_hash_high) = from_u256(message_hash);
+impl Secp256r1CurveSignerImpl of SignerTrait<
+    KeyPair<u256, Secp256r1Point>, u256, (u256, u256), SignError
+> {
+    fn sign(
+        self: KeyPair<u256, Secp256r1Point>, message_hash: u256
+    ) -> Result<(u256, u256), SignError> {
+        let mut input = array!['Secp256r1'];
+        self.secret_key.serialize(ref input);
+        message_hash.serialize(ref input);
 
-        let output = handle_cheatcode(
-            cheatcode::<
-                'ecdsa_sign_message'
-            >(array!['Secp256r1', sk_low, sk_high, msg_hash_low, msg_hash_high].span())
-        );
+        let mut output = handle_cheatcode(cheatcode::<'ecdsa_sign_message'>(input.span()));
 
-        if *output[0] == 1 {
-            core::panic_with_felt252(*output[1]);
-        }
-
-        let r = to_u256(*output[1], *output[2]);
-        let s = to_u256(*output[3], *output[4]);
-
-        (r, s)
+        Serde::deserialize(ref output).unwrap()
     }
 }
 

--- a/snforge_std/src/signature/secp256r1_curve.cairo
+++ b/snforge_std/src/signature/secp256r1_curve.cairo
@@ -34,9 +34,7 @@ impl Secp256r1CurveKeyPairImpl of KeyPairTrait<u256, Secp256r1Point> {
     }
 }
 
-impl Secp256r1CurveSignerImpl of SignerTrait<
-    KeyPair<u256, Secp256r1Point>, u256, (u256, u256), SignError
-> {
+impl Secp256r1CurveSignerImpl of SignerTrait<KeyPair<u256, Secp256r1Point>, u256, (u256, u256)> {
     fn sign(
         self: KeyPair<u256, Secp256r1Point>, message_hash: u256
     ) -> Result<(u256, u256), SignError> {

--- a/snforge_std/src/signature/stark_curve.cairo
+++ b/snforge_std/src/signature/stark_curve.cairo
@@ -31,9 +31,7 @@ impl StarkCurveKeyPairImpl of KeyPairTrait<felt252, felt252> {
     }
 }
 
-impl StarkCurveSignerImpl of SignerTrait<
-    KeyPair<felt252, felt252>, felt252, (felt252, felt252), SignError
-> {
+impl StarkCurveSignerImpl of SignerTrait<KeyPair<felt252, felt252>, felt252, (felt252, felt252)> {
     fn sign(
         self: KeyPair<felt252, felt252>, message_hash: felt252
     ) -> Result<(felt252, felt252), SignError> {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2116 

## Introduced changes

<!-- A brief description of the changes -->

- As in title, also align serialization with cairo

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
