### PR TITLE
Introduced chain ID discovery in fork tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - `account create` outputs hint about the type of the tokens required to prefund a newly created account with before deployment
 
+### Forge
+
+#### Changed
+- Fork tests now discover chain ID via provided RPC URL, defaulting to `SN_SEPOLIA`
+
 ## [0.27.0] - 2024-07-24
 
 ### Forge

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -18,10 +18,11 @@ use starknet::core::types::{
     BlockId, ContractClass as ContractClassStarknet, FieldElement, MaybePendingBlockWithTxHashes,
     StarknetError,
 };
+use starknet::core::utils::parse_cairo_short_string;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider, ProviderError};
 use starknet_api::block::{BlockNumber, BlockTimestamp};
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::{
     ContractClass as DeprecatedContractClass, EntryPoint, EntryPointType,
 };
@@ -55,10 +56,14 @@ impl ForkStateReader {
         })
     }
 
-    pub fn get_chain_id(&self) -> Result<FieldElement> {
-        self.runtime
+    pub fn chain_id(&self) -> Result<ChainId> {
+        let id = self
+            .runtime
             .block_on(self.client.chain_id())
-            .map_err(anyhow::Error::from)
+            .map_err(anyhow::Error::from)?;
+
+        let id = parse_cairo_short_string(&id).map_err(anyhow::Error::from)?;
+        Ok(ChainId(id))
     }
 
     fn block_id(&self) -> BlockId {

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -57,12 +57,8 @@ impl ForkStateReader {
     }
 
     pub fn chain_id(&self) -> Result<ChainId> {
-        let id = self
-            .runtime
-            .block_on(self.client.chain_id())
-            .map_err(anyhow::Error::from)?;
-
-        let id = parse_cairo_short_string(&id).map_err(anyhow::Error::from)?;
+        let id = self.runtime.block_on(self.client.chain_id())?;
+        let id = parse_cairo_short_string(&id)?;
         Ok(ChainId(id))
     }
 

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -55,6 +55,12 @@ impl ForkStateReader {
         })
     }
 
+    pub fn get_chain_id(&self) -> Result<FieldElement> {
+        self.runtime
+            .block_on(self.client.chain_id())
+            .map_err(anyhow::Error::from)
+    }
+
     fn block_id(&self) -> BlockId {
         BlockId::Number(self.block_number.0)
     }

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -22,8 +22,7 @@ use conversions::serde::deserialize::CairoDeserialize;
 use conversions::serde::serialize::{BufferWriter, CairoSerialize};
 use runtime::starknet::context::SerializableBlockInfo;
 use runtime::starknet::state::DictStateReader;
