### PR TITLE
Change scarb plugin name in Cargo manifest to match the Scarb manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
       - uses: software-mansion/setup-scarb@v1.3.3
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - name: Run Forge Scarb Plugin tests
-        run: cargo test --release -p snforge-scarb-plugin
+        run: cargo test --release -p snforge_scarb_plugin
 
   test-cast:
     name: Test Cast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "snforge-scarb-plugin"
+name = "snforge_scarb_plugin"
 version = "0.32.0"
 dependencies = [
  "cairo-lang-diagnostics",

--- a/crates/snforge-scarb-plugin/Cargo.toml
+++ b/crates/snforge-scarb-plugin/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "snforge-scarb-plugin"
+name = "snforge_scarb_plugin"
 version.workspace = true
 edition.workspace = true
 publish = false


### PR DESCRIPTION
This is a warning now, but may be enforced in future Scarb releases. 