### PR TITLE
Disabled `snforge_std` dependency addition in smoke test

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export DEV_DISABLE_SNFORGE_STD_DEPENDENCY=true
+
 RPC_URL="$1"
 SNFORGE_PATH="$2"
 SNCAST_PATH="$3"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes [#2414](https://github.com/foundry-rs/starknet-foundry/issues/2414#issue-2493823773)

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
