### PR TITLE
Enable coverage test on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,8 @@ jobs:
       - name: nextest partition ${{ matrix.partition }}/8
         run: cargo nextest run --partition 'count:${{ matrix.partition }}/8' --archive-file 'nextest-archive.tar.zst' e2e
 
-  test-forge-init:
-    name: Test Forge / init
+  test-coverage:
+    name: Test coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +99,12 @@ jobs:
         with:
           scarb-version: "2.8.1"
       - uses: software-mansion/setup-universal-sierra-compiler@v1
-      - run: cargo test --package forge --test main e2e::running::init_new_project
+
+      - name: Install cairo-coverage
+        run: |
+          curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+
+      - run: cargo test --package forge --features scarb_2_8_1 --test main e2e::coverage::test_coverage_project
 
   test-forge-runner:
     name: Test Forge Runner

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [features]
 smoke = []
+scarb_2_8_1 = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/forge/tests/e2e/coverage.rs
+++ b/crates/forge/tests/e2e/coverage.rs
@@ -2,7 +2,7 @@ use super::common::runner::{setup_package, test_runner};
 use forge_runner::coverage_api::{COVERAGE_DIR, OUTPUT_FILE_NAME};
 
 #[test]
-#[ignore] // TODO(#2426) this will only work for scarb 2.8.0 or above
+#[cfg_attr(not(feature = "scarb_2_8_1"), ignore)]
 fn test_coverage_project() {
     let temp = setup_package("coverage_project");
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to #2426 

## Introduced changes

<!-- A brief description of the changes -->

- Removed running `init_new_project` and `init_new_project_from_scarb` tests for Scarb `2.8.1`. These tests are executed in the job `test-forge-e2e` with Scarb `2.7.0`
- Enabled running coverage test on CI