### PR TITLE
Fix location of html artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/book
+          path: ./docs/book/html
   # Deployment job
   deploy:
     environment:


### PR DESCRIPTION
Now mdbook generates 2 dirs:
- `linkcheck` 
- `html` 
instead of just html contents in the docs
this makes the page 404 on upload 