### PR TITLE
Catch non provider errors in sncast commands

### DIFF
--- a/crates/sncast/src/response/errors.rs
+++ b/crates/sncast/src/response/errors.rs
@@ -4,9 +4,6 @@ use conversions::serde::serialize::CairoSerialize;
 
 use conversions::byte_array::ByteArray;
 
-use starknet::core::types::StarknetError::{
-    ContractError, TransactionExecutionError, ValidationFailure,
-};
 use starknet::core::types::{ContractErrorData, StarknetError, TransactionExecutionErrorData};
 use starknet::providers::ProviderError;
 use thiserror::Error;
@@ -111,15 +108,17 @@ impl From<StarknetError> for SNCastStarknetError {
             StarknetError::InvalidTransactionIndex => SNCastStarknetError::InvalidTransactionIndex,
             StarknetError::ClassHashNotFound => SNCastStarknetError::ClassHashNotFound,
             StarknetError::TransactionHashNotFound => SNCastStarknetError::TransactionHashNotFound,
-            ContractError(err) => SNCastStarknetError::ContractError(err),
-            TransactionExecutionError(err) => SNCastStarknetError::TransactionExecutionError(err),
+            StarknetError::ContractError(err) => SNCastStarknetError::ContractError(err),
+            StarknetError::TransactionExecutionError(err) => {
+                SNCastStarknetError::TransactionExecutionError(err)
+            }
             StarknetError::ClassAlreadyDeclared => SNCastStarknetError::ClassAlreadyDeclared,
             StarknetError::InvalidTransactionNonce => SNCastStarknetError::InvalidTransactionNonce,
             StarknetError::InsufficientMaxFee => SNCastStarknetError::InsufficientMaxFee,
             StarknetError::InsufficientAccountBalance => {
                 SNCastStarknetError::InsufficientAccountBalance
             }
-            ValidationFailure(err) => {
+            StarknetError::ValidationFailure(err) => {
                 SNCastStarknetError::ValidationFailure(ByteArray::from(err.as_str()))
             }
             StarknetError::CompilationFailed => SNCastStarknetError::CompilationFailed,

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -150,6 +150,6 @@ pub async fn declare(
             }))
         }
         Err(Provider(error)) => Err(StarknetCommandError::ProviderError(error.into())),
-        _ => Err(anyhow!("Unknown RPC error").into()),
+        Err(error) => Err(anyhow!(format!("Unexpected error occurred: {error}")).into()),
     }
 }

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -140,6 +140,6 @@ pub async fn deploy(
         .await
         .map_err(StarknetCommandError::from),
         Err(Provider(error)) => Err(StarknetCommandError::ProviderError(error.into())),
-        _ => Err(anyhow!("Unknown RPC error").into()),
+        Err(error) => Err(anyhow!(format!("Unexpected error occurred: {error}")).into()),
     }
 }

--- a/crates/sncast/src/starknet_commands/invoke.rs
+++ b/crates/sncast/src/starknet_commands/invoke.rs
@@ -118,6 +118,6 @@ pub async fn execute_calls(
         .await
         .map_err(StarknetCommandError::from),
         Err(Provider(error)) => Err(StarknetCommandError::ProviderError(error.into())),
-        _ => Err(anyhow!("Unknown RPC error").into()),
+        Err(error) => Err(anyhow!(format!("Unexpected error occurred: {error}")).into()),
     }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2536 

## Introduced changes

<!-- A brief description of the changes -->

- Catch errors that can occur before sending the transaction. They are very unlikely to happen, but if they do occur they will be displayed with relevant information instead of printing `Unknown RPC error`
- Slight formatting improvement

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
