### PR TITLE
Fix `snforge init` logic, exit smoke tests on any error

### DIFF
--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -98,7 +98,7 @@ pub fn run(project_name: &str) -> Result<()> {
             .current_dir(current_dir)
             .arg("new")
             .arg(&project_path)
-            .env("SCARB_INIT_TEST_RUNNER", "starknet-foundry")
+            .env("SCARB_INIT_TEST_RUNNER", "cairo-test")
             .run()
             .context("Failed to initialize a new project")?;
     }

--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -109,6 +109,16 @@ pub fn run(project_name: &str) -> Result<()> {
         .current_dir(&project_path)
         .manifest_path(manifest_path.clone())
         .offline()
+        .arg("remove")
+        .arg("--dev")
+        .arg("cairo_test")
+        .run()
+        .context("Failed to remove cairo_test")?;
+
+    ScarbCommand::new_with_stdio()
+        .current_dir(&project_path)
+        .manifest_path(manifest_path.clone())
+        .offline()
         .arg("add")
         .arg("--dev")
         .arg("snforge_std")

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 RPC_URL="$1"
 SNFORGE_PATH="$2"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- `snforge init` will first create a project using scarb's `cairo-test` template and then override dependencies accordingly. This is so scarb doesn't call snforge init again internally
- Added `set -e` to `smoke_tests.sh` so it fails on any error

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
