### PR TITLE
Added deploy by name

### DIFF
--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -1,19 +1,20 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use clap::{Args, ValueEnum};
 use scarb_api::StarknetContractArtifacts;
+use sncast::helpers::error::token_not_supported_for_declaration;
+use sncast::helpers::fee::{FeeArgs, FeeSettings, FeeToken, PayableTransaction};
+use sncast::helpers::scarb_utils::CompiledContract;
+use sncast::response::errors::StarknetCommandError;
 use sncast::response::structs::DeclareResponse;
 use sncast::response::structs::Felt;
 use sncast::{apply_optional, handle_wait_for_tx, impl_payable_transaction, ErrorData, WaitForTx};
+use starknet::accounts::AccountError;
 use starknet::accounts::AccountError::Provider;
 use starknet::accounts::{ConnectedAccount, DeclarationV2, DeclarationV3};
-
-use sncast::helpers::error::token_not_supported_for_declaration;
-use sncast::helpers::fee::{FeeArgs, FeeSettings, FeeToken, PayableTransaction};
-use sncast::response::errors::StarknetCommandError;
+use starknet::core::types::DeclareTransactionResult;
 use starknet::core::types::FieldElement;
 use starknet::{
     accounts::{Account, SingleOwnerAccount},
-    core::types::contract::{CompiledClass, SierraClass},
     providers::jsonrpc::{HttpTransport, JsonRpcClient},
     signers::LocalWallet,
 };
@@ -54,79 +55,105 @@ impl_payable_transaction!(Declare, token_not_supported_for_declaration,
     DeclareVersion::V3 => FeeToken::Strk
 );
 
