### PR TITLE
Fix string escapes in snforge plugin

### DIFF
--- a/crates/snforge-scarb-plugin/src/attributes/should_panic/expected.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/should_panic/expected.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{Felt, ParseFromExpr},
 };
 use cairo_lang_macro::Diagnostic;
-use cairo_lang_syntax::node::{ast::Expr, db::SyntaxGroup};
+use cairo_lang_syntax::node::{ast::Expr, db::SyntaxGroup, Terminal};
 
 #[derive(Debug, Clone, Default)]
 pub enum Expected {
@@ -58,7 +58,7 @@ impl ParseFromExpr<Expr> for Expected {
                 ))
             }
             Expr::String(string) => {
-                let string = string.string_value(db).unwrap();
+                let string = string.text(db).trim_matches('"').to_string();
 
                 Ok(Self::ByteArray(string))
             }

--- a/crates/snforge-scarb-plugin/src/types.rs
+++ b/crates/snforge-scarb-plugin/src/types.rs
@@ -107,10 +107,7 @@ impl ParseFromExpr<Expr> for String {
         arg_name: &str,
     ) -> Result<Self, Diagnostic> {
         match expr {
-            Expr::String(string) => match string.string_value(db) {
-                None => Err(T::error(format!("<{arg_name}> is not a valid string"))),
-                Some(string) => Ok(string),
-            },
+            Expr::String(string) => Ok(string.text(db).trim_matches('"').to_string()),
             _ => Err(T::error(format!(
                 "<{arg_name}> invalid type, should be: double quotted string"
             ))),

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
@@ -62,6 +62,35 @@ fn work_with_expected_string() {
 }
 
 #[test]
+fn work_with_expected_string_escaped() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new(r#"(expected: "can\"t \0 null byte")"#.into());
+
+    let result = should_panic(args, item);
+
+    assert_diagnostics(&result, &[]);
+
+    assert_output(
+        &result,
+        r#"
+            fn empty_fn() {
+                if snforge_std::_cheatcode::_is_config_run() {
+                    let mut data = array![];
+
+                    snforge_std::_config_types::ShouldPanicConfig {
+                        expected: snforge_std::_config_types::Expected::ByteArray("can\"t \0 null byte")
+                    }
+                    .serialize(ref data);
+
+                    starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
+                    return;
+                }
+            }
+        "#,
+    );
+}
+
+#[test]
 fn work_with_expected_short_string() {
     let item = TokenStream::new(EMPTY_FN.into());
     let args = TokenStream::new(r"(expected: 'panic data')".into());


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes ##2633

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
