### PR TITLE
Added the expected prefund token type to `account create` output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `multicall new` no longer prints generated template to stdout and now requires specifying output path. [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/multicall/new.html)
 
+- `account create` outputs hint about the type of the tokens required to prefund a newly created account with before deployment
+
 ## [0.26.0] - 2024-07-03
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cast
+
+#### Changed
+- `account create` outputs hint about the type of the tokens required to prefund a newly created account with before deployment
+
 ## [0.27.0] - 2024-07-24
 
 ### Forge
@@ -29,8 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `multicall new` no longer prints generated template to stdout and now requires specifying output path. [Read more here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/multicall/new.html)
-
-- `account create` outputs hint about the type of the tokens required to prefund a newly created account with before deployment
 
 ## [0.26.0] - 2024-07-03
 

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -128,7 +128,7 @@ pub async fn create(
             "--add-profile flag was not set. No profile added to snfoundry.toml".to_string()
         },
         message: if account_json["deployed"] == json!(false) {
-            "Account successfully created. Prefund generated address with at least <max_fee> tokens. It is good to send more in the case of higher demand.".to_string()
+            "Account successfully created. Prefund generated address with at least <max_fee> STRK tokens or an equivalent amount of ETH tokens. It is good to send more in the case of higher demand.".to_string()
         } else {
             "Account already deployed".to_string()
         },

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -50,7 +50,7 @@ pub async fn test_happy_case(account_type: &str) {
         add_profile: --add-profile flag was not set. No profile added to snfoundry.toml
         address: 0x[..]
         max_fee: [..]
-        message: Account successfully created. Prefund generated address with at least <max_fee> tokens. It is good to send more in the case of higher demand.
+        message: Account successfully created. Prefund generated address with at least <max_fee> STRK tokens or an equivalent amount of ETH tokens. It is good to send more in the case of higher demand.
         "},
     );
 

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -40,9 +40,12 @@ Do the following to start interacting with the Starknet:
 
 
 - prefund generated address with tokens
-  
+
+	To deploy an account in the next step, you need to prefund it with either STRK or ETH tokens (read more about them [here](https://docs.starknet.io/architecture-and-concepts/economics-of-starknet/)).
     You can do it both by sending tokens from another starknet account or by bridging them with [StarkGate](https://starkgate.starknet.io/).
 
+ >💡 **Info**
+> When deploying on a Sepolia test network, you can also fund your account with artificial tokens via the [Starknet Faucet](https://starknet-faucet.vercel.app)
 
 - deploy account with the `sncast account deploy` command
 


### PR DESCRIPTION
Closes [#2247](https://github.com/orgs/foundry-rs/projects/3/views/3?filterQuery=&pane=issue&itemId=68288252)

## Introduced changes
- `account create` now outputs information about the expected type of tokens needed to prefund a newly created account with
- documentation explains it too

## Checklist
- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
