### PR TITLE
Added `sncast account list` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,27 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 - Renamed global cheatcodes listed [here](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes.html) - cheatcode invocations affecting the global scope and working indefinitely, already marked with a `_global` suffix, received a `start_` prefix
+- Updated `cheat_account_contract_address` cheatcode - read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes/account_contract_address.html) - added a `start_` prefix to the `..._global` invocation which works globally and indefinitely
 
 ### Cast
 
-#### Added 
+#### Added
 
 - `spy_messages_to_l1()` for listening in on messages to L1 sent by your contracts. [Read more here](https://foundry-rs.github.io/starknet-foundry/testing/testing-messages-to-l1.html).
 
-#### Cast
 - `verify` subcommand to verify contract (walnut APIs supported as of this version). [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/verify.html)
 - support for v3 transactions on account deploy
 - Newest class hash for OpenZeppelin account contracts
 
-### Forge
+- `account list` subcommand for listing all available accounts [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/list.html)
 
 #### Changed
 
-- Updated `cheat_account_contract_address` cheatcode - read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/cheatcodes/account_contract_address.html) - added a `start_` prefix to the `..._global` invocation which works globally and indefinitely
+- `multicall new` no longer prints generated template to stdout and now requires specifying output path. [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/multicall/new.html)
 
 ## [0.26.0] - 2024-07-03
 
-### Forge 
+### Forge
 
 #### Changed
 - Updated event testing - read more [here](./docs/src/testing/testing-events.md) on how it now works and [here](./docs/src/appendix/cheatcodes/spy_events.md)
@@ -112,7 +112,7 @@ produced by Scarb if they were present. Setting up `casm = true` in `Scarb.toml`
 down the compilation.
 
 #### Fixed
-- scripts built with release profile are now properly recognized and ran 
+- scripts built with release profile are now properly recognized and ran
 
 ## [0.22.0] - 2024-04-17
 
@@ -141,8 +141,8 @@ down the compilation.
 
 #### Added
 
-- sncast script idempotency feature - every action done by the script that alters the network state will be tracked in state file, 
-and won't be replayed if previously succeeded 
+- sncast script idempotency feature - every action done by the script that alters the network state will be tracked in state file,
+and won't be replayed if previously succeeded
 
 ## [0.20.1] - 2024-03-22
 
@@ -165,7 +165,7 @@ and won't be replayed if previously succeeded
 - Default `chain_id` has been changed from `SN_GOERLI` to `SN_SEPOLIA`
 - Supported RPC version is now 0.7.0
 - Gas calculation is in sync with starknet 0.13.1 (with EIP 4844 blob usage enabled)
-- Resources displayed (steps, builtins) now include OS costs of syscalls 
+- Resources displayed (steps, builtins) now include OS costs of syscalls
 
 ### Cast
 
@@ -333,7 +333,7 @@ binary, which will allow forge to be independent of sierra version
 #### Changed
 
 - maximum number of computational steps per call set to current Starknet limit (3M)
-- `mean` and `std deviation` fields are displayed for gas usage while running fuzzing tests 
+- `mean` and `std deviation` fields are displayed for gas usage while running fuzzing tests
 - Cairo edition in `snforge_std` and `sncast_std` set to `2023_10`
 - `snforge_std::signature` module with `stark_curve`, `secp256k1_curve` and `secp256r1_curve` submodules
 
@@ -349,7 +349,7 @@ binary, which will allow forge to be independent of sierra version
 
 - `assert_not_emitted` assert to check if an event was not emitted
 
-#### Changed 
+#### Changed
 
 - fields from `starknet::info::v2::TxInfo` are now part of `TxInfoMock` from `snforge_std::cheatcodes::tx_info`
 - consistent latest block numbers for each url are now used across the whole run when testing against forks
@@ -360,7 +360,7 @@ binary, which will allow forge to be independent of sierra version
 
 ### Cast
 
-#### Added 
+#### Added
 
 - add support for sepolia network
 - `--yes` option to `account delete` command that allows to skip confirmation prompt
@@ -407,7 +407,7 @@ binary, which will allow forge to be independent of sierra version
 - `--rerun-failed` option to run tests that failed during the last run.
 
 #### Changed
-- `start_warp` and `stop_warp` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/block_timestamp/start_warp.md). 
+- `start_warp` and `stop_warp` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/block_timestamp/start_warp.md).
 - `start_prank` and `stop_prank` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/caller_address/start_prank.md).
 - `start_roll` and `stop_roll` now take `CheatTarget` as the first argument instead of `ContractAddress`. Read more [here](./docs/src/appendix/cheatcodes/block_number/start_roll.md).
 
@@ -493,7 +493,7 @@ PS: Credits to @bllu404 for the help with the new interfaces for cheats!
 - updated Cairo version to 2.3.0 - compatible Scarb version is 2.3.0:
   - tests in `src` folder now have to be in a module annotated with `#[cfg(test)]`
 - `snforge_std::PrintTrait` will not convert values representing ASCII control characters to strings
-- separated `snforge` to subcommands: `snforge test`, `snforge init` and `snforge clean-cache`. 
+- separated `snforge` to subcommands: `snforge test`, `snforge init` and `snforge clean-cache`.
 Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.html).
 - `starknet::get_block_info` now returns correct block info in a forked block
 
@@ -510,7 +510,7 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 
 ## [0.8.3] - 2023-10-17
 
-### Forge 
+### Forge
 
 #### Changed
 
@@ -559,7 +559,7 @@ Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge.
 
 #### Changed
 
-- dropped official support for cairo 1 compiled contracts. While they still should be working without any problems, 
+- dropped official support for cairo 1 compiled contracts. While they still should be working without any problems,
 from now on the only officially supported cairo compiler version is 2
 
 ## [0.7.1] - 2023-09-27
@@ -571,7 +571,7 @@ from now on the only officially supported cairo compiler version is 2
 - `var` library function for reading environmental variables
 
 #### Fixed
