### PR TITLE
Add scheduled workflow to test against different Scarb versions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,128 @@
+name: Scheduled
+
+on:
+  pull_request:
+    paths:
+      - scripts/get_scarb_versions.sh
+      - .github/workflows/scheduled.yml
+  schedule:
+    - cron: '0 0 * * 3,6'
+
+jobs:
+  get-scarb-versions:
+    name: Get Scarb versions
+    outputs:
+      versions: ${{ steps.get_versions.outputs.versions }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+        with:
+          tool_versions: |
+            scarb latest
+
+      - name: Get versions
+        id: get_versions
+        run: |
+          scarb_versions=$(./scripts/get_scarb_versions.sh)
+          echo ${scarb_versions[@]}
+          echo "versions=[${scarb_versions[@]}]" >> "$GITHUB_OUTPUT"
+
+  test-forge-unit-and-integration:
+    runs-on: ubuntu-latest
+    needs: get-scarb-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.get-scarb-versions.outputs.versions) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: ${{ matrix.version }}
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+      - name: Install cairo-profiler
+        run: |
+          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+
+      - run: cargo test --release --lib -p forge
+      - run: cargo test --release -p forge integration
+
+  test-forge-e2e:
+    runs-on: ubuntu-latest
+    needs: get-scarb-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.get-scarb-versions.outputs.versions) }}
+
+    steps:
+      - name: Extract branch name
+        if: github.event_name != 'pull_request'
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
+
+      - name: Extract branch name on pull request
+        if: github.event_name == 'pull_request'
+        run: echo "BRANCH_NAME=$(echo $GITHUB_HEAD_REF)" >> $GITHUB_ENV
+
+      - name: Extract repo name and owner
+        if: github.event_name != 'pull_request'
+        run: echo "REPO_NAME=$(echo ${{ github.repository }}.git)" >> $GITHUB_ENV
+
+      - name: Extract repo name and owner on pull request
+        if: github.event_name == 'pull_request'
+        run: echo "REPO_NAME=$(echo ${{ github.event.pull_request.head.repo.full_name }}.git)" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: ${{ matrix.version }}
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+      - name: Install cairo-profiler
+        run: |
+          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+      - uses: taiki-e/install-action@nextest
+
+      - run: cargo test --release -p forge e2e
+
+  test-cast:
+    runs-on: ubuntu-latest
+    needs: get-scarb-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.get-scarb-versions.outputs.versions) }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: ${{ matrix.version }}
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+
+      - name: Install starknet-devnet-rs
+        run: ./scripts/install_devnet.sh
+
+      - run: cargo test --release -p sncast
+
+  notify_if_failed:
+    runs-on: ubuntu-latest
+    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
+    needs: [ test-forge-unit-and-integration, test-forge-e2e, test-cast ]
+    steps:
+      - name: Notify that the workflow has failed
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_SCHEDULED_TESTS_FAILURE_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -44,9 +44,6 @@ jobs:
         with:
           scarb-version: ${{ matrix.version }}
       - uses: software-mansion/setup-universal-sierra-compiler@v1
-      - name: Install cairo-profiler
-        run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
 
       - run: cargo test --release --lib -p forge
       - run: cargo test --release -p forge integration

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,7 +6,7 @@ on:
       - scripts/get_scarb_versions.sh
       - .github/workflows/scheduled.yml
   schedule:
-    - cron: '0 0 * * 3,6'
+    - cron: '0 0 * * 3,7'
 
 jobs:
   get-scarb-versions:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -6,7 +6,7 @@ on:
       - scripts/get_scarb_versions.sh
       - .github/workflows/scheduled.yml
   schedule:
-    - cron: '0 0 * * 3,7'
+    - cron: '0 0 * * 3,0'
 
 jobs:
   get-scarb-versions:

--- a/scripts/get_scarb_versions.sh
+++ b/scripts/get_scarb_versions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# This script is used to find the following Scarb versions:
+# The current major.minor version along with all its patch versions
+# The latest patch versions for the two versions preceding the current one
+
+function get_all_patch_versions() {
+  # Omit version 2.8.0 as it has a bug when using the `assert_macros` package
+  asdf list all scarb $1 | grep -v "rc" | grep -v "2.8.0"
+}
+
+function get_latest_patch_version() {
+  get_all_patch_versions $1 | sort -u | tail -1
+}
+
+major_minor_versions=($(get_all_patch_versions | cut -d . -f 1,2 | sort -u | tail -3))
+
+scarb_versions=()
+
+if [[ ${major_minor_versions[0]} != "2.6" ]]; then
+  scarb_versions+=($(get_latest_patch_version ${major_minor_versions[0]}))
+fi
+
+scarb_versions+=($(get_latest_patch_version ${major_minor_versions[1]}))
+
+scarb_versions+=($(get_all_patch_versions ${major_minor_versions[2]}))
+
+echo \"$(echo ${scarb_versions[@]} | sed 's/ /", "/g')\"

--- a/scripts/get_scarb_versions.sh
+++ b/scripts/get_scarb_versions.sh
@@ -11,10 +11,10 @@ function get_all_patch_versions() {
 }
 
 function get_latest_patch_version() {
-  get_all_patch_versions $1 | sort -u | tail -1
+  get_all_patch_versions $1 | sort -uV | tail -1
 }
 
-major_minor_versions=($(get_all_patch_versions | cut -d . -f 1,2 | sort -u | tail -3))
+major_minor_versions=($(get_all_patch_versions | cut -d . -f 1,2 | sort -uV | tail -3))
 
 scarb_versions=()
 

--- a/scripts/get_scarb_versions.sh
+++ b/scripts/get_scarb_versions.sh
@@ -7,23 +7,23 @@ set -e
 
 function get_all_patch_versions() {
   # Omit version 2.8.0 as it has a bug when using the `assert_macros` package
-  asdf list all scarb $1 | grep -v "rc" | grep -v "2.8.0"
+  asdf list all scarb "$1" | grep -v "rc" | grep -v "2.8.0"
 }
 
 function get_latest_patch_version() {
-  get_all_patch_versions $1 | sort -uV | tail -1
+  get_all_patch_versions "$1" | sort -uV | tail -1
 }
 
 major_minor_versions=($(get_all_patch_versions | cut -d . -f 1,2 | sort -uV | tail -3))
 
-scarb_versions=()
+declare -a scarb_versions
 
 if [[ ${major_minor_versions[0]} != "2.6" ]]; then
-  scarb_versions+=($(get_latest_patch_version ${major_minor_versions[0]}))
+  scarb_versions+=($(get_latest_patch_version "${major_minor_versions[0]}"))
 fi
 
-scarb_versions+=($(get_latest_patch_version ${major_minor_versions[1]}))
+scarb_versions+=($(get_latest_patch_version "${major_minor_versions[1]}"))
 
-scarb_versions+=($(get_all_patch_versions ${major_minor_versions[2]}))
+scarb_versions+=($(get_all_patch_versions "${major_minor_versions[2]}"))
 
-echo \"$(echo ${scarb_versions[@]} | sed 's/ /", "/g')\"
+printf '"%s", ' "${scarb_versions[@]}" | sed 's/, $/\n/'


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2578

## Introduced changes

<!-- A brief description of the changes -->

- Added a scheduled workflow to run all unit, integration and e2e tests for `sncast` and `snforge` for different Scarb versions, every Wednesday and Sunday at 0:00 UTC

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
