### PR TITLE
Add missing `pub` to storage field in testing internals

### DIFF
--- a/docs/listings/snforge_overview/crates/testing_contract_internals/src/basic_example.cairo
+++ b/docs/listings/snforge_overview/crates/testing_contract_internals/src/basic_example.cairo
@@ -5,7 +5,7 @@ trait IContract<TContractState> {}
 pub mod Contract {
     #[storage]
     pub struct Storage {
-        balance: felt252,
+        pub balance: felt252,
     }
 
     #[generate_trait]


### PR DESCRIPTION
## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md` <-- **Is this necessary for docs change?**
