### PR TITLE
Fix snforge plugin compilation in packaging

### DIFF
--- a/crates/snforge-scarb-plugin/src/parse.rs
+++ b/crates/snforge-scarb-plugin/src/parse.rs
@@ -16,7 +16,7 @@ pub fn parse<T: AttributeInfo>(
     code: &str,
 ) -> Result<(SimpleParserDatabase, FunctionWithBody), Diagnostic> {
     let simple_db = SimpleParserDatabase::default();
-    let code = Arc::new(code.to_string());
+    let code: Arc<str> = Arc::from(code);
     let db: &dyn SyntaxGroup = simple_db.upcast();
     // TODO(#2357): Use `db.parse_virtual` here instead of creating the virtual file manually
     let virtual_file = db.intern_file(FileLongId::Virtual(VirtualFile {
@@ -27,7 +27,7 @@ pub fn parse<T: AttributeInfo>(
         kind: FileKind::Module,
     }));
     let mut diagnostics = DiagnosticsBuilder::default();
-    let elements = Parser::parse_file(&simple_db, &mut diagnostics, virtual_file, code.as_str())
+    let elements = Parser::parse_file(&simple_db, &mut diagnostics, virtual_file, &code)
         .items(db)
         .elements(db);
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

- Fix mismatched types to allow plugin packaging. Packaging of the plugin will be needed for the new snforge release, because it will have to be uploaded to the registry.

While building the plugin works perfectly fine, there are problems with its packaging (probably the compiler is less lenient):

```bash
crates/snforge-scarb-plugin $ cargo package
(...)
error[E0308]: mismatched types
  --> src/parse.rs:25:18
   |
25 |         content: code.clone(),
   |                  ^^^^^^^^^^^^ expected `Arc<str>`, found `Arc<String>`
   |
   = note: expected struct `Arc<str>`
              found struct `Arc<std::string::String>`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `snforge-scarb-plugin` (lib) due to 1 previous error
error: failed to verify package tarball
```

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
