### PR TITLE
Move sepolia URL to constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,7 @@ jobs:
       - uses: software-mansion/setup-scarb@v1.3.2
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - name: Run tests
-        env:
-          NODE_URL: ${{ secrets.NODE_URL }}
-        run: |
-          SEPOLIA_RPC_URL="${NODE_URL}:7070/rpc/v0_7" cargo test --release -p sncast
+        run: cargo test --release -p sncast
 
   test-conversions:
     name: Test Conversions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,12 +1697,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,7 +4499,6 @@ dependencies = [
  "console",
  "conversions",
  "ctor",
- "dotenv",
  "fs_extra",
  "indoc",
  "itertools 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ tokio-util = "0.7.9"
 futures = "0.3.30"
 num-bigint = { version = "0.4.4", features = ["rand"] }
 walkdir = "2.5.0"
-dotenv = "0.15.0"
 rand = "0.8.5"
 project-root = "0.2.2"
 which = "5.0.0"

--- a/crates/sncast/Cargo.toml
+++ b/crates/sncast/Cargo.toml
@@ -55,7 +55,6 @@ project-root.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
 fs_extra.workspace = true
-dotenv.workspace = true
 
 [[bin]]
 name = "sncast"

--- a/crates/sncast/README.md
+++ b/crates/sncast/README.md
@@ -145,6 +145,3 @@ $HOME/.asdf/shims/scarb
 ```
 
 If you previously installed scarb using official installer, you may need to remove this installation or modify your PATH to make sure asdf installed one is always used.
-
-To run `sncast` tests, it is required to set `SEPOLIA_RPC_URL` environment variable, which is
-used to fork the Sepolia testnet network in the devnet tests. This variable can be set in the `.env` file.

--- a/crates/sncast/tests/helpers/constants.rs
+++ b/crates/sncast/tests/helpers/constants.rs
@@ -1,5 +1,6 @@
 pub const ACCOUNT: &str = "user1";
 pub const ACCOUNT_FILE_PATH: &str = "tests/data/accounts/accounts.json";
+pub const SEPOLIA_RPC_URL: &str = "http://188.34.188.184:7070/rpc/v0_7";
 
 pub const URL: &str = "http://127.0.0.1:5055/rpc";
 pub const NETWORK: &str = "testnet";

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -1,7 +1,6 @@
-use crate::helpers::constants::{FORK_BLOCK_NUMBER, SEED, URL};
+use crate::helpers::constants::{FORK_BLOCK_NUMBER, SEED, SEPOLIA_RPC_URL, URL};
 use crate::helpers::fixtures::{
     deploy_argent_account, deploy_braavos_account, deploy_cairo_0_account, deploy_keystore_account,
-    from_env,
 };
 use ctor::{ctor, dtor};
 use std::net::TcpStream;
@@ -33,10 +32,6 @@ fn start_devnet() {
         }
     }
 
-    dotenv::dotenv().ok();
-    let sepolia_rpc_url =
-        from_env("SEPOLIA_RPC_URL").expect("Failed to get SEPOLIA_RPC_URL environment variable");
-
     Command::new("tests/utils/devnet/starknet-devnet")
         .args([
             "--port",
@@ -46,7 +41,7 @@ fn start_devnet() {
             "--state-archive-capacity",
             "full",
             "--fork-network",
-            &sepolia_rpc_url,
+            &SEPOLIA_RPC_URL,
             "--fork-block",
             &FORK_BLOCK_NUMBER.to_string(),
             "--initial-balance",

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -41,7 +41,7 @@ fn start_devnet() {
             "--state-archive-capacity",
             "full",
             "--fork-network",
-            &SEPOLIA_RPC_URL,
+            SEPOLIA_RPC_URL,
             "--fork-block",
             &FORK_BLOCK_NUMBER.to_string(),
             "--initial-balance",

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -448,13 +448,6 @@ pub fn get_deps_map_from_paths(
     deps
 }
 
-pub fn from_env(name: &str) -> Result<String, String> {
-    match env::var(name) {
-        Ok(value) => Ok(value),
-        Err(_) => Err(format!("Variable {name} not available in env!")),
-    }
-}
-
 pub fn get_address_from_keystore(
     keystore_path: impl AsRef<std::path::Path>,
     account_path: impl AsRef<std::path::Path>,

--- a/docs/src/development/environment-setup.md
+++ b/docs/src/development/environment-setup.md
@@ -43,9 +43,6 @@ Please make sure you're using Scarb installed via [asdf](https://asdf-vm.com/) -
 ### Starknet Devnet
 To install it run `./scripts/install_devnet.sh`
 
-To run `sncast` tests, it is required to set `SEPOLIA_RPC_URL` environment variable, which is
-used to fork the Sepolia testnet network in the devnet tests. This variable can be set in the `.env` file.
-
 ### Universal sierra compiler
 Install the latest [universal-sierra-compiler](https://github.com/software-mansion/universal-sierra-compiler) version.
 


### PR DESCRIPTION

## Introduced changes

<!-- A brief description of the changes -->

Reverts changes with .env being required in `cast`, move it to constants. Was needed since contributor PRs are failing because of this

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [ ] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
