### PR TITLE
Update OpenZeppelin UDC link

### DIFF
--- a/docs/src/starknet/deploy.md
+++ b/docs/src/starknet/deploy.md
@@ -4,7 +4,7 @@
 
 Starknet Foundry `sncast` supports deploying smart contracts to a given network with the `sncast deploy` command.
 
-It works by invoking a [Universal Deployer Contract](https://docs.openzeppelin.com/contracts-cairo/0.6.1/udc), which deploys the contract with the given class hash and constructor arguments.
+It works by invoking a [Universal Deployer Contract](https://docs.openzeppelin.com/contracts-cairo/0.19.0/udc), which deploys the contract with the given class hash and constructor arguments.
 
 For detailed CLI description, see [deploy command reference](../appendix/sncast/deploy.md).
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Updated OpenZeppelin UDC link in the docs - the old subpage which was pointed by link didn't exist anymore. Due to it CI failed (as in [this example](https://github.com/foundry-rs/starknet-foundry/pull/2658/checks)).

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