-- Using any concrete `block_id` when using forking mode, would lead to crashes 
+- Using any concrete `block_id` when using forking mode, would lead to crashes
 
 ## [0.7.0] - 2023-09-27
 

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -104,21 +104,12 @@ pub struct AccountData {
 
 impl Display for AccountData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        macro_rules! repr_or_unspecified {
-            ($item:expr) => {
-                ($item).map_or("unspecified".to_string(), |it| it.to_string())
-            };
-        }
-
-        macro_rules! hex {
-            ($item:expr) => {
-                format!("{:#x}", $item)
-            };
-        }
-
-        macro_rules! hex_or_unspecified {
-            ($item:expr) => {
-                ($item).map_or("unspecified".to_string(), |it| hex!(it))
+        macro_rules! write_some {
+            ($dest:expr, $format_spec:expr, $item:expr) => {
+                match $item {
+                    Some(it) => write!($dest, $format_spec, it),
+                    None => Ok(()),
+                }
             };
         }
 
@@ -126,24 +117,21 @@ impl Display for AccountData {
             f,
             "
             Account data:
-              private key: {}
-              public key: {}
-              address: {}
-              salt: {}
-              class hash: {}
-              deployed: {}
-              legacy: {}
-              type: {}
+              private key: {:#x}
+              public key: {:#x}
             ",
-            hex!(self.private_key),
-            hex!(self.public_key),
-            hex_or_unspecified!(self.address),
-            hex_or_unspecified!(self.salt),
-            hex_or_unspecified!(self.class_hash),
-            repr_or_unspecified!(self.deployed),
-            repr_or_unspecified!(self.legacy),
-            repr_or_unspecified!(self.account_type)
-        )
+            self.private_key,
+            self.public_key,
+        )?;
+
+        write_some!(f, "  address: {:#x}\n", self.address)?;
+        write_some!(f, "  salt: {:#x}\n", self.salt)?;
+        write_some!(f, "  class hash: {:#x}\n", self.class_hash)?;
+        write_some!(f, "  deployed: {}\n", self.deployed)?;
+        write_some!(f, "  legacy: {}\n", self.legacy)?;
+        write_some!(f, "  type: {}\n", self.account_type)?;
+
+        Ok(())
     }
 }
 

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use camino::Utf8PathBuf;
 use clap::ValueEnum;
 use helpers::constants::{KEYSTORE_PASSWORD_ENV_VAR, UDC_ADDRESS};
-use indoc::indoc;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -105,15 +104,15 @@ impl Display for AccountData {
         }
 
         let repr = format!(
-            indoc! {"
-                private key: {}
-                public key: {}
-                address: {}
-                salt: {}
-                class hash: {}
-                deployed: {}
-                legacy: {}
-            "},
+            concat!(
+                "  private key: {}\n",
+                "  public key: {}\n",
+                "  address: {}\n",
+                "  salt: {}\n",
+                "  class hash: {}\n",
+                "  deployed: {}\n",
+                "  legacy: {}\n"
+            ),
             hex!(self.private_key),
             hex!(self.public_key),
             hex_or_unspecified!(self.address),

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -65,7 +65,7 @@ impl FromStr for AccountType {
 }
 
 impl AccountType {
-    fn to_string_pretty(&self) -> String {
+    fn to_string_pretty(self) -> String {
         let repr = match self {
             AccountType::Oz => "OpenZeppelin",
             AccountType::Argent => "Argent",
@@ -393,7 +393,7 @@ pub fn get_account_data_from_keystore(
     let account_type = get_string_value_from_json(&account_info, "/variant/type")
         .and_then(|account_type| account_type.parse().ok());
 
-    let public_key = match account_type.clone().context("Failed to get type key")? {
+    let public_key = match account_type.context("Failed to get type key")? {
         AccountType::Argent => parse_to_felt("/variant/owner"),
         AccountType::Oz => parse_to_felt("/variant/public_key"),
         AccountType::Braavos => get_braavos_account_public_key(&account_info)?,

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, bail, Context, Error, Result};
 use camino::Utf8PathBuf;
 use clap::ValueEnum;
 use helpers::constants::{KEYSTORE_PASSWORD_ENV_VAR, UDC_ADDRESS};
-use itertools::Itertools;
 use rand::rngs::OsRng;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
@@ -28,7 +27,6 @@ use starknet::{
 use crate::helpers::constants::{DEFAULT_STATE_FILE_SUFFIX, WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
 use crate::response::errors::SNCastProviderError;
 use conversions::serde::serialize::CairoSerialize;
-use indoc::formatdoc;
 use serde::de::DeserializeOwned;
 use shared::rpc::create_rpc_client;
 use starknet::accounts::{AccountFactory, AccountFactoryError};
@@ -89,47 +87,6 @@ pub struct AccountData {
 
     #[serde(default, rename(serialize = "type", deserialize = "type"))]
     pub account_type: Option<AccountType>,
-}
-
-impl AccountData {
-    #[must_use]
-    pub fn to_string_pretty(&self, display_private_key: bool) -> String {
-        macro_rules! format_some {
-            ( $format_spec:expr, $item:expr) => {
-                match $item {
-                    Some(it) => format!($format_spec, it),
-                    None => String::new(),
-                }
-            };
-        }
-
-        let header = formatdoc!(
-            "
-            Account data:
-              public key: {:#x}
-            ",
-            self.public_key,
-        );
-
-        let private = if display_private_key {
-            format!("  private key: {:#x}", self.private_key)
-        } else {
-            String::new()
-        };
-
-        let lines = [
-            header,
-            private,
-            format_some!("  address: {:#x}", self.address),
-            format_some!("  salt: {:#x}", self.salt),
-            format_some!("  class hash: {:#x}", self.class_hash),
-            format_some!("  deployed: {}", self.deployed),
-            format_some!("  legacy: {}", self.legacy),
-            format_some!("  type: {}", self.account_type),
-        ];
-
-        lines.iter().format("\n").to_string()
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -107,7 +107,7 @@ impl Display for AccountData {
         macro_rules! write_some {
             ($dest:expr, $format_spec:expr, $item:expr) => {
                 match $item {
-                    Some(it) => write!($dest, $format_spec, it),
+                    Some(it) => writeln!($dest, $format_spec, it),
                     None => Ok(()),
                 }
             };
@@ -124,12 +124,12 @@ impl Display for AccountData {
             self.public_key,
         )?;
 
-        write_some!(f, "  address: {:#x}\n", self.address)?;
-        write_some!(f, "  salt: {:#x}\n", self.salt)?;
-        write_some!(f, "  class hash: {:#x}\n", self.class_hash)?;
-        write_some!(f, "  deployed: {}\n", self.deployed)?;
-        write_some!(f, "  legacy: {}\n", self.legacy)?;
-        write_some!(f, "  type: {}\n", self.account_type)?;
+        write_some!(f, "  address: {:#x}", self.address)?;
+        write_some!(f, "  salt: {:#x}", self.salt)?;
+        write_some!(f, "  class hash: {:#x}", self.class_hash)?;
+        write_some!(f, "  deployed: {}", self.deployed)?;
+        write_some!(f, "  legacy: {}", self.legacy)?;
+        write_some!(f, "  type: {}", self.account_type)?;
 
         Ok(())
     }

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -46,7 +46,7 @@ pub mod state;
 #[serde(rename_all = "lowercase")]
 pub enum AccountType {
     #[serde(rename = "open_zeppelin")]
-    Oz,
+    OpenZeppelin,
     Argent,
     Braavos,
 }
@@ -56,7 +56,7 @@ impl FromStr for AccountType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "open_zeppelin" | "oz" => Ok(AccountType::Oz),
+            "open_zeppelin" | "oz" => Ok(AccountType::OpenZeppelin),
             "argent" => Ok(AccountType::Argent),
             "braavos" => Ok(AccountType::Braavos),
             account_type => Err(anyhow!("Invalid account type = {account_type}")),
@@ -64,21 +64,9 @@ impl FromStr for AccountType {
     }
 }
 
-impl AccountType {
-    fn to_string_pretty(self) -> String {
-        let repr = match self {
-            AccountType::Oz => "OpenZeppelin",
-            AccountType::Argent => "Argent",
-            AccountType::Braavos => "Braavos",
-        };
-
-        repr.to_string()
-    }
-}
-
 impl Display for AccountType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_string_pretty())
+        write!(f, "{self:?}")
     }
 }
 
@@ -383,7 +371,7 @@ pub fn get_account_data_from_keystore(
 
     let public_key = match account_type.context("Failed to get type key")? {
         AccountType::Argent => parse_to_felt("/variant/owner"),
-        AccountType::Oz => parse_to_felt("/variant/public_key"),
+        AccountType::OpenZeppelin => parse_to_felt("/variant/public_key"),
         AccountType::Braavos => get_braavos_account_public_key(&account_info)?,
     }
     .context("Failed to get public key from account JSON file")?;
@@ -845,7 +833,7 @@ mod tests {
         assert_eq!(account.deployed, Some(true));
         assert_eq!(account.class_hash, None);
         assert_eq!(account.legacy, None);
-        assert_eq!(account.account_type, Some(AccountType::Oz));
+        assert_eq!(account.account_type, Some(AccountType::OpenZeppelin));
     }
 
     #[test]
@@ -871,7 +859,7 @@ mod tests {
         assert_eq!(account.salt, None);
         assert_eq!(account.deployed, Some(true));
         assert_eq!(account.legacy, Some(true));
-        assert_eq!(account.account_type, Some(AccountType::Oz));
+        assert_eq!(account.account_type, Some(AccountType::OpenZeppelin));
     }
 
     #[test]

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -25,6 +25,7 @@ use sncast::{
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
+use starknet_commands::account::list::list;
 use starknet_commands::verify::Verify;
 use tokio::runtime::Runtime;
 
@@ -73,7 +74,7 @@ struct Cli {
     rpc_url: Option<String>,
 
     /// Account to be used for contract declaration;
-    /// When using keystore (`--keystore`), this should be a path to account file    
+    /// When using keystore (`--keystore`), this should be a path to account file
     /// When using accounts file, this should be an account name
     #[clap(short = 'a', long)]
     account: Option<String>,
@@ -220,6 +221,7 @@ async fn run_async_command(
             print_command_result("declare", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Deploy(deploy) => {
             let account = get_account(
                 &config.account,
@@ -244,6 +246,7 @@ async fn run_async_command(
             print_command_result("deploy", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Call(call) => {
             let block_id = get_block_id(&call.block_id)?;
 
@@ -261,6 +264,7 @@ async fn run_async_command(
             print_command_result("call", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Invoke(invoke) => {
             let account = get_account(
                 &config.account,
@@ -285,6 +289,7 @@ async fn run_async_command(
             print_command_result("invoke", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Multicall(multicall) => {
             match &multicall.command {
                 starknet_commands::multicall::Commands::New(new) => {
@@ -327,6 +332,7 @@ async fn run_async_command(
             }
             Ok(())
         }
+
         Commands::Account(account) => match account.command {
             account::Commands::Add(add) => {
                 let mut result = starknet_commands::account::add::add(
@@ -341,6 +347,7 @@ async fn run_async_command(
                 print_command_result("account add", &mut result, numbers_format, &output_format)?;
                 Ok(())
             }
+
             account::Commands::Create(create) => {
                 let chain_id = get_chain_id(&provider).await?;
                 let account = if config.keystore.is_none() {
@@ -372,6 +379,7 @@ async fn run_async_command(
                 )?;
                 Ok(())
             }
+
             account::Commands::Deploy(deploy) => {
                 deploy.validate()?;
                 let chain_id = get_chain_id(&provider).await?;
@@ -395,6 +403,7 @@ async fn run_async_command(
                 )?;
                 Ok(())
             }
+
             account::Commands::Delete(delete) => {
                 let network_name = match delete.network {
                     Some(network) => network,
@@ -416,13 +425,20 @@ async fn run_async_command(
                 )?;
                 Ok(())
             }
+
+            account::Commands::List(_) => {
+                list(&config.accounts_file)?;
+                Ok(())
+            }
         },
+
         Commands::ShowConfig(_) => {
             let mut result =
                 starknet_commands::show_config::show_config(&provider, config, cli.profile).await;
             print_command_result("show-config", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::TxStatus(tx_status) => {
             let mut result =
                 starknet_commands::tx_status::tx_status(&provider, tx_status.transaction_hash)
@@ -431,6 +447,7 @@ async fn run_async_command(
             print_command_result("tx-status", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Verify(verify) => {
             let manifest_path = assert_manifest_path_exists()?;
             let package_metadata = get_package_metadata(&manifest_path, &verify.package)?;
@@ -457,6 +474,7 @@ async fn run_async_command(
             print_command_result("verify", &mut result, numbers_format, &output_format)?;
             Ok(())
         }
+
         Commands::Script(_) => unreachable!(),
     }
 }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -25,7 +25,7 @@ use sncast::{
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
-use starknet_commands::account::list::list;
+use starknet_commands::account::list::print_account_list;
 use starknet_commands::verify::Verify;
 use tokio::runtime::Runtime;
 
@@ -430,7 +430,7 @@ async fn run_async_command(
             }
 
             account::Commands::List(_) => {
-                list(&config.accounts_file)?;
+                print_account_list(&config.accounts_file)?;
                 Ok(())
             }
         },

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -422,10 +422,12 @@ async fn run_async_command(
                 Ok(())
             }
 
-            account::Commands::List(options) => {
-                print_account_list(&config.accounts_file, options.display_private_keys)?;
-                Ok(())
-            }
+            account::Commands::List(options) => print_account_list(
+                &config.accounts_file,
+                options.display_private_keys,
+                numbers_format,
+                &output_format,
+            ),
         },
 
         Commands::ShowConfig(_) => {

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -429,8 +429,8 @@ async fn run_async_command(
                 Ok(())
             }
 
-            account::Commands::List(_) => {
-                print_account_list(&config.accounts_file)?;
+            account::Commands::List(options) => {
+                print_account_list(&config.accounts_file, options.display_private_keys)?;
                 Ok(())
             }
         },

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -171,7 +171,7 @@ async fn deploy_from_keystore(
             &[private_key.verifying_key().scalar(), FieldElement::ZERO],
             FieldElement::ZERO,
         ),
-        AccountType::Oz => get_contract_address(
+        AccountType::OpenZeppelin => get_contract_address(
             salt,
             class_hash,
             &[private_key.verifying_key().scalar()],
@@ -279,7 +279,7 @@ async fn get_deployment_result(
             )
             .await
         }
-        AccountType::Oz => {
+        AccountType::OpenZeppelin => {
             let factory = OpenZeppelinAccountFactory::new(
                 class_hash,
                 chain_id,

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -1,15 +1,18 @@
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
+use conversions::string::IntoDecStr;
+use conversions::string::IntoHexStr;
 use itertools::Itertools;
-use serde_json::Value;
+use serde::Deserialize;
+use serde::Serialize;
+use sncast::AccountType;
 use sncast::{
     check_account_file_exists, read_and_parse_json_file, response::print::OutputFormat,
     AccountData, NumbersFormat,
 };
-use starknet::core::types::FieldElement;
 use std::collections::HashMap;
-use std::fmt::{Debug, Display, LowerHex};
+use std::fmt::Display;
 
 #[derive(Args, Debug)]
 #[command(
@@ -23,52 +26,122 @@ pub struct List {
     pub display_private_keys: bool,
 }
 
-fn println_numeric_field<T: Debug + Display + LowerHex>(
-    title: &'static str,
-    format: NumbersFormat,
-    item: T,
-) {
-    match format {
-        NumbersFormat::Default | NumbersFormat::Hex => println!("  {title}: {item:#x}"),
-        NumbersFormat::Decimal => println!("  {title}: {item}"),
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct AccountDataRepresentation {
+    pub public_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy: Option<bool>,
+    #[serde(default, rename(serialize = "type", deserialize = "type"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_type: Option<AccountType>,
+}
+
+impl AccountDataRepresentation {
+    fn new(
+        account: &AccountData,
+        display_private_key: bool,
+        numbers_format: NumbersFormat,
+    ) -> Self {
+        match numbers_format {
+            NumbersFormat::Default | NumbersFormat::Hex => Self {
+                private_key: display_private_key.then(|| account.private_key.into_hex_string()),
+                public_key: account.public_key.into_hex_string(),
+                network: None,
+                address: account.address.map(IntoHexStr::into_hex_string),
+                salt: account.salt.map(IntoHexStr::into_hex_string),
+                deployed: account.deployed,
+                class_hash: account.class_hash.map(IntoHexStr::into_hex_string),
+                legacy: account.legacy,
+                account_type: account.account_type,
+            },
+            NumbersFormat::Decimal => Self {
+                private_key: display_private_key.then(|| account.private_key.into_dec_string()),
+                public_key: account.public_key.into_dec_string(),
+                network: None,
+                address: account.address.map(IntoDecStr::into_dec_string),
+                salt: account.salt.map(IntoDecStr::into_dec_string),
+                deployed: account.deployed,
+                class_hash: account.class_hash.map(IntoDecStr::into_dec_string),
+                legacy: account.legacy,
+                account_type: account.account_type,
+            },
+        }
+    }
+
+    fn set_network(&mut self, network: &str) {
+        self.network = Some(network.to_owned());
     }
 }
 
-fn print_pretty(
-    account: &AccountData,
-    name: &str,
-    network: &str,
+type NestedMap<T> = HashMap<String, HashMap<String, T>>;
+
+fn represent(
+    data: &NestedMap<AccountData>,
     display_private_keys: bool,
     numbers_format: NumbersFormat,
-) {
-    macro_rules! println_some {
-        ($title:expr, $numbers_format:expr, $item:expr) => {
-            if let Some(it) = $item {
-                println_numeric_field($title, $numbers_format, it);
-            }
-        };
+) -> NestedMap<AccountDataRepresentation> {
+    data.iter()
+        .map(|(network, accounts)| {
+            let accounts = accounts
+                .iter()
+                .map(|(name, account)| {
+                    (
+                        name.to_owned(),
+                        AccountDataRepresentation::new(
+                            account,
+                            display_private_keys,
+                            numbers_format,
+                        ),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
 
-        ($title:expr, $item:expr) => {
-            if let Some(it) = $item {
-                println!("  {}: {}", $title, it);
-            }
-        };
+            (network.to_owned(), accounts)
+        })
+        .collect::<HashMap<_, _>>()
+}
+
+fn print_as_json(networks: &NestedMap<AccountDataRepresentation>) -> anyhow::Result<()> {
+    if networks.values().all(|net| net.values().len() == 0) {
+        println!("{{}}");
+        return Ok(());
     }
 
+    let json = serde_json::to_string_pretty(networks)?;
+    print!("{json}");
+
+    Ok(())
+}
+
+fn print_if_some<T: Display>(title: &str, item: &Option<T>) {
+    if let Some(ref item) = item {
+        println!("  {title}: {item}");
+    }
+}
+
+fn print_pretty(data: &AccountDataRepresentation, name: &str) {
     println!("- {name}:");
-
-    if display_private_keys {
-        println_numeric_field("private key", numbers_format, account.private_key);
-    };
-
-    println_numeric_field("public key", numbers_format, account.public_key);
-    println!("  network: {network}");
-    println_some!("address", numbers_format, account.address);
-    println_some!("salt", numbers_format, account.salt);
-    println_some!("class hash", numbers_format, account.class_hash);
-    println_some!("deployed", account.deployed);
-    println_some!("legacy", account.legacy);
-    println_some!("type", account.account_type);
+    print_if_some("network", &data.network);
+    print_if_some("private key", &data.private_key);
+    println!("  public key: {}", data.public_key);
+    print_if_some("address", &data.address);
+    print_if_some("salt", &data.salt);
+    print_if_some("class hash", &data.class_hash);
+    print_if_some("deployed", &data.deployed);
+    print_if_some("legacy", &data.legacy);
+    print_if_some("type", &data.account_type);
     println!();
 }
 
@@ -87,71 +160,17 @@ fn print_as_human(
 
     for (network, accounts) in networks.iter().sorted_by_key(|(name, _)| *name) {
         for (name, data) in accounts.iter().sorted_by_key(|(name, _)| *name) {
-            print_pretty(data, name, network, display_private_keys, numbers_format);
+            let mut data_repr =
+                AccountDataRepresentation::new(data, display_private_keys, numbers_format);
+
+            data_repr.set_network(network);
+            print_pretty(&data_repr, name);
         }
     }
 
     if !display_private_keys {
         println!("\nTo show private keys too, run with --display-private-keys or -p");
     }
-}
-
-type JsonMap = HashMap<String, HashMap<String, HashMap<String, Value>>>;
-
-fn erase_private_keys(networks: &mut JsonMap) {
-    for (_, accounts) in networks.iter_mut() {
-        for (_, account) in accounts.iter_mut() {
-            account.remove("private_key");
-        }
-    }
-}
-
-fn reformat_numeric_fields(networks: &mut JsonMap) -> anyhow::Result<()> {
-    macro_rules! replace_some {
-        ($account:expr, $field:expr) => {
-            if let Some(field) = $account.get_mut($field) {
-                let value = FieldElement::from_hex_be(field.as_str().unwrap())
-                    .context("Failed to parse account JSON")?;
-                *field = Value::String(format!("{value}"));
-            }
-        };
-    }
-
-    for (_, accounts) in networks.iter_mut() {
-        for (_, account) in accounts.iter_mut() {
-            replace_some!(account, "private_key");
-            replace_some!(account, "public_key");
-            replace_some!(account, "address");
-            replace_some!(account, "salt");
-            replace_some!(account, "class_hash");
-        }
-    }
-
-    Ok(())
-}
-
-fn print_as_json(
-    networks: &mut JsonMap,
-    display_private_keys: bool,
-    numbers_format: NumbersFormat,
-) -> anyhow::Result<()> {
-    if networks.values().all(|net| net.values().len() == 0) {
-        println!("{{}}");
-        return Ok(());
-    }
-
-    if !display_private_keys {
-        erase_private_keys(networks);
-    }
-
-    if numbers_format == NumbersFormat::Decimal {
-        reformat_numeric_fields(networks)?;
-    }
-
-    let json = serde_json::to_string_pretty(networks)?;
-    print!("{json}");
-
-    Ok(())
 }
 
 pub fn print_account_list(
@@ -169,9 +188,10 @@ pub fn print_account_list(
 
     match output_format {
         OutputFormat::Json => {
-            let mut networks: JsonMap = read_and_parse_json_file(accounts_file)?;
+            let networks: NestedMap<AccountData> = read_and_parse_json_file(accounts_file)?;
+            let networks = represent(&networks, display_private_keys, numbers_format);
 
-            print_as_json(&mut networks, display_private_keys, numbers_format)?;
+            print_as_json(&networks)?;
         }
         OutputFormat::Human => {
             let networks: HashMap<String, HashMap<String, AccountData>> =

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::anyhow;
+use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
 use indoc::printdoc;
@@ -26,9 +26,9 @@ pub fn print_account_list(
     check_account_file_exists(accounts_file)?;
 
     let accounts_file_path = accounts_file.canonicalize()?;
-    let accounts_file_path = accounts_file_path.to_str().ok_or(anyhow!(
-        "Failed to resolve an absolute path to the accounts file"
-    ))?;
+    let accounts_file_path = accounts_file_path
+        .to_str()
+        .context("Failed to resolve an absolute path to the accounts file")?;
 
     let networks: HashMap<String, HashMap<String, AccountData>> =
         read_and_parse_json_file(accounts_file)?;

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -15,7 +15,7 @@ pub fn list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {
     let networks: HashMap<String, HashMap<String, AccountData>> =
         read_and_parse_json_file(accounts_file)?;
 
-    let no_networks = networks.len() == 0;
+    let no_networks = networks.is_empty();
     let no_accounts = networks.values().all(|net| net.values().len() == 0);
 
     if no_networks || no_accounts {

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -109,11 +109,6 @@ fn read_and_flatten(
 }
 
 fn print_as_json(networks: &HashMap<String, AccountDataRepresentation>) -> anyhow::Result<()> {
-    if networks.is_empty() {
-        println!("{{}}");
-        return Ok(());
-    }
-
     let json = serde_json::to_string_pretty(networks)?;
     print!("{json}");
 

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+
+use camino::Utf8PathBuf;
+use clap::Args;
+use itertools::Itertools;
+use sncast::{check_account_file_exists, read_and_parse_json_file, AccountData};
+
+#[derive(Args, Debug)]
+#[command(about = "List available accounts")]
+pub struct List {}
+
+pub fn list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {
+    check_account_file_exists(accounts_file)?;
+
+    let networks: HashMap<String, HashMap<String, AccountData>> =
+        read_and_parse_json_file(accounts_file)?;
+
+    let no_networks = networks.len() == 0;
+    let no_accounts = networks.values().all(|net| net.values().len() == 0);
+
+    if no_networks || no_accounts {
+        println!("No accounts available");
+        return Ok(());
+    }
+
+    let repr = networks
+        .iter()
+        .sorted_by_key(|(name, _)| *name)
+        .map(|(name, accounts)| {
+            format!(
+                "Network \"{}\":\n{}",
+                name,
+                accounts
+                    .iter()
+                    .sorted_by_key(|(name, _)| *name)
+                    .map(|(name, account)| format!("- {name}:\n{account}"))
+                    .format("\n")
+            )
+        })
+        .format("\n");
+
+    print!("Available accounts:\n{repr}");
+    Ok(())
+}

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -9,7 +9,7 @@ use sncast::{check_account_file_exists, read_and_parse_json_file, AccountData};
 #[command(about = "List available accounts")]
 pub struct List {}
 
-pub fn list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {
+pub fn print_account_list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {
     check_account_file_exists(accounts_file)?;
 
     let networks: HashMap<String, HashMap<String, AccountData>> =

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -26,10 +26,7 @@ pub fn print_account_list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {
     let networks: HashMap<String, HashMap<String, AccountData>> =
         read_and_parse_json_file(accounts_file)?;
 
-    let no_networks = networks.is_empty();
-    let no_accounts = networks.values().all(|net| net.values().len() == 0);
-
-    if no_networks || no_accounts {
+    if networks.values().all(|net| net.values().len() == 0) {
         println!("No accounts available at {accounts_file_path}");
         return Ok(());
     }

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -1,10 +1,15 @@
-use std::collections::HashMap;
-
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Args;
 use itertools::Itertools;
-use sncast::{check_account_file_exists, read_and_parse_json_file, AccountData};
+use serde_json::Value;
+use sncast::{
+    check_account_file_exists, read_and_parse_json_file, response::print::OutputFormat,
+    AccountData, NumbersFormat,
+};
+use starknet::core::types::FieldElement;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display, LowerHex};
 
 #[derive(Args, Debug)]
 #[command(
@@ -18,11 +23,34 @@ pub struct List {
     pub display_private_keys: bool,
 }
 
-fn print_pretty(account: &AccountData, name: &str, network: &str, display_private_keys: bool) {
+fn println_numeric_field<T: Debug + Display + LowerHex>(
+    title: &'static str,
+    format: NumbersFormat,
+    item: T,
+) {
+    match format {
+        NumbersFormat::Default | NumbersFormat::Hex => println!("  {title}: {item:#x}"),
+        NumbersFormat::Decimal => println!("  {title}: {item}"),
+    }
+}
+
+fn print_pretty(
+    account: &AccountData,
+    name: &str,
+    network: &str,
+    display_private_keys: bool,
+    numbers_format: NumbersFormat,
+) {
     macro_rules! println_some {
-        ( $format_spec:expr, $item:expr) => {
+        ($title:expr, $numbers_format:expr, $item:expr) => {
             if let Some(it) = $item {
-                println!($format_spec, it);
+                println_numeric_field($title, $numbers_format, it);
+            }
+        };
+
+        ($title:expr, $item:expr) => {
+            if let Some(it) = $item {
+                println!("  {}: {}", $title, it);
             }
         };
     }
@@ -30,23 +58,107 @@ fn print_pretty(account: &AccountData, name: &str, network: &str, display_privat
     println!("- {name}:");
 
     if display_private_keys {
-        println!("  private key: {:#x}", account.private_key);
+        println_numeric_field("private key", numbers_format, account.private_key);
     };
 
-    println!("  public key: {:#x}", account.public_key);
+    println_numeric_field("public key", numbers_format, account.public_key);
     println!("  network: {network}");
-    println_some!("  address: {:#x}", account.address);
-    println_some!("  salt: {:#x}", account.salt);
-    println_some!("  class hash: {:#x}", account.class_hash);
-    println_some!("  deployed: {}", account.deployed);
-    println_some!("  legacy: {}", account.legacy);
-    println_some!("  type: {}", account.account_type);
+    println_some!("address", numbers_format, account.address);
+    println_some!("salt", numbers_format, account.salt);
+    println_some!("class hash", numbers_format, account.class_hash);
+    println_some!("deployed", account.deployed);
+    println_some!("legacy", account.legacy);
+    println_some!("type", account.account_type);
     println!();
+}
+
+fn print_as_human(
+    networks: &HashMap<String, HashMap<String, AccountData>>,
+    accounts_file_path: &str,
+    display_private_keys: bool,
+    numbers_format: NumbersFormat,
+) {
+    if networks.values().all(|net| net.values().len() == 0) {
+        println!("No accounts available at {accounts_file_path}");
+        return;
+    }
+
+    println!("Available accounts (at {accounts_file_path}):");
+
+    for (network, accounts) in networks.iter().sorted_by_key(|(name, _)| *name) {
+        for (name, data) in accounts.iter().sorted_by_key(|(name, _)| *name) {
+            print_pretty(data, name, network, display_private_keys, numbers_format);
+        }
+    }
+
+    if !display_private_keys {
+        println!("\nTo show private keys too, run with --display-private-keys or -p");
+    }
+}
+
+type JsonMap = HashMap<String, HashMap<String, HashMap<String, Value>>>;
+
+fn erase_private_keys(networks: &mut JsonMap) {
+    for (_, accounts) in networks.iter_mut() {
+        for (_, account) in accounts.iter_mut() {
+            account.remove("private_key");
+        }
+    }
+}
+
+fn reformat_numeric_fields(networks: &mut JsonMap) -> anyhow::Result<()> {
+    macro_rules! replace_some {
+        ($account:expr, $field:expr) => {
+            if let Some(field) = $account.get_mut($field) {
+                let value = FieldElement::from_hex_be(field.as_str().unwrap())
+                    .context("Failed to parse account JSON")?;
+                *field = Value::String(format!("{value}"));
+            }
+        };
+    }
+
+    for (_, accounts) in networks.iter_mut() {
+        for (_, account) in accounts.iter_mut() {
+            replace_some!(account, "private_key");
+            replace_some!(account, "public_key");
+            replace_some!(account, "address");
+            replace_some!(account, "salt");
+            replace_some!(account, "class_hash");
+        }
+    }
+
+    Ok(())
+}
+
+fn print_as_json(
+    networks: &mut JsonMap,
+    display_private_keys: bool,
+    numbers_format: NumbersFormat,
+) -> anyhow::Result<()> {
+    if networks.values().all(|net| net.values().len() == 0) {
+        println!("{{}}");
+        return Ok(());
+    }
+
+    if !display_private_keys {
+        erase_private_keys(networks);
+    }
+
+    if numbers_format == NumbersFormat::Decimal {
+        reformat_numeric_fields(networks)?;
+    }
+
+    let json = serde_json::to_string_pretty(networks)?;
+    print!("{json}");
+
+    Ok(())
 }
 
 pub fn print_account_list(
     accounts_file: &Utf8PathBuf,
     display_private_keys: bool,
+    numbers_format: NumbersFormat,
+    output_format: &OutputFormat,
 ) -> anyhow::Result<()> {
     check_account_file_exists(accounts_file)?;
 
@@ -55,24 +167,23 @@ pub fn print_account_list(
         .to_str()
         .context("Failed to resolve an absolute path to the accounts file")?;
 
-    let networks: HashMap<String, HashMap<String, AccountData>> =
-        read_and_parse_json_file(accounts_file)?;
+    match output_format {
+        OutputFormat::Json => {
+            let mut networks: JsonMap = read_and_parse_json_file(accounts_file)?;
 
-    if networks.values().all(|net| net.values().len() == 0) {
-        println!("No accounts available at {accounts_file_path}");
-        return Ok(());
-    }
-
-    println!("Available accounts (at {accounts_file_path}):");
-
-    for (network, accounts) in networks.iter().sorted_by_key(|(name, _)| *name) {
-        for (name, data) in accounts.iter().sorted_by_key(|(name, _)| *name) {
-            print_pretty(data, name, network, display_private_keys);
+            print_as_json(&mut networks, display_private_keys, numbers_format)?;
         }
-    }
+        OutputFormat::Human => {
+            let networks: HashMap<String, HashMap<String, AccountData>> =
+                read_and_parse_json_file(accounts_file)?;
 
-    if !display_private_keys {
-        println!("\nTo show private keys too, run with --display-private-keys or -p");
+            print_as_human(
+                &networks,
+                accounts_file_path,
+                display_private_keys,
+                numbers_format,
+            );
+        }
     }
 
     Ok(())

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -8,7 +8,11 @@ use itertools::Itertools;
 use sncast::{check_account_file_exists, read_and_parse_json_file, AccountData};
 
 #[derive(Args, Debug)]
-#[command(about = "List available accounts")]
+#[command(
+    name = "list",
+    about = "List available accounts",
+    before_help = "Warning! This command exposes cryptographic information, e.g. accounts' private keys"
+)]
 pub struct List {}
 
 pub fn print_account_list(accounts_file: &Utf8PathBuf) -> anyhow::Result<()> {

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -34,7 +34,7 @@ pub enum Commands {
     Create(Create),
     Deploy(Deploy),
     Delete(Delete),
-    List(List)
+    List(List),
 }
 
 #[allow(clippy::doc_markdown)]

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -2,6 +2,7 @@ use crate::starknet_commands::account::add::Add;
 use crate::starknet_commands::account::create::Create;
 use crate::starknet_commands::account::delete::Delete;
 use crate::starknet_commands::account::deploy::Deploy;
+use crate::starknet_commands::account::list::List;
 use anyhow::{anyhow, bail, Context, Result};
 use camino::Utf8PathBuf;
 use clap::{Args, Subcommand, ValueEnum};
@@ -18,6 +19,7 @@ pub mod add;
 pub mod create;
 pub mod delete;
 pub mod deploy;
+pub mod list;
 
 #[derive(Args)]
 #[command(about = "Creates and deploys an account to the Starknet")]
@@ -32,6 +34,7 @@ pub enum Commands {
     Create(Create),
     Deploy(Deploy),
     Delete(Delete),
+    List(List)
 }
 
 #[allow(clippy::doc_markdown)]

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -554,7 +554,7 @@ fn get_formatted_account_type(account_type: &str) -> &str {
 
 fn get_keystore_account_pattern(account_type: AccountType, class_hash: Option<&str>) -> String {
     let account_json = match account_type {
-        AccountType::Oz => {
+        AccountType::OpenZeppelin => {
             json!(
                 {
                     "version": 1,

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -313,7 +313,7 @@ pub async fn test_happy_case_keystore(account_type: &str) {
         .expect("Unable to read created file");
 
     assert_matches(
-        get_keystore_account_pattern(&account_type.parse().unwrap(), None),
+        get_keystore_account_pattern(account_type.parse().unwrap(), None),
         contents,
     );
 }
@@ -552,7 +552,7 @@ fn get_formatted_account_type(account_type: &str) -> &str {
     }
 }
 
-fn get_keystore_account_pattern(account_type: &AccountType, class_hash: Option<&str>) -> String {
+fn get_keystore_account_pattern(account_type: AccountType, class_hash: Option<&str>) -> String {
     let account_json = match account_type {
         AccountType::Oz => {
             json!(

--- a/crates/sncast/tests/e2e/account/delete.rs
+++ b/crates/sncast/tests/e2e/account/delete.rs
@@ -1,11 +1,8 @@
-use crate::helpers::constants::URL;
 use crate::helpers::fixtures::default_cli_args;
 use crate::helpers::runner::runner;
+use crate::{e2e::account::helpers::create_tempdir_with_accounts_file, helpers::constants::URL};
 use indoc::indoc;
 use shared::test_utils::output_assert::{assert_stderr_contains, AsOutput};
-use tempfile::{tempdir, TempDir};
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
 
 #[tokio::test]
 pub async fn test_no_accounts_in_network() {
@@ -167,45 +164,4 @@ pub async fn test_happy_case_with_yes_flag() {
         command: account delete
         result: Account successfully removed
     "});
-}
-
-#[must_use]
-async fn create_tempdir_with_accounts_file(file_name: &str) -> TempDir {
-    let tempdir = tempdir().expect("Unable to create temporary directory");
-
-    let json_data = indoc! {r#"
-    {
-        "alpha-sepolia": {
-            "user0": {
-                "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
-                "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
-                "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a"
-            }
-        },
-        "custom-network": {
-            "user3": {
-                "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
-                "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
-                "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a"
-            },
-            "user4": {
-                "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
-                "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
-                "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
-                "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
-                "deployed": true
-            }
-        }
-    }
-    "#};
-
-    let mut file = File::create(tempdir.path().join(file_name))
-        .await
-        .expect("Could not create temporary accounts file!");
-    file.write_all(json_data.as_bytes())
-        .await
-        .expect("Could not write temporary testing accounts");
-    let _ = file.flush().await;
-
-    tempdir
 }

--- a/crates/sncast/tests/e2e/account/delete.rs
+++ b/crates/sncast/tests/e2e/account/delete.rs
@@ -49,7 +49,7 @@ pub async fn test_account_does_not_exist() {
 pub async fn test_delete_abort() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
 
     // Now delete dummy account
     let args = vec![
@@ -82,7 +82,7 @@ pub async fn test_delete_abort() {
 pub async fn test_happy_case() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
 
     // Now delete dummy account
     let args = vec![
@@ -111,7 +111,7 @@ pub async fn test_happy_case() {
 pub async fn test_happy_case_without_network_args() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
 
     // Now delete dummy account
     let args = vec![
@@ -138,7 +138,7 @@ pub async fn test_happy_case_without_network_args() {
 pub async fn test_happy_case_with_yes_flag() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
 
     // Now delete dummy account
     let args = vec![

--- a/crates/sncast/tests/e2e/account/delete.rs
+++ b/crates/sncast/tests/e2e/account/delete.rs
@@ -4,8 +4,8 @@ use crate::{e2e::account::helpers::create_tempdir_with_accounts_file, helpers::c
 use indoc::indoc;
 use shared::test_utils::output_assert::{assert_stderr_contains, AsOutput};
 
-#[tokio::test]
-pub async fn test_no_accounts_in_network() {
+#[test]
+pub fn test_no_accounts_in_network() {
     let mut args = default_cli_args();
     args.append(&mut vec![
         "account",
@@ -28,8 +28,8 @@ pub async fn test_no_accounts_in_network() {
     );
 }
 
-#[tokio::test]
-pub async fn test_account_does_not_exist() {
+#[test]
+pub fn test_account_does_not_exist() {
     let mut args = default_cli_args();
     args.append(&mut vec!["account", "delete", "--name", "user99"]);
 
@@ -45,11 +45,11 @@ pub async fn test_account_does_not_exist() {
     );
 }
 
-#[tokio::test]
-pub async fn test_delete_abort() {
+#[test]
+pub fn test_delete_abort() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
     // Now delete dummy account
     let args = vec![
@@ -78,11 +78,11 @@ pub async fn test_delete_abort() {
     );
 }
 
-#[tokio::test]
-pub async fn test_happy_case() {
+#[test]
+pub fn test_happy_case() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
     // Now delete dummy account
     let args = vec![
@@ -107,11 +107,11 @@ pub async fn test_happy_case() {
     "});
 }
 
-#[tokio::test]
-pub async fn test_happy_case_without_network_args() {
+#[test]
+pub fn test_happy_case_without_network_args() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
     // Now delete dummy account
     let args = vec![
@@ -134,11 +134,11 @@ pub async fn test_happy_case_without_network_args() {
     "});
 }
 
-#[tokio::test]
-pub async fn test_happy_case_with_yes_flag() {
+#[test]
+pub fn test_happy_case_with_yes_flag() {
     // Creating dummy accounts test file
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
     // Now delete dummy account
     let args = vec![

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -762,7 +762,7 @@ pub async fn test_deploy_keystore_other_args() {
         tempdir.path().join(keystore_file),
         tempdir.path().join(account_file),
         KEYSTORE_PASSWORD_ENV_VAR,
-        &AccountType::Oz,
+        &AccountType::OpenZeppelin,
     );
 
     mint_token(&address.into_hex_string(), 9_999_999_999_999_999_999).await;

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -4,6 +4,25 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 #[must_use]
+pub async fn create_tempdir_with_empty_json(file_name: &str) -> TempDir {
+    let tempdir = tempdir().expect("Unable to create temporary directory");
+
+    let data = r#"{}"#;
+
+    let mut file = File::create(tempdir.path().join(file_name))
+        .await
+        .expect("Could not create temporary accounts file!");
+
+    file.write_all(data.as_bytes())
+        .await
+        .expect("Could not write temporary testing accounts");
+
+    let _ = file.flush().await;
+
+    tempdir
+}
+
+#[must_use]
 pub async fn create_tempdir_with_accounts_file(file_name: &str) -> TempDir {
     let tempdir = tempdir().expect("Unable to create temporary directory");
 

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -4,64 +4,52 @@ use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 #[must_use]
-pub async fn create_tempdir_with_empty_json(file_name: &str) -> TempDir {
-    let tempdir = tempdir().expect("Unable to create temporary directory");
+pub async fn create_tempdir_with_accounts_file(file_name: &str, with_sample_data: bool) -> TempDir {
+    let dir = tempdir().expect("Unable to create a temporary directory");
+    let location = dir.path().join(file_name);
 
-    let data = r"{}";
-
-    let mut file = File::create(tempdir.path().join(file_name))
+    let mut file = File::create(location)
         .await
-        .expect("Could not create temporary accounts file!");
+        .expect("Unable to create a temporary accounts file");
+
+    let data = if with_sample_data {
+        indoc! {r#"
+        {
+            "alpha-sepolia": {
+                "user0": {
+                    "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
+                    "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
+                    "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
+                    "type": "open_zeppelin"
+                }
+            },
+            "custom-network": {
+                "user3": {
+                    "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
+                    "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
+                    "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a"
+                },
+                "user4": {
+                    "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
+                    "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
+                    "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
+                    "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
+                    "deployed": true
+                }
+            }
+        }
+        "#}
+    } else {
+        r"{}"
+    };
 
     file.write_all(data.as_bytes())
         .await
-        .expect("Could not write temporary testing accounts");
+        .expect("Unable to write test data to a temporary file");
 
-    let _ = file.flush().await;
-
-    tempdir
-}
-
-#[must_use]
-pub async fn create_tempdir_with_accounts_file(file_name: &str) -> TempDir {
-    let tempdir = tempdir().expect("Unable to create temporary directory");
-
-    let json_data = indoc! {r#"
-    {
-        "alpha-sepolia": {
-            "user0": {
-                "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
-                "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
-                "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
-                "type": "open_zeppelin"
-            }
-        },
-        "custom-network": {
-            "user3": {
-                "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
-                "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
-                "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a"
-            },
-            "user4": {
-                "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
-                "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
-                "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
-                "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
-                "deployed": true
-            }
-        }
-    }
-    "#};
-
-    let mut file = File::create(tempdir.path().join(file_name))
+    file.flush()
         .await
-        .expect("Could not create temporary accounts file!");
+        .expect("Unable to fulsh a temporary file");
 
-    file.write_all(json_data.as_bytes())
-        .await
-        .expect("Could not write temporary testing accounts");
-
-    let _ = file.flush().await;
-
-    tempdir
+    dir
 }

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncWriteExt;
 pub async fn create_tempdir_with_empty_json(file_name: &str) -> TempDir {
     let tempdir = tempdir().expect("Unable to create temporary directory");
 
-    let data = r#"{}"#;
+    let data = r"{}";
 
     let mut file = File::create(tempdir.path().join(file_name))
         .await

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -1,16 +1,13 @@
 use indoc::indoc;
+use std::{fs::File, io::Write};
 use tempfile::{tempdir, TempDir};
-use tokio::fs::File;
-use tokio::io::AsyncWriteExt;
 
 #[must_use]
-pub async fn create_tempdir_with_accounts_file(file_name: &str, with_sample_data: bool) -> TempDir {
+pub fn create_tempdir_with_accounts_file(file_name: &str, with_sample_data: bool) -> TempDir {
     let dir = tempdir().expect("Unable to create a temporary directory");
     let location = dir.path().join(file_name);
 
-    let mut file = File::create(location)
-        .await
-        .expect("Unable to create a temporary accounts file");
+    let mut file = File::create(location).expect("Unable to create a temporary accounts file");
 
     let data = if with_sample_data {
         indoc! {r#"
@@ -44,12 +41,9 @@ pub async fn create_tempdir_with_accounts_file(file_name: &str, with_sample_data
     };
 
     file.write_all(data.as_bytes())
-        .await
         .expect("Unable to write test data to a temporary file");
 
-    file.flush()
-        .await
-        .expect("Unable to flush a temporary file");
+    file.flush().expect("Unable to flush a temporary file");
 
     dir
 }

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -32,7 +32,8 @@ pub async fn create_tempdir_with_accounts_file(file_name: &str) -> TempDir {
             "user0": {
                 "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
                 "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
-                "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a"
+                "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
+                "type": "open_zeppelin"
             }
         },
         "custom-network": {

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -1,0 +1,47 @@
+use indoc::indoc;
+use tempfile::{tempdir, TempDir};
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+#[must_use]
+pub async fn create_tempdir_with_accounts_file(file_name: &str) -> TempDir {
+    let tempdir = tempdir().expect("Unable to create temporary directory");
+
+    let json_data = indoc! {r#"
+    {
+        "alpha-sepolia": {
+            "user0": {
+                "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
+                "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
+                "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a"
+            }
+        },
+        "custom-network": {
+            "user3": {
+                "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
+                "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
+                "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a"
+            },
+            "user4": {
+                "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
+                "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
+                "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
+                "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
+                "deployed": true
+            }
+        }
+    }
+    "#};
+
+    let mut file = File::create(tempdir.path().join(file_name))
+        .await
+        .expect("Could not create temporary accounts file!");
+
+    file.write_all(json_data.as_bytes())
+        .await
+        .expect("Could not write temporary testing accounts");
+
+    let _ = file.flush().await;
+
+    tempdir
+}

--- a/crates/sncast/tests/e2e/account/helpers.rs
+++ b/crates/sncast/tests/e2e/account/helpers.rs
@@ -49,7 +49,7 @@ pub async fn create_tempdir_with_accounts_file(file_name: &str, with_sample_data
 
     file.flush()
         .await
-        .expect("Unable to fulsh a temporary file");
+        .expect("Unable to flush a temporary file");
 
     dir
 }

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -7,10 +7,10 @@ use crate::{
     helpers::{constants::URL, runner::runner},
 };
 
-#[tokio::test]
-async fn test_happy_case() {
+#[test]
+fn test_happy_case() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
     let accounts_file_path = temp_dir
         .path()
@@ -92,10 +92,10 @@ fn test_accounts_file_does_not_exist() {
     assert_stderr_contains(output, expected);
 }
 
-#[tokio::test]
-async fn test_no_accounts_available() {
+#[test]
+fn test_no_accounts_available() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, false).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, false);
 
     let accounts_file_path = temp_dir
         .path()

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -1,0 +1,89 @@
+use indoc::indoc;
+use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains, AsOutput};
+use tempfile::tempdir;
+
+use crate::{
+    e2e::account::helpers::create_tempdir_with_accounts_file,
+    helpers::{constants::URL, runner::runner},
+};
+
+#[tokio::test]
+async fn test_happy_case() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(&accounts_file_name).await;
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let expected = indoc! {"
+        Available accounts:
+        Network \"alpha-sepolia\":
+        - user0:
+        private key: 0x1e9038bdc68ce1d27d54205256988e85
+        public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+        address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+        salt: unspecified
+        class hash: unspecified
+        deployed: unspecified
+        legacy: unspecified
+
+        Network \"custom-network\":
+        - user3:
+        private key: 0xe3e70682c2094cac629f6fbed82c07cd
+        public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+        address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
+        salt: unspecified
+        class hash: unspecified
+        deployed: unspecified
+        legacy: unspecified
+
+        - user4:
+        private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
+        public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+        address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
+        salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
+        class hash: unspecified
+        deployed: true
+        legacy: unspecified
+    "};
+
+    assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_accounts_file_does_not_exist() {
+    let accounts_file_name = "some_inexistent_file.json";
+    let temp_dir = tempdir().expect("Unable to create temporary directory");
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().failure();
+
+    assert!(output.as_stdout().is_empty());
+
+    let expected = "Error: Accounts file = some_inexistent_file.json does not exist! \
+        If you do not have an account create one with `account create` command \
+        or if you're using a custom accounts file, make sure \
+        to supply correct path to it with `--accounts-file` argument.";
+
+    assert_stderr_contains(output, expected);
+}

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -15,7 +15,7 @@ async fn test_happy_case() {
     let accounts_file_path = temp_dir
         .path()
         .canonicalize()
-        .expect("Failed to resolve temporary directory path")
+        .expect("Unable to resolve a temporary directory path")
         .join(accounts_file_name);
 
     let args = vec![
@@ -68,7 +68,7 @@ async fn test_happy_case() {
 #[test]
 fn test_accounts_file_does_not_exist() {
     let accounts_file_name = "some_inexistent_file.json";
-    let temp_dir = tempdir().expect("Unable to create temporary directory");
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
 
     let args = vec![
         "--url",
@@ -100,7 +100,7 @@ async fn test_no_accounts_available() {
     let accounts_file_path = temp_dir
         .path()
         .canonicalize()
-        .expect("Failed to resolve temporary directory path")
+        .expect("Unable to resolve a temporary directory path")
         .join(accounts_file_name);
 
     let args = vec![

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -35,22 +35,19 @@ fn test_happy_case() {
     let expected = formatdoc!(
         "
         Available accounts (at {}):
-
-        Network \"alpha-sepolia\":
         - user0:
-        Account data:
+          network: alpha-sepolia
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
           type: OpenZeppelin
 
-        Network \"custom-network\":
         - user3:
-        Account data:
+          network: custom-network
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
 
         - user4:
-        Account data:
+          network: custom-network
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
           salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
@@ -93,24 +90,21 @@ fn test_happy_case_with_private_keys() {
     let expected = formatdoc!(
         "
         Available accounts (at {}):
-
-        Network \"alpha-sepolia\":
         - user0:
-        Account data:
+          network: alpha-sepolia
           private key: 0x1e9038bdc68ce1d27d54205256988e85
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
           type: OpenZeppelin
 
-        Network \"custom-network\":
         - user3:
-        Account data:
+          network: custom-network
           private key: 0xe3e70682c2094cac629f6fbed82c07cd
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
 
         - user4:
-        Account data:
+          network: custom-network
           private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -260,25 +260,24 @@ fn test_happy_case_json() {
 
     let expected = json!(
         {
-          "custom-network": {
             "user3": {
               "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
-              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9"
+              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
+              "network": "custom-network"
             },
             "user4": {
               "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
               "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
               "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
-              "deployed": true
-            }
-          },
-          "alpha-sepolia": {
+              "deployed": true,
+              "network": "custom-network"
+            },
             "user0": {
               "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
               "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
-              "type": "open_zeppelin"
+              "type": "open_zeppelin",
+              "network": "alpha-sepolia"
             }
-          }
         }
     );
 
@@ -313,27 +312,26 @@ fn test_happy_case_with_private_keys_json() {
 
     let expected = json!(
         {
-          "custom-network": {
-            "user3": {
+          "user3": {
               "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
               "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
-              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9"
-            },
-            "user4": {
-              "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
-              "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
-              "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
-              "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
-              "deployed": true
-            }
+              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
+              "network": "custom-network"
           },
-          "alpha-sepolia": {
-            "user0": {
-              "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
-              "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
-              "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
-              "type": "open_zeppelin"
-            }
+          "user4": {
+            "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
+            "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
+            "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
+            "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
+            "deployed": true,
+            "network": "custom-network"
+          },
+          "user0": {
+            "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
+            "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
+            "type": "open_zeppelin",
+            "network": "alpha-sepolia",
+            "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
           }
         }
     );
@@ -370,27 +368,26 @@ fn test_happy_case_with_private_keys_json_int_format() {
 
     let expected = json!(
         {
-          "custom-network": {
-            "user3": {
-              "address": "3562055384976875123115280411327378123839557441680670463096306030682092229914",
-              "private_key": "302934307671667531413257853548643485645",
-              "public_key": "3571077580641057962019375980836964323430604474979724507958294224671833227961"
-            },
-            "user4": {
-              "public_key": "1912535824053513524044241194146845716933313499165320136252999660831350960514",
-              "address": "3528166482527127075479645747648835917396168866434791003742065878852209458833",
-              "salt": "2393464100970799969082151102468006585314800480204341526354458084672178651236",
-              "private_key": "3278793552591849920356004222758625564696225216399892679169751024513874444319",
-              "deployed": true
-            }
+          "user3": {
+            "address": "3562055384976875123115280411327378123839557441680670463096306030682092229914",
+            "private_key": "302934307671667531413257853548643485645",
+            "public_key": "3571077580641057962019375980836964323430604474979724507958294224671833227961",
+            "network": "custom-network"
           },
-          "alpha-sepolia": {
-            "user0": {
-              "public_key": "1344783310009133679377326611173868415467858937993314384123595886829324020537",
-              "private_key": "40625681471685359029804301037638028933",
-              "address": "2243801221490456549135145738506528093449479171219304558490820973710020585018",
-              "type": "open_zeppelin"
-            }
+          "user4": {
+            "public_key": "1912535824053513524044241194146845716933313499165320136252999660831350960514",
+            "address": "3528166482527127075479645747648835917396168866434791003742065878852209458833",
+            "salt": "2393464100970799969082151102468006585314800480204341526354458084672178651236",
+            "private_key": "3278793552591849920356004222758625564696225216399892679169751024513874444319",
+            "deployed": true,
+            "network": "custom-network"
+            },
+          "user0": {
+            "public_key": "1344783310009133679377326611173868415467858937993314384123595886829324020537",
+            "private_key": "40625681471685359029804301037638028933",
+            "address": "2243801221490456549135145738506528093449479171219304558490820973710020585018",
+            "type": "open_zeppelin",
+            "network": "alpha-sepolia"
           }
         }
     );

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -30,6 +30,7 @@ async fn test_happy_case() {
         Available accounts:
         Network \"alpha-sepolia\":
         - user0:
+        Account data:
           private key: 0x1e9038bdc68ce1d27d54205256988e85
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
@@ -37,9 +38,11 @@ async fn test_happy_case() {
           class hash: unspecified
           deployed: unspecified
           legacy: unspecified
+          type: OpenZeppelin
 
         Network \"custom-network\":
         - user3:
+        Account data:
           private key: 0xe3e70682c2094cac629f6fbed82c07cd
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
@@ -47,8 +50,10 @@ async fn test_happy_case() {
           class hash: unspecified
           deployed: unspecified
           legacy: unspecified
+          type: unspecified
 
         - user4:
+        Account data:
           private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
@@ -56,6 +61,7 @@ async fn test_happy_case() {
           class hash: unspecified
           deployed: true
           legacy: unspecified
+          type: unspecified
     "};
 
     assert_stdout_contains(output, expected);

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -1,4 +1,6 @@
+use anyhow::Context;
 use indoc::formatdoc;
+use serde_json::{json, Value};
 use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains, AsOutput};
 use tempfile::tempdir;
 
@@ -115,6 +117,285 @@ fn test_happy_case_with_private_keys() {
     );
 
     assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_happy_case_hex_format() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let accounts_file_path = temp_dir
+        .path()
+        .canonicalize()
+        .expect("Unable to resolve a temporary directory path")
+        .join(accounts_file_name);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--hex-format",
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+        "--display-private-keys",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let expected = formatdoc!(
+        "
+        Available accounts (at {}):
+        - user0:
+          network: alpha-sepolia
+          private key: 0x1e9038bdc68ce1d27d54205256988e85
+          public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+          address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+          type: OpenZeppelin
+
+        - user3:
+          network: custom-network
+          private key: 0xe3e70682c2094cac629f6fbed82c07cd
+          public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+          address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
+
+        - user4:
+          network: custom-network
+          private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
+          public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+          address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
+          salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
+          deployed: true
+        ",
+        accounts_file_path.to_str().unwrap()
+    );
+
+    assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_happy_case_int_format() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let accounts_file_path = temp_dir
+        .path()
+        .canonicalize()
+        .expect("Unable to resolve a temporary directory path")
+        .join(accounts_file_name);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--int-format",
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+        "--display-private-keys",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let expected = formatdoc!(
+        "
+        Available accounts (at {}):
+        - user0:
+          network: alpha-sepolia
+          private key: 40625681471685359029804301037638028933
+          public key: 1344783310009133679377326611173868415467858937993314384123595886829324020537
+          address: 2243801221490456549135145738506528093449479171219304558490820973710020585018
+          type: OpenZeppelin
+
+        - user3:
+          network: custom-network
+          private key: 302934307671667531413257853548643485645
+          public key: 3571077580641057962019375980836964323430604474979724507958294224671833227961
+          address: 3562055384976875123115280411327378123839557441680670463096306030682092229914
+
+        - user4:
+          network: custom-network
+          private key: 3278793552591849920356004222758625564696225216399892679169751024513874444319
+          public key: 1912535824053513524044241194146845716933313499165320136252999660831350960514
+          address: 3528166482527127075479645747648835917396168866434791003742065878852209458833
+          salt: 2393464100970799969082151102468006585314800480204341526354458084672178651236
+          deployed: true
+        ",
+        accounts_file_path.to_str().unwrap()
+    );
+
+    assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_happy_case_json() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--json",
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let output_plain = output.as_stdout().to_string();
+    let output_parsed: Value = serde_json::from_str(&output_plain)
+        .context("Failed to parse command's output to JSON")
+        .unwrap();
+
+    let expected = json!(
+        {
+          "custom-network": {
+            "user3": {
+              "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
+              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9"
+            },
+            "user4": {
+              "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
+              "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
+              "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
+              "deployed": true
+            }
+          },
+          "alpha-sepolia": {
+            "user0": {
+              "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
+              "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
+              "type": "open_zeppelin"
+            }
+          }
+        }
+    );
+
+    assert_eq!(output_parsed, expected);
+}
+
+#[test]
+fn test_happy_case_with_private_keys_json() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--json",
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+        "--display-private-keys",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let output_plain = output.as_stdout().to_string();
+    let output_parsed: Value = serde_json::from_str(&output_plain)
+        .context("Failed to parse command's output to JSON")
+        .unwrap();
+
+    let expected = json!(
+        {
+          "custom-network": {
+            "user3": {
+              "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
+              "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
+              "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9"
+            },
+            "user4": {
+              "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
+              "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
+              "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
+              "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
+              "deployed": true
+            }
+          },
+          "alpha-sepolia": {
+            "user0": {
+              "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
+              "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
+              "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
+              "type": "open_zeppelin"
+            }
+          }
+        }
+    );
+
+    assert_eq!(output_parsed, expected);
+}
+
+#[test]
+fn test_happy_case_with_private_keys_json_int_format() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--json",
+        "--int-format",
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+        "--display-private-keys",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let output_plain = output.as_stdout().to_string();
+    let output_parsed: Value = serde_json::from_str(&output_plain)
+        .context("Failed to parse command's output to JSON")
+        .unwrap();
+
+    let expected = json!(
+        {
+          "custom-network": {
+            "user3": {
+              "address": "3562055384976875123115280411327378123839557441680670463096306030682092229914",
+              "private_key": "302934307671667531413257853548643485645",
+              "public_key": "3571077580641057962019375980836964323430604474979724507958294224671833227961"
+            },
+            "user4": {
+              "public_key": "1912535824053513524044241194146845716933313499165320136252999660831350960514",
+              "address": "3528166482527127075479645747648835917396168866434791003742065878852209458833",
+              "salt": "2393464100970799969082151102468006585314800480204341526354458084672178651236",
+              "private_key": "3278793552591849920356004222758625564696225216399892679169751024513874444319",
+              "deployed": true
+            }
+          },
+          "alpha-sepolia": {
+            "user0": {
+              "public_key": "1344783310009133679377326611173868415467858937993314384123595886829324020537",
+              "private_key": "40625681471685359029804301037638028933",
+              "address": "2243801221490456549135145738506528093449479171219304558490820973710020585018",
+              "type": "open_zeppelin"
+            }
+          }
+        }
+    );
+
+    assert_eq!(output_parsed, expected);
 }
 
 #[test]

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -3,7 +3,7 @@ use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_co
 use tempfile::tempdir;
 
 use crate::{
-    e2e::account::helpers::create_tempdir_with_accounts_file,
+    e2e::account::helpers::{create_tempdir_with_accounts_file, create_tempdir_with_empty_json},
     helpers::{constants::URL, runner::runner},
 };
 
@@ -86,4 +86,25 @@ fn test_accounts_file_does_not_exist() {
         to supply correct path to it with `--accounts-file` argument.";
 
     assert_stderr_contains(output, expected);
+}
+
+#[tokio::test]
+async fn test_no_accounts_available() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_empty_json(&accounts_file_name).await;
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+    assert_stdout_contains(output, "No accounts available");
 }

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -34,10 +34,6 @@ async fn test_happy_case() {
           private key: 0x1e9038bdc68ce1d27d54205256988e85
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
-          salt: unspecified
-          class hash: unspecified
-          deployed: unspecified
-          legacy: unspecified
           type: OpenZeppelin
 
         Network \"custom-network\":
@@ -46,11 +42,6 @@ async fn test_happy_case() {
           private key: 0xe3e70682c2094cac629f6fbed82c07cd
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
-          salt: unspecified
-          class hash: unspecified
-          deployed: unspecified
-          legacy: unspecified
-          type: unspecified
 
         - user4:
         Account data:
@@ -58,10 +49,7 @@ async fn test_happy_case() {
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
           salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
-          class hash: unspecified
           deployed: true
-          legacy: unspecified
-          type: unspecified
     "};
 
     assert_stdout_contains(output, expected);

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -3,14 +3,14 @@ use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_co
 use tempfile::tempdir;
 
 use crate::{
-    e2e::account::helpers::{create_tempdir_with_accounts_file, create_tempdir_with_empty_json},
+    e2e::account::helpers::create_tempdir_with_accounts_file,
     helpers::{constants::URL, runner::runner},
 };
 
 #[tokio::test]
 async fn test_happy_case() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true).await;
 
     let accounts_file_path = temp_dir
         .path()
@@ -95,7 +95,7 @@ fn test_accounts_file_does_not_exist() {
 #[tokio::test]
 async fn test_no_accounts_available() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_empty_json(accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, false).await;
 
     let accounts_file_path = temp_dir
         .path()

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -39,6 +39,64 @@ fn test_happy_case() {
         Network \"alpha-sepolia\":
         - user0:
         Account data:
+          public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+          address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+          type: OpenZeppelin
+
+        Network \"custom-network\":
+        - user3:
+        Account data:
+          public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+          address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
+
+        - user4:
+        Account data:
+          public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+          address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
+          salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
+          deployed: true
+
+        To show private keys too, run with --display-private-keys or -p
+        ",
+        accounts_file_path.to_str().unwrap()
+    );
+
+    assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_happy_case_with_private_keys() {
+    let accounts_file_name = "temp_accounts.json";
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
+
+    let accounts_file_path = temp_dir
+        .path()
+        .canonicalize()
+        .expect("Unable to resolve a temporary directory path")
+        .join(accounts_file_name);
+
+    let args = vec![
+        "--url",
+        URL,
+        "--accounts-file",
+        &accounts_file_name,
+        "account",
+        "list",
+        "--display-private-keys",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let expected = formatdoc!(
+        "
+        Available accounts (at {}):
+
+        Network \"alpha-sepolia\":
+        - user0:
+        Account data:
           private key: 0x1e9038bdc68ce1d27d54205256988e85
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -30,32 +30,32 @@ async fn test_happy_case() {
         Available accounts:
         Network \"alpha-sepolia\":
         - user0:
-        private key: 0x1e9038bdc68ce1d27d54205256988e85
-        public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
-        address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
-        salt: unspecified
-        class hash: unspecified
-        deployed: unspecified
-        legacy: unspecified
+          private key: 0x1e9038bdc68ce1d27d54205256988e85
+          public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+          address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+          salt: unspecified
+          class hash: unspecified
+          deployed: unspecified
+          legacy: unspecified
 
         Network \"custom-network\":
         - user3:
-        private key: 0xe3e70682c2094cac629f6fbed82c07cd
-        public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
-        address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
-        salt: unspecified
-        class hash: unspecified
-        deployed: unspecified
-        legacy: unspecified
+          private key: 0xe3e70682c2094cac629f6fbed82c07cd
+          public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+          address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
+          salt: unspecified
+          class hash: unspecified
+          deployed: unspecified
+          legacy: unspecified
 
         - user4:
-        private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
-        public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
-        address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
-        salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
-        class hash: unspecified
-        deployed: true
-        legacy: unspecified
+          private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
+          public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+          address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
+          salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
+          class hash: unspecified
+          deployed: true
+          legacy: unspecified
     "};
 
     assert_stdout_contains(output, expected);

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -10,7 +10,7 @@ use crate::{
 #[tokio::test]
 async fn test_happy_case() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_accounts_file(&accounts_file_name).await;
+    let temp_dir = create_tempdir_with_accounts_file(accounts_file_name).await;
 
     let args = vec![
         "--url",
@@ -91,7 +91,7 @@ fn test_accounts_file_does_not_exist() {
 #[tokio::test]
 async fn test_no_accounts_available() {
     let accounts_file_name = "temp_accounts.json";
-    let temp_dir = create_tempdir_with_empty_json(&accounts_file_name).await;
+    let temp_dir = create_tempdir_with_empty_json(accounts_file_name).await;
 
     let args = vec![
         "--url",

--- a/crates/sncast/tests/e2e/account/mod.rs
+++ b/crates/sncast/tests/e2e/account/mod.rs
@@ -2,3 +2,5 @@ mod add;
 mod create;
 mod delete;
 mod deploy;
+mod helpers;
+mod list;

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -49,8 +49,8 @@ async fn test_happy_case_eth(account: &str) {
     assert!(matches!(receipt, Deploy(_)));
 }
 
-#[test_case(DEVNET_OZ_CLASS_HASH_CAIRO_0.parse().unwrap(), AccountType::Oz; "cairo_0_class_hash")]
-#[test_case(OZ_CLASS_HASH, AccountType::Oz; "cairo_1_class_hash")]
+#[test_case(DEVNET_OZ_CLASS_HASH_CAIRO_0.parse().unwrap(), AccountType::OpenZeppelin; "cairo_0_class_hash")]
+#[test_case(OZ_CLASS_HASH, AccountType::OpenZeppelin; "cairo_1_class_hash")]
 #[test_case(ARGENT_CLASS_HASH, AccountType::Argent; "argent_class_hash")]
 #[test_case(BRAAVOS_CLASS_HASH, AccountType::Braavos; "braavos_class_hash")]
 #[tokio::test]

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -488,7 +488,7 @@ pub fn get_address_from_keystore(
     .unwrap();
     let class_hash = match account_type {
         AccountType::Braavos => BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
-        AccountType::Oz | AccountType::Argent => FieldElement::from_hex_be(
+        AccountType::OpenZeppelin | AccountType::Argent => FieldElement::from_hex_be(
             deployment
                 .get("class_hash")
                 .and_then(serde_json::Value::as_str)
@@ -498,7 +498,9 @@ pub fn get_address_from_keystore(
     };
 
     let calldata = match account_type {
-        AccountType::Oz | AccountType::Braavos => vec![private_key.verifying_key().scalar()],
+        AccountType::OpenZeppelin | AccountType::Braavos => {
+            vec![private_key.verifying_key().scalar()]
+        }
         AccountType::Argent => vec![private_key.verifying_key().scalar(), FieldElement::ZERO],
     };
 

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -563,7 +563,7 @@ pub fn assert_tx_entry_success(tx_entry: &ScriptTransactionEntry, name: &str) {
 }
 
 pub async fn create_and_deploy_oz_account() -> TempDir {
-    create_and_deploy_account(OZ_CLASS_HASH, AccountType::Oz).await
+    create_and_deploy_account(OZ_CLASS_HASH, AccountType::OpenZeppelin).await
 }
 pub async fn create_and_deploy_account(
     class_hash: FieldElement,
@@ -571,7 +571,7 @@ pub async fn create_and_deploy_account(
 ) -> TempDir {
     let class_hash = &class_hash.into_hex_string();
     let account_type = match account_type {
-        AccountType::Oz => "oz",
+        AccountType::OpenZeppelin => "oz",
         AccountType::Argent => "argent",
         AccountType::Braavos => "braavos",
     };

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -101,6 +101,7 @@
         * [create](appendix/sncast/account/create.md)
         * [deploy](appendix/sncast/account/deploy.md)
         * [delete](appendix/sncast/account/delete.md)
+        * [list](appendix/sncast/account/list.md)
     * [declare](appendix/sncast/declare.md)
     * [deploy](appendix/sncast/deploy.md)
     * [invoke](appendix/sncast/invoke.md)

--- a/docs/src/appendix/sncast/account/account.md
+++ b/docs/src/appendix/sncast/account/account.md
@@ -6,3 +6,4 @@ It has the following subcommands:
 * [`create`](./create.md)
 * [`deploy`](./deploy.md)
 * [`delete`](./delete.md)
+* [`list`](./list.md)

--- a/docs/src/appendix/sncast/account/list.md
+++ b/docs/src/appendix/sncast/account/list.md
@@ -3,6 +3,7 @@ List all available accounts.
 
 Account information will be retrieved from the file specified by `--accounts-file` argument,
 which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
+Hides user's private keys by default.
 
 > ⚠️ **Warning**
 > This command outputs cryptographic information about accounts, e.g. user's private key.
@@ -11,3 +12,9 @@ which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
 ## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
 
 * [`url`](../common.md#--url--u-rpc_url)
+
+## `--display-private-keys`, `-p`
+Optional.
+
+If passed, show private keys along with the rest of the account information.
+

--- a/docs/src/appendix/sncast/account/list.md
+++ b/docs/src/appendix/sncast/account/list.md
@@ -2,6 +2,7 @@
 List all available accounts.
 
 Account information will be retrieved from the file specified in user's environment.
+The output format is dependent on user's configuration, either provided via CLI or specified in `snfoundry.toml`.
 Hides user's private keys by default.
 
 > ⚠️ **Warning**
@@ -12,6 +13,11 @@ Hides user's private keys by default.
 
 * [`url`](../common.md#--url--u-rpc_url)
 * [`accounts-file`](../common.md#--accounts-file--f-path_to_accounts_file)
+
+## Optional Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
+* [`int-format`]()
+* [`hex-format`]()
+* [`json`]()
 
 ## `--display-private-keys`, `-p`
 Optional.

--- a/docs/src/appendix/sncast/account/list.md
+++ b/docs/src/appendix/sncast/account/list.md
@@ -1,8 +1,7 @@
 # `list`
 List all available accounts.
 
-Account information will be retrieved from the file specified by `--accounts-file` argument,
-which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
+Account information will be retrieved from the file specified in user's environment.
 Hides user's private keys by default.
 
 > ⚠️ **Warning**
@@ -12,6 +11,7 @@ Hides user's private keys by default.
 ## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
 
 * [`url`](../common.md#--url--u-rpc_url)
+* [`accounts-file`](../common.md#--accounts-file--f-path_to_accounts_file)
 
 ## `--display-private-keys`, `-p`
 Optional.

--- a/docs/src/appendix/sncast/account/list.md
+++ b/docs/src/appendix/sncast/account/list.md
@@ -4,6 +4,10 @@ List all available accounts.
 Account information will be retrieved from the file specified by `--accounts-file` argument,
 which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
 
+> ⚠️ **Warning**
+> This command outputs cryptographic information about accounts, e.g. user's private key.
+> Use it responsibly to not cause any vulnerabilities to your environment and confidential data.
+
 ## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
 
 * [`url`](../common.md#--url--u-rpc_url)

--- a/docs/src/appendix/sncast/account/list.md
+++ b/docs/src/appendix/sncast/account/list.md
@@ -1,0 +1,9 @@
+# `list`
+List all available accounts.
+
+Account information will be retrieved from the file specified by `--accounts-file` argument,
+which is `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default.
+
+## Required Common Arguments — Passed By CLI or Specified in `snfoundry.toml`
+
+* [`url`](../common.md#--url--u-rpc_url)

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -107,15 +107,28 @@ List all accounts saved in `accounts file`, grouped based on the networks they a
 
 ```shell
 $ sncast --accounts-file my-account-file.json account list
-
 Available accounts (at <current-directory>/my-account-file.json):
-
-Network "alpha-sepolia":
 - user0
 public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+network: alpha-sepolia
 address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
-salt: unspecified
-class hash: unspecified
+type: OpenZeppelin
+deployed: false
+legacy: false
+
+- user1
+[...]
+
+To show private keys too, run with --display-private-keys or -p
+
+$ sncast --accounts-file my-account-file.json account list --display-private-keys
+Available accounts (at <current-directory>/my-account-file.json):
+- user0
+private key: 0x1e9038bdc68ce1d27d54205256988e85
+public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+network: alpha-sepolia
+address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+type: OpenZeppelin
 deployed: false
 legacy: false
 

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -101,6 +101,28 @@ result: Account successfully removed
 
 For a detailed CLI description, see [account delete command reference](../appendix/sncast/account/delete.md).
 
+### `account list`
+
+List all accounts saved in `accounts file`, grouped based on the networks they are defined on.
+
+```shell
+$ sncast --accounts-file my-account-file.json account list
+
+Available accounts:
+Network "alpha-sepolia":
+- user0
+private key: 0x1e9038bdc68ce1d27d54205256988e85
+public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
+salt: unspecified
+class hash: unspecified
+deployed: false
+legacy: false
+
+- user1
+[...]
+```
+
 ### Custom Account Contract
 
 By default, `sncast` creates/deploys an account using [OpenZeppelin's account contract class hash](https://starkscan.co/class/0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6).

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -112,7 +112,6 @@ Available accounts (at <current-directory>/my-account-file.json):
 
 Network "alpha-sepolia":
 - user0
-private key: 0x1e9038bdc68ce1d27d54205256988e85
 public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
 address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
 salt: unspecified

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -108,7 +108,8 @@ List all accounts saved in `accounts file`, grouped based on the networks they a
 ```shell
 $ sncast --accounts-file my-account-file.json account list
 
-Available accounts:
+Available accounts (at <current-directory>/my-account-file.json):
+
 Network "alpha-sepolia":
 - user0
 private key: 0x1e9038bdc68ce1d27d54205256988e85


### PR DESCRIPTION
Closes [#2222](https://github.com/orgs/foundry-rs/projects/3/views/2?filterQuery=assignee%3Aintegraledelebesgue&pane=issue&itemId=67984329)

## Introduced changes
- added new `list` subcommand to `sncast account`
- it is used to list all accounts available to deploy contracts from
- accounts are retrieved from `accounts-file` parameter received from CLI or read from `.toml` config 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
