### PR TITLE
removed `target` argument in stop global cheatcodes

### DIFF
--- a/docs/src/appendix/cheatcodes/account_contract_address.md
+++ b/docs/src/appendix/cheatcodes/account_contract_address.md
@@ -23,6 +23,6 @@ Changes the address of an account which the transaction originates from, for the
 Cancels the `cheat_account_contract_address` / `start_cheat_account_contract_address` for the given target.
 
 ## `stop_cheat_account_contract_address_global`
-> `fn stop_cheat_account_contract_address_global(target: ContractAddress)`
+> `fn stop_cheat_account_contract_address_global()`
 
 Cancels the `start_cheat_account_contract_address_global`.

--- a/docs/src/appendix/cheatcodes/account_deployment_data.md
+++ b/docs/src/appendix/cheatcodes/account_deployment_data.md
@@ -23,6 +23,6 @@ Changes the transaction account deployment data for the given target.
 Cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for the given target.
 
 ## `stop_cheat_account_deployment_data_global`
-> `fn stop_cheat_account_deployment_data_global(target: ContractAddress)`
+> `fn stop_cheat_account_deployment_data_global()`
 
 Cancels the `start_cheat_account_deployment_data_global`.

--- a/docs/src/appendix/cheatcodes/chain_id.md
+++ b/docs/src/appendix/cheatcodes/chain_id.md
@@ -23,6 +23,6 @@ Changes the transaction chain_id for the given target.
 Cancels the `cheat_chain_id` / `start_cheat_chain_id` for the given target.
 
 ## `stop_cheat_chain_id_global`
-> `fn stop_cheat_chain_id_global(target: ContractAddress)`
+> `fn stop_cheat_chain_id_global()`
 
 Cancels the `start_cheat_chain_id_global`.

--- a/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/fee_data_availability_mode.md
@@ -23,6 +23,6 @@ Changes the transaction fee data availability mode for the given target.
 Cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availability_mode` for the given target.
 
 ## `stop_cheat_fee_data_availability_mode_global`
-> `fn stop_cheat_fee_data_availability_mode_global(target: ContractAddress)`
+> `fn stop_cheat_fee_data_availability_mode_global()`
 
 Cancels the `start_cheat_fee_data_availability_mode_global`.

--- a/docs/src/appendix/cheatcodes/max_fee.md
+++ b/docs/src/appendix/cheatcodes/max_fee.md
@@ -23,6 +23,6 @@ Changes the transaction max fee for the given target.
 Cancels the `cheat_max_fee` / `start_cheat_max_fee` for the given target.
 
 ## `stop_cheat_max_fee_global`
-> `fn stop_cheat_max_fee_global(target: ContractAddress)`
+> `fn stop_cheat_max_fee_global()`
 
 Cancels the `start_cheat_max_fee_global`.

--- a/docs/src/appendix/cheatcodes/nonce.md
+++ b/docs/src/appendix/cheatcodes/nonce.md
@@ -23,6 +23,6 @@ Changes the transaction nonce for the given target.
 Cancels the `cheat_nonce` / `start_cheat_nonce` for the given target.
 
 ## `stop_cheat_nonce_global`
-> `fn stop_cheat_nonce_global(target: ContractAddress)`
+> `fn stop_cheat_nonce_global()`
 
 Cancels the `start_cheat_nonce_global`.

--- a/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
+++ b/docs/src/appendix/cheatcodes/nonce_data_availability_mode.md
@@ -23,6 +23,6 @@ Changes the transaction nonce data availability mode for the given target.
 Cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_availability_mode` for the given target.
 
 ## `stop_cheat_nonce_data_availability_mode_global`
-> `fn stop_cheat_nonce_data_availability_mode_global(target: ContractAddress)`
+> `fn stop_cheat_nonce_data_availability_mode_global()`
 
 Cancels the `start_cheat_nonce_data_availability_mode_global`.

--- a/docs/src/appendix/cheatcodes/paymaster_data.md
+++ b/docs/src/appendix/cheatcodes/paymaster_data.md
@@ -23,6 +23,6 @@ Changes the transaction paymaster data for the given target.
 Cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for the given target.
 
 ## `stop_cheat_paymaster_data_global`
-> `fn stop_cheat_paymaster_data_global(target: ContractAddress)`
+> `fn stop_cheat_paymaster_data_global()`
 
 Cancels the `start_cheat_paymaster_data_global`.

--- a/docs/src/appendix/cheatcodes/resource_bounds.md
+++ b/docs/src/appendix/cheatcodes/resource_bounds.md
@@ -23,6 +23,6 @@ Changes the transaction resource bounds for the given target.
 Cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for the given target.
 
 ## `stop_cheat_resource_bounds_global`
-> `fn stop_cheat_resource_bounds_global(target: ContractAddress)`
+> `fn stop_cheat_resource_bounds_global()`
 
 Cancels the `start_cheat_resource_bounds_global`.

--- a/docs/src/appendix/cheatcodes/sequencer_address.md
+++ b/docs/src/appendix/cheatcodes/sequencer_address.md
@@ -23,6 +23,6 @@ Changes the sequencer address for the given target.
 Cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for the given target.
 
 ## `stop_cheat_sequencer_address_global`
-> `fn stop_cheat_sequencer_address_global(target: ContractAddress)`
+> `fn stop_cheat_sequencer_address_global()`
 
 Cancels the `start_cheat_sequencer_address_global`.

--- a/docs/src/appendix/cheatcodes/signature.md
+++ b/docs/src/appendix/cheatcodes/signature.md
@@ -23,6 +23,6 @@ Changes the transaction signature for the given target.
 Cancels the `cheat_signature` / `start_cheat_signature` for the given target.
 
 ## `stop_cheat_signature_global`
-> `fn stop_cheat_signature_global(target: ContractAddress)`
+> `fn stop_cheat_signature_global()`
 
 Cancels the `start_cheat_signature_global`.

--- a/docs/src/appendix/cheatcodes/tip.md
+++ b/docs/src/appendix/cheatcodes/tip.md
@@ -23,6 +23,6 @@ Changes the transaction tip for the given target.
 Cancels the `cheat_tip` / `start_cheat_tip` for the given target.
 
 ## `stop_cheat_tip_global`
-> `fn stop_cheat_tip_global(target: ContractAddress)`
+> `fn stop_cheat_tip_global()`
 
 Cancels the `start_cheat_tip_global`.

--- a/docs/src/appendix/cheatcodes/transaction_hash.md
+++ b/docs/src/appendix/cheatcodes/transaction_hash.md
@@ -23,6 +23,6 @@ Changes the transaction hash for the given target.
 Cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for the given target.
 
 ## `stop_cheat_transaction_hash_global`
-> `fn stop_cheat_transaction_hash_global(target: ContractAddress)`
+> `fn stop_cheat_transaction_hash_global()`
 
 Cancels the `start_cheat_transaction_hash_global`.

--- a/docs/src/appendix/cheatcodes/transaction_version.md
+++ b/docs/src/appendix/cheatcodes/transaction_version.md
@@ -23,6 +23,6 @@ Changes the transaction version for the given target.
 Cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for the given target.
 
 ## `stop_cheat_transaction_version_global`
-> `fn stop_cheat_transaction_version_global(target: ContractAddress)`
+> `fn stop_cheat_transaction_version_global()`
 
 Cancels the `start_cheat_transaction_version_global`.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- docs on cheatcodes usage is more accurate

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
