### PR TITLE
Add info for scarb packages uploads

### DIFF
--- a/crates/snforge-scarb-plugin/Scarb.toml
+++ b/crates/snforge-scarb-plugin/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
 name = "snforge_scarb_plugin"
-version = "0.1.0"
+version = "0.2.0"
 
 [cairo-plugin]

--- a/sncast_std/README.md
+++ b/sncast_std/README.md
@@ -1,0 +1,4 @@
+# sncast_std
+
+For a library reference please visit https://foundry-rs.github.io/starknet-foundry/appendix/sncast-library.html
+

--- a/sncast_std/Scarb.toml
+++ b/sncast_std/Scarb.toml
@@ -2,3 +2,8 @@
 name = "sncast_std"
 version = "0.30.0"
 edition = "2023_11"
+description = "Library used for writing deployment scripts in cairo"
+homepage = "https://foundry-rs.github.io/starknet-foundry/starknet/script.html"
+documentation = "https://foundry-rs.github.io/starknet-foundry/appendix/sncast-library.html"
+repository = "https://github.com/foundry-rs/starknet-foundry"
+license-file = "../LICENSE"

--- a/snforge_std/README.md
+++ b/snforge_std/README.md
@@ -1,0 +1,3 @@
+# snforge_std
+
+For a library reference please visit https://foundry-rs.github.io/starknet-foundry/appendix/snforge-library.html

--- a/snforge_std/Scarb.toml
+++ b/snforge_std/Scarb.toml
@@ -2,6 +2,10 @@
 name = "snforge_std"
 version = "0.30.0"
 edition = "2023_10"
+description = "Cairo testing library"
+documentation = "https://foundry-rs.github.io/starknet-foundry/appendix/snforge-library.html"
+repository = "https://github.com/foundry-rs/starknet-foundry"
+license-file = "../LICENSE"
 
 [dependencies]
 snforge_scarb_plugin = { path = "../crates/snforge-scarb-plugin" }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related to https://github.com/foundry-rs/starknet-foundry/issues/2344

This PR is a part of the stack:
--> Add missing info recommended for package uploads (This PR)
-- Add github action workflow for automatic registry uploads during release ()

## Introduced changes

<!-- A brief description of the changes -->

- Adds readmes and links to respective Scarb.tomls, so to view this metadata on the registry and supress scarb warnings
- Bump snforge_scarb_plugin version to 0.2.0, to properly reflect its version in regards to the registry. **From now on all changes made to this crate should be concluded with version bump**

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
