### PR TITLE
Use `snforge_std` from registry

### DIFF
--- a/crates/forge/src/init.rs
+++ b/crates/forge/src/init.rs
@@ -193,11 +193,7 @@ pub fn run(project_name: &str) -> Result<()> {
             .offline()
             .arg("add")
             .arg("--dev")
-            .arg("snforge_std")
-            .arg("--git")
-            .arg("https://github.com/foundry-rs/starknet-foundry.git")
-            .arg("--tag")
-            .arg(format!("v{version}"))
+            .arg(format!("snforge_std@{version}"))
             .run()
             .context("Failed to add snforge_std")?;
     }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -729,7 +729,7 @@ fn validate_init(temp: &TempDir, validate_snforge_std: bool) {
     let scarb_toml = fs::read_to_string(manifest_path.clone()).unwrap();
 
     let snforge_std_assert = if validate_snforge_std {
-        "\nsnforge_std = { git = \"https://github.com/foundry-rs/starknet-foundry\", tag = \"v[..]\" }"
+        "\nsnforge_std = \"[..]\""
     } else {
         ""
     };


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2587

## Introduced changes

<!-- A brief description of the changes -->

- Updated the template so it uses `snforge_std` from package registry.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
