### PR TITLE
Integraledelebesgue/fix 2213

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_block_number.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_block_number.rs
@@ -25,7 +25,7 @@ impl CheatnetState {
         });
     }
 
-    pub fn cheat_block_number_global(&mut self, block_number: u64) {
+    pub fn start_cheat_block_number_global(&mut self, block_number: u64) {
         self.cheat_execution_info(ExecutionInfoMockOperations {
             block_info: BlockInfoMockOperations {
                 block_number: Operation::StartGlobal(block_number),

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_block_timestamp.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_block_timestamp.rs
@@ -25,7 +25,7 @@ impl CheatnetState {
         });
     }
 
-    pub fn cheat_block_timestamp_global(&mut self, timestamp: u64) {
+    pub fn start_cheat_block_timestamp_global(&mut self, timestamp: u64) {
         self.cheat_execution_info(ExecutionInfoMockOperations {
             block_info: BlockInfoMockOperations {
                 block_timestamp: Operation::StartGlobal(timestamp),

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_caller_address.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_caller_address.rs
@@ -20,7 +20,7 @@ impl CheatnetState {
         });
     }
 
-    pub fn cheat_caller_address_global(&mut self, caller_address: ContractAddress) {
+    pub fn start_cheat_caller_address_global(&mut self, caller_address: ContractAddress) {
         self.cheat_execution_info(ExecutionInfoMockOperations {
             caller_address: Operation::StartGlobal(caller_address),
             ..Default::default()

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_sequencer_address.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/cheat_sequencer_address.rs
@@ -33,7 +33,7 @@ impl CheatnetState {
         self.cheat_sequencer_address(contract_address, sequencer_address, CheatSpan::Indefinite);
     }
 
-    pub fn cheat_sequencer_address_global(&mut self, sequencer_address: ContractAddress) {
+    pub fn start_cheat_sequencer_address_global(&mut self, sequencer_address: ContractAddress) {
         self.cheat_execution_info(ExecutionInfoMockOperations {
             block_info: BlockInfoMockOperations {
                 sequencer_address: Operation::StartGlobal(sequencer_address),

--- a/crates/cheatnet/tests/cheatcodes/cheat_block_number.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_block_number.rs
@@ -178,7 +178,7 @@ fn cheat_block_number_all_simple() {
 
     let contract_address = test_env.deploy("CheatBlockNumberChecker", &[]);
 
-    test_env.cheatnet_state.cheat_block_number_global(123);
+    test_env.cheatnet_state.start_cheat_block_number_global(123);
 
     let output = test_env.call_contract(&contract_address, "get_block_number", &[]);
     assert_success(output, &[Felt252::from(123)]);
@@ -190,7 +190,7 @@ fn cheat_block_number_all_then_one() {
 
     let contract_address = test_env.deploy("CheatBlockNumberChecker", &[]);
 
-    test_env.cheatnet_state.cheat_block_number_global(321);
+    test_env.cheatnet_state.start_cheat_block_number_global(321);
     test_env.start_cheat_block_number(contract_address, 123);
 
     let output = test_env.call_contract(&contract_address, "get_block_number", &[]);
@@ -204,7 +204,7 @@ fn cheat_block_number_one_then_all() {
     let contract_address = test_env.deploy("CheatBlockNumberChecker", &[]);
 
     test_env.start_cheat_block_number(contract_address, 123);
-    test_env.cheatnet_state.cheat_block_number_global(321);
+    test_env.cheatnet_state.start_cheat_block_number_global(321);
 
     let output = test_env.call_contract(&contract_address, "get_block_number", &[]);
     assert_success(output, &[Felt252::from(321)]);
@@ -217,7 +217,7 @@ fn cheat_block_number_all_stop() {
     let cheat_block_number_checker = test_env.declare("CheatBlockNumberChecker", &get_contracts());
     let contract_address = test_env.deploy_wrapper(&cheat_block_number_checker, &[]);
 
-    test_env.cheatnet_state.cheat_block_number_global(123);
+    test_env.cheatnet_state.start_cheat_block_number_global(123);
 
     assert_success(
         test_env.call_contract(&contract_address, "get_block_number", &[]),

--- a/crates/cheatnet/tests/cheatcodes/cheat_block_timestamp.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_block_timestamp.rs
@@ -180,7 +180,7 @@ fn cheat_block_timestamp_all_simple() {
 
     let contract_address = test_env.deploy("CheatBlockTimestampChecker", &[]);
 
-    test_env.cheatnet_state.cheat_block_timestamp_global(123);
+    test_env.cheatnet_state.start_cheat_block_timestamp_global(123);
 
     let output = test_env.call_contract(&contract_address, "get_block_timestamp", &[]);
     assert_success(output, &[Felt252::from(123)]);
@@ -192,7 +192,7 @@ fn cheat_block_timestamp_all_then_one() {
 
     let contract_address = test_env.deploy("CheatBlockTimestampChecker", &[]);
 
-    test_env.cheatnet_state.cheat_block_timestamp_global(321);
+    test_env.cheatnet_state.start_cheat_block_timestamp_global(321);
 
     test_env.start_cheat_block_timestamp(contract_address, 123);
 
@@ -208,7 +208,7 @@ fn cheat_block_timestamp_one_then_all() {
 
     test_env.start_cheat_block_timestamp(contract_address, 123);
 
-    test_env.cheatnet_state.cheat_block_timestamp_global(321);
+    test_env.cheatnet_state.start_cheat_block_timestamp_global(321);
 
     let output = test_env.call_contract(&contract_address, "get_block_timestamp", &[]);
     assert_success(output, &[Felt252::from(321)]);
@@ -223,7 +223,7 @@ fn cheat_block_timestamp_all_stop() {
 
     let contract_address = test_env.deploy_wrapper(&cheat_block_timestamp_checker, &[]);
 
-    test_env.cheatnet_state.cheat_block_timestamp_global(123);
+    test_env.cheatnet_state.start_cheat_block_timestamp_global(123);
 
     assert_success(
         test_env.call_contract(&contract_address, "get_block_timestamp", &[]),

--- a/crates/cheatnet/tests/cheatcodes/cheat_caller_address.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_caller_address.rs
@@ -198,7 +198,7 @@ fn cheat_caller_address_all() {
 
     test_env
         .cheatnet_state
-        .cheat_caller_address_global(123_u8.into());
+        .start_cheat_caller_address_global(123_u8.into());
 
     assert_success(
         test_env.call_contract(&contract_address, "get_caller_address", &[]),
@@ -267,7 +267,7 @@ fn cheat_caller_address_all_then_one() {
 
     test_env
         .cheatnet_state
-        .cheat_caller_address_global(111_u8.into());
+        .start_cheat_caller_address_global(111_u8.into());
     test_env.start_cheat_caller_address(contract_address, 222);
 
     assert_success(
@@ -285,7 +285,7 @@ fn cheat_caller_address_one_then_all() {
     test_env.start_cheat_caller_address(contract_address, 111);
     test_env
         .cheatnet_state
-        .cheat_caller_address_global(222_u8.into());
+        .start_cheat_caller_address_global(222_u8.into());
 
     assert_success(
         test_env.call_contract(&contract_address, "get_caller_address", &[]),

--- a/crates/cheatnet/tests/cheatcodes/cheat_sequencer_address.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_sequencer_address.rs
@@ -203,7 +203,7 @@ fn cheat_sequencer_address_all_simple() {
 
     test_env
         .cheatnet_state
-        .cheat_sequencer_address_global(123_u8.into());
+        .start_cheat_sequencer_address_global(123_u8.into());
 
     assert_success(
         test_env.call_contract(&contract_address, "get_sequencer_address", &[]),
@@ -219,7 +219,7 @@ fn cheat_sequencer_address_all_then_one() {
 
     test_env
         .cheatnet_state
-        .cheat_sequencer_address_global(111_u8.into());
+        .start_cheat_sequencer_address_global(111_u8.into());
 
     test_env.start_cheat_sequencer_address(contract_address, 222);
 
@@ -238,7 +238,7 @@ fn cheat_sequencer_address_one_then_all() {
     test_env.start_cheat_sequencer_address(contract_address, 111);
     test_env
         .cheatnet_state
-        .cheat_sequencer_address_global(222_u8.into());
+        .start_cheat_sequencer_address_global(222_u8.into());
 
     assert_success(
         test_env.call_contract(&contract_address, "get_sequencer_address", &[]),
@@ -256,7 +256,7 @@ fn cheat_sequencer_address_all_stop() {
 
     test_env
         .cheatnet_state
-        .cheat_sequencer_address_global(123_u8.into());
+        .start_cheat_sequencer_address_global(123_u8.into());
 
     assert_success(
         test_env.call_contract(&contract_address, "get_sequencer_address", &[]),

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -126,7 +126,7 @@
 ### Transaction Nonce Data Availability Mode
 
 - [`cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode) - changes the transaction nonce data availability mode for contracts, for a number of calls
-- [`cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode_global) - changes the transaction nonce data availability mode for all contracts
+- [`start_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode_global) - changes the transaction nonce data availability mode for all contracts
 - [`start_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#start_cheat_nonce_data_availability_mode) - changes the transaction nonce data availability mode for contracts
 - [`stop_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode) - cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_availability_mode` for contracts
 - [`stop_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode_global) - cancels the `cheat_nonce_data_availability_mode_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -110,7 +110,7 @@
 ### Transaction Tip
 
 - [`cheat_tip`](cheatcodes/tip.md#cheat_tip) - changes the transaction tip for contracts, for a number of calls
-- [`cheat_tip_global`](cheatcodes/tip.md#cheat_tip_global) - changes the transaction tip for all contracts
+- [`start_cheat_tip_global`](cheatcodes/tip.md#cheat_tip_global) - changes the transaction tip for all contracts
 - [`start_cheat_tip`](cheatcodes/tip.md#start_cheat_tip) - changes the transaction tip for contracts
 - [`stop_cheat_tip`](cheatcodes/tip.md#stop_cheat_tip) - cancels the `cheat_tip` / `start_cheat_tip` for contracts
 - [`stop_cheat_tip_global`](cheatcodes/tip.md#stop_cheat_tip_global) - cancels the `cheat_tip_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -142,7 +142,7 @@
 ### Transaction Account Deployment
 
 - [`cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data) - changes the transaction account deployment data for contracts, for a number of calls
-- [`cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data_global) - changes the transaction account deployment data for all contracts
+- [`start_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data_global) - changes the transaction account deployment data for all contracts
 - [`start_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#start_cheat_account_deployment_data) - changes the transaction account deployment data for contracts
 - [`stop_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for contracts
 - [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `cheat_account_deployment_data_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -54,7 +54,7 @@
 ### Transaction Version
 
 - [`cheat_transaction_version`](cheatcodes/transaction_version.md#cheat_transaction_version) - changes the transaction version for contracts, for a number of calls
-- [`cheat_transaction_version_global`](cheatcodes/transaction_version.md#cheat_transaction_version_global) - changes the transaction version for all contracts
+- [`start_cheat_transaction_version_global`](cheatcodes/transaction_version.md#cheat_transaction_version_global) - changes the transaction version for all contracts
 - [`start_cheat_transaction_version`](cheatcodes/transaction_version.md#start_cheat_transaction_version) - changes the transaction version for contracts
 - [`stop_cheat_transaction_version`](cheatcodes/transaction_version.md#stop_cheat_transaction_version) - cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for contracts
 - [`stop_cheat_transaction_version_global`](cheatcodes/transaction_version.md#stop_cheat_transaction_version_global) - cancels the `cheat_transaction_version_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -118,7 +118,7 @@
 ### Transaction Paymaster Data
 
 - [`cheat_paymaster_data`](cheatcodes/paymaster_data.md#cheat_paymaster_data) - changes the transaction paymaster data for contracts, for a number of calls
-- [`cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#cheat_paymaster_data_global) - changes the transaction paymaster data for all contracts
+- [`start_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#cheat_paymaster_data_global) - changes the transaction paymaster data for all contracts
 - [`start_cheat_paymaster_data`](cheatcodes/paymaster_data.md#start_cheat_paymaster_data) - changes the transaction paymaster data for contracts
 - [`stop_cheat_paymaster_data`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data) - cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for contracts
 - [`stop_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data_global) - cancels the `cheat_paymaster_data_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -21,7 +21,7 @@
 - [`start_cheat_caller_address_global`](cheatcodes/caller_address.md#cheat_caller_address_global) - changes the caller address for all contracts
 - [`start_cheat_caller_address`](cheatcodes/caller_address.md#start_cheat_caller_address) - changes the caller address for contracts
 - [`stop_cheat_caller_address`](cheatcodes/caller_address.md#stop_cheat_caller_address) - cancels the `cheat_caller_address` / `start_cheat_caller_address` for contracts
-- [`stop_cheat_caller_address_global`](cheatcodes/caller_address.md#stop_cheat_caller_address_global) - cancels the `cheat_caller_address_global`
+- [`stop_cheat_caller_address_global`](cheatcodes/caller_address.md#stop_cheat_caller_address_global) - cancels the `start_cheat_caller_address_global`
 
 ## Block Info
 
@@ -31,7 +31,7 @@
 - [`start_cheat_block_number_global`](cheatcodes/block_number.md#cheat_block_number_global) - changes the block number for all contracts
 - [`start_cheat_block_number`](cheatcodes/block_number.md#start_cheat_block_number) - changes the block number for contracts
 - [`stop_cheat_block_number`](cheatcodes/block_number.md#stop_cheat_block_number) - cancels the `cheat_block_number` / `start_cheat_block_number` for contracts
-- [`stop_cheat_block_number_global`](cheatcodes/block_number.md#stop_cheat_block_number_global) - cancels the `cheat_block_number_global`
+- [`stop_cheat_block_number_global`](cheatcodes/block_number.md#stop_cheat_block_number_global) - cancels the `start_cheat_block_number_global`
 
 ### Block Timestamp
 
@@ -39,7 +39,7 @@
 - [`start_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#cheat_block_timestamp_global) - changes the block timestamp for all contracts
 - [`start_cheat_block_timestamp`](cheatcodes/block_timestamp.md#start_cheat_block_timestamp) - changes the block timestamp for contracts
 - [`stop_cheat_block_timestamp`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp) - cancels the `cheat_block_timestamp` / `start_cheat_block_timestamp` for contracts
-- [`stop_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp_global) - cancels the `cheat_block_timestamp_global`
+- [`stop_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp_global) - cancels the `start_cheat_block_timestamp_global`
 
 ### Sequencer Address
 
@@ -47,7 +47,7 @@
 - [`start_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#cheat_sequencer_address_global) - changes the sequencer address for all contracts
 - [`start_cheat_sequencer_address`](cheatcodes/sequencer_address.md#start_cheat_sequencer_address) - changes the sequencer address for contracts
 - [`stop_cheat_sequencer_address`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address) - cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for contracts
-- [`stop_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address_global) - cancels the `cheat_sequencer_address_global`
+- [`stop_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address_global) - cancels the `start_cheat_sequencer_address_global`
 
 ## Transaction Info
 
@@ -57,7 +57,7 @@
 - [`start_cheat_transaction_version_global`](cheatcodes/transaction_version.md#cheat_transaction_version_global) - changes the transaction version for all contracts
 - [`start_cheat_transaction_version`](cheatcodes/transaction_version.md#start_cheat_transaction_version) - changes the transaction version for contracts
 - [`stop_cheat_transaction_version`](cheatcodes/transaction_version.md#stop_cheat_transaction_version) - cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for contracts
-- [`stop_cheat_transaction_version_global`](cheatcodes/transaction_version.md#stop_cheat_transaction_version_global) - cancels the `cheat_transaction_version_global`
+- [`stop_cheat_transaction_version_global`](cheatcodes/transaction_version.md#stop_cheat_transaction_version_global) - cancels the `start_cheat_transaction_version_global`
 
 ### Transaction Max Fee
 
@@ -65,7 +65,7 @@
 - [`start_cheat_max_fee_global`](cheatcodes/max_fee.md#cheat_max_fee_global) - changes the transaction max fee for all contracts
 - [`start_cheat_max_fee`](cheatcodes/max_fee.md#start_cheat_max_fee) - changes the transaction max fee for contracts
 - [`stop_cheat_max_fee`](cheatcodes/max_fee.md#stop_cheat_max_fee) - cancels the `cheat_max_fee` / `start_cheat_max_fee` for contracts
-- [`stop_cheat_max_fee_global`](cheatcodes/max_fee.md#stop_cheat_max_fee_global) - cancels the `cheat_max_fee_global`
+- [`stop_cheat_max_fee_global`](cheatcodes/max_fee.md#stop_cheat_max_fee_global) - cancels the `start_cheat_max_fee_global`
 
 ### Transaction Signature
 
@@ -73,7 +73,7 @@
 - [`start_cheat_signature_global`](cheatcodes/signature.md#cheat_signature_global) - changes the transaction signature for all contracts
 - [`start_cheat_signature`](cheatcodes/signature.md#start_cheat_signature) - changes the transaction signature for contracts
 - [`stop_cheat_signature`](cheatcodes/signature.md#stop_cheat_signature) - cancels the `cheat_signature` / `start_cheat_signature` for contracts
-- [`stop_cheat_signature_global`](cheatcodes/signature.md#stop_cheat_signature_global) - cancels the `cheat_signature_global`
+- [`stop_cheat_signature_global`](cheatcodes/signature.md#stop_cheat_signature_global) - cancels the `start_cheat_signature_global`
 
 ### Transaction Hash
 
@@ -81,7 +81,7 @@
 - [`start_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#cheat_transaction_hash_global) - changes the transaction hash for all contracts
 - [`start_cheat_transaction_hash`](cheatcodes/transaction_hash.md#start_cheat_transaction_hash) - changes the transaction hash for contracts
 - [`stop_cheat_transaction_hash`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash) - cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for contracts
-- [`stop_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash_global) - cancels the `cheat_transaction_hash_global`
+- [`stop_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash_global) - cancels the `start_cheat_transaction_hash_global`
 
 ### Transaction Chain ID
 
@@ -89,7 +89,7 @@
 - [`start_cheat_chain_id_global`](cheatcodes/chain_id.md#cheat_chain_id_global) - changes the transaction chain_id for all contracts
 - [`start_cheat_chain_id`](cheatcodes/chain_id.md#start_cheat_chain_id) - changes the transaction chain_id for contracts
 - [`stop_cheat_chain_id`](cheatcodes/chain_id.md#stop_cheat_chain_id) - cancels the `cheat_chain_id` / `start_cheat_chain_id` for contracts
-- [`stop_cheat_chain_id_global`](cheatcodes/chain_id.md#stop_cheat_chain_id_global) - cancels the `cheat_chain_id_global`
+- [`stop_cheat_chain_id_global`](cheatcodes/chain_id.md#stop_cheat_chain_id_global) - cancels the `start_cheat_chain_id_global`
 
 ### Transaction Nonce
 
@@ -97,7 +97,7 @@
 - [`start_cheat_nonce_global`](cheatcodes/nonce.md#cheat_nonce_global) - changes the transaction nonce for all contracts
 - [`start_cheat_nonce`](cheatcodes/nonce.md#start_cheat_nonce) - changes the transaction nonce for contracts
 - [`stop_cheat_nonce`](cheatcodes/nonce.md#stop_cheat_nonce) - cancels the `cheat_nonce` / `start_cheat_nonce` for contracts
-- [`stop_cheat_nonce_global`](cheatcodes/nonce.md#stop_cheat_nonce_global) - cancels the `cheat_nonce_global`
+- [`stop_cheat_nonce_global`](cheatcodes/nonce.md#stop_cheat_nonce_global) - cancels the `start_cheat_nonce_global`
 
 ### Transaction Resource Bounds
 
@@ -105,7 +105,7 @@
 - [`start_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#cheat_resource_bounds_global) - changes the transaction resource bounds for all contracts
 - [`start_cheat_resource_bounds`](cheatcodes/resource_bounds.md#start_cheat_resource_bounds) - changes the transaction resource bounds for contracts
 - [`stop_cheat_resource_bounds`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds) - cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for contracts
-- [`stop_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds_global) - cancels the `cheat_resource_bounds_global`
+- [`stop_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds_global) - cancels the `start_cheat_resource_bounds_global`
 
 ### Transaction Tip
 
@@ -113,7 +113,7 @@
 - [`start_cheat_tip_global`](cheatcodes/tip.md#cheat_tip_global) - changes the transaction tip for all contracts
 - [`start_cheat_tip`](cheatcodes/tip.md#start_cheat_tip) - changes the transaction tip for contracts
 - [`stop_cheat_tip`](cheatcodes/tip.md#stop_cheat_tip) - cancels the `cheat_tip` / `start_cheat_tip` for contracts
-- [`stop_cheat_tip_global`](cheatcodes/tip.md#stop_cheat_tip_global) - cancels the `cheat_tip_global`
+- [`stop_cheat_tip_global`](cheatcodes/tip.md#stop_cheat_tip_global) - cancels the `start_cheat_tip_global`
 
 ### Transaction Paymaster Data
 
@@ -121,7 +121,7 @@
 - [`start_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#cheat_paymaster_data_global) - changes the transaction paymaster data for all contracts
 - [`start_cheat_paymaster_data`](cheatcodes/paymaster_data.md#start_cheat_paymaster_data) - changes the transaction paymaster data for contracts
 - [`stop_cheat_paymaster_data`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data) - cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for contracts
-- [`stop_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data_global) - cancels the `cheat_paymaster_data_global`
+- [`stop_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data_global) - cancels the `start_cheat_paymaster_data_global`
 
 ### Transaction Nonce Data Availability Mode
 
@@ -129,7 +129,7 @@
 - [`start_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode_global) - changes the transaction nonce data availability mode for all contracts
 - [`start_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#start_cheat_nonce_data_availability_mode) - changes the transaction nonce data availability mode for contracts
 - [`stop_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode) - cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_availability_mode` for contracts
-- [`stop_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode_global) - cancels the `cheat_nonce_data_availability_mode_global`
+- [`stop_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode_global) - cancels the `start_cheat_nonce_data_availability_mode_global`
 
 ### Transaction Fee Data Availability Mode
 
@@ -137,7 +137,7 @@
 - [`start_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode_global) - changes the transaction fee data availability mode for all contracts
 - [`start_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#start_cheat_fee_data_availability_mode) - changes the transaction fee data availability mode for contracts
 - [`stop_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode) - cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availability_mode` for contracts
-- [`stop_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode_global) - cancels the `cheat_fee_data_availability_mode_global`
+- [`stop_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode_global) - cancels the `start_cheat_fee_data_availability_mode_global`
 
 ### Transaction Account Deployment
 
@@ -145,7 +145,7 @@
 - [`start_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data_global) - changes the transaction account deployment data for all contracts
 - [`start_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#start_cheat_account_deployment_data) - changes the transaction account deployment data for contracts
 - [`stop_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for contracts
-- [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `cheat_account_deployment_data_global`
+- [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `start_cheat_account_deployment_data_global`
 
 > ℹ️ **Info**
 > To use cheatcodes you need to add `snforge_std` package as a development dependency in

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -147,6 +147,14 @@
 - [`stop_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for contracts
 - [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `start_cheat_account_deployment_data_global`
 
+### Account Contract Address
+
+- [`cheat_account_contract_address`](cheatcodes/account_contract_address.md#cheat_account_contract_address) - changes the transaction account deployment data for contracts, for a number of calls
+- [`start_cheat_account_contract_address_global`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address_global) - changes the transaction account deployment data for all contracts
+- [`start_cheat_account_contract_address`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address) - changes the transaction account deployment data for contracts
+- [`stop_cheat_account_contract_address`](cheatcodes/account_contract_address.md#stop_cheat_account_contract_address) - cancels the `cheat_account_contract_address` / `start_cheat_account_deployment_data` for contracts
+- [`stop_cheat_account_contract_address_global`](cheatcodes/account_contract_address.md#stop_cheat_account_contract_address_global) - cancels the `start_cheat_account_contract_address_global`
+
 > ℹ️ **Info**
 > To use cheatcodes you need to add `snforge_std` package as a development dependency in
 > your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#development-dependencies)

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -94,7 +94,7 @@
 ### Transaction Nonce
 
 - [`cheat_nonce`](cheatcodes/nonce.md#cheat_nonce) - changes the transaction nonce for contracts, for a number of calls
-- [`cheat_nonce_global`](cheatcodes/nonce.md#cheat_nonce_global) - changes the transaction nonce for all contracts
+- [`start_cheat_nonce_global`](cheatcodes/nonce.md#cheat_nonce_global) - changes the transaction nonce for all contracts
 - [`start_cheat_nonce`](cheatcodes/nonce.md#start_cheat_nonce) - changes the transaction nonce for contracts
 - [`stop_cheat_nonce`](cheatcodes/nonce.md#stop_cheat_nonce) - cancels the `cheat_nonce` / `start_cheat_nonce` for contracts
 - [`stop_cheat_nonce_global`](cheatcodes/nonce.md#stop_cheat_nonce_global) - cancels the `cheat_nonce_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -78,7 +78,7 @@
 ### Transaction Hash
 
 - [`cheat_transaction_hash`](cheatcodes/transaction_hash.md#cheat_transaction_hash) - changes the transaction hash for contracts, for a number of calls
-- [`cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#cheat_transaction_hash_global) - changes the transaction hash for all contracts
+- [`start_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#cheat_transaction_hash_global) - changes the transaction hash for all contracts
 - [`start_cheat_transaction_hash`](cheatcodes/transaction_hash.md#start_cheat_transaction_hash) - changes the transaction hash for contracts
 - [`stop_cheat_transaction_hash`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash) - cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for contracts
 - [`stop_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash_global) - cancels the `cheat_transaction_hash_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -18,7 +18,7 @@
 ### Caller Address
 
 - [`cheat_caller_address`](cheatcodes/caller_address.md#cheat_caller_address) - changes the caller address for contracts, for a number of calls
-- [`start_cheat_caller_address_global`](cheatcodes/caller_address.md#cheat_caller_address_global) - changes the caller address for all contracts
+- [`start_cheat_caller_address_global`](cheatcodes/caller_address.md#start_cheat_caller_address_global) - changes the caller address for all contracts
 - [`start_cheat_caller_address`](cheatcodes/caller_address.md#start_cheat_caller_address) - changes the caller address for contracts
 - [`stop_cheat_caller_address`](cheatcodes/caller_address.md#stop_cheat_caller_address) - cancels the `cheat_caller_address` / `start_cheat_caller_address` for contracts
 - [`stop_cheat_caller_address_global`](cheatcodes/caller_address.md#stop_cheat_caller_address_global) - cancels the `start_cheat_caller_address_global`
@@ -28,7 +28,7 @@
 ### Block Number
 
 - [`cheat_block_number`](cheatcodes/block_number.md#cheat_block_number) - changes the block number for contracts, for a number of calls
-- [`start_cheat_block_number_global`](cheatcodes/block_number.md#cheat_block_number_global) - changes the block number for all contracts
+- [`start_cheat_block_number_global`](cheatcodes/block_number.md#start_cheat_block_number_global) - changes the block number for all contracts
 - [`start_cheat_block_number`](cheatcodes/block_number.md#start_cheat_block_number) - changes the block number for contracts
 - [`stop_cheat_block_number`](cheatcodes/block_number.md#stop_cheat_block_number) - cancels the `cheat_block_number` / `start_cheat_block_number` for contracts
 - [`stop_cheat_block_number_global`](cheatcodes/block_number.md#stop_cheat_block_number_global) - cancels the `start_cheat_block_number_global`
@@ -36,7 +36,7 @@
 ### Block Timestamp
 
 - [`cheat_block_timestamp`](cheatcodes/block_timestamp.md#cheat_block_timestamp) - changes the block timestamp for contracts, for a number of calls
-- [`start_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#cheat_block_timestamp_global) - changes the block timestamp for all contracts
+- [`start_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#start_cheat_block_timestamp_global) - changes the block timestamp for all contracts
 - [`start_cheat_block_timestamp`](cheatcodes/block_timestamp.md#start_cheat_block_timestamp) - changes the block timestamp for contracts
 - [`stop_cheat_block_timestamp`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp) - cancels the `cheat_block_timestamp` / `start_cheat_block_timestamp` for contracts
 - [`stop_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp_global) - cancels the `start_cheat_block_timestamp_global`
@@ -44,7 +44,7 @@
 ### Sequencer Address
 
 - [`cheat_sequencer_address`](cheatcodes/sequencer_address.md#cheat_sequencer_address) - changes the sequencer address for contracts, for a number of calls
-- [`start_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#cheat_sequencer_address_global) - changes the sequencer address for all contracts
+- [`start_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#start_cheat_sequencer_address_global) - changes the sequencer address for all contracts
 - [`start_cheat_sequencer_address`](cheatcodes/sequencer_address.md#start_cheat_sequencer_address) - changes the sequencer address for contracts
 - [`stop_cheat_sequencer_address`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address) - cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for contracts
 - [`stop_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address_global) - cancels the `start_cheat_sequencer_address_global`
@@ -54,7 +54,7 @@
 ### Transaction Version
 
 - [`cheat_transaction_version`](cheatcodes/transaction_version.md#cheat_transaction_version) - changes the transaction version for contracts, for a number of calls
-- [`start_cheat_transaction_version_global`](cheatcodes/transaction_version.md#cheat_transaction_version_global) - changes the transaction version for all contracts
+- [`start_cheat_transaction_version_global`](cheatcodes/transaction_version.md#start_cheat_transaction_version_global) - changes the transaction version for all contracts
 - [`start_cheat_transaction_version`](cheatcodes/transaction_version.md#start_cheat_transaction_version) - changes the transaction version for contracts
 - [`stop_cheat_transaction_version`](cheatcodes/transaction_version.md#stop_cheat_transaction_version) - cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for contracts
 - [`stop_cheat_transaction_version_global`](cheatcodes/transaction_version.md#stop_cheat_transaction_version_global) - cancels the `start_cheat_transaction_version_global`
@@ -62,7 +62,7 @@
 ### Transaction Max Fee
 
 - [`cheat_max_fee`](cheatcodes/max_fee.md#cheat_max_fee) - changes the transaction max fee for contracts, for a number of calls
-- [`start_cheat_max_fee_global`](cheatcodes/max_fee.md#cheat_max_fee_global) - changes the transaction max fee for all contracts
+- [`start_cheat_max_fee_global`](cheatcodes/max_fee.md#start_cheat_max_fee_global) - changes the transaction max fee for all contracts
 - [`start_cheat_max_fee`](cheatcodes/max_fee.md#start_cheat_max_fee) - changes the transaction max fee for contracts
 - [`stop_cheat_max_fee`](cheatcodes/max_fee.md#stop_cheat_max_fee) - cancels the `cheat_max_fee` / `start_cheat_max_fee` for contracts
 - [`stop_cheat_max_fee_global`](cheatcodes/max_fee.md#stop_cheat_max_fee_global) - cancels the `start_cheat_max_fee_global`
@@ -70,7 +70,7 @@
 ### Transaction Signature
 
 - [`cheat_signature`](cheatcodes/signature.md#cheat_signature) - changes the transaction signature for contracts, for a number of calls
-- [`start_cheat_signature_global`](cheatcodes/signature.md#cheat_signature_global) - changes the transaction signature for all contracts
+- [`start_cheat_signature_global`](cheatcodes/signature.md#start_cheat_signature_global) - changes the transaction signature for all contracts
 - [`start_cheat_signature`](cheatcodes/signature.md#start_cheat_signature) - changes the transaction signature for contracts
 - [`stop_cheat_signature`](cheatcodes/signature.md#stop_cheat_signature) - cancels the `cheat_signature` / `start_cheat_signature` for contracts
 - [`stop_cheat_signature_global`](cheatcodes/signature.md#stop_cheat_signature_global) - cancels the `start_cheat_signature_global`
@@ -78,7 +78,7 @@
 ### Transaction Hash
 
 - [`cheat_transaction_hash`](cheatcodes/transaction_hash.md#cheat_transaction_hash) - changes the transaction hash for contracts, for a number of calls
-- [`start_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#cheat_transaction_hash_global) - changes the transaction hash for all contracts
+- [`start_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#start_cheat_transaction_hash_global) - changes the transaction hash for all contracts
 - [`start_cheat_transaction_hash`](cheatcodes/transaction_hash.md#start_cheat_transaction_hash) - changes the transaction hash for contracts
 - [`stop_cheat_transaction_hash`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash) - cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for contracts
 - [`stop_cheat_transaction_hash_global`](cheatcodes/transaction_hash.md#stop_cheat_transaction_hash_global) - cancels the `start_cheat_transaction_hash_global`
@@ -86,7 +86,7 @@
 ### Transaction Chain ID
 
 - [`cheat_chain_id`](cheatcodes/chain_id.md#cheat_chain_id) - changes the transaction chain_id for contracts, for a number of calls
-- [`start_cheat_chain_id_global`](cheatcodes/chain_id.md#cheat_chain_id_global) - changes the transaction chain_id for all contracts
+- [`start_cheat_chain_id_global`](cheatcodes/chain_id.md#start_cheat_chain_id_global) - changes the transaction chain_id for all contracts
 - [`start_cheat_chain_id`](cheatcodes/chain_id.md#start_cheat_chain_id) - changes the transaction chain_id for contracts
 - [`stop_cheat_chain_id`](cheatcodes/chain_id.md#stop_cheat_chain_id) - cancels the `cheat_chain_id` / `start_cheat_chain_id` for contracts
 - [`stop_cheat_chain_id_global`](cheatcodes/chain_id.md#stop_cheat_chain_id_global) - cancels the `start_cheat_chain_id_global`
@@ -94,7 +94,7 @@
 ### Transaction Nonce
 
 - [`cheat_nonce`](cheatcodes/nonce.md#cheat_nonce) - changes the transaction nonce for contracts, for a number of calls
-- [`start_cheat_nonce_global`](cheatcodes/nonce.md#cheat_nonce_global) - changes the transaction nonce for all contracts
+- [`start_cheat_nonce_global`](cheatcodes/nonce.md#start_cheat_nonce_global) - changes the transaction nonce for all contracts
 - [`start_cheat_nonce`](cheatcodes/nonce.md#start_cheat_nonce) - changes the transaction nonce for contracts
 - [`stop_cheat_nonce`](cheatcodes/nonce.md#stop_cheat_nonce) - cancels the `cheat_nonce` / `start_cheat_nonce` for contracts
 - [`stop_cheat_nonce_global`](cheatcodes/nonce.md#stop_cheat_nonce_global) - cancels the `start_cheat_nonce_global`
@@ -102,7 +102,7 @@
 ### Transaction Resource Bounds
 
 - [`cheat_resource_bounds`](cheatcodes/resource_bounds.md#cheat_resource_bounds) - changes the transaction resource bounds for contracts, for a number of calls
-- [`start_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#cheat_resource_bounds_global) - changes the transaction resource bounds for all contracts
+- [`start_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#start_cheat_resource_bounds_global) - changes the transaction resource bounds for all contracts
 - [`start_cheat_resource_bounds`](cheatcodes/resource_bounds.md#start_cheat_resource_bounds) - changes the transaction resource bounds for contracts
 - [`stop_cheat_resource_bounds`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds) - cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for contracts
 - [`stop_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds_global) - cancels the `start_cheat_resource_bounds_global`
@@ -110,7 +110,7 @@
 ### Transaction Tip
 
 - [`cheat_tip`](cheatcodes/tip.md#cheat_tip) - changes the transaction tip for contracts, for a number of calls
-- [`start_cheat_tip_global`](cheatcodes/tip.md#cheat_tip_global) - changes the transaction tip for all contracts
+- [`start_cheat_tip_global`](cheatcodes/tip.md#start_cheat_tip_global) - changes the transaction tip for all contracts
 - [`start_cheat_tip`](cheatcodes/tip.md#start_cheat_tip) - changes the transaction tip for contracts
 - [`stop_cheat_tip`](cheatcodes/tip.md#stop_cheat_tip) - cancels the `cheat_tip` / `start_cheat_tip` for contracts
 - [`stop_cheat_tip_global`](cheatcodes/tip.md#stop_cheat_tip_global) - cancels the `start_cheat_tip_global`
@@ -118,7 +118,7 @@
 ### Transaction Paymaster Data
 
 - [`cheat_paymaster_data`](cheatcodes/paymaster_data.md#cheat_paymaster_data) - changes the transaction paymaster data for contracts, for a number of calls
-- [`start_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#cheat_paymaster_data_global) - changes the transaction paymaster data for all contracts
+- [`start_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#start_cheat_paymaster_data_global) - changes the transaction paymaster data for all contracts
 - [`start_cheat_paymaster_data`](cheatcodes/paymaster_data.md#start_cheat_paymaster_data) - changes the transaction paymaster data for contracts
 - [`stop_cheat_paymaster_data`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data) - cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for contracts
 - [`stop_cheat_paymaster_data_global`](cheatcodes/paymaster_data.md#stop_cheat_paymaster_data_global) - cancels the `start_cheat_paymaster_data_global`
@@ -126,7 +126,7 @@
 ### Transaction Nonce Data Availability Mode
 
 - [`cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode) - changes the transaction nonce data availability mode for contracts, for a number of calls
-- [`start_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#cheat_nonce_data_availability_mode_global) - changes the transaction nonce data availability mode for all contracts
+- [`start_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#start_cheat_nonce_data_availability_mode_global) - changes the transaction nonce data availability mode for all contracts
 - [`start_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#start_cheat_nonce_data_availability_mode) - changes the transaction nonce data availability mode for contracts
 - [`stop_cheat_nonce_data_availability_mode`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode) - cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_availability_mode` for contracts
 - [`stop_cheat_nonce_data_availability_mode_global`](cheatcodes/nonce_data_availability_mode.md#stop_cheat_nonce_data_availability_mode_global) - cancels the `start_cheat_nonce_data_availability_mode_global`
@@ -134,7 +134,7 @@
 ### Transaction Fee Data Availability Mode
 
 - [`cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode) - changes the transaction fee data availability mode for contracts, for a number of calls
-- [`start_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode_global) - changes the transaction fee data availability mode for all contracts
+- [`start_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#start_cheat_fee_data_availability_mode_global) - changes the transaction fee data availability mode for all contracts
 - [`start_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#start_cheat_fee_data_availability_mode) - changes the transaction fee data availability mode for contracts
 - [`stop_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode) - cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availability_mode` for contracts
 - [`stop_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode_global) - cancels the `start_cheat_fee_data_availability_mode_global`
@@ -142,7 +142,7 @@
 ### Transaction Account Deployment
 
 - [`cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data) - changes the transaction account deployment data for contracts, for a number of calls
-- [`start_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#cheat_account_deployment_data_global) - changes the transaction account deployment data for all contracts
+- [`start_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#start_cheat_account_deployment_data_global) - changes the transaction account deployment data for all contracts
 - [`start_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#start_cheat_account_deployment_data) - changes the transaction account deployment data for contracts
 - [`stop_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for contracts
 - [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `start_cheat_account_deployment_data_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -102,7 +102,7 @@
 ### Transaction Resource Bounds
 
 - [`cheat_resource_bounds`](cheatcodes/resource_bounds.md#cheat_resource_bounds) - changes the transaction resource bounds for contracts, for a number of calls
-- [`cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#cheat_resource_bounds_global) - changes the transaction resource bounds for all contracts
+- [`start_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#cheat_resource_bounds_global) - changes the transaction resource bounds for all contracts
 - [`start_cheat_resource_bounds`](cheatcodes/resource_bounds.md#start_cheat_resource_bounds) - changes the transaction resource bounds for contracts
 - [`stop_cheat_resource_bounds`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds) - cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for contracts
 - [`stop_cheat_resource_bounds_global`](cheatcodes/resource_bounds.md#stop_cheat_resource_bounds_global) - cancels the `cheat_resource_bounds_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -62,7 +62,7 @@
 ### Transaction Max Fee
 
 - [`cheat_max_fee`](cheatcodes/max_fee.md#cheat_max_fee) - changes the transaction max fee for contracts, for a number of calls
-- [`cheat_max_fee_global`](cheatcodes/max_fee.md#cheat_max_fee_global) - changes the transaction max fee for all contracts
+- [`start_cheat_max_fee_global`](cheatcodes/max_fee.md#cheat_max_fee_global) - changes the transaction max fee for all contracts
 - [`start_cheat_max_fee`](cheatcodes/max_fee.md#start_cheat_max_fee) - changes the transaction max fee for contracts
 - [`stop_cheat_max_fee`](cheatcodes/max_fee.md#stop_cheat_max_fee) - cancels the `cheat_max_fee` / `start_cheat_max_fee` for contracts
 - [`stop_cheat_max_fee_global`](cheatcodes/max_fee.md#stop_cheat_max_fee_global) - cancels the `cheat_max_fee_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -18,7 +18,7 @@
 ### Caller Address
 
 - [`cheat_caller_address`](cheatcodes/caller_address.md#cheat_caller_address) - changes the caller address for contracts, for a number of calls
-- [`cheat_caller_address_global`](cheatcodes/caller_address.md#cheat_caller_address_global) - changes the caller address for all contracts
+- [`start_cheat_caller_address_global`](cheatcodes/caller_address.md#cheat_caller_address_global) - changes the caller address for all contracts
 - [`start_cheat_caller_address`](cheatcodes/caller_address.md#start_cheat_caller_address) - changes the caller address for contracts
 - [`stop_cheat_caller_address`](cheatcodes/caller_address.md#stop_cheat_caller_address) - cancels the `cheat_caller_address` / `start_cheat_caller_address` for contracts
 - [`stop_cheat_caller_address_global`](cheatcodes/caller_address.md#stop_cheat_caller_address_global) - cancels the `cheat_caller_address_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -70,7 +70,7 @@
 ### Transaction Signature
 
 - [`cheat_signature`](cheatcodes/signature.md#cheat_signature) - changes the transaction signature for contracts, for a number of calls
-- [`cheat_signature_global`](cheatcodes/signature.md#cheat_signature_global) - changes the transaction signature for all contracts
+- [`start_cheat_signature_global`](cheatcodes/signature.md#cheat_signature_global) - changes the transaction signature for all contracts
 - [`start_cheat_signature`](cheatcodes/signature.md#start_cheat_signature) - changes the transaction signature for contracts
 - [`stop_cheat_signature`](cheatcodes/signature.md#stop_cheat_signature) - cancels the `cheat_signature` / `start_cheat_signature` for contracts
 - [`stop_cheat_signature_global`](cheatcodes/signature.md#stop_cheat_signature_global) - cancels the `cheat_signature_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -36,7 +36,7 @@
 ### Block Timestamp
 
 - [`cheat_block_timestamp`](cheatcodes/block_timestamp.md#cheat_block_timestamp) - changes the block timestamp for contracts, for a number of calls
-- [`cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#cheat_block_timestamp_global) - changes the block timestamp for all contracts
+- [`start_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#cheat_block_timestamp_global) - changes the block timestamp for all contracts
 - [`start_cheat_block_timestamp`](cheatcodes/block_timestamp.md#start_cheat_block_timestamp) - changes the block timestamp for contracts
 - [`stop_cheat_block_timestamp`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp) - cancels the `cheat_block_timestamp` / `start_cheat_block_timestamp` for contracts
 - [`stop_cheat_block_timestamp_global`](cheatcodes/block_timestamp.md#stop_cheat_block_timestamp_global) - cancels the `cheat_block_timestamp_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -28,7 +28,7 @@
 ### Block Number
 
 - [`cheat_block_number`](cheatcodes/block_number.md#cheat_block_number) - changes the block number for contracts, for a number of calls
-- [`cheat_block_number_global`](cheatcodes/block_number.md#cheat_block_number_global) - changes the block number for all contracts
+- [`start_cheat_block_number_global`](cheatcodes/block_number.md#cheat_block_number_global) - changes the block number for all contracts
 - [`start_cheat_block_number`](cheatcodes/block_number.md#start_cheat_block_number) - changes the block number for contracts
 - [`stop_cheat_block_number`](cheatcodes/block_number.md#stop_cheat_block_number) - cancels the `cheat_block_number` / `start_cheat_block_number` for contracts
 - [`stop_cheat_block_number_global`](cheatcodes/block_number.md#stop_cheat_block_number_global) - cancels the `cheat_block_number_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -86,7 +86,7 @@
 ### Transaction Chain ID
 
 - [`cheat_chain_id`](cheatcodes/chain_id.md#cheat_chain_id) - changes the transaction chain_id for contracts, for a number of calls
-- [`cheat_chain_id_global`](cheatcodes/chain_id.md#cheat_chain_id_global) - changes the transaction chain_id for all contracts
+- [`start_cheat_chain_id_global`](cheatcodes/chain_id.md#cheat_chain_id_global) - changes the transaction chain_id for all contracts
 - [`start_cheat_chain_id`](cheatcodes/chain_id.md#start_cheat_chain_id) - changes the transaction chain_id for contracts
 - [`stop_cheat_chain_id`](cheatcodes/chain_id.md#stop_cheat_chain_id) - cancels the `cheat_chain_id` / `start_cheat_chain_id` for contracts
 - [`stop_cheat_chain_id_global`](cheatcodes/chain_id.md#stop_cheat_chain_id_global) - cancels the `cheat_chain_id_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -134,7 +134,7 @@
 ### Transaction Fee Data Availability Mode
 
 - [`cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode) - changes the transaction fee data availability mode for contracts, for a number of calls
-- [`cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode_global) - changes the transaction fee data availability mode for all contracts
+- [`start_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#cheat_fee_data_availability_mode_global) - changes the transaction fee data availability mode for all contracts
 - [`start_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#start_cheat_fee_data_availability_mode) - changes the transaction fee data availability mode for contracts
 - [`stop_cheat_fee_data_availability_mode`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode) - cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availability_mode` for contracts
 - [`stop_cheat_fee_data_availability_mode_global`](cheatcodes/fee_data_availability_mode.md#stop_cheat_fee_data_availability_mode_global) - cancels the `cheat_fee_data_availability_mode_global`

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -44,7 +44,7 @@
 ### Sequencer Address
 
 - [`cheat_sequencer_address`](cheatcodes/sequencer_address.md#cheat_sequencer_address) - changes the sequencer address for contracts, for a number of calls
-- [`cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#cheat_sequencer_address_global) - changes the sequencer address for all contracts
+- [`start_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#cheat_sequencer_address_global) - changes the sequencer address for all contracts
 - [`start_cheat_sequencer_address`](cheatcodes/sequencer_address.md#start_cheat_sequencer_address) - changes the sequencer address for contracts
 - [`stop_cheat_sequencer_address`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address) - cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for contracts
 - [`stop_cheat_sequencer_address_global`](cheatcodes/sequencer_address.md#stop_cheat_sequencer_address_global) - cancels the `cheat_sequencer_address_global`

--- a/docs/src/appendix/cheatcodes/account_contract_address.md
+++ b/docs/src/appendix/cheatcodes/account_contract_address.md
@@ -7,8 +7,8 @@ Cheatcodes modifying `account_contract_address`:
 
 Changes the transaction account deployment data for the given target and span.
 
-## `cheat_account_contract_address_global`
-> `fn cheat_account_contract_address_global(account_contract_address: ContractAddress)`
+## `start_cheat_account_contract_address_global`
+> `fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress)`
 
 Changes the transaction account deployment data for all targets.
 
@@ -25,4 +25,4 @@ Cancels the `cheat_account_contract_address` / `start_cheat_account_contract_add
 ## `stop_cheat_account_contract_address_global`
 > `fn stop_cheat_account_contract_address_global(target: ContractAddress)`
 
-Cancels the `cheat_account_contract_address_global`.
+Cancels the `start_cheat_account_contract_address_global`.

--- a/docs/src/appendix/cheatcodes/account_deployment_data.md
+++ b/docs/src/appendix/cheatcodes/account_deployment_data.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `account_deployment_data`:
 
 Changes the transaction account deployment data for the given target and span.
 
-## `cheat_account_deployment_data_global`
+## `start_cheat_account_deployment_data_global`
 > `fn cheat_account_deployment_data_global(account_deployment_data: Span<felt252>)`
 
 Changes the transaction account deployment data for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_da
 ## `stop_cheat_account_deployment_data_global`
 > `fn stop_cheat_account_deployment_data_global(target: ContractAddress)`
 
-Cancels the `cheat_account_deployment_data_global`.
+Cancels the `start_cheat_account_deployment_data_global`.

--- a/docs/src/appendix/cheatcodes/account_deployment_data.md
+++ b/docs/src/appendix/cheatcodes/account_deployment_data.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `account_deployment_data`:
 Changes the transaction account deployment data for the given target and span.
 
 ## `start_cheat_account_deployment_data_global`
-> `fn cheat_account_deployment_data_global(account_deployment_data: Span<felt252>)`
+> `fn start_cheat_account_deployment_data_global(account_deployment_data: Span<felt252>)`
 
 Changes the transaction account deployment data for all targets.
 

--- a/docs/src/appendix/cheatcodes/block_number.md
+++ b/docs/src/appendix/cheatcodes/block_number.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `block_number`:
 Changes the block number for the given target and span.
 
 ## `start_cheat_block_number_global`
-> `fn cheat_block_number_global(block_number: u64)`
+> `fn start_cheat_block_number_global(block_number: u64)`
 
 Changes the block number for all targets.
 

--- a/docs/src/appendix/cheatcodes/block_number.md
+++ b/docs/src/appendix/cheatcodes/block_number.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `block_number`:
 
 Changes the block number for the given target and span.
 
-## `cheat_block_number_global`
+## `start_cheat_block_number_global`
 > `fn cheat_block_number_global(block_number: u64)`
 
 Changes the block number for all targets.
@@ -25,5 +25,5 @@ Cancels the `cheat_block_number` / `start_cheat_block_number` for the given targ
 ## `stop_cheat_block_number_global`
 > `fn stop_cheat_block_number_global(target: ContractAddress)`
 
-Cancels the `cheat_block_number_global`.
+Cancels the `start_cheat_block_number_global`.
 

--- a/docs/src/appendix/cheatcodes/block_timestamp.md
+++ b/docs/src/appendix/cheatcodes/block_timestamp.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `block_timestamp`:
 Changes the block timestamp for the given target and span.
 
 ## `start_cheat_block_timestamp_global`
-> `fn cheat_block_timestamp_global(block_timestamp: u64)`
+> `fn start_cheat_block_timestamp_global(block_timestamp: u64)`
 
 Changes the block timestamp for all targets.
 

--- a/docs/src/appendix/cheatcodes/block_timestamp.md
+++ b/docs/src/appendix/cheatcodes/block_timestamp.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `block_timestamp`:
 
 Changes the block timestamp for the given target and span.
 
-## `cheat_block_timestamp_global`
+## `start_cheat_block_timestamp_global`
 > `fn cheat_block_timestamp_global(block_timestamp: u64)`
 
 Changes the block timestamp for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_block_timestamp` / `start_cheat_block_timestamp` for the give
 ## `stop_cheat_block_timestamp_global`
 > `fn stop_cheat_block_timestamp_global(target: ContractAddress)`
 
-Cancels the `cheat_block_timestamp_global`.
+Cancels the `start_cheat_block_timestamp_global`.

--- a/docs/src/appendix/cheatcodes/caller_address.md
+++ b/docs/src/appendix/cheatcodes/caller_address.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `caller_address`:
 Changes the caller address for the given target and span.
 
 ## `start_cheat_caller_address_global`
-> `fn cheat_caller_address_global(caller_address: ContractAddress)`
+> `fn start_cheat_caller_address_global(caller_address: ContractAddress)`
 
 Changes the caller address for all targets.
 

--- a/docs/src/appendix/cheatcodes/caller_address.md
+++ b/docs/src/appendix/cheatcodes/caller_address.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `caller_address`:
 
 Changes the caller address for the given target and span.
 
-## `cheat_caller_address_global`
+## `start_cheat_caller_address_global`
 > `fn cheat_caller_address_global(caller_address: ContractAddress)`
 
 Changes the caller address for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_caller_address` / `start_cheat_caller_address` for the given 
 ## `stop_cheat_caller_address_global`
 > `fn stop_cheat_caller_address_global(target: ContractAddress)`
 
-Cancels the `cheat_caller_address_global`.
+Cancels the `start_cheat_caller_address_global`.

--- a/docs/src/appendix/cheatcodes/chain_id.md
+++ b/docs/src/appendix/cheatcodes/chain_id.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `chain_id`:
 
 Changes the transaction chain_id for the given target and span.
 
-## `cheat_chain_id_global`
+## `start_cheat_chain_id_global`
 > `fn cheat_chain_id_global(chain_id: felt252)`
 
 Changes the transaction chain_id for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_chain_id` / `start_cheat_chain_id` for the given target.
 ## `stop_cheat_chain_id_global`
 > `fn stop_cheat_chain_id_global(target: ContractAddress)`
 
-Cancels the `cheat_chain_id_global`.
+Cancels the `start_cheat_chain_id_global`.

--- a/docs/src/appendix/cheatcodes/chain_id.md
+++ b/docs/src/appendix/cheatcodes/chain_id.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `chain_id`:
 Changes the transaction chain_id for the given target and span.
 
 ## `start_cheat_chain_id_global`
-> `fn cheat_chain_id_global(chain_id: felt252)`
+> `fn start_cheat_chain_id_global(chain_id: felt252)`
 
 Changes the transaction chain_id for all targets.
 

--- a/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `fee_data_availability_mode`:
 
 Changes the transaction fee data availability mode for the given target and span.
 
-## `cheat_fee_data_availability_mode_global`
+## start_`cheat_fee_data_availability_mode_global`
 > `fn cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32)`
 
 Changes the transaction fee data availability mode for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availabil
 ## `stop_cheat_fee_data_availability_mode_global`
 > `fn stop_cheat_fee_data_availability_mode_global(target: ContractAddress)`
 
-Cancels the `cheat_fee_data_availability_mode_global`.
+Cancels the `start_cheat_fee_data_availability_mode_global`.

--- a/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
@@ -7,8 +7,8 @@ Cheatcodes modifying `fee_data_availability_mode`:
 
 Changes the transaction fee data availability mode for the given target and span.
 
-## start_`cheat_fee_data_availability_mode_global`
-> `fn cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32)`
+## `start_cheat_fee_data_availability_mode_global`
+> `fn start_cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32)`
 
 Changes the transaction fee data availability mode for all targets.
 

--- a/docs/src/appendix/cheatcodes/max_fee.md
+++ b/docs/src/appendix/cheatcodes/max_fee.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `max_fee`:
 Changes the transaction max fee for the given target and span.
 
 ## `start_cheat_max_fee_global`
-> `fn cheat_max_fee_global(max_fee: u128)`
+> `fn start_cheat_max_fee_global(max_fee: u128)`
 
 Changes the transaction max fee for all targets.
 

--- a/docs/src/appendix/cheatcodes/max_fee.md
+++ b/docs/src/appendix/cheatcodes/max_fee.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `max_fee`:
 
 Changes the transaction max fee for the given target and span.
 
-## `cheat_max_fee_global`
+## `start_cheat_max_fee_global`
 > `fn cheat_max_fee_global(max_fee: u128)`
 
 Changes the transaction max fee for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_max_fee` / `start_cheat_max_fee` for the given target.
 ## `stop_cheat_max_fee_global`
 > `fn stop_cheat_max_fee_global(target: ContractAddress)`
 
-Cancels the `cheat_max_fee_global`.
+Cancels the `start_cheat_max_fee_global`.

--- a/docs/src/appendix/cheatcodes/nonce.md
+++ b/docs/src/appendix/cheatcodes/nonce.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `nonce`:
 
 Changes the transaction nonce for the given target and span.
 
-## `cheat_nonce_global`
+## `start_cheat_nonce_global`
 > `fn cheat_nonce_global(nonce: felt252)`
 
 Changes the transaction nonce for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_nonce` / `start_cheat_nonce` for the given target.
 ## `stop_cheat_nonce_global`
 > `fn stop_cheat_nonce_global(target: ContractAddress)`
 
-Cancels the `cheat_nonce_global`.
+Cancels the `start_cheat_nonce_global`.

--- a/docs/src/appendix/cheatcodes/nonce.md
+++ b/docs/src/appendix/cheatcodes/nonce.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `nonce`:
 Changes the transaction nonce for the given target and span.
 
 ## `start_cheat_nonce_global`
-> `fn cheat_nonce_global(nonce: felt252)`
+> `fn start_cheat_nonce_global(nonce: felt252)`
 
 Changes the transaction nonce for all targets.
 

--- a/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `nonce_data_availability_mode`:
 
 Changes the transaction nonce data availability mode for the given target and span.
 
-## `cheat_nonce_data_availability_mode_global`
+## `start_cheat_nonce_data_availability_mode_global`
 > `fn cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32)`
 
 Changes the transaction nonce data availability mode for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_avail
 ## `stop_cheat_nonce_data_availability_mode_global`
 > `fn stop_cheat_nonce_data_availability_mode_global(target: ContractAddress)`
 
-Cancels the `cheat_nonce_data_availability_mode_global`.
+Cancels the `start_cheat_nonce_data_availability_mode_global`.

--- a/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `nonce_data_availability_mode`:
 Changes the transaction nonce data availability mode for the given target and span.
 
 ## `start_cheat_nonce_data_availability_mode_global`
-> `fn cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32)`
+> `fn start_cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32)`
 
 Changes the transaction nonce data availability mode for all targets.
 

--- a/docs/src/appendix/cheatcodes/paymaster_data.md
+++ b/docs/src/appendix/cheatcodes/paymaster_data.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `paymaster_data`:
 Changes the transaction paymaster data for the given target and span.
 
 ## `start_cheat_paymaster_data_global`
-> `fn cheat_paymaster_data_global(paymaster_data: Span<felt252>)`
+> `fn start_cheat_paymaster_data_global(paymaster_data: Span<felt252>)`
 
 Changes the transaction paymaster data for all targets.
 

--- a/docs/src/appendix/cheatcodes/paymaster_data.md
+++ b/docs/src/appendix/cheatcodes/paymaster_data.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `paymaster_data`:
 
 Changes the transaction paymaster data for the given target and span.
 
-## `cheat_paymaster_data_global`
+## `start_cheat_paymaster_data_global`
 > `fn cheat_paymaster_data_global(paymaster_data: Span<felt252>)`
 
 Changes the transaction paymaster data for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for the given 
 ## `stop_cheat_paymaster_data_global`
 > `fn stop_cheat_paymaster_data_global(target: ContractAddress)`
 
-Cancels the `cheat_paymaster_data_global`.
+Cancels the `start_cheat_paymaster_data_global`.

--- a/docs/src/appendix/cheatcodes/resource_bounds.md
+++ b/docs/src/appendix/cheatcodes/resource_bounds.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `resource_bounds`:
 
 Changes the transaction resource bounds for the given target and span.
 
-## `cheat_resource_bounds_global`
+## `start_cheat_resource_bounds_global`
 > `fn cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>)`
 
 Changes the transaction resource bounds for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for the give
 ## `stop_cheat_resource_bounds_global`
 > `fn stop_cheat_resource_bounds_global(target: ContractAddress)`
 
-Cancels the `cheat_resource_bounds_global`.
+Cancels the `start_cheat_resource_bounds_global`.

--- a/docs/src/appendix/cheatcodes/resource_bounds.md
+++ b/docs/src/appendix/cheatcodes/resource_bounds.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `resource_bounds`:
 Changes the transaction resource bounds for the given target and span.
 
 ## `start_cheat_resource_bounds_global`
-> `fn cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>)`
+> `fn start_cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>)`
 
 Changes the transaction resource bounds for all targets.
 

--- a/docs/src/appendix/cheatcodes/sequencer_address.md
+++ b/docs/src/appendix/cheatcodes/sequencer_address.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `sequencer_address`:
 
 Changes the sequencer address for the given target and span.
 
-## `cheat_sequencer_address_global`
+## `start_cheat_sequencer_address_global`
 > `fn cheat_sequencer_address_global(sequencer_address: ContractAddress)`
 
 Changes the sequencer address for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for the 
 ## `stop_cheat_sequencer_address_global`
 > `fn stop_cheat_sequencer_address_global(target: ContractAddress)`
 
-Cancels the `cheat_sequencer_address_global`.
+Cancels the `start_cheat_sequencer_address_global`.

--- a/docs/src/appendix/cheatcodes/sequencer_address.md
+++ b/docs/src/appendix/cheatcodes/sequencer_address.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `sequencer_address`:
 Changes the sequencer address for the given target and span.
 
 ## `start_cheat_sequencer_address_global`
-> `fn cheat_sequencer_address_global(sequencer_address: ContractAddress)`
+> `fn start_cheat_sequencer_address_global(sequencer_address: ContractAddress)`
 
 Changes the sequencer address for all targets.
 

--- a/docs/src/appendix/cheatcodes/signature.md
+++ b/docs/src/appendix/cheatcodes/signature.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `signature`:
 Changes the transaction signature for the given target and span.
 
 ## `start_cheat_signature_global`
-> `fn cheat_signature_global(signature: Span<felt252>)`
+> `fn start_cheat_signature_global(signature: Span<felt252>)`
 
 Changes the transaction signature for all targets.
 

--- a/docs/src/appendix/cheatcodes/signature.md
+++ b/docs/src/appendix/cheatcodes/signature.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `signature`:
 
 Changes the transaction signature for the given target and span.
 
-## `cheat_signature_global`
+## `start_cheat_signature_global`
 > `fn cheat_signature_global(signature: Span<felt252>)`
 
 Changes the transaction signature for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_signature` / `start_cheat_signature` for the given target.
 ## `stop_cheat_signature_global`
 > `fn stop_cheat_signature_global(target: ContractAddress)`
 
-Cancels the `cheat_signature_global`.
+Cancels the `start_cheat_signature_global`.

--- a/docs/src/appendix/cheatcodes/tip.md
+++ b/docs/src/appendix/cheatcodes/tip.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `tip`:
 
 Changes the transaction tip for the given target and span.
 
-## `cheat_tip_global`
+## `start_cheat_tip_global`
 > `fn cheat_tip_global(tip: u128)`
 
 Changes the transaction tip for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_tip` / `start_cheat_tip` for the given target.
 ## `stop_cheat_tip_global`
 > `fn stop_cheat_tip_global(target: ContractAddress)`
 
-Cancels the `cheat_tip_global`.
+Cancels the `start_cheat_tip_global`.

--- a/docs/src/appendix/cheatcodes/tip.md
+++ b/docs/src/appendix/cheatcodes/tip.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `tip`:
 Changes the transaction tip for the given target and span.
 
 ## `start_cheat_tip_global`
-> `fn cheat_tip_global(tip: u128)`
+> `fn start_cheat_tip_global(tip: u128)`
 
 Changes the transaction tip for all targets.
 

--- a/docs/src/appendix/cheatcodes/transaction_hash.md
+++ b/docs/src/appendix/cheatcodes/transaction_hash.md
@@ -7,7 +7,7 @@ Cheatcodes modifying `transaction_hash`:
 
 Changes the transaction hash for the given target and span.
 
-## `cheat_transaction_hash_global`
+## `start_cheat_transaction_hash_global`
 > `fn cheat_transaction_hash_global(transaction_hash: felt252)`
 
 Changes the transaction hash for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for the gi
 ## `stop_cheat_transaction_hash_global`
 > `fn stop_cheat_transaction_hash_global(target: ContractAddress)`
 
-Cancels the `cheat_transaction_hash_global`.
+Cancels the `start_cheat_transaction_hash_global`.

--- a/docs/src/appendix/cheatcodes/transaction_hash.md
+++ b/docs/src/appendix/cheatcodes/transaction_hash.md
@@ -8,7 +8,7 @@ Cheatcodes modifying `transaction_hash`:
 Changes the transaction hash for the given target and span.
 
 ## `start_cheat_transaction_hash_global`
-> `fn cheat_transaction_hash_global(transaction_hash: felt252)`
+> `fn start_cheat_transaction_hash_global(transaction_hash: felt252)`
 
 Changes the transaction hash for all targets.
 

--- a/docs/src/appendix/cheatcodes/transaction_version.md
+++ b/docs/src/appendix/cheatcodes/transaction_version.md
@@ -7,7 +7,7 @@ Cheatcodes modifying transaction `version`:
 
 Changes the transaction version for the given target and span.
 
-## `cheat_transaction_version_global`
+## `start_cheat_transaction_version_global`
 > `fn cheat_transaction_version_global(version: felt252)`
 
 Changes the transaction version for all targets.
@@ -25,4 +25,4 @@ Cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for 
 ## `stop_cheat_transaction_version_global`
 > `fn stop_cheat_transaction_version_global(target: ContractAddress)`
 
-Cancels the `cheat_transaction_version_global`.
+Cancels the `start_cheat_transaction_version_global`.

--- a/docs/src/appendix/cheatcodes/transaction_version.md
+++ b/docs/src/appendix/cheatcodes/transaction_version.md
@@ -8,7 +8,7 @@ Cheatcodes modifying transaction `version`:
 Changes the transaction version for the given target and span.
 
 ## `start_cheat_transaction_version_global`
-> `fn cheat_transaction_version_global(version: felt252)`
+> `fn start_cheat_transaction_version_global(version: felt252)`
 
 Changes the transaction version for all targets.
 

--- a/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
@@ -23,7 +23,7 @@ fn cheat_account_contract_address(
 
 /// Changes the transaction account deployment data.
 /// - `account_contract_address` - transaction account deployment data to be set
-fn cheat_account_contract_address_global(account_contract_address: ContractAddress) {
+fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
@@ -33,7 +33,7 @@ fn cheat_account_contract_address_global(account_contract_address: ContractAddre
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_account_contract_address_global`.
+/// Cancels the `start_cheat_account_contract_address_global`.
 fn stop_cheat_account_contract_address_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/account_deployment_data.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_deployment_data.cairo
@@ -23,7 +23,7 @@ fn cheat_account_deployment_data(
 
 /// Changes the transaction account deployment data.
 /// - `account_deployment_data` - transaction account deployment data to be set
-fn cheat_account_deployment_data_global(account_deployment_data: Span<felt252>) {
+fn start_cheat_account_deployment_data_global(account_deployment_data: Span<felt252>) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info

--- a/snforge_std/src/cheatcodes/execution_info/block_number.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/block_number.cairo
@@ -21,7 +21,7 @@ fn cheat_block_number(contract_address: ContractAddress, block_number: u64, span
 
 /// Changes the block number.
 /// - `block_number` - block number to be set
-fn cheat_block_number_global(block_number: u64) {
+fn start_cheat_block_number_global(block_number: u64) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.block_info.block_number = Operation::StartGlobal(block_number);
@@ -29,7 +29,7 @@ fn cheat_block_number_global(block_number: u64) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_block_number_global`.
+/// Cancels the `start_cheat_block_number_global`.
 fn stop_cheat_block_number_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/block_timestamp.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/block_timestamp.cairo
@@ -21,7 +21,7 @@ fn cheat_block_timestamp(contract_address: ContractAddress, block_timestamp: u64
 
 /// Changes the block timestamp.
 /// - `block_timestamp` - block timestamp to be set
-fn cheat_block_timestamp_global(block_timestamp: u64) {
+fn start_cheat_block_timestamp_global(block_timestamp: u64) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.block_info.block_timestamp = Operation::StartGlobal(block_timestamp);
@@ -29,7 +29,7 @@ fn cheat_block_timestamp_global(block_timestamp: u64) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_block_timestamp_global`.
+/// Cancels the `start_cheat_block_timestamp_global`.
 fn stop_cheat_block_timestamp_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/caller_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/caller_address.cairo
@@ -22,7 +22,7 @@ fn cheat_caller_address(
 
 /// Changes the caller address.
 /// - `caller_address` - caller address to be set
-fn cheat_caller_address_global(caller_address: ContractAddress) {
+fn start_cheat_caller_address_global(caller_address: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.caller_address = Operation::StartGlobal(caller_address);
@@ -30,7 +30,7 @@ fn cheat_caller_address_global(caller_address: ContractAddress) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_caller_address_global`.
+/// Cancels the `start_cheat_caller_address_global`.
 fn stop_cheat_caller_address_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/chain_id.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/chain_id.cairo
@@ -19,7 +19,7 @@ fn cheat_chain_id(contract_address: ContractAddress, chain_id: felt252, span: Ch
 
 /// Changes the transaction chain_id.
 /// - `chain_id` - transaction chain_id to be set
-fn cheat_chain_id_global(chain_id: felt252) {
+fn start_cheat_chain_id_global(chain_id: felt252) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.chain_id = Operation::StartGlobal(chain_id);
@@ -27,7 +27,7 @@ fn cheat_chain_id_global(chain_id: felt252) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_chain_id_global`.
+/// Cancels the `start_cheat_chain_id_global`.
 fn stop_cheat_chain_id_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/fee_data_availability_mode.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/fee_data_availability_mode.cairo
@@ -25,7 +25,7 @@ fn cheat_fee_data_availability_mode(
 
 /// Changes the transaction fee data availability mode.
 /// - `fee_data_availability_mode` - transaction fee data availability mode to be set
-fn cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32) {
+fn start_cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
@@ -35,7 +35,7 @@ fn cheat_fee_data_availability_mode_global(fee_data_availability_mode: u32) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_fee_data_availability_mode_global`.
+/// Cancels the `start_cheat_fee_data_availability_mode_global`.
 fn stop_cheat_fee_data_availability_mode_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/max_fee.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/max_fee.cairo
@@ -19,7 +19,7 @@ fn cheat_max_fee(contract_address: ContractAddress, max_fee: u128, span: CheatSp
 
 /// Changes the transaction max fee.
 /// - `max_fee` - transaction max fee to be set
-fn cheat_max_fee_global(max_fee: u128) {
+fn start_cheat_max_fee_global(max_fee: u128) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.max_fee = Operation::StartGlobal(max_fee);
@@ -27,7 +27,7 @@ fn cheat_max_fee_global(max_fee: u128) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_max_fee_global`.
+/// Cancels the `start_cheat_max_fee_global`.
 fn stop_cheat_max_fee_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/nonce.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/nonce.cairo
@@ -18,7 +18,7 @@ fn cheat_nonce(contract_address: ContractAddress, nonce: felt252, span: CheatSpa
 
 /// Changes the transaction nonce.
 /// - `nonce` - transaction nonce to be set
-fn cheat_nonce_global(nonce: felt252) {
+fn start_cheat_nonce_global(nonce: felt252) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.nonce = Operation::StartGlobal(nonce);
@@ -26,7 +26,7 @@ fn cheat_nonce_global(nonce: felt252) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_nonce_global`.
+/// Cancels the `start_cheat_nonce_global`.
 fn stop_cheat_nonce_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/nonce_data_availability_mode.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/nonce_data_availability_mode.cairo
@@ -25,7 +25,7 @@ fn cheat_nonce_data_availability_mode(
 
 /// Changes the transaction nonce data availability mode.
 /// - `nonce_data_availability_mode` - transaction nonce data availability mode to be set
-fn cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32) {
+fn start_cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
@@ -35,7 +35,7 @@ fn cheat_nonce_data_availability_mode_global(nonce_data_availability_mode: u32) 
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_nonce_data_availability_mode_global`.
+/// Cancels the `start_cheat_nonce_data_availability_mode_global`.
 fn stop_cheat_nonce_data_availability_mode_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/paymaster_data.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/paymaster_data.cairo
@@ -23,7 +23,7 @@ fn cheat_paymaster_data(
 
 /// Changes the transaction paymaster data.
 /// - `paymaster_data` - transaction paymaster data to be set
-fn cheat_paymaster_data_global(paymaster_data: Span<felt252>) {
+fn start_cheat_paymaster_data_global(paymaster_data: Span<felt252>) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.paymaster_data = Operation::StartGlobal(paymaster_data);
@@ -31,7 +31,7 @@ fn cheat_paymaster_data_global(paymaster_data: Span<felt252>) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_paymaster_data_global`.
+/// Cancels the `start_cheat_paymaster_data_global`.
 fn stop_cheat_paymaster_data_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/resource_bounds.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/resource_bounds.cairo
@@ -25,7 +25,7 @@ fn cheat_resource_bounds(
 
 /// Changes the transaction resource bounds.
 /// - `resource_bounds` - transaction resource bounds to be set
-fn cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>) {
+fn start_cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.resource_bounds = Operation::StartGlobal(resource_bounds);
@@ -33,7 +33,7 @@ fn cheat_resource_bounds_global(resource_bounds: Span<ResourceBounds>) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_resource_bounds_global`.
+/// Cancels the `start_cheat_resource_bounds_global`.
 fn stop_cheat_resource_bounds_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/sequencer_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/sequencer_address.cairo
@@ -23,7 +23,7 @@ fn cheat_sequencer_address(
 
 /// Changes the sequencer address.
 /// - `sequencer_address` - sequencer address to be set
-fn cheat_sequencer_address_global(sequencer_address: ContractAddress) {
+fn start_cheat_sequencer_address_global(sequencer_address: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.block_info.sequencer_address = Operation::StartGlobal(sequencer_address);
@@ -31,7 +31,7 @@ fn cheat_sequencer_address_global(sequencer_address: ContractAddress) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_sequencer_address_global`.
+/// Cancels the `start_cheat_sequencer_address_global`.
 fn stop_cheat_sequencer_address_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/signature.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/signature.cairo
@@ -19,7 +19,7 @@ fn cheat_signature(contract_address: ContractAddress, signature: Span<felt252>, 
 
 /// Changes the transaction signature.
 /// - `signature` - transaction signature to be set
-fn cheat_signature_global(signature: Span<felt252>) {
+fn start_cheat_signature_global(signature: Span<felt252>) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.signature = Operation::StartGlobal(signature);
@@ -27,7 +27,7 @@ fn cheat_signature_global(signature: Span<felt252>) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_signature_global`.
+/// Cancels the `start_cheat_signature_global`.
 fn stop_cheat_signature_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/tip.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/tip.cairo
@@ -18,7 +18,7 @@ fn cheat_tip(contract_address: ContractAddress, tip: u128, span: CheatSpan) {
 
 /// Changes the transaction tip.
 /// - `tip` - transaction tip to be set
-fn cheat_tip_global(tip: u128) {
+fn start_cheat_tip_global(tip: u128) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.tip = Operation::StartGlobal(tip);
@@ -26,7 +26,7 @@ fn cheat_tip_global(tip: u128) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_tip_global`.
+/// Cancels the `start_cheat_tip_global`.
 fn stop_cheat_tip_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/transaction_hash.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/transaction_hash.cairo
@@ -23,7 +23,7 @@ fn cheat_transaction_hash(
 
 /// Changes the transaction hash.
 /// - `transaction_hash` - transaction hash to be set
-fn cheat_transaction_hash_global(transaction_hash: felt252) {
+fn start_cheat_transaction_hash_global(transaction_hash: felt252) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.transaction_hash = Operation::StartGlobal(transaction_hash);
@@ -31,7 +31,7 @@ fn cheat_transaction_hash_global(transaction_hash: felt252) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_transaction_hash_global`.
+/// Cancels the `start_cheat_transaction_hash_global`.
 fn stop_cheat_transaction_hash_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/cheatcodes/execution_info/version.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/version.cairo
@@ -19,7 +19,7 @@ fn cheat_transaction_version(contract_address: ContractAddress, version: felt252
 
 /// Changes the transaction version.
 /// - `version` - transaction version to be set
-fn cheat_transaction_version_global(version: felt252) {
+fn start_cheat_transaction_version_global(version: felt252) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info.tx_info.version = Operation::StartGlobal(version);
@@ -27,7 +27,7 @@ fn cheat_transaction_version_global(version: felt252) {
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_transaction_version_global`.
+/// Cancels the `start_cheat_transaction_version_global`.
 fn stop_cheat_transaction_version_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -38,7 +38,7 @@ use cheatcodes::execution_info::Operation;
 use cheatcodes::execution_info::CheatArguments;
 
 use cheatcodes::execution_info::caller_address::cheat_caller_address;
-use cheatcodes::execution_info::caller_address::cheat_caller_address_global;
+use cheatcodes::execution_info::caller_address::start_cheat_caller_address_global;
 use cheatcodes::execution_info::caller_address::stop_cheat_caller_address;
 use cheatcodes::execution_info::caller_address::stop_cheat_caller_address_global;
 use cheatcodes::execution_info::caller_address::start_cheat_caller_address;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -58,7 +58,7 @@ use cheatcodes::execution_info::sequencer_address::stop_cheat_sequencer_address;
 use cheatcodes::execution_info::sequencer_address::stop_cheat_sequencer_address_global;
 use cheatcodes::execution_info::sequencer_address::start_cheat_sequencer_address;
 use cheatcodes::execution_info::version::cheat_transaction_version;
-use cheatcodes::execution_info::version::cheat_transaction_version_global;
+use cheatcodes::execution_info::version::start_cheat_transaction_version_global;
 use cheatcodes::execution_info::version::stop_cheat_transaction_version;
 use cheatcodes::execution_info::version::stop_cheat_transaction_version_global;
 use cheatcodes::execution_info::version::start_cheat_transaction_version;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -83,7 +83,7 @@ use cheatcodes::execution_info::chain_id::stop_cheat_chain_id;
 use cheatcodes::execution_info::chain_id::stop_cheat_chain_id_global;
 use cheatcodes::execution_info::chain_id::start_cheat_chain_id;
 use cheatcodes::execution_info::nonce::cheat_nonce;
-use cheatcodes::execution_info::nonce::cheat_nonce_global;
+use cheatcodes::execution_info::nonce::start_cheat_nonce_global;
 use cheatcodes::execution_info::nonce::stop_cheat_nonce;
 use cheatcodes::execution_info::nonce::stop_cheat_nonce_global;
 use cheatcodes::execution_info::nonce::start_cheat_nonce;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -103,7 +103,7 @@ use cheatcodes::execution_info::paymaster_data::stop_cheat_paymaster_data;
 use cheatcodes::execution_info::paymaster_data::stop_cheat_paymaster_data_global;
 use cheatcodes::execution_info::paymaster_data::start_cheat_paymaster_data;
 use cheatcodes::execution_info::nonce_data_availability_mode::cheat_nonce_data_availability_mode;
-use cheatcodes::execution_info::nonce_data_availability_mode::cheat_nonce_data_availability_mode_global;
+use cheatcodes::execution_info::nonce_data_availability_mode::start_cheat_nonce_data_availability_mode_global;
 use cheatcodes::execution_info::nonce_data_availability_mode::stop_cheat_nonce_data_availability_mode;
 use cheatcodes::execution_info::nonce_data_availability_mode::stop_cheat_nonce_data_availability_mode_global;
 use cheatcodes::execution_info::nonce_data_availability_mode::start_cheat_nonce_data_availability_mode;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -73,7 +73,7 @@ use cheatcodes::execution_info::signature::stop_cheat_signature;
 use cheatcodes::execution_info::signature::stop_cheat_signature_global;
 use cheatcodes::execution_info::signature::start_cheat_signature;
 use cheatcodes::execution_info::transaction_hash::cheat_transaction_hash;
-use cheatcodes::execution_info::transaction_hash::cheat_transaction_hash_global;
+use cheatcodes::execution_info::transaction_hash::start_cheat_transaction_hash_global;
 use cheatcodes::execution_info::transaction_hash::stop_cheat_transaction_hash;
 use cheatcodes::execution_info::transaction_hash::stop_cheat_transaction_hash_global;
 use cheatcodes::execution_info::transaction_hash::start_cheat_transaction_hash;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -118,7 +118,7 @@ use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_depl
 use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_deployment_data_global;
 use cheatcodes::execution_info::account_deployment_data::start_cheat_account_deployment_data;
 use cheatcodes::execution_info::account_contract_address::cheat_account_contract_address;
-use cheatcodes::execution_info::account_contract_address::cheat_account_contract_address_global;
+use cheatcodes::execution_info::account_contract_address::start_cheat_account_contract_address_global;
 use cheatcodes::execution_info::account_contract_address::stop_cheat_account_contract_address;
 use cheatcodes::execution_info::account_contract_address::stop_cheat_account_contract_address_global;
 use cheatcodes::execution_info::account_contract_address::start_cheat_account_contract_address;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -68,7 +68,7 @@ use cheatcodes::execution_info::max_fee::stop_cheat_max_fee;
 use cheatcodes::execution_info::max_fee::stop_cheat_max_fee_global;
 use cheatcodes::execution_info::max_fee::start_cheat_max_fee;
 use cheatcodes::execution_info::signature::cheat_signature;
-use cheatcodes::execution_info::signature::cheat_signature_global;
+use cheatcodes::execution_info::signature::start_cheat_signature_global;
 use cheatcodes::execution_info::signature::stop_cheat_signature;
 use cheatcodes::execution_info::signature::stop_cheat_signature_global;
 use cheatcodes::execution_info::signature::start_cheat_signature;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -113,7 +113,7 @@ use cheatcodes::execution_info::fee_data_availability_mode::stop_cheat_fee_data_
 use cheatcodes::execution_info::fee_data_availability_mode::stop_cheat_fee_data_availability_mode_global;
 use cheatcodes::execution_info::fee_data_availability_mode::start_cheat_fee_data_availability_mode;
 use cheatcodes::execution_info::account_deployment_data::cheat_account_deployment_data;
-use cheatcodes::execution_info::account_deployment_data::cheat_account_deployment_data_global;
+use cheatcodes::execution_info::account_deployment_data::start_cheat_account_deployment_data_global;
 use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_deployment_data;
 use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_deployment_data_global;
 use cheatcodes::execution_info::account_deployment_data::start_cheat_account_deployment_data;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -48,7 +48,7 @@ use cheatcodes::execution_info::block_number::stop_cheat_block_number;
 use cheatcodes::execution_info::block_number::stop_cheat_block_number_global;
 use cheatcodes::execution_info::block_number::start_cheat_block_number;
 use cheatcodes::execution_info::block_timestamp::cheat_block_timestamp;
-use cheatcodes::execution_info::block_timestamp::cheat_block_timestamp_global;
+use cheatcodes::execution_info::block_timestamp::start_cheat_block_timestamp_global;
 use cheatcodes::execution_info::block_timestamp::stop_cheat_block_timestamp;
 use cheatcodes::execution_info::block_timestamp::stop_cheat_block_timestamp_global;
 use cheatcodes::execution_info::block_timestamp::start_cheat_block_timestamp;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -78,7 +78,7 @@ use cheatcodes::execution_info::transaction_hash::stop_cheat_transaction_hash;
 use cheatcodes::execution_info::transaction_hash::stop_cheat_transaction_hash_global;
 use cheatcodes::execution_info::transaction_hash::start_cheat_transaction_hash;
 use cheatcodes::execution_info::chain_id::cheat_chain_id;
-use cheatcodes::execution_info::chain_id::cheat_chain_id_global;
+use cheatcodes::execution_info::chain_id::start_cheat_chain_id_global;
 use cheatcodes::execution_info::chain_id::stop_cheat_chain_id;
 use cheatcodes::execution_info::chain_id::stop_cheat_chain_id_global;
 use cheatcodes::execution_info::chain_id::start_cheat_chain_id;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -108,7 +108,7 @@ use cheatcodes::execution_info::nonce_data_availability_mode::stop_cheat_nonce_d
 use cheatcodes::execution_info::nonce_data_availability_mode::stop_cheat_nonce_data_availability_mode_global;
 use cheatcodes::execution_info::nonce_data_availability_mode::start_cheat_nonce_data_availability_mode;
 use cheatcodes::execution_info::fee_data_availability_mode::cheat_fee_data_availability_mode;
-use cheatcodes::execution_info::fee_data_availability_mode::cheat_fee_data_availability_mode_global;
+use cheatcodes::execution_info::fee_data_availability_mode::start_cheat_fee_data_availability_mode_global;
 use cheatcodes::execution_info::fee_data_availability_mode::stop_cheat_fee_data_availability_mode;
 use cheatcodes::execution_info::fee_data_availability_mode::stop_cheat_fee_data_availability_mode_global;
 use cheatcodes::execution_info::fee_data_availability_mode::start_cheat_fee_data_availability_mode;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -43,7 +43,7 @@ use cheatcodes::execution_info::caller_address::stop_cheat_caller_address;
 use cheatcodes::execution_info::caller_address::stop_cheat_caller_address_global;
 use cheatcodes::execution_info::caller_address::start_cheat_caller_address;
 use cheatcodes::execution_info::block_number::cheat_block_number;
-use cheatcodes::execution_info::block_number::cheat_block_number_global;
+use cheatcodes::execution_info::block_number::start_cheat_block_number_global;
 use cheatcodes::execution_info::block_number::stop_cheat_block_number;
 use cheatcodes::execution_info::block_number::stop_cheat_block_number_global;
 use cheatcodes::execution_info::block_number::start_cheat_block_number;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -53,7 +53,7 @@ use cheatcodes::execution_info::block_timestamp::stop_cheat_block_timestamp;
 use cheatcodes::execution_info::block_timestamp::stop_cheat_block_timestamp_global;
 use cheatcodes::execution_info::block_timestamp::start_cheat_block_timestamp;
 use cheatcodes::execution_info::sequencer_address::cheat_sequencer_address;
-use cheatcodes::execution_info::sequencer_address::cheat_sequencer_address_global;
+use cheatcodes::execution_info::sequencer_address::start_cheat_sequencer_address_global;
 use cheatcodes::execution_info::sequencer_address::stop_cheat_sequencer_address;
 use cheatcodes::execution_info::sequencer_address::stop_cheat_sequencer_address_global;
 use cheatcodes::execution_info::sequencer_address::start_cheat_sequencer_address;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -63,7 +63,7 @@ use cheatcodes::execution_info::version::stop_cheat_transaction_version;
 use cheatcodes::execution_info::version::stop_cheat_transaction_version_global;
 use cheatcodes::execution_info::version::start_cheat_transaction_version;
 use cheatcodes::execution_info::max_fee::cheat_max_fee;
-use cheatcodes::execution_info::max_fee::cheat_max_fee_global;
+use cheatcodes::execution_info::max_fee::start_cheat_max_fee_global;
 use cheatcodes::execution_info::max_fee::stop_cheat_max_fee;
 use cheatcodes::execution_info::max_fee::stop_cheat_max_fee_global;
 use cheatcodes::execution_info::max_fee::start_cheat_max_fee;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -88,7 +88,7 @@ use cheatcodes::execution_info::nonce::stop_cheat_nonce;
 use cheatcodes::execution_info::nonce::stop_cheat_nonce_global;
 use cheatcodes::execution_info::nonce::start_cheat_nonce;
 use cheatcodes::execution_info::resource_bounds::cheat_resource_bounds;
-use cheatcodes::execution_info::resource_bounds::cheat_resource_bounds_global;
+use cheatcodes::execution_info::resource_bounds::start_cheat_resource_bounds_global;
 use cheatcodes::execution_info::resource_bounds::stop_cheat_resource_bounds;
 use cheatcodes::execution_info::resource_bounds::stop_cheat_resource_bounds_global;
 use cheatcodes::execution_info::resource_bounds::start_cheat_resource_bounds;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -98,7 +98,7 @@ use cheatcodes::execution_info::tip::stop_cheat_tip;
 use cheatcodes::execution_info::tip::stop_cheat_tip_global;
 use cheatcodes::execution_info::tip::start_cheat_tip;
 use cheatcodes::execution_info::paymaster_data::cheat_paymaster_data;
-use cheatcodes::execution_info::paymaster_data::cheat_paymaster_data_global;
+use cheatcodes::execution_info::paymaster_data::start_cheat_paymaster_data_global;
 use cheatcodes::execution_info::paymaster_data::stop_cheat_paymaster_data;
 use cheatcodes::execution_info::paymaster_data::stop_cheat_paymaster_data_global;
 use cheatcodes::execution_info::paymaster_data::start_cheat_paymaster_data;

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -93,7 +93,7 @@ use cheatcodes::execution_info::resource_bounds::stop_cheat_resource_bounds;
 use cheatcodes::execution_info::resource_bounds::stop_cheat_resource_bounds_global;
 use cheatcodes::execution_info::resource_bounds::start_cheat_resource_bounds;
 use cheatcodes::execution_info::tip::cheat_tip;
-use cheatcodes::execution_info::tip::cheat_tip_global;
+use cheatcodes::execution_info::tip::start_cheat_tip_global;
 use cheatcodes::execution_info::tip::stop_cheat_tip;
 use cheatcodes::execution_info::tip::stop_cheat_tip_global;
 use cheatcodes::execution_info::tip::start_cheat_tip;


### PR DESCRIPTION
Closes #[2213](https://github.com/orgs/foundry-rs/projects/3/views/2?pane=issue&itemId=67823035)

## Introduced changes

Updated names of those cheatcodes which work globally and indefinitely (i.e. until they get cancelled).
Project parts affected:
- Cairo functions in snforge_std
- docs
- Cheatnet's Forge runtime extensions 
