### PR TITLE
Fix docs snippets test for Scarb >=2.8.1

### DIFF
--- a/crates/docs/src/validation.rs
+++ b/crates/docs/src/validation.rs
@@ -1,5 +1,6 @@
 use crate::snippet::{Snippet, SnippetConfig, SnippetType};
 use regex::Regex;
+use std::sync::LazyLock;
 use std::{fs, io, path::Path};
 
 const EXTENSION: Option<&str> = Some("md");
@@ -24,7 +25,7 @@ pub fn extract_snippets_from_file(
                 .map_or_else(String::new, |m| m.as_str().to_string());
             let command_match = caps.name("command")?;
             let output = caps.name("output").map(|m| {
-               static GAS_RE: LazyLock<Regex> =
+                static GAS_RE: LazyLock<Regex> =
                     LazyLock::new(|| Regex::new(r"gas: ~\d+").unwrap());
                 static EXECUTION_RESOURCES_RE: LazyLock<Regex> = LazyLock::new(|| {
                     Regex::new(r"(steps|memory holes|builtins|syscalls): (\d+|\(.+\))").unwrap()

--- a/crates/docs/src/validation.rs
+++ b/crates/docs/src/validation.rs
@@ -24,12 +24,14 @@ pub fn extract_snippets_from_file(
                 .map_or_else(String::new, |m| m.as_str().to_string());
             let command_match = caps.name("command")?;
             let output = caps.name("output").map(|m| {
-                let gas_re = Regex::new(r"gas: ~\d+").unwrap();
-                let execution_resources_re =
-                    Regex::new(r"(steps|memory holes|builtins|syscalls): (\d+|\(.+\))").unwrap();
+               static GAS_RE: LazyLock<Regex> =
+                    LazyLock::new(|| Regex::new(r"gas: ~\d+").unwrap());
+                static EXECUTION_RESOURCES_RE: LazyLock<Regex> = LazyLock::new(|| {
+                    Regex::new(r"(steps|memory holes|builtins|syscalls): (\d+|\(.+\))").unwrap()
+                });
 
-                let output = gas_re.replace_all(m.as_str(), "gas: ~[..]").to_string();
-                execution_resources_re
+                let output = GAS_RE.replace_all(m.as_str(), "gas: ~[..]").to_string();
+                EXECUTION_RESOURCES_RE
                     .replace_all(output.as_str(), "${1}: [..]")
                     .to_string()
             });

--- a/crates/forge/tests/e2e/common/runner.rs
+++ b/crates/forge/tests/e2e/common/runner.rs
@@ -88,12 +88,6 @@ pub(crate) fn setup_package_with_file_patterns(
         value(get_assert_macros_version().unwrap().to_string());
     scarb_toml["target.starknet-contract"]["sierra"] = value(true);
 
-    if is_from_docs_listings {
-        scarb_toml["dev-dependencies"]["snforge_std"]
-            .as_table_mut()
-            .and_then(|snforge_std| snforge_std.remove("workspace"));
-    }
-
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
 
     // TODO (#2074): do that on .cairo.template files only

--- a/docs/listings/hello_workspaces/Scarb.toml
+++ b/docs/listings/hello_workspaces/Scarb.toml
@@ -27,6 +27,9 @@ fibonacci = { path = "crates/fibonacci" }
 addition = { path = "crates/addition" }
 starknet = "2.7.0"
 
+[dev-dependencies]
+snforge_std.workspace = true
+
 [workspace.dependencies]
 snforge_std = { path = "../../../snforge_std" }
 

--- a/docs/src/testing/gas-and-resource-estimation.md
+++ b/docs/src/testing/gas-and-resource-estimation.md
@@ -49,14 +49,14 @@ Running 2 test(s) from tests/
 [PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (gas: ~105)
         steps: 3405
         memory holes: 22
-        builtins: ([..])
-        syscalls: ([..])
+        builtins: (range_check: 77, pedersen: 7)
+        syscalls: (CallContract: 2, StorageRead: 1, Deploy: 1)
         
 [PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (gas: ~172)
         steps: 4535
         memory holes: 15
-        builtins: ([..])
-        syscalls: ([..])
+        builtins: (range_check: 95, pedersen: 7)
+        syscalls: (CallContract: 3, StorageRead: 3, Deploy: 1, StorageWrite: 1)
         
 Running 0 test(s) from src/
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out

--- a/docs/src/testing/running-tests.md
+++ b/docs/src/testing/running-tests.md
@@ -117,14 +117,14 @@ Running 2 test(s) from tests/
 [PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (gas: ~105)
         steps: 3405
         memory holes: 22
-        builtins: ([..])
-        syscalls: ([..])
+        builtins: (range_check: 77, pedersen: 7)
+        syscalls: (CallContract: 2, StorageRead: 1, Deploy: 1)
         
 [PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (gas: ~172)
         steps: 4535
         memory holes: 15
-        builtins: ([..])
-        syscalls: ([..])
+        builtins: (range_check: 95, pedersen: 7)
+        syscalls: (CallContract: 3, StorageRead: 3, Deploy: 1, StorageWrite: 1)
         
 Running 0 test(s) from src/
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Fix `e2e::docs_snippets_validation::test_docs_snippets` which failed in the [last scheduled run](https://github.com/foundry-rs/starknet-foundry/actions/runs/12100509808/job/33739201518)
- Replace changeable values: gas and execution resources with wildcard `[..]` in outputs validation
