### PR TITLE
Changed `ShortString` conversion logic

### DIFF
--- a/crates/snforge-scarb-plugin/src/types.rs
+++ b/crates/snforge-scarb-plugin/src/types.rs
@@ -3,7 +3,7 @@ use crate::{
     cairo_expression::CairoExpression,
 };
 use cairo_lang_macro::Diagnostic;
-use cairo_lang_syntax::node::{ast::Expr, db::SyntaxGroup};
+use cairo_lang_syntax::node::{ast::Expr, db::SyntaxGroup, Terminal};
 use num_bigint::BigInt;
 use url::Url;
 
@@ -36,9 +36,11 @@ impl ParseFromExpr<Expr> for Felt {
         expr: &Expr,
         arg_name: &str,
     ) -> Result<Self, Diagnostic> {
+        // panic!("Dupa zbita");
         match expr {
             Expr::ShortString(string) => {
-                let string = string.string_value(db).unwrap();
+                // let string = string.string_value(db).unwrap();
+                let string = string.text(db).trim_matches('\'').to_string();
 
                 Ok(Self::ShortString(ShortString(string)))
             }
@@ -118,17 +120,22 @@ impl ParseFromExpr<Expr> for String {
         }
     }
 }
+
 impl ParseFromExpr<Expr> for ShortString {
     fn parse_from_expr<T: AttributeInfo>(
         db: &dyn SyntaxGroup,
         expr: &Expr,
         arg_name: &str,
     ) -> Result<Self, Diagnostic> {
+        // panic!("Dupa zbita");
         match expr {
-            Expr::ShortString(string) => match string.string_value(db) {
-                None => Err(T::error(format!("<{arg_name}> is not a valid string"))),
-                Some(string) => Ok(ShortString(string)),
-            },
+            // Expr::ShortString(string) => match string.string_value(db) {
+            //     None => Err(T::error(format!("<{arg_name}> is not a valid string"))),
+            //     Some(string) => Ok(ShortString(string)),
+            // },
+            Expr::ShortString(string) => {
+                Ok(ShortString(string.text(db).trim_matches('\'').to_string()))
+            }
             _ => Err(T::error(format!(
                 "<{arg_name}> invalid type, should be: double quotted string"
             ))),

--- a/crates/snforge-scarb-plugin/src/types.rs
+++ b/crates/snforge-scarb-plugin/src/types.rs
@@ -36,12 +36,9 @@ impl ParseFromExpr<Expr> for Felt {
         expr: &Expr,
         arg_name: &str,
     ) -> Result<Self, Diagnostic> {
-        // panic!("Dupa zbita");
         match expr {
             Expr::ShortString(string) => {
-                // let string = string.string_value(db).unwrap();
                 let string = string.text(db).trim_matches('\'').to_string();
-
                 Ok(Self::ShortString(ShortString(string)))
             }
             Expr::Literal(string) => {
@@ -127,14 +124,10 @@ impl ParseFromExpr<Expr> for ShortString {
         expr: &Expr,
         arg_name: &str,
     ) -> Result<Self, Diagnostic> {
-        // panic!("Dupa zbita");
         match expr {
-            // Expr::ShortString(string) => match string.string_value(db) {
-            //     None => Err(T::error(format!("<{arg_name}> is not a valid string"))),
-            //     Some(string) => Ok(ShortString(string)),
-            // },
             Expr::ShortString(string) => {
-                Ok(ShortString(string.text(db).trim_matches('\'').to_string()))
+                let string = string.text(db).trim_matches('\'').to_string();
+                Ok(ShortString(string))
             }
             _ => Err(T::error(format!(
                 "<{arg_name}> invalid type, should be: double quotted string"

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
@@ -62,6 +62,35 @@ fn work_with_expected_string() {
 }
 
 #[test]
+fn work_with_expected_string_escaped() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new(r#"(expected: "can't")"#.into());
+
+    let result = should_panic(args, item);
+
+    assert_diagnostics(&result, &[]);
+
+    assert_output(
+        &result,
+        r#"
+            fn empty_fn() {
+                if snforge_std::_cheatcode::_is_config_run() {
+                    let mut data = array![];
+
+                    snforge_std::_config_types::ShouldPanicConfig {
+                        expected: snforge_std::_config_types::Expected::ByteArray("can't")
+                    }
+                    .serialize(ref data);
+
+                    starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
+                    return;
+                }
+            }
+        "#,
+    );
+}
+
+#[test]
 fn work_with_expected_short_string() {
     let item = TokenStream::new(EMPTY_FN.into());
     let args = TokenStream::new(r"(expected: 'panic data')".into());
@@ -79,6 +108,35 @@ fn work_with_expected_short_string() {
 
                     snforge_std::_config_types::ShouldPanicConfig {
                         expected: snforge_std::_config_types::Expected::ShortString('panic data')
+                    }
+                    .serialize(ref data);
+
+                    starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
+                    return;
+                }
+            }
+        ",
+    );
+}
+
+#[test]
+fn work_with_expected_short_string_escaped() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new(r"(expected: 'can\'t')".into());
+
+    let result = should_panic(args, item);
+
+    assert_diagnostics(&result, &[]);
+
+    assert_output(
+        &result,
+        r"
+            fn empty_fn() {
+                if snforge_std::_cheatcode::_is_config_run() {
+                    let mut data = array![];
+
+                    snforge_std::_config_types::ShouldPanicConfig {
+                        expected: snforge_std::_config_types::Expected::ShortString('can\'t')
                     }
                     .serialize(ref data);
 

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
@@ -62,35 +62,6 @@ fn work_with_expected_string() {
 }
 
 #[test]
-fn work_with_expected_string_escaped() {
-    let item = TokenStream::new(EMPTY_FN.into());
-    let args = TokenStream::new(r#"(expected: "can't")"#.into());
-
-    let result = should_panic(args, item);
-
-    assert_diagnostics(&result, &[]);
-
-    assert_output(
-        &result,
-        r#"
-            fn empty_fn() {
-                if snforge_std::_cheatcode::_is_config_run() {
-                    let mut data = array![];
-
-                    snforge_std::_config_types::ShouldPanicConfig {
-                        expected: snforge_std::_config_types::Expected::ByteArray("can't")
-                    }
-                    .serialize(ref data);
-
-                    starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
-                    return;
-                }
-            }
-        "#,
-    );
-}
-
-#[test]
 fn work_with_expected_short_string() {
     let item = TokenStream::new(EMPTY_FN.into());
     let args = TokenStream::new(r"(expected: 'panic data')".into());


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes [#2410](https://github.com/orgs/foundry-rs/projects/3/views/2?pane=issue&itemId=76997279)

## Introduced changes

<!-- A brief description of the changes -->
- `#[should_panic(expceted: <felt>)]` correctly escapes single quotation mark

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
