### PR TITLE
Don't put Box<CairoRunError> into RunnerError::CairoRunError()

### DIFF
--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -132,7 +132,7 @@ pub fn run_for_test_case(
                 maybe_versioned_program_path,
                 send,
             )
-            .await??;
+            .await?;
             Ok(AnyTestCaseSummary::Single(res))
         })
     } else {
@@ -214,7 +214,7 @@ fn run_with_fuzzing(
 
         let mut results = vec![];
         while let Some(task) = tasks.next().await {
-            let result = task??;
+            let result = task?;
 
             results.push(result.clone());
 

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -3,10 +3,11 @@ use crate::forge_config::{RuntimeConfig, TestRunnerConfig};
 use crate::gas::calculate_used_gas;
 use crate::package_tests::with_config_resolved::{ResolvedForkConfig, TestCaseWithResolvedConfig};
 use crate::test_case_summary::{Single, TestCaseSummary};
-use anyhow::{bail, ensure, Result};
+use anyhow::{ensure, Result};
 use blockifier::execution::entry_point::EntryPointExecutionContext;
 use blockifier::state::cached_state::CachedState;
-use cairo_lang_runner::{RunResult, RunnerError, SierraCasmRunner};
+use cairo_lang_runner::{RunResult, SierraCasmRunner};
+use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use cairo_vm::Felt252;
 use camino::Utf8Path;
@@ -50,13 +51,13 @@ pub fn run_test(
     test_runner_config: Arc<TestRunnerConfig>,
     maybe_versioned_program_path: Arc<Option<VersionedProgramPath>>,
     send: Sender<()>,
-) -> JoinHandle<Result<TestCaseSummary<Single>>> {
+) -> JoinHandle<TestCaseSummary<Single>> {
     tokio::task::spawn_blocking(move || {
         // Due to the inability of spawn_blocking to be abruptly cancelled,
         // a channel is used to receive information indicating
         // that the execution of the task is no longer necessary.
         if send.is_closed() {
-            return Ok(TestCaseSummary::Skipped {});
+            return TestCaseSummary::Skipped {};
         }
         let run_result = run_test_case(
             vec![],
@@ -69,7 +70,7 @@ pub fn run_test(
         // remove it after improve exit-first tests
         // issue #1043
         if send.is_closed() {
-            return Ok(TestCaseSummary::Skipped {});
+            return TestCaseSummary::Skipped {};
         }
 
         extract_test_case_summary(
@@ -90,13 +91,13 @@ pub(crate) fn run_fuzz_test(
     maybe_versioned_program_path: Arc<Option<VersionedProgramPath>>,
     send: Sender<()>,
     fuzzing_send: Sender<()>,
-) -> JoinHandle<Result<TestCaseSummary<Single>>> {
+) -> JoinHandle<TestCaseSummary<Single>> {
     tokio::task::spawn_blocking(move || {
         // Due to the inability of spawn_blocking to be abruptly cancelled,
         // a channel is used to receive information indicating
         // that the execution of the task is no longer necessary.
         if send.is_closed() | fuzzing_send.is_closed() {
-            return Ok(TestCaseSummary::Skipped {});
+            return TestCaseSummary::Skipped {};
         }
 
         let run_result = run_test_case(
@@ -110,7 +111,7 @@ pub(crate) fn run_fuzz_test(
         // remove it after improve exit-first tests
         // issue #1043
         if send.is_closed() {
-            return Ok(TestCaseSummary::Skipped {});
+            return TestCaseSummary::Skipped {};
         }
 
         extract_test_case_summary(
@@ -124,7 +125,7 @@ pub(crate) fn run_fuzz_test(
 }
 
 pub struct RunResultWithInfo {
-    pub(crate) run_result: Result<RunResult, RunnerError>,
+    pub(crate) run_result: Result<RunResult, Box<CairoRunError>>,
     pub(crate) call_trace: Rc<RefCell<CallTrace>>,
     pub(crate) gas_used: u128,
     pub(crate) used_resources: UsedResources,
@@ -242,7 +243,7 @@ pub fn run_test_case(
 
                 Ok((gas_counter, runner.relocated_memory, value))
             }
-            Err(err) => Err(RunnerError::CairoRunError(err)),
+            Err(err) => Err(err),
         };
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
@@ -277,11 +278,11 @@ fn extract_test_case_summary(
     args: Vec<Felt252>,
     contracts_data: &ContractsData,
     maybe_versioned_program_path: &Option<VersionedProgramPath>,
-) -> Result<TestCaseSummary<Single>> {
+) -> TestCaseSummary<Single> {
     match run_result {
         Ok(result_with_info) => {
             match result_with_info.run_result {
-                Ok(run_result) => Ok(TestCaseSummary::from_run_result_and_info(
+                Ok(run_result) => TestCaseSummary::from_run_result_and_info(
                     run_result,
                     case,
                     args,
@@ -290,9 +291,9 @@ fn extract_test_case_summary(
                     &result_with_info.call_trace,
                     contracts_data,
                     maybe_versioned_program_path,
-                )),
+                ),
                 // CairoRunError comes from VirtualMachineError which may come from HintException that originates in TestExecutionSyscallHandler
-                Err(RunnerError::CairoRunError(error)) => Ok(TestCaseSummary::Failed {
+                Err(error) => TestCaseSummary::Failed {
                     name: case.name.clone(),
                     msg: Some(format!(
                         "\n    {}\n",
@@ -300,18 +301,17 @@ fn extract_test_case_summary(
                     )),
                     arguments: args,
                     test_statistics: (),
-                }),
-                Err(err) => bail!(err),
+                },
             }
         }
         // `ForkStateReader.get_block_info`, `get_fork_state_reader, `calculate_used_gas` may return an error
         // `available_gas` may be specified with Scarb ~2.4
-        Err(error) => Ok(TestCaseSummary::Failed {
+        Err(error) => TestCaseSummary::Failed {
             name: case.name.clone(),
             msg: Some(error.to_string()),
             arguments: args,
             test_statistics: (),
-        }),
+        },
     }
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

Some unnecessary code that i found during working on https://github.com/foundry-rs/starknet-foundry/issues/2468

- Don't put `Box<CairoRunError>` into `RunnerError::CairoRunError()` as it fools type system that other variants of `RunnerError` could be return 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
