### PR TITLE
Remove `starknet` dep from `sncast_std`

### DIFF
--- a/sncast_std/Scarb.toml
+++ b/sncast_std/Scarb.toml
@@ -2,6 +2,3 @@
 name = "sncast_std"
 version = "0.25.0"
 edition = "2023_11"
-
-[dependencies]
-starknet = "2.4.0"


### PR DESCRIPTION
Was redundant