### PR TITLE
Updated `cheat_account_contract_address` docs and global call name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Updated event testing - read more [here](./docs/src/testing/testing-events.md) on how it now works and [here](./docs/src/appendix/cheatcodes/spy_events.md)
 about updated `spy_events` cheatcode
+- Updated `cheat_account_contract_address` docs [here](./docs/src/appendix/cheatcodes.md#account-contract-address) and added a `start_` prefix to the `..._global` invocation which works globally and indefinitely
 
 ## [0.25.0] - 2024-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `verify` subcommand to verify contract (walnut APIs supported as of this version). [Read more here](./docs/src/appendix/sncast/verify.md)
 
+### Forge
+
+#### Changed
+
+- Updated `cheat_account_contract_address` cheatcode - read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes/account_contract_address.html) - added a `start_` prefix to the `..._global` invocation which works globally and indefinitely
+
 ## [0.26.0] - 2024-07-03
 
 ### Forge 
@@ -20,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Updated event testing - read more [here](./docs/src/testing/testing-events.md) on how it now works and [here](./docs/src/appendix/cheatcodes/spy_events.md)
 about updated `spy_events` cheatcode
-- Updated `cheat_account_contract_address` docs [here](./docs/src/appendix/cheatcodes.md#account-contract-address) and added a `start_` prefix to the `..._global` invocation which works globally and indefinitely
 
 ## [0.25.0] - 2024-06-12
 

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -147,6 +147,14 @@
 - [`stop_cheat_account_deployment_data`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for contracts
 - [`stop_cheat_account_deployment_data_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_deployment_data_global) - cancels the `cheat_account_deployment_data_global`
 
+## Account Contract Address
+
+- [`cheat_account_contract_address`](cheatcodes/account_contract_address.md#cheat_account_contract_address) - changes the addres of an account which the transaction originates from, for the given target and span
+- [`start_cheat_account_contract_address_global`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address_global) - changes the addres of an account which the transaction originates from, for all targets
+- [`start_cheat_account_contract_address`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address) - changes the addres of an account which the transaction originates from, for the given target 
+- [`stop_cheat_account_contract_address`](cheatcodes/account_deployment_data.md#stop_cheat_account_contract_address) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for the given target
+- [`stop_cheat_account_contract_address_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_contract_address_global) - cancels the `start_cheat_account_contract_address_global`
+
 > ℹ️ **Info**
 > To use cheatcodes you need to add `snforge_std` package as a development dependency in
 > your [`Scarb.toml`](https://docs.swmansion.com/scarb/docs/guides/dependencies.html#development-dependencies)

--- a/docs/src/appendix/cheatcodes.md
+++ b/docs/src/appendix/cheatcodes.md
@@ -149,9 +149,9 @@
 
 ## Account Contract Address
 
-- [`cheat_account_contract_address`](cheatcodes/account_contract_address.md#cheat_account_contract_address) - changes the addres of an account which the transaction originates from, for the given target and span
-- [`start_cheat_account_contract_address_global`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address_global) - changes the addres of an account which the transaction originates from, for all targets
-- [`start_cheat_account_contract_address`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address) - changes the addres of an account which the transaction originates from, for the given target 
+- [`cheat_account_contract_address`](cheatcodes/account_contract_address.md#cheat_account_contract_address) - changes the address of an account which the transaction originates from, for the given target and span
+- [`start_cheat_account_contract_address_global`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address_global) - changes the address of an account which the transaction originates from, for all targets
+- [`start_cheat_account_contract_address`](cheatcodes/account_contract_address.md#start_cheat_account_contract_address) - changes the address of an account which the transaction originates from, for the given target 
 - [`stop_cheat_account_contract_address`](cheatcodes/account_deployment_data.md#stop_cheat_account_contract_address) - cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for the given target
 - [`stop_cheat_account_contract_address_global`](cheatcodes/account_deployment_data.md#stop_cheat_account_contract_address_global) - cancels the `start_cheat_account_contract_address_global`
 

--- a/docs/src/appendix/cheatcodes/account_contract_address.md
+++ b/docs/src/appendix/cheatcodes/account_contract_address.md
@@ -5,17 +5,17 @@ Cheatcodes modifying `account_contract_address`:
 ## `cheat_account_contract_address`
 > `fn cheat_account_contract_address(target: ContractAddress, account_contract_address: ContractAddress, span: CheatSpan)`
 
-Changes the transaction account deployment data for the given target and span.
+Changes the addres of an account which the transaction originates from, for the given target and span.
 
-## `cheat_account_contract_address_global`
-> `fn cheat_account_contract_address_global(account_contract_address: ContractAddress)`
+## `start_cheat_account_contract_address_global`
+> `fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress)`
 
-Changes the transaction account deployment data for all targets.
+Changes the addres of an account which the transaction originates from, for all targets.
 
 ## `start_cheat_account_contract_address`
 > `fn start_cheat_account_contract_address(target: ContractAddress, account_contract_address: ContractAddress)`
 
-Changes the transaction account deployment data for the given target.
+Changes the addres of an account which the transaction originates from, for the given target.
 
 ## `stop_cheat_account_contract_address`
 > `fn stop_cheat_account_contract_address(target: ContractAddress)`
@@ -25,4 +25,4 @@ Cancels the `cheat_account_contract_address` / `start_cheat_account_contract_add
 ## `stop_cheat_account_contract_address_global`
 > `fn stop_cheat_account_contract_address_global(target: ContractAddress)`
 
-Cancels the `cheat_account_contract_address_global`.
+Cancels the `start_cheat_account_contract_address_global`.

--- a/docs/src/appendix/cheatcodes/account_contract_address.md
+++ b/docs/src/appendix/cheatcodes/account_contract_address.md
@@ -5,17 +5,17 @@ Cheatcodes modifying `account_contract_address`:
 ## `cheat_account_contract_address`
 > `fn cheat_account_contract_address(target: ContractAddress, account_contract_address: ContractAddress, span: CheatSpan)`
 
-Changes the addres of an account which the transaction originates from, for the given target and span.
+Changes the address of an account which the transaction originates from, for the given target and span.
 
 ## `start_cheat_account_contract_address_global`
 > `fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress)`
 
-Changes the addres of an account which the transaction originates from, for all targets.
+Changes the address of an account which the transaction originates from, for all targets.
 
 ## `start_cheat_account_contract_address`
 > `fn start_cheat_account_contract_address(target: ContractAddress, account_contract_address: ContractAddress)`
 
-Changes the addres of an account which the transaction originates from, for the given target.
+Changes the address of an account which the transaction originates from, for the given target.
 
 ## `stop_cheat_account_contract_address`
 > `fn stop_cheat_account_contract_address(target: ContractAddress)`

--- a/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
@@ -2,7 +2,7 @@ use super::{
     ExecutionInfoMock, Operation, CheatArguments, CheatSpan, cheat_execution_info, ContractAddress
 };
 
-/// Changes the transaction account deployment data for the given contract address and span.
+/// Changes the addres of an account which the transaction originates from, for the given contract address and span.
 /// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat applied
@@ -21,9 +21,9 @@ fn cheat_account_contract_address(
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction account deployment data.
+/// Changes the addres of an account which the transaction originates from.
 /// - `account_contract_address` - transaction account deployment data to be set
-fn cheat_account_contract_address_global(account_contract_address: ContractAddress) {
+fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
@@ -33,7 +33,7 @@ fn cheat_account_contract_address_global(account_contract_address: ContractAddre
     cheat_execution_info(execution_info);
 }
 
-/// Cancels the `cheat_account_contract_address_global`.
+/// Cancels the `start_cheat_account_contract_address_global`.
 fn stop_cheat_account_contract_address_global() {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -42,7 +42,7 @@ fn stop_cheat_account_contract_address_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction account deployment data for the given contract_address.
+/// Changes the addres of an account which the transaction originates from, for the given contract_address.
 /// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 fn start_cheat_account_contract_address(

--- a/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
@@ -2,7 +2,7 @@ use super::{
     ExecutionInfoMock, Operation, CheatArguments, CheatSpan, cheat_execution_info, ContractAddress
 };
 
-/// Changes the addres of an account which the transaction originates from, for the given contract address and span.
+/// Changes the address of an account which the transaction originates from, for the given contract address and span.
 /// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat applied
@@ -21,7 +21,7 @@ fn cheat_account_contract_address(
     cheat_execution_info(execution_info);
 }
 
-/// Changes the addres of an account which the transaction originates from.
+/// Changes the address of an account which the transaction originates from.
 /// - `account_contract_address` - transaction account deployment data to be set
 fn start_cheat_account_contract_address_global(account_contract_address: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
@@ -42,7 +42,7 @@ fn stop_cheat_account_contract_address_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the addres of an account which the transaction originates from, for the given contract_address.
+/// Changes the address of an account which the transaction originates from, for the given contract_address.
 /// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 fn start_cheat_account_contract_address(

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -118,7 +118,7 @@ use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_depl
 use cheatcodes::execution_info::account_deployment_data::stop_cheat_account_deployment_data_global;
 use cheatcodes::execution_info::account_deployment_data::start_cheat_account_deployment_data;
 use cheatcodes::execution_info::account_contract_address::cheat_account_contract_address;
-use cheatcodes::execution_info::account_contract_address::cheat_account_contract_address_global;
+use cheatcodes::execution_info::account_contract_address::start_cheat_account_contract_address_global;
 use cheatcodes::execution_info::account_contract_address::stop_cheat_account_contract_address;
 use cheatcodes::execution_info::account_contract_address::stop_cheat_account_contract_address_global;
 use cheatcodes::execution_info::account_contract_address::start_cheat_account_contract_address;


### PR DESCRIPTION
Closes [#2259](https://github.com/orgs/foundry-rs/projects/3/views/2?pane=issue&itemId=68875894)

## Introduced changes
- Changed the `cheat_account_contract_address` cheatcode's docs to describe it more accurately
- Added the `start_` prefix to the global variant to match the convention stated in [#2213](https://github.com/orgs/foundry-rs/projects/3/views/2?pane=issue&itemId=67823035)

## Checklist
- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