-use starknet::core::types::FieldElement;
-use starknet_api::core::EntryPointSelector;
+use starknet_api::core::{ChainId, EntryPointSelector};
 use starknet_api::transaction::ContractAddressSalt;
 use starknet_api::{
     class_hash,
@@ -125,10 +124,10 @@ impl StateReader for ExtendedStateReader {
 }
 
 impl ExtendedStateReader {
-    pub fn get_chain_id(&self) -> anyhow::Result<Option<FieldElement>> {
+    pub fn get_chain_id(&self) -> anyhow::Result<Option<ChainId>> {
         self.fork_state_reader
             .as_ref()
-            .map(ForkStateReader::get_chain_id)
+            .map(ForkStateReader::chain_id)
             .transpose()
     }
 }

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -22,6 +22,7 @@ use conversions::serde::deserialize::CairoDeserialize;
 use conversions::serde::serialize::{BufferWriter, CairoSerialize};
 use runtime::starknet::context::SerializableBlockInfo;
 use runtime::starknet::state::DictStateReader;
+use starknet::core::types::FieldElement;
 use starknet_api::core::EntryPointSelector;
 use starknet_api::transaction::ContractAddressSalt;
 use starknet_api::{
@@ -120,6 +121,15 @@ impl StateReader for ExtendedStateReader {
             .dict_state_reader
             .get_compiled_class_hash(class_hash)
             .unwrap_or_default())
+    }
+}
+
+impl ExtendedStateReader {
+    pub fn get_chain_id(&self) -> anyhow::Result<Option<FieldElement>> {
+        self.fork_state_reader
+            .as_ref()
+            .map(ForkStateReader::get_chain_id)
+            .transpose()
     }
 }
 

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -93,7 +93,7 @@ pub fn deploy_contract(
     let class_hash = declare(state, contract_name, &contracts_data).unwrap();
 
     let mut execution_resources = ExecutionResources::default();
-    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info);
+    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info, None);
     let hints = HashMap::new();
 
     let mut syscall_hint_processor = build_syscall_hint_processor(
@@ -122,7 +122,7 @@ pub fn deploy_wrapper(
     calldata: &[Felt252],
 ) -> Result<ContractAddress, CheatcodeError> {
     let mut execution_resources = ExecutionResources::default();
-    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info);
+    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info, None);
     let hints = HashMap::new();
 
     let mut syscall_hint_processor = build_syscall_hint_processor(
@@ -151,7 +151,7 @@ pub fn deploy_at_wrapper(
     contract_address: ContractAddress,
 ) -> Result<ContractAddress, CheatcodeError> {
     let mut execution_resources = ExecutionResources::default();
-    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info);
+    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info, None);
     let hints = HashMap::new();
 
     let mut syscall_hint_processor = build_syscall_hint_processor(
@@ -197,7 +197,7 @@ pub fn call_contract(
     };
 
     let mut execution_resources = ExecutionResources::default();
-    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info);
+    let mut entry_point_execution_context = build_context(&cheatnet_state.block_info, None);
     let hints = HashMap::new();
 
     let mut syscall_hint_processor = build_syscall_hint_processor(

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -47,8 +47,6 @@ use cheatnet::runtime_extensions::forge_runtime_extension::{
 use cheatnet::state::{BlockInfoReader, CallTrace, CheatnetState, ExtendedStateReader};
 use runtime::starknet::context::{build_context, set_max_steps};
 use runtime::{ExtendedRuntime, StarknetRuntime};
-use starknet::core::utils::parse_cairo_short_string;
-use starknet_api::core::ChainId;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use universal_sierra_compiler_api::{
@@ -219,12 +217,7 @@ pub fn run_test_case(
         )?,
     };
     let block_info = state_reader.get_block_info()?;
-    let chain_id = state_reader
-        .get_chain_id()?
-        .as_ref()
-        .map(parse_cairo_short_string)
-        .transpose()?
-        .map(ChainId);
+    let chain_id = state_reader.get_chain_id()?;
 
     let mut context = build_context(&block_info, chain_id);
 

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -45,8 +45,10 @@ use cheatnet::runtime_extensions::forge_runtime_extension::{
     update_top_call_vm_trace, ForgeExtension, ForgeRuntime,
 };
 use cheatnet::state::{BlockInfoReader, CallTrace, CheatnetState, ExtendedStateReader};
+use conversions::string::IntoHexStr;
 use runtime::starknet::context::{build_context, set_max_steps};
 use runtime::{ExtendedRuntime, StarknetRuntime};
+use starknet_api::core::ChainId;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
 use universal_sierra_compiler_api::{
@@ -217,8 +219,11 @@ pub fn run_test_case(
         )?,
     };
     let block_info = state_reader.get_block_info()?;
+    let chain_id = state_reader
+        .get_chain_id()?
+        .map(|id| ChainId(id.into_hex_string()));
 
-    let mut context = build_context(&block_info);
+    let mut context = build_context(&block_info, chain_id);
 
     if let Some(max_n_steps) = runtime_config.max_n_steps {
         set_max_steps(&mut context, max_n_steps);

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -45,9 +45,9 @@ use cheatnet::runtime_extensions::forge_runtime_extension::{
     update_top_call_vm_trace, ForgeExtension, ForgeRuntime,
 };
 use cheatnet::state::{BlockInfoReader, CallTrace, CheatnetState, ExtendedStateReader};
-use conversions::string::IntoHexStr;
 use runtime::starknet::context::{build_context, set_max_steps};
 use runtime::{ExtendedRuntime, StarknetRuntime};
+use starknet::core::utils::parse_cairo_short_string;
 use starknet_api::core::ChainId;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -221,7 +221,10 @@ pub fn run_test_case(
     let block_info = state_reader.get_block_info()?;
     let chain_id = state_reader
         .get_chain_id()?
-        .map(|id| ChainId(id.into_hex_string()));
+        .as_ref()
+        .map(parse_cairo_short_string)
+        .transpose()?
+        .map(ChainId);
 
     let mut context = build_context(&block_info, chain_id);
 

--- a/crates/runtime/src/starknet/context.rs
+++ b/crates/runtime/src/starknet/context.rs
@@ -25,16 +25,17 @@ use starknet_api::{
     transaction::{TransactionHash, TransactionSignature, TransactionVersion},
 };
 
+pub const DEFAULT_CHAIN_ID: &str = "SN_SEPOLIA";
 pub const DEFAULT_BLOCK_NUMBER: u64 = 2000;
 pub const SEQUENCER_ADDRESS: &str = "0x1000";
 pub const ERC20_CONTRACT_ADDRESS: &str = "0x1001";
 
 #[must_use]
-pub fn build_block_context(block_info: &BlockInfo) -> BlockContext {
+pub fn build_block_context(block_info: &BlockInfo, chain_id: Option<ChainId>) -> BlockContext {
     BlockContext::new_unchecked(
         block_info,
         &ChainInfo {
-            chain_id: ChainId("SN_SEPOLIA".to_string()),
+            chain_id: chain_id.unwrap_or(ChainId(String::from(DEFAULT_CHAIN_ID))),
             fee_token_addresses: FeeTokenAddresses {
                 strk_fee_token_address: contract_address!(ERC20_CONTRACT_ADDRESS),
                 eth_fee_token_address: contract_address!(ERC20_CONTRACT_ADDRESS),
@@ -79,16 +80,22 @@ fn build_tx_info() -> TransactionInfo {
 }
 
 #[must_use]
-pub fn build_transaction_context(block_info: &BlockInfo) -> TransactionContext {
+pub fn build_transaction_context(
+    block_info: &BlockInfo,
+    chain_id: Option<ChainId>,
+) -> TransactionContext {
     TransactionContext {
-        block_context: build_block_context(block_info),
+        block_context: build_block_context(block_info, chain_id),
         tx_info: build_tx_info(),
     }
 }
 
 #[must_use]
-pub fn build_context(block_info: &BlockInfo) -> EntryPointExecutionContext {
-    let transaction_context = Arc::new(build_transaction_context(block_info));
+pub fn build_context(
+    block_info: &BlockInfo,
+    chain_id: Option<ChainId>,
+) -> EntryPointExecutionContext {
+    let transaction_context = Arc::new(build_transaction_context(block_info, chain_id));
 
     EntryPointExecutionContext::new(transaction_context, ExecutionMode::Execute, false).unwrap()
 }

--- a/crates/runtime/src/starknet/context.rs
+++ b/crates/runtime/src/starknet/context.rs
@@ -30,12 +30,16 @@ pub const DEFAULT_BLOCK_NUMBER: u64 = 2000;
 pub const SEQUENCER_ADDRESS: &str = "0x1000";
 pub const ERC20_CONTRACT_ADDRESS: &str = "0x1001";
 
+fn default_chain_id() -> ChainId {
+    ChainId(String::from(DEFAULT_CHAIN_ID))
+}
+
 #[must_use]
 pub fn build_block_context(block_info: &BlockInfo, chain_id: Option<ChainId>) -> BlockContext {
     BlockContext::new_unchecked(
         block_info,
         &ChainInfo {
-            chain_id: chain_id.unwrap_or(ChainId(String::from(DEFAULT_CHAIN_ID))),
+            chain_id: chain_id.unwrap_or_else(default_chain_id),
             fee_token_addresses: FeeTokenAddresses {
                 strk_fee_token_address: contract_address!(ERC20_CONTRACT_ADDRESS),
                 eth_fee_token_address: contract_address!(ERC20_CONTRACT_ADDRESS),

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -328,7 +328,7 @@ pub fn run(
         .assemble_ex(&entry_code, &footer);
 
     // hint processor
-    let mut context = build_context(&SerializableBlockInfo::default().into());
+    let mut context = build_context(&SerializableBlockInfo::default().into(), None);
 
     let mut blockifier_state = CachedState::new(
         DictStateReader::default(),


### PR DESCRIPTION
Closes [#2117](https://github.com/foundry-rs/starknet-foundry/issues/2117#issue-2298469750)

## Introduced changes
- During fork tests, Forge Runner acquires the chain ID basing on the RPC URL with fallback to default `SN_SEPOLIA`

## Checklist
- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
