### PR TITLE
Added missing Cairo `core` implicits to `BUILTINS`

### DIFF
--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub mod running;
 
 pub const CACHE_DIR: &str = ".snfoundry_cache";
 
-const BUILTINS: [&str; 8] = [
+const BUILTINS: [&str; 11] = [
     "Pedersen",
     "RangeCheck",
     "Bitwise",
@@ -45,6 +45,9 @@ const BUILTINS: [&str; 8] = [
     "SegmentArena",
     "GasBuiltin",
     "System",
+    "RangeCheck96",
+    "AddMod",
+    "MulMod",
 ];
 
 pub trait TestCaseFilter {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes [#2397](https://github.com/foundry-rs/starknet-foundry/issues/2397#issue-2487117976)

## Introduced changes
- Added missing implicits present in Cairo `core` but not ignored by `forge-runner`: `RangeCheck96`, `AddMod`, `MulMod`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
