### PR TITLE
Added `assert_macros` dependency to `snforge_std`

### DIFF
--- a/snforge_std/Scarb.toml
+++ b/snforge_std/Scarb.toml
@@ -5,3 +5,4 @@ edition = "2023_10"
 
 [dependencies]
 snforge_scarb_plugin = { path = "../crates/snforge-scarb-plugin" }
+assert_macros = "0.1.0"


### PR DESCRIPTION
Closes [#2388](https://github.com/foundry-rs/starknet-foundry/issues/2388#issue-2482543412)

## Introduced changes
- `snforge_std` includes new `assert_macros` package as a dependency

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