-#[allow(clippy::too_many_lines)]
+type SendDeclarationError<'client> = AccountError<<SingleOwnerAccount<&'client JsonRpcClient<HttpTransport>, LocalWallet> as starknet::accounts::Account>::SignError>;
+
+async fn send_declaration<'client>(
+    contract: CompiledContract,
+    account: &'client SingleOwnerAccount<&'client JsonRpcClient<HttpTransport>, LocalWallet>,
+    nonce: Option<FieldElement>,
+    fee_settings: FeeSettings,
+) -> Result<DeclareTransactionResult, SendDeclarationError<'client>> {
+    let CompiledContract { class, hash } = contract;
+
+    match fee_settings {
+        FeeSettings::Eth { max_fee } => {
+            let declaration = account.declare_v2(Arc::new(class), hash);
+
+            let declaration = apply_optional(declaration, max_fee, DeclarationV2::max_fee);
+            let declaration = apply_optional(declaration, nonce, DeclarationV2::nonce);
+
+            declaration.send().await
+        }
+
+        FeeSettings::Strk {
+            max_gas,
+            max_gas_unit_price,
+        } => {
+            let declaration = account.declare_v3(Arc::new(class), hash);
+
+            let declaration = apply_optional(declaration, max_gas, DeclarationV3::gas);
+            let declaration =
+                apply_optional(declaration, max_gas_unit_price, DeclarationV3::gas_price);
+            let declaration = apply_optional(declaration, nonce, DeclarationV3::nonce);
+
+            declaration.send().await
+        }
+    }
+}
+
+async fn handle_declaration<'client>(
+    result: Result<DeclareTransactionResult, SendDeclarationError<'client>>,
+    account: &'client SingleOwnerAccount<&'client JsonRpcClient<HttpTransport>, LocalWallet>,
+    wait_config: WaitForTx,
+) -> Result<DeclareResponse, StarknetCommandError> {
+    match result {
+        Ok(result) => {
+            let wait = handle_wait_for_tx(
+                account.provider(),
+                result.transaction_hash,
+                DeclareResponse {
+                    class_hash: Felt(result.class_hash),
+                    transaction_hash: Felt(result.transaction_hash),
+                },
+                wait_config,
+            );
+
+            wait.await.map_err(StarknetCommandError::from)
+        }
+
+        Err(Provider(error)) => Err(StarknetCommandError::ProviderError(error.into())),
+
+        _ => Err(anyhow!("Unknown RPC error").into()),
+    }
+}
+
+async fn get_fee_settings(
+    declare: &Declare,
+    account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
+) -> Result<FeeSettings> {
+    declare
+        .fee_args
+        .clone()
+        .fee_token(declare.token_from_version())
+        .try_into_fee_settings(account.provider(), account.block_id())
+        .await
+}
+
+pub async fn declare_compiled(
+    declare: Declare,
+    account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
+    contract: CompiledContract,
+    wait_config: WaitForTx,
+) -> Result<DeclareResponse, StarknetCommandError> {
+    let fee_settings = get_fee_settings(&declare, account).await?;
+    let declared = send_declaration(contract, &account, declare.nonce, fee_settings).await;
+    handle_declaration(declared, &account, wait_config).await
+}
+
 pub async fn declare(
     declare: Declare,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
     artifacts: &HashMap<String, StarknetContractArtifacts>,
     wait_config: WaitForTx,
 ) -> Result<DeclareResponse, StarknetCommandError> {
-    let fee_settings = declare
-        .fee_args
-        .clone()
-        .fee_token(declare.token_from_version())
-        .try_into_fee_settings(account.provider(), account.block_id())
-        .await?;
-
     let contract_artifacts =
         artifacts
             .get(&declare.contract)
             .ok_or(StarknetCommandError::ContractArtifactsNotFound(
-                ErrorData::new(declare.contract),
+                ErrorData::new(declare.contract.clone()),
             ))?;
 
-    let contract_definition: SierraClass = serde_json::from_str(&contract_artifacts.sierra)
-        .context("Failed to parse sierra artifact")?;
-    let casm_contract_definition: CompiledClass =
-        serde_json::from_str(&contract_artifacts.casm).context("Failed to parse casm artifact")?;
+    let contract = CompiledContract::from(&contract_artifacts)?;
 
-    let casm_class_hash = casm_contract_definition
-        .class_hash()
-        .map_err(anyhow::Error::from)?;
-
-    let declared = match fee_settings {
-        FeeSettings::Eth { max_fee } => {
-            let declaration = account.declare_v2(
-                Arc::new(contract_definition.flatten().map_err(anyhow::Error::from)?),
-                casm_class_hash,
-            );
-
-            let declaration = apply_optional(declaration, max_fee, DeclarationV2::max_fee);
-            let declaration = apply_optional(declaration, declare.nonce, DeclarationV2::nonce);
-
-            declaration.send().await
-        }
-        FeeSettings::Strk {
-            max_gas,
-            max_gas_unit_price,
-        } => {
-            let declaration = account.declare_v3(
-                Arc::new(contract_definition.flatten().map_err(anyhow::Error::from)?),
-                casm_class_hash,
-            );
-
-            let declaration = apply_optional(declaration, max_gas, DeclarationV3::gas);
-            let declaration =
-                apply_optional(declaration, max_gas_unit_price, DeclarationV3::gas_price);
-            let declaration = apply_optional(declaration, declare.nonce, DeclarationV3::nonce);
-
-            declaration.send().await
-        }
-    };
-
-    match declared {
-        Ok(result) => handle_wait_for_tx(
-            account.provider(),
-            result.transaction_hash,
-            DeclareResponse {
-                class_hash: Felt(result.class_hash),
-                transaction_hash: Felt(result.transaction_hash),
-            },
-            wait_config,
-        )
-        .await
-        .map_err(StarknetCommandError::from),
-        Err(Provider(error)) => Err(StarknetCommandError::ProviderError(error.into())),
-        _ => Err(anyhow!("Unknown RPC error").into()),
-    }
+    declare_compiled(declare, account, contract, wait_config).await
 }

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -1,7 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::{Args, ValueEnum};
 use sncast::helpers::error::token_not_supported_for_deployment;
 use sncast::helpers::fee::{FeeArgs, FeeSettings, FeeToken, PayableTransaction};
