### PR TITLE
Updated cairo-profiler version and added missing syscall selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5558,8 +5558,8 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "trace-data"
-version = "0.3.0"
-source = "git+https://github.com/software-mansion/cairo-profiler/?rev=e031b09#e031b09722a3129bf63d3c6f2012c302b4e7bf10"
+version = "0.4.0"
+source = "git+https://github.com/software-mansion/cairo-profiler/?rev=e61a4a7#e61a4a78af6409714024dbdbe3f1b6be2603491a"
 dependencies = [
  "camino",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.119"
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "56177d2" }
 starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "56177d2" }
-trace-data = { git = "https://github.com/software-mansion/cairo-profiler/", rev = "e031b09" }
+trace-data = { git = "https://github.com/software-mansion/cairo-profiler/", rev = "e61a4a7" }
 tempfile = "3.10.1"
 thiserror = "1.0.61"
 ctor = "0.2.8"

--- a/crates/forge-runner/src/build_trace_data.rs
+++ b/crates/forge-runner/src/build_trace_data.rs
@@ -286,7 +286,7 @@ fn build_profiler_deprecated_syscall_selector(
         DeprecatedSyscallSelector::StorageRead => ProfilerDeprecatedSyscallSelector::StorageRead,
         DeprecatedSyscallSelector::StorageWrite => ProfilerDeprecatedSyscallSelector::StorageWrite,
         DeprecatedSyscallSelector::Sha256ProcessBlock => {
-            todo!("Add support for Sha256ProcessBlock in profiler")
+            ProfilerDeprecatedSyscallSelector::Sha256ProcessBlock
         }
     }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes [#2376](https://github.com/foundry-rs/starknet-foundry/issues/2376)

## Introduced changes

<!-- A brief description of the changes -->

- Updated `cairo-profiler` dependency ref to the latest commit introducing a new syscall

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
