### PR TITLE
Bug fix: add missing debug info to versioned program

### DIFF
--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -77,7 +77,7 @@ pub fn maybe_save_versioned_program(
 ) -> Result<Option<VersionedProgramPath>> {
     let maybe_versioned_program_path = if execution_data_to_save.is_vm_trace_needed() {
         Some(VersionedProgramPath::save_versioned_program(
-            &test_target.sierra_program.program.clone().into_artifact(),
+            &test_target.sierra_program.clone().into(),
             test_target.tests_location,
             versioned_programs_dir,
             package_name,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->
We do not save debug info to versioned program. This is a bug as profiler need this. Also code coverage uses them

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
