### PR TITLE
Use felt! for constants.rs. Delete parse_number and use .parse()

### DIFF
--- a/crates/sncast/src/helpers/constants.rs
+++ b/crates/sncast/src/helpers/constants.rs
@@ -1,3 +1,6 @@
+use starknet::core::types::FieldElement;
+use starknet::macros::felt;
+
 pub static DEFAULT_MULTICALL_CONTENTS: &str = r#"[[call]]
 call_type = "deploy"
 class_hash = ""
@@ -12,17 +15,18 @@ function = ""
 inputs = []
 "#;
 
-pub const UDC_ADDRESS: &str = "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf";
-pub const OZ_CLASS_HASH: &str =
-    "0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f";
-pub const ARGENT_CLASS_HASH: &str =
-    "0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b";
+pub const UDC_ADDRESS: FieldElement =
+    felt!("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf");
+pub const OZ_CLASS_HASH: FieldElement =
+    felt!("0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f");
+pub const ARGENT_CLASS_HASH: FieldElement =
+    felt!("0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b");
 
-pub const BRAAVOS_CLASS_HASH: &str =
-    "0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253";
+pub const BRAAVOS_CLASS_HASH: FieldElement =
+    felt!("0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253");
 
-pub const BRAAVOS_BASE_ACCOUNT_CLASS_HASH: &str =
-    "0x013bfe114fb1cf405bfc3a7f8dbe2d91db146c17521d40dcf57e16d6b59fa8e6";
+pub const BRAAVOS_BASE_ACCOUNT_CLASS_HASH: FieldElement =
+    felt!("0x013bfe114fb1cf405bfc3a7f8dbe2d91db146c17521d40dcf57e16d6b59fa8e6");
 
 // used in wait_for_tx. Txs will be fetched every 5s with timeout of 300s - so 60 attempts
 #[allow(dead_code)]

--- a/crates/sncast/src/starknet_commands/account/add.rs
+++ b/crates/sncast/src/starknet_commands/account/add.rs
@@ -7,7 +7,7 @@ use camino::Utf8PathBuf;
 use clap::Args;
 use sncast::helpers::configuration::CastConfig;
 use sncast::response::structs::AccountAddResponse;
-use sncast::{check_class_hash_exists, get_chain_id, parse_number};
+use sncast::{check_class_hash_exists, get_chain_id};
 use sncast::{check_if_legacy_contract, get_class_hash_by_address};
 use starknet::core::types::FieldElement;
 use starknet::providers::jsonrpc::{HttpTransport, JsonRpcClient};
