### PR TITLE
Updated `snforge init` project template to match new `declare` cheatcode interface

### DIFF
--- a/starknet_forge_template/tests/test_contract.cairo
+++ b/starknet_forge_template/tests/test_contract.cairo
@@ -1,6 +1,6 @@
 use starknet::ContractAddress;
 
-use snforge_std::{declare, ContractClassTrait};
+use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
 
 use {{ PROJECT_NAME }}::IHelloStarknetSafeDispatcher;
 use {{ PROJECT_NAME }}::IHelloStarknetSafeDispatcherTrait;
@@ -8,7 +8,7 @@ use {{ PROJECT_NAME }}::IHelloStarknetDispatcher;
 use {{ PROJECT_NAME }}::IHelloStarknetDispatcherTrait;
 
 fn deploy_contract(name: ByteArray) -> ContractAddress {
-    let contract = declare(name).unwrap();
+    let contract = declare(name).unwrap().contract_class();
     let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
     contract_address
 }


### PR DESCRIPTION
Closes [#2387](https://github.com/foundry-rs/starknet-foundry/issues/2387#issue-2482542184)

## Introduced changes

<!-- A brief description of the changes -->
- Sample project created by `snforge init` contain valid contract declaration snippet

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
