### PR TITLE
Fixed `cairo-test` dependency removal logic in `snforge init`

### DIFF
--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -102,17 +102,17 @@ pub fn run(project_name: &str) -> Result<()> {
             .env("SCARB_INIT_TEST_RUNNER", "cairo-test")
             .run()
             .context("Failed to initialize a new project")?;
-    }
 
-    ScarbCommand::new_with_stdio()
-        .current_dir(&project_path)
-        .manifest_path(manifest_path.clone())
-        .offline()
-        .arg("remove")
-        .arg("--dev")
-        .arg("cairo_test")
-        .run()
-        .context("Failed to remove cairo_test")?;
+        ScarbCommand::new_with_stdio()
+            .current_dir(&project_path)
+            .manifest_path(manifest_path.clone())
+            .offline()
+            .arg("remove")
+            .arg("--dev")
+            .arg("cairo_test")
+            .run()
+            .context("Failed to remove cairo_test")?;
+    }
 
     let version = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
Closes [#2427](https://github.com/foundry-rs/starknet-foundry/issues/2427#issue-2496798112)

## Introduced changes
- Moved invocation of `scarb remove --dev cairo-test` to the place where it's logically correct

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