@@ -134,5 +134,5 @@ pub async fn add(
 
 fn get_private_key_from_file(file_path: &Utf8PathBuf) -> Result<FieldElement> {
     let private_key_string = std::fs::read_to_string(file_path.clone())?;
-    parse_number(&private_key_string)
+    Ok(private_key_string.parse()?)
 }

--- a/crates/sncast/src/starknet_commands/multicall/run.rs
+++ b/crates/sncast/src/starknet_commands/multicall/run.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use sncast::helpers::constants::UDC_ADDRESS;
 use sncast::response::errors::handle_starknet_command_error;
 use sncast::response::structs::InvokeResponse;
-use sncast::{extract_or_generate_salt, parse_number, udc_uniqueness, WaitForTx};
+use sncast::{extract_or_generate_salt, udc_uniqueness, WaitForTx};
 use starknet::accounts::{Account, Call, SingleOwnerAccount};
 use starknet::core::types::FieldElement;
 use starknet::core::utils::{get_selector_from_name, get_udc_deployed_address};
@@ -83,7 +83,7 @@ pub async fn run(
                 calldata.extend(&parsed_inputs);
 
                 parsed_calls.push(Call {
-                    to: parse_number(UDC_ADDRESS)?,
+                    to: UDC_ADDRESS,
                     selector: get_selector_from_name("deployContract")?,
                     calldata,
                 });
@@ -107,7 +107,8 @@ pub async fn run(
                 let calldata = parse_inputs(&invoke_call.inputs, &contracts)?;
 
                 parsed_calls.push(Call {
-                    to: parse_number(contract_address)
+                    to: contract_address
+                        .parse()
                         .context("Failed to parse contract address to FieldElement")?,
                     selector: get_selector_from_name(&invoke_call.function)?,
                     calldata,
@@ -132,8 +133,11 @@ fn parse_inputs(
     let mut parsed_inputs = Vec::new();
     for input in inputs {
         let current_input = contracts.get(input).unwrap_or(input);
-        parsed_inputs
-            .push(parse_number(current_input).context("Failed to parse input to FieldElement")?);
+        parsed_inputs.push(
+            current_input
+                .parse()
+                .context("Failed to parse input to FieldElement")?,
+        );
     }
 
     Ok(parsed_inputs)

--- a/crates/sncast/tests/e2e/account/add.rs
+++ b/crates/sncast/tests/e2e/account/add.rs
@@ -1,13 +1,14 @@
 use crate::helpers::constants::{
-    DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_OZ_CLASS_HASH_CAIRO_1, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
-    URL,
+    DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS, URL,
 };
 use crate::helpers::runner::runner;
 use camino::Utf8PathBuf;
 use configuration::CONFIG_FILENAME;
+use conversions::string::IntoHexStr;
 use indoc::{formatdoc, indoc};
 use serde_json::json;
 use shared::test_utils::output_assert::assert_stderr_contains;
+use sncast::helpers::constants::OZ_CLASS_HASH;
 use std::fs::{self, File};
 use tempfile::tempdir;
 use test_case::test_case;
@@ -103,7 +104,7 @@ pub async fn test_existent_account_address() {
                 "alpha-sepolia": {
                   "my_account_add": {
                     "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
-                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_1,
+                    "class_hash": &OZ_CLASS_HASH.into_hex_string(),
                     "deployed": true,
                     "legacy": false,
                     "private_key": "0x456",
@@ -316,7 +317,7 @@ pub async fn test_detect_deployed() {
                 "alpha-sepolia": {
                   "my_account_add": {
                     "address": DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
-                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_1,
+                    "class_hash": &OZ_CLASS_HASH.into_hex_string(),
                     "deployed": true,
                     "private_key": "0x5",
                     "public_key": "0x788435d61046d3eec54d77d25bd194525f4fa26ebe6575536bc6f656656b74c",
@@ -572,7 +573,7 @@ pub async fn test_private_key_as_int_in_file() {
                     "legacy": false,
                     "private_key": "0x456",
                     "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
-                    "class_hash": DEVNET_OZ_CLASS_HASH_CAIRO_1,
+                    "class_hash": &OZ_CLASS_HASH.into_hex_string(),
                     "type": "open_zeppelin"
                   }
                 }

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -1,17 +1,16 @@
-use crate::helpers::constants::{
-    ARGENT_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH, DEVNET_OZ_CLASS_HASH_CAIRO_0,
-    DEVNET_OZ_CLASS_HASH_CAIRO_1, URL,
-};
+use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
 use crate::helpers::fixtures::{copy_file, default_cli_args};
 use crate::helpers::runner::runner;
 use configuration::copy_config_to_tempdir;
 use indoc::indoc;
 
+use conversions::string::IntoHexStr;
 use serde_json::{json, to_string_pretty};
 use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains};
 use snapbox::assert_matches;
 use sncast::helpers::constants::{
-    BRAAVOS_BASE_ACCOUNT_CLASS_HASH, CREATE_KEYSTORE_PASSWORD_ENV_VAR,
+    ARGENT_CLASS_HASH, BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH,
+    CREATE_KEYSTORE_PASSWORD_ENV_VAR, OZ_CLASS_HASH,
 };
 use sncast::AccountType;
 use std::{env, fs};
@@ -567,7 +566,7 @@ fn get_keystore_account_pattern(account_type: &AccountType, class_hash: Option<&
                     },
                     "deployment": {
                         "status": "undeployed",
-                        "class_hash": class_hash.unwrap_or(DEVNET_OZ_CLASS_HASH_CAIRO_1),
+                        "class_hash": class_hash.unwrap_or(&OZ_CLASS_HASH.into_hex_string()),
                         "salt": "0x[..]",
                     }
                 }
@@ -585,7 +584,7 @@ fn get_keystore_account_pattern(account_type: &AccountType, class_hash: Option<&
                     },
                     "deployment": {
                         "status": "undeployed",
-                        "class_hash": class_hash.unwrap_or(ARGENT_ACCOUNT_CLASS_HASH),
+                        "class_hash": class_hash.unwrap_or(&ARGENT_CLASS_HASH.into_hex_string()),
                         "salt": "0x[..]",
                     }
                 }
@@ -610,7 +609,7 @@ fn get_keystore_account_pattern(account_type: &AccountType, class_hash: Option<&
                   },
                   "deployment": {
                     "status": "undeployed",
-                    "class_hash": class_hash.unwrap_or(BRAAVOS_CLASS_HASH),
+                    "class_hash": class_hash.unwrap_or(&BRAAVOS_CLASS_HASH.into_hex_string()),
                     "salt": "0x[..]",
                     "context": {
                       "variant": "braavos",

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -1,6 +1,4 @@
-use crate::helpers::constants::{
-    ARGENT_ACCOUNT_CLASS_HASH, DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_OZ_CLASS_HASH_CAIRO_1, URL,
-};
+use crate::helpers::constants::{DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
 use crate::helpers::fixtures::copy_file;
 use crate::helpers::fixtures::{
     get_address_from_keystore, get_transaction_hash, get_transaction_receipt, mint_token,
@@ -11,7 +9,9 @@ use conversions::string::IntoHexStr;
 use indoc::indoc;
 use serde_json::Value;
 use shared::test_utils::output_assert::{assert_stderr_contains, AsOutput};
-use sncast::helpers::constants::{BRAAVOS_CLASS_HASH, KEYSTORE_PASSWORD_ENV_VAR};
+use sncast::helpers::constants::{
+    ARGENT_CLASS_HASH, BRAAVOS_CLASS_HASH, KEYSTORE_PASSWORD_ENV_VAR, OZ_CLASS_HASH,
+};
 use sncast::AccountType;
 use starknet::core::types::TransactionReceipt::DeployAccount;
 use std::{env, fs};
@@ -19,9 +19,9 @@ use tempfile::{tempdir, TempDir};
 use test_case::test_case;
 
 #[test_case(DEVNET_OZ_CLASS_HASH_CAIRO_0, "oz"; "cairo_0_class_hash")]
-#[test_case(DEVNET_OZ_CLASS_HASH_CAIRO_1, "oz"; "cairo_1_class_hash")]
-#[test_case(ARGENT_ACCOUNT_CLASS_HASH, "argent"; "argent_class_hash")]
-#[test_case(BRAAVOS_CLASS_HASH, "braavos"; "braavos_class_hash")]
+#[test_case(&OZ_CLASS_HASH.into_hex_string(), "oz"; "cairo_1_class_hash")]
+#[test_case(&ARGENT_CLASS_HASH.into_hex_string(), "argent"; "argent_class_hash")]
+#[test_case(&BRAAVOS_CLASS_HASH.into_hex_string(), "braavos"; "braavos_class_hash")]
 #[tokio::test]
 pub async fn test_happy_case(class_hash: &str, account_type: &str) {
     let tempdir = create_account(false, class_hash, account_type).await;
@@ -61,7 +61,7 @@ pub async fn test_happy_case(class_hash: &str, account_type: &str) {
 
 #[tokio::test]
 pub async fn test_happy_case_add_profile() {
-    let tempdir = create_account(true, DEVNET_OZ_CLASS_HASH_CAIRO_1, "oz").await;
+    let tempdir = create_account(true, &OZ_CLASS_HASH.into_hex_string(), "oz").await;
     let accounts_file = "accounts.json";
 
     let args = vec![
@@ -120,7 +120,7 @@ fn test_account_deploy_error(accounts_content: &str, error: &str) {
 
 #[tokio::test]
 async fn test_too_low_max_fee() {
-    let tempdir = create_account(false, DEVNET_OZ_CLASS_HASH_CAIRO_1, "oz").await;
+    let tempdir = create_account(false, &OZ_CLASS_HASH.into_hex_string(), "oz").await;
     let accounts_file = "accounts.json";
 
     let args = vec![
@@ -151,7 +151,7 @@ async fn test_too_low_max_fee() {
 
 #[tokio::test]
 pub async fn test_valid_class_hash() {
-    let tempdir = create_account(true, DEVNET_OZ_CLASS_HASH_CAIRO_1, "oz").await;
+    let tempdir = create_account(true, &OZ_CLASS_HASH.into_hex_string(), "oz").await;
     let accounts_file = "accounts.json";
 
     let args = vec![
@@ -177,7 +177,7 @@ pub async fn test_valid_class_hash() {
 
 #[tokio::test]
 pub async fn test_valid_no_max_fee() {
-    let tempdir = create_account(true, DEVNET_OZ_CLASS_HASH_CAIRO_1, "oz").await;
+    let tempdir = create_account(true, &OZ_CLASS_HASH.into_hex_string(), "oz").await;
     let accounts_file = "accounts.json";
 
     let args = vec![

--- a/crates/sncast/tests/helpers/constants.rs
+++ b/crates/sncast/tests/helpers/constants.rs
@@ -18,10 +18,6 @@ pub const DEVNET_OZ_CLASS_HASH_CAIRO_0: &str =
 pub const DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS: &str =
     "0x691a61b12a7105b1372cc377f135213c11e8400a546f6b0e7ea0296046690ce";
 
-// https://github.com/0xSpaceShard/starknet-devnet-rs/blob/1a76e9d29541af2667ca815c47bb332cead27c55/crates/starknet/src/constants.rs#L17
-pub const DEVNET_OZ_CLASS_HASH_CAIRO_1: &str =
-    "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f";
-
 pub const MAP_CONTRACT_ADDRESS_SEPOLIA: &str =
     "0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008";
 
@@ -33,9 +29,3 @@ pub const MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA: &str =
 
 pub const CONSTRUCTOR_WITH_PARAMS_CONTRACT_CLASS_HASH_SEPOLIA: &str =
     "0x59426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded";
-
-pub const ARGENT_ACCOUNT_CLASS_HASH: &str =
-    "0x29927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b";
-
-pub const BRAAVOS_CLASS_HASH: &str =
-    "0x816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253";

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -1,19 +1,19 @@
-use crate::helpers::constants::{
-    ACCOUNT_FILE_PATH, ARGENT_ACCOUNT_CLASS_HASH, DEVNET_OZ_CLASS_HASH_CAIRO_0, URL,
-};
+use crate::helpers::constants::{ACCOUNT_FILE_PATH, DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Map, Value};
 use sncast::helpers::braavos::BraavosAccountFactory;
-use sncast::helpers::constants::{BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH};
+use sncast::helpers::constants::{
+    ARGENT_CLASS_HASH, BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH,
+};
 use sncast::helpers::scarb_utils::get_package_metadata;
 use sncast::state::state_file::{
     ScriptTransactionEntry, ScriptTransactionOutput, ScriptTransactionStatus,
 };
 use sncast::{apply_optional, get_chain_id, get_keystore_password, AccountType};
-use sncast::{get_account, get_provider, parse_number};
+use sncast::{get_account, get_provider};
 use starknet::accounts::{
     Account, AccountFactory, ArgentAccountFactory, Call, Execution, OpenZeppelinAccountFactory,
 };
@@ -79,7 +79,7 @@ pub async fn deploy_argent_account() {
     let (address, salt, private_key) = get_account_deployment_data("argent");
 
     let factory = ArgentAccountFactory::new(
-        parse_number(ARGENT_ACCOUNT_CLASS_HASH).expect("Failed to parse class hash"),
+        ARGENT_CLASS_HASH,
         chain_id,
         FieldElement::ZERO,
         LocalWallet::from_signing_key(private_key),
@@ -99,13 +99,9 @@ pub async fn deploy_braavos_account() {
 
     let (address, salt, private_key) = get_account_deployment_data("braavos");
 
-    let base_class_hash = parse_number(BRAAVOS_BASE_ACCOUNT_CLASS_HASH)
-        .expect("Failed to parse Braavos base class hash");
-    let class_hash = parse_number(BRAAVOS_CLASS_HASH).expect("Failed to parse Braavos class hash");
-
     let factory = BraavosAccountFactory::new(
-        class_hash,
-        base_class_hash,
+        BRAAVOS_CLASS_HASH,
+        BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
         chain_id,
         LocalWallet::from_signing_key(private_key),
         provider,
@@ -123,7 +119,7 @@ async fn deploy_oz_account(address: &str, class_hash: &str, salt: &str, private_
         .expect("Failed to get chain id");
 
     let factory = OpenZeppelinAccountFactory::new(
-        parse_number(class_hash).expect("Failed to parse class hash"),
+        class_hash.parse().expect("Failed to parse class hash"),
         chain_id,
         LocalWallet::from_signing_key(private_key),
         provider,
@@ -137,7 +133,7 @@ async fn deploy_oz_account(address: &str, class_hash: &str, salt: &str, private_
 async fn deploy_account_to_devnet<T: AccountFactory + Sync>(factory: T, address: &str, salt: &str) {
     mint_token(address, u64::MAX).await;
     factory
-        .deploy(parse_number(salt).expect("Failed to parse salt"))
+        .deploy(salt.parse().expect("Failed to parse salt"))
         .send()
         .await
         .expect("Failed to deploy account");
@@ -158,7 +154,9 @@ fn get_account_deployment_data(account: &str) -> (String, String, SigningKey) {
     let private_key = get_from_json_as_str(account_data, "private_key");
 
     let private_key = SigningKey::from_secret_scalar(
-        parse_number(private_key).expect("Failed to convert private key to FieldElement"),
+        private_key
+            .parse()
+            .expect("Failed to convert private key to FieldElement"),
     );
 
     (address.to_string(), salt.to_string(), private_key)
@@ -191,12 +189,14 @@ pub async fn invoke_contract(
     let mut calldata: Vec<FieldElement> = vec![];
 
     for value in constructor_calldata {
-        let value: FieldElement = parse_number(value).expect("Could not parse the calldata");
+        let value: FieldElement = value.parse().expect("Could not parse the calldata");
         calldata.push(value);
     }
 
     let call = Call {
-        to: parse_number(contract_address).expect("Could not parse the contract address"),
+        to: contract_address
+            .parse()
+            .expect("Could not parse the contract address"),
         selector: get_selector_from_name(entry_point_name)
             .unwrap_or_else(|_| panic!("Could not get selector from {entry_point_name}")),
         calldata,
@@ -255,7 +255,10 @@ struct TransactionHashOutput {
 #[must_use]
 pub fn get_transaction_hash(output: &[u8]) -> FieldElement {
     let output = parse_output::<TransactionHashOutput>(output);
-    parse_number(output.transaction_hash.as_str()).expect("Could not parse a number")
+    output
+        .transaction_hash
+        .parse()
+        .expect("Could not parse a number")
 }
 
 pub async fn get_transaction_receipt(tx_hash: FieldElement) -> TransactionReceipt {
@@ -471,8 +474,7 @@ pub fn get_address_from_keystore(
     )
     .unwrap();
     let class_hash = match account_type {
-        AccountType::Braavos => parse_number(BRAAVOS_BASE_ACCOUNT_CLASS_HASH)
-            .expect("Failed to parse Braavos account class hash"),
+        AccountType::Braavos => BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
         AccountType::Oz | AccountType::Argent => FieldElement::from_hex_be(
             deployment
                 .get("class_hash")

--- a/crates/sncast/tests/integration/lib_tests.rs
+++ b/crates/sncast/tests/integration/lib_tests.rs
@@ -5,7 +5,7 @@ use crate::helpers::fixtures::create_test_provider;
 
 use camino::Utf8PathBuf;
 use shared::rpc::{get_rpc_version, is_expected_version};
-use sncast::{check_if_legacy_contract, get_account, get_provider, parse_number};
+use sncast::{check_if_legacy_contract, get_account, get_provider};
 use std::fs;
 use url::ParseError;
 
@@ -163,9 +163,10 @@ async fn test_supported_rpc_version_matches_devnet_version() {
 #[tokio::test]
 async fn test_check_if_legacy_contract_by_class_hash() {
     let provider = create_test_provider();
-    let class_hash = parse_number(DEVNET_OZ_CLASS_HASH_CAIRO_0)
+    let class_hash = DEVNET_OZ_CLASS_HASH_CAIRO_0
+        .parse()
         .expect("Failed to parse DEVNET_OZ_CLASS_HASH_CAIRO_0");
-    let mock_address = parse_number("0x1").unwrap();
+    let mock_address = "0x1".parse().unwrap();
     let is_legacy = check_if_legacy_contract(Some(class_hash), mock_address, &provider)
         .await
         .unwrap();
@@ -175,7 +176,8 @@ async fn test_check_if_legacy_contract_by_class_hash() {
 #[tokio::test]
 async fn test_check_if_legacy_contract_by_address() {
     let provider = create_test_provider();
-    let address = parse_number(DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS)
+    let address = DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS
+        .parse()
         .expect("Failed to parse DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS");
     let is_legacy = check_if_legacy_contract(None, address, &provider)
         .await

--- a/crates/sncast/tests/integration/wait_for_tx.rs
+++ b/crates/sncast/tests/integration/wait_for_tx.rs
@@ -9,8 +9,9 @@ use crate::helpers::constants::{
     MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA,
 };
 use camino::Utf8PathBuf;
+use conversions::string::IntoHexStr;
 use sncast::{get_account, ValidatedWaitParams};
-use sncast::{handle_wait_for_tx, parse_number, wait_for_tx, WaitForTx};
+use sncast::{handle_wait_for_tx, wait_for_tx, WaitForTx};
 use starknet::contract::ContractFactory;
 use starknet::core::types::FieldElement;
 
@@ -19,7 +20,7 @@ async fn test_happy_path() {
     let provider = create_test_provider();
     let res = wait_for_tx(
         &provider,
-        parse_number(MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA).unwrap(),
+        MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA.parse().unwrap(),
         ValidatedWaitParams::default(),
     )
     .await;
@@ -40,10 +41,7 @@ async fn test_rejected_transaction() {
     .await
     .expect("Could not get the account");
 
-    let factory = ContractFactory::new(
-        parse_number(MAP_CONTRACT_CLASS_HASH_SEPOLIA).unwrap(),
-        account,
-    );
+    let factory = ContractFactory::new(MAP_CONTRACT_CLASS_HASH_SEPOLIA.parse().unwrap(), account);
     let deployment = factory
         .deploy(Vec::new(), FieldElement::ONE, false)
         .max_fee(FieldElement::ONE);
@@ -61,7 +59,7 @@ async fn test_wait_for_reverted_transaction() {
 
     let transaction_hash = invoke_contract(
         ACCOUNT,
-        UDC_ADDRESS,
+        UDC_ADDRESS.into_hex_string().as_str(),
         "deployContract",
         Some(max_fee.into()),
         &[
@@ -89,7 +87,7 @@ async fn test_wait_for_nonexistent_tx() {
     let provider = create_test_provider();
     wait_for_tx(
         &provider,
-        parse_number("0x123456789").expect("Could not parse a number"),
+        "0x123456789".parse().expect("Could not parse a number"),
         ValidatedWaitParams::new(1, 3),
     )
     .await
@@ -102,7 +100,7 @@ async fn test_happy_path_handle_wait_for_tx() {
     let provider = create_test_provider();
     let res = handle_wait_for_tx(
         &provider,
-        parse_number(MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA).unwrap(),
+        MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA.parse().unwrap(),
         1,
         WaitForTx {
             wait: true,
@@ -120,7 +118,7 @@ async fn test_wait_for_wrong_retry_values() {
     let provider = create_test_provider();
     wait_for_tx(
         &provider,
-        parse_number(MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA).unwrap(),
+        MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA.parse().unwrap(),
         ValidatedWaitParams::new(2, 1),
     )
     .await
@@ -133,7 +131,7 @@ async fn test_wait_for_wrong_retry_values_timeout_zero() {
     let provider = create_test_provider();
     wait_for_tx(
         &provider,
-        parse_number(MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA).unwrap(),
+        MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA.parse().unwrap(),
         ValidatedWaitParams::new(2, 0),
     )
     .await
@@ -146,7 +144,7 @@ async fn test_wait_for_wrong_retry_values_interval_zero() {
     let provider = create_test_provider();
     wait_for_tx(
         &provider,
-        parse_number(MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA).unwrap(),
+        MAP_CONTRACT_DECLARE_TX_HASH_SEPOLIA.parse().unwrap(),
         ValidatedWaitParams::new(0, 1),
     )
     .await


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related  https://github.com/foundry-rs/starknet-foundry/issues/1854
Related https://github.com/foundry-rs/starknet-foundry/pull/2188

## Introduced changes

<!-- A brief description of the changes -->

- Change base_clash_hashes from &str to FieldElement to avoid parsing them at runtime
- Delete `parse_number` and use `.parse()` method of `FieldElement` as both do the same. 

## Checklist

<!-- Make sure all of these are complete -->


- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
