### PR TITLE
feat: add specific directories to .gitignore when calling snforge init

### DIFF
--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -142,6 +142,9 @@ fn extend_gitignore(path: &Path) -> Result<()> {
         .append(true)
         .open(path.join(".gitignore"))?;
     writeln!(file, ".snfoundry_cache/")?;
+    writeln!(file, "snfoundry_trace/")?;
+    writeln!(file, ".snfoundry_versioned_programs/")?;
+    writeln!(file, "coverage/")?;
 
     Ok(())
 }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -741,7 +741,7 @@ fn validate_init(temp: &TempDir, validate_snforge_std: bool) {
         .snfoundry_cache/
         snfoundry_trace/ 
         .snfoundry_versioned_programs/
-        coverage/∅
+        coverage/
         "#,
     )
     .trim_end()

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -726,13 +726,26 @@ pub fn append_to_path_var(path: &Path) -> OsString {
 
 fn validate_init(temp: &TempDir, validate_snforge_std: bool) {
     let manifest_path = temp.join("test_name/Scarb.toml");
+    let gitignore_path = temp.join("test_name/.gitignore");
     let scarb_toml = fs::read_to_string(manifest_path.clone()).unwrap();
+    let gitignore_content = fs::read_to_string(gitignore_path.clone()).unwrap();
 
     let snforge_std_assert = if validate_snforge_std {
         "\nsnforge_std = { git = \"https://github.com/foundry-rs/starknet-foundry\", tag = \"v[..]\" }"
     } else {
         ""
     };
+
+    let expected_gitignore = formatdoc!(
+        r#"
+        .snfoundry_cache/
+        snfoundry_trace/ 
+        .snfoundry_versioned_programs/
+        coverage/
+        "#,
+    )
+    .trim_end()
+    .to_string();
 
     let expected = formatdoc!(
         r#"
@@ -761,6 +774,7 @@ fn validate_init(temp: &TempDir, validate_snforge_std: bool) {
     .to_string()+ "\n";
 
     assert_matches(&expected, &scarb_toml);
+    assert_matches(&expected_gitignore, &gitignore_content);
 
     let mut scarb_toml = DocumentMut::from_str(&scarb_toml).unwrap();
 

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -741,7 +741,7 @@ fn validate_init(temp: &TempDir, validate_snforge_std: bool) {
         .snfoundry_cache/
         snfoundry_trace/ 
         .snfoundry_versioned_programs/
-        coverage/
+        coverage/∅
         "#,
     )
     .trim_end()


### PR DESCRIPTION
# Update `.gitignore` in `snforge init` to Include Additional Files

## Description

This PR modifies the `snforge init` functionality to ensure that the `.gitignore` file generated by `snforge` includes additional paths for files that may be created during its execution. These files are often specific to `snforge` and can otherwise be mistakenly committed to version control.

Closes #2298

## Changes

The following updates were made to `snforge init`:

- Modified the code to append the following paths to the `.gitignore`:
  - `snfoundry_trace`
  - `.snfoundry_cache`
  - `.snfoundry_versioned_programs`
  - `coverage`
  -  Added end-to-end (e2e) tests to validate that running `snforge init <project>` now generates a `.gitignore` file containing all required paths.

## Checklist

- [x] Modify `snforge init` to include additional files in `.gitignore`.
- [x] Add e2e tests to confirm changes are effective.
- [x] Verify that `snforge init <project>` correctly generates a `.gitignore` with all specified paths.
