### PR TITLE
Update docs since specifying account file path is not an option anymore

### DIFF
--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -582,8 +582,7 @@ pub fn raise_if_empty(value: &str, value_name: &str) -> Result<()> {
 
 pub fn check_account_file_exists(accounts_file_path: &Utf8PathBuf) -> Result<()> {
     if !accounts_file_path.exists() {
-        bail! {"Accounts file = {} does not exist! If you do not have an account create one with `account create` command \
-        or if you're using a custom accounts file, make sure to supply correct path to it with `--accounts-file` argument.", accounts_file_path}
+        bail! {"Accounts file = {} does not exist! If you do not have an account create one with `account create` command.", accounts_file_path}
     }
     Ok(())
 }

--- a/docs/src/appendix/sncast/account/add.md
+++ b/docs/src/appendix/sncast/account/add.md
@@ -1,8 +1,7 @@
 # `add`
 Import an account to accounts file.
 
-Account information will be saved to the file specified by `--accounts-file` argument,
-which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
+Account information will be saved to `~/.starknet_accounts/starknet_open_zeppelin_accounts.json`.
 
 ## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
 

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -1,8 +1,7 @@
 # `create`
 Prepare all prerequisites for account deployment.
 
-Account information will be saved to the file specified by `--accounts-file` argument,
-which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
+Account information will be saved to the file `~/.starknet_accounts/starknet_open_zeppelin_accounts.json`.
 
 ## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
 

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -30,8 +30,6 @@ Do the following to start interacting with the Starknet:
     max_fee: 0x64a7168300
     address: 0x7a949e83b243068d0cbedd8d5b8b32fafea66c54de23c40e68b126b5c845b61
     ```
-
-    You can also pass common `--accounts-file` argument with a path to (existing or not existing) file where you want to save account info.
     
     For a detailed CLI description, see [account create command reference](../appendix/sncast/account/create.md).
 


### PR DESCRIPTION
The docs indicate that one can specify a path to the accounts file via the flag --accounts-file.

But that does not seem to work. Should i also make updates to the code anywhere? I am happy to dive into the code base and make the changes if you guide me a little. Recently my company moved to the starknet ecosystem so i am happy to contribute here!

I do think however on this issue its just an error message and the docs that seem to be needed correction.

Thanks
