### PR TITLE
chore: minor doc update

### DIFF
--- a/docs/src/appendix/cheatcodes/caller_address.md
+++ b/docs/src/appendix/cheatcodes/caller_address.md
@@ -23,6 +23,6 @@ Changes the caller address for the given target.
 Cancels the `cheat_caller_address` / `start_cheat_caller_address` for the given target.
 
 ## `stop_cheat_caller_address_global`
-> `fn stop_cheat_caller_address_global(target: ContractAddress)`
+> `fn stop_cheat_caller_address_global()`
 
 Cancels the `start_cheat_caller_address_global`.


### PR DESCRIPTION
`stop_cheat_caller_address_global` doesn't take any parameters.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
