### PR TITLE
Make rpc url optional for `show-config` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - Changed return type of `declare` in Cairo Deployment Scripts so it can handle already declared contracts without failing
+- Allow using `show-config` command without providing rpc url
 
 ## [0.33.0] - 2024-11-04
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -586,7 +586,7 @@ async fn run_async_command(
         },
 
         Commands::ShowConfig(show) => {
-            let provider = show.rpc.get_provider(&config).await?;
+            let provider = show.rpc.get_provider(&config).await.ok();
 
             let result =
                 starknet_commands::show_config::show_config(&show, &provider, config, cli.profile)

--- a/crates/sncast/src/response/print.rs
+++ b/crates/sncast/src/response/print.rs
@@ -75,6 +75,7 @@ impl From<Value> for OutputValue {
                     .collect(),
             ),
             Value::String(s) => OutputValue::String(s.to_string()),
+            Value::Bool(b) => OutputValue::String(b.to_string()),
             s => panic!("{s:?} cannot be auto-serialized to output"),
         }
     }

--- a/crates/sncast/src/response/structs.rs
+++ b/crates/sncast/src/response/structs.rs
@@ -107,13 +107,14 @@ impl CommandResponse for MulticallNewResponse {}
 #[derive(Serialize)]
 pub struct ShowConfigResponse {
     pub profile: Option<String>,
-    pub chain_id: String,
+    pub chain_id: Option<String>,
     pub rpc_url: Option<String>,
     pub account: Option<String>,
     pub accounts_file_path: Option<Utf8PathBuf>,
     pub keystore: Option<Utf8PathBuf>,
     pub wait_timeout: Option<Decimal>,
     pub wait_retry_interval: Option<Decimal>,
+    pub show_explorer_links: bool,
 }
 impl CommandResponse for ShowConfigResponse {}
 

--- a/crates/sncast/src/starknet_commands/show_config.rs
+++ b/crates/sncast/src/starknet_commands/show_config.rs
@@ -18,12 +18,17 @@ pub struct ShowConfig {
 #[allow(clippy::ptr_arg)]
 pub async fn show_config(
     show: &ShowConfig,
-    provider: &JsonRpcClient<HttpTransport>,
+    provider: &Option<JsonRpcClient<HttpTransport>>,
     cast_config: CastConfig,
     profile: Option<String>,
 ) -> Result<ShowConfigResponse> {
-    let chain_id_field = get_chain_id(provider).await?;
-    let chain_id = chain_id_to_network_name(chain_id_field);
+    let chain_id = if let Some(provider) = provider {
+        let chain_id_field = get_chain_id(provider).await?;
+        Some(chain_id_to_network_name(chain_id_field))
+    } else {
+        None
+    };
+
     let rpc_url = Some(show.rpc.url.clone().unwrap_or(cast_config.url)).filter(|p| !p.is_empty());
     let account = Some(cast_config.account).filter(|p| !p.is_empty());
     let mut accounts_file_path =
@@ -44,5 +49,6 @@ pub async fn show_config(
         keystore,
         wait_timeout: wait_timeout.map(|x| Decimal(u64::from(x))),
         wait_retry_interval: wait_retry_interval.map(|x| Decimal(u64::from(x))),
+        show_explorer_links: cast_config.show_explorer_links,
     })
 }

--- a/crates/sncast/tests/data/files/correct_snfoundry.toml
+++ b/crates/sncast/tests/data/files/correct_snfoundry.toml
@@ -25,3 +25,9 @@ account = "user3"
 [sncast.profile5]
 url = "http://127.0.0.1:5055/rpc"
 account = "user8"
+
+[sncast.profile6]
+accounts-file = "/path/to/account.json"
+account = "user1"
+wait-params = { timeout = 500, retry-interval = 10 }
+show-explorer-links = false

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -15,6 +15,7 @@ async fn test_show_config_from_snfoundry_toml() {
         accounts_file_path: ../account-file
         chain_id: alpha-sepolia
         rpc_url: {}
+        show_explorer_links: true
         wait_retry_interval: 5
         wait_timeout: 300
     ", URL});
@@ -44,6 +45,7 @@ async fn test_show_config_from_cli() {
         chain_id: alpha-sepolia
         keystore: ../keystore
         rpc_url: {}
+        show_explorer_links: true
         wait_retry_interval: 1
         wait_timeout: 2
     ", URL});
@@ -63,6 +65,7 @@ async fn test_show_config_from_cli_and_snfoundry_toml() {
         chain_id: alpha-sepolia
         profile: profile2
         rpc_url: {}
+        show_explorer_links: true
         wait_retry_interval: 5
         wait_timeout: 300
     ", URL});
@@ -82,6 +85,7 @@ async fn test_show_config_when_no_keystore() {
         chain_id: alpha-sepolia
         profile: profile4
         rpc_url: {}
+        show_explorer_links: true
         wait_retry_interval: 5
         wait_timeout: 300
     ", URL});
@@ -101,7 +105,26 @@ async fn test_show_config_when_keystore() {
         keystore: ../keystore
         profile: profile3
         rpc_url: {}
+        show_explorer_links: true
         wait_retry_interval: 5
         wait_timeout: 300
     ", URL});
+}
+
+#[tokio::test]
+async fn test_show_config_no_url() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None).unwrap();
+    let args = vec!["--profile", "profile6", "show-config"];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+
+    snapbox.assert().success().stdout_eq(formatdoc! {r"
+        command: show-config
+        account: user1
+        accounts_file_path: /path/to/account.json
+        profile: profile6
+        show_explorer_links: false
+        wait_retry_interval: 10
+        wait_timeout: 500
+    "});
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2644 

## Introduced changes

<!-- A brief description of the changes -->

- Do not require rpc url for `show-config` command to work
- Added missing `show_explorer_links` field to the `ShowConfigResponse`

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