+use sncast::helpers::scarb_utils::{read_manifest_and_build_artifacts, CompiledContract};
 use sncast::response::errors::StarknetCommandError;
 use sncast::response::structs::{DeployResponse, Felt};
 use sncast::{extract_or_generate_salt, impl_payable_transaction, udc_uniqueness};
@@ -15,12 +16,21 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet::signers::LocalWallet;
 
+use super::declare::Declare;
+
 #[derive(Args)]
 #[command(about = "Deploy a contract on Starknet")]
 pub struct Deploy {
     /// Class hash of contract to deploy
-    #[clap(short = 'g', long)]
-    pub class_hash: FieldElement,
+    #[clap(short = 'g', long, conflicts_with = "contract_name")]
+    pub class_hash: Option<FieldElement>,
+
+    // Name of the contract to deploy
+    #[clap(long, conflicts_with = "class_hash")]
+    pub contract_name: Option<String>,
+
+    #[clap(long)]
+    pub package: Option<String>,
 
     /// Calldata for the contract constructor
     #[clap(short, long, value_delimiter = ' ', num_args = 1..)]
@@ -46,19 +56,113 @@ pub struct Deploy {
     pub version: Option<DeployVersion>,
 }
 
+impl Deploy {
+    pub fn build_artifacts(
+        &self,
+        json: bool,
+        profile: &Option<String>,
+    ) -> Result<CompiledContract> {
+        let contract_name = self
+            .contract_name
+            .clone()
+            .ok_or(anyhow!("Contract name unspecified"))?;
+
+        let artifacts = read_manifest_and_build_artifacts(&self.package, json, profile)?;
+
+        let contract_artifacts = artifacts.get(&contract_name).ok_or(anyhow!(
+            "No artifacts found for contract: {}",
+            contract_name
+        ))?;
+
+        CompiledContract::from(&contract_artifacts)
+    }
+
+    pub fn declare_data(&self) -> Result<Declare> {
+        if self.contract_name.is_none() {
+            bail!("Deploy-by-name data unspecified");
+        }
+
+        let Deploy {
+            contract_name,
+            package,
+            fee_args,
+            ..
+        } = &self;
+
+        let declare = Declare {
+            contract: contract_name.to_owned().unwrap(),
+            fee_args: fee_args.to_owned(),
+            nonce: None,
+            package: package.to_owned(),
+            version: None,
+        };
+
+        Ok(declare)
+    }
+
+    pub fn resolve_class_hash(mut self, value: FieldElement) -> DeployResolved {
+        if self.class_hash.is_none() {
+            self.class_hash = Some(value);
+        }
+
+        self.try_into().unwrap()
+    }
+}
+
+impl TryInto<DeployResolved> for Deploy {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> std::result::Result<DeployResolved, Self::Error> {
+        if self.class_hash.is_none() {
+            bail!("Class hash unspecified");
+        }
+
+        let Deploy {
+            class_hash,
+            constructor_calldata,
+            salt,
+            unique,
+            fee_args,
+            nonce,
+            version,
+            ..
+        } = self;
+
+        Ok(DeployResolved {
+            class_hash: class_hash.unwrap(),
+            constructor_calldata,
+            salt,
+            unique,
+            fee_args,
+            nonce,
+            version,
+        })
+    }
+}
+
+pub struct DeployResolved {
+    pub class_hash: FieldElement,
+    pub constructor_calldata: Vec<FieldElement>,
+    pub salt: Option<FieldElement>,
+    pub unique: bool,
+    pub fee_args: FeeArgs,
+    pub nonce: Option<FieldElement>,
+    pub version: Option<DeployVersion>,
+}
+
 #[derive(ValueEnum, Debug, Clone)]
 pub enum DeployVersion {
     V1,
     V3,
 }
 
-impl_payable_transaction!(Deploy, token_not_supported_for_deployment,
+impl_payable_transaction!(DeployResolved, token_not_supported_for_deployment,
     DeployVersion::V1 => FeeToken::Eth,
     DeployVersion::V3 => FeeToken::Strk
 );
 
 pub async fn deploy(
-    deploy: Deploy,
+    deploy: DeployResolved,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
     wait_config: WaitForTx,
 ) -> Result<DeployResponse, StarknetCommandError> {

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::fs;
 
 use crate::starknet_commands::declare::Declare;
-use crate::starknet_commands::deploy::Deploy;
+use crate::starknet_commands::deploy::DeployResolved;
 use crate::starknet_commands::invoke::Invoke;
 use crate::starknet_commands::{call, declare, deploy, invoke, tx_status};
-use crate::{get_account, get_nonce, WaitForTx};
+use crate::{get_account, WaitForTx};
 use anyhow::{anyhow, Context, Result};
 use blockifier::execution::deprecated_syscalls::DeprecatedSyscallSelector;
 use blockifier::execution::entry_point::CallEntryPoint;
@@ -39,6 +39,7 @@ use scarb_metadata::{Metadata, PackageMetadata};
 use semver::{Comparator, Op, Version, VersionReq};
 use shared::print::print_as_warning;
 use shared::utils::build_readable_text;
+use sncast::get_nonce;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::SCRIPT_LIB_ARTIFACT_NAME;
 use sncast::helpers::fee::ScriptFeeSettings;
@@ -159,7 +160,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let fee_args = input_reader.read::<ScriptFeeSettings>()?.into();
                 let nonce = input_reader.read()?;
 
-                let deploy = Deploy {
+                let deploy = DeployResolved {
                     class_hash,
                     constructor_calldata,
                     salt,

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -377,13 +377,19 @@ fn test_scarb_build_fails_when_wrong_cairo_path() {
 
     let snapbox = runner(&args).current_dir(tempdir.path());
     let output = snapbox.assert().failure();
-    assert_stderr_contains(
-        output,
-        "Failed to build contract: Failed to build using scarb; `scarb` exited with error",
-    );
+
+    let expected = indoc! {
+        "
+        Error: Failed to build contract
+
+        Caused by:
+            Failed to build using scarb; `scarb` exited with error
+        "
+    };
+
+    assert_stderr_contains(output, expected);
 }
 
-#[should_panic(expected = "Path to Scarb.toml manifest does not exist")]
 #[test]
 fn test_scarb_build_fails_scarb_toml_does_not_exist() {
     let tempdir = copy_directory_to_tempdir(CONTRACTS_DIR);
@@ -403,7 +409,13 @@ fn test_scarb_build_fails_scarb_toml_does_not_exist() {
         "eth",
     ];
 
-    runner(&args).current_dir(tempdir.path()).assert().success();
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        "Error: Path to Scarb.toml manifest does not exist =[..]",
+    )
 }
 
 #[test]
@@ -471,7 +483,6 @@ fn test_too_low_max_fee() {
     );
 }
 
-#[should_panic(expected = "Make sure you have enabled sierra code generation in Scarb.toml")]
 #[test]
 fn test_scarb_no_sierra_artifact() {
     let tempdir = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/no_sierra");
@@ -491,7 +502,19 @@ fn test_scarb_no_sierra_artifact() {
         "eth",
     ];
 
-    runner(&args).current_dir(tempdir.path()).assert().success();
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    let expected = indoc! {
+        "
+        Error: Failed to build contract
+
+        Caused by:
+            [..]Make sure you have enabled sierra code generation in Scarb.toml[..]
+        "
+    };
+
+    assert_stderr_contains(output, expected)
 }
 
 #[test]


### PR DESCRIPTION
Closes [#2279](https://github.com/orgs/foundry-rs/projects/3?pane=issue&itemId=69935167)

## Introduced changes
- `sncast deploy` now allows to deploy a contract by its name instead of class hash
- `deploy` handler builds necessary artifacts and declares previously undeclared contracts
- `--contract-name` and `--class-hash` arguments are mutually exclusive

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
