### PR TITLE
Remove todo for hash validation

### DIFF
--- a/crates/snforge-scarb-plugin/src/attributes/fork/block_id.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/fork/block_id.rs
@@ -78,8 +78,6 @@ impl ParseFromExpr<(BlockIdVariants, &Expr)> for BlockId {
                     BlockIdVariants::Hash.as_ref(),
                 )?;
 
-                // TODO(#1179): Add hash range validation here
-
                 Ok(Self::Hash(hash))
             }
             BlockIdVariants::Number => {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1179 

## Introduced changes

<!-- A brief description of the changes -->

Remove todo for hash validation. Block hash is calculated by [Poseidon hash](https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/#block_hash) (for more please see [implementation](https://github.com/starkware-libs/sequencer/blob/bb361ec67396660d5468fd088171913e11482708/crates/starknet_api/src/block_hash/block_hash_calculator.rs#L68)). `BlockHash` holds value of type `StarkHash` which is simply `Felt` so ultimately there's no need to add extra range validation.


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
