### PR TITLE
Fix version capturing regex

### DIFF
--- a/crates/scarb-api/src/version.rs
+++ b/crates/scarb-api/src/version.rs
@@ -31,7 +31,9 @@ impl VersionCommand {
     }
 
     fn extract_version(version_output: &str, tool: &str) -> Result<Version> {
-        let version_regex = Regex::new(&format!(r#"(?:{tool}?\s*)([0-9]+.[0-9]+.[0-9]+)"#))
+        // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        let version_regex = Regex::new(
+            &format!(r#"{tool}?\s*((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"#))
             .context("Could not create version matching regex")?;
 
         let version_capture = version_regex

--- a/snforge_std/src/cheatcodes.cairo
+++ b/snforge_std/src/cheatcodes.cairo
@@ -11,7 +11,7 @@ mod storage;
 mod execution_info;
 
 /// Enum used to specify how long the target should be cheated for.
-#[derive(Copy, Drop, Serde, PartialEq, Clone, Debug, Display)]
+#[derive(Copy, Drop, Serde, PartialEq, Clone, Debug)]
 enum CheatSpan {
     /// Applies the cheatcode indefinitely, until the cheat is canceled manually (e.g. using
     /// `stop_cheat_block_timestamp`).


### PR DESCRIPTION
Closes #2258

I want new `snforge` to work with Scarb `2.6.4` and `2.7.0-rc.0` (planning to release new profiler soon)

Disclaimer: no, it doesn't match 0.13.1.1 xD