### PR TITLE
Fix scheduled tests for Scarb `2.9.2`

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/scheduled.yml
   schedule:
     - cron: '0 0 * * 3,0'
+  workflow_dispatch:
 
 jobs:
   get-scarb-versions:

--- a/crates/forge/test_utils/src/runner.rs
+++ b/crates/forge/test_utils/src/runner.rs
@@ -16,6 +16,7 @@ use scarb_api::{
     get_contracts_artifacts_and_source_sierra_paths, metadata::MetadataCommandExt,
     target_dir_for_workspace, ScarbCommand, StarknetContractArtifacts,
 };
+use semver::Version;
 use shared::command::CommandExt;
 use std::{
     collections::HashMap,
@@ -334,6 +335,14 @@ pub fn assert_builtin(
     builtin: BuiltinName,
     expected_count: usize,
 ) {
+    let scarb_version = ScarbCommand::version().run().unwrap();
+    let expected_count =
+        if builtin == BuiltinName::range_check && scarb_version.scarb >= Version::new(2, 9, 2) {
+            expected_count - 1
+        } else {
+            expected_count
+        };
+
     let test_name_suffix = format!("::{test_case_name}");
     let result = TestCase::find_test_result(result);
 

--- a/crates/forge/test_utils/src/runner.rs
+++ b/crates/forge/test_utils/src/runner.rs
@@ -335,6 +335,7 @@ pub fn assert_builtin(
     builtin: BuiltinName,
     expected_count: usize,
 ) {
+    // TODO(#2806)
     let scarb_version = ScarbCommand::version().run().unwrap();
     let expected_count =
         if builtin == BuiltinName::range_check && scarb_version.scarb >= Version::new(2, 9, 2) {

--- a/crates/forge/tests/data/nonexistent_selector/tests/test_contract.cairo
+++ b/crates/forge/tests/data/nonexistent_selector/tests/test_contract.cairo
@@ -1,5 +1,3 @@
-use starknet::ContractAddress;
-
 use snforge_std::{declare, ContractClassTrait, DeclareResultTrait};
 
 use nonexistent_selector::IMyContractSafeDispatcher;

--- a/crates/forge/tests/data/steps/src/lib.cairo
+++ b/crates/forge/tests/data/steps/src/lib.cairo
@@ -1,4 +1,4 @@
-// 75 constant cost
+// 75/70 constant cost depending on the Cairo version
 // 15 steps per iteration
 #[cfg(test)]
 mod tests {

--- a/crates/forge/tests/data/steps/src/lib.cairo
+++ b/crates/forge/tests/data/steps/src/lib.cairo
@@ -3,8 +3,7 @@
 #[cfg(test)]
 mod tests {
     #[test]
-    // requires 570030 steps
-    fn steps_570030() {
+    fn steps_much_less_than_10000000() {
         let mut i = 0;
 
         while i != 37_997 {
@@ -14,7 +13,7 @@ mod tests {
     }
 
     #[test]
-    fn steps_9999990() {
+    fn steps_less_than_10000000() {
         let mut i = 0;
 
         while i != 666_661 {
@@ -24,17 +23,17 @@ mod tests {
     }
 
     #[test]
-    fn steps_10000005() {
+    fn steps_more_than_10000000() {
         let mut i = 0;
 
-        while i != 666_662 {
+        while i != 666_663 {
             i = i + 1;
             assert(1 + 1 == 2, 'who knows?');
         }
     }
 
     #[test]
-    fn steps_11250075() {
+    fn steps_much_more_than_10000000() {
         let mut i = 0;
 
         while i != 750_000 {

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1032,10 +1032,7 @@ fn incompatible_snforge_std_version_warning() {
         .unwrap()
         .parse::<DocumentMut>()
         .unwrap();
-    scarb_toml["dev-dependencies"]["snforge_std"]["path"] = Item::None;
-    scarb_toml["dev-dependencies"]["snforge_std"]["git"] =
-        value("https://github.com/foundry-rs/starknet-foundry.git");
-    scarb_toml["dev-dependencies"]["snforge_std"]["tag"] = value("v0.28.0");
+    scarb_toml["dev-dependencies"]["snforge_std"] = value("0.34.0");
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
 
     let output = test_runner(&temp).assert().failure();
@@ -1043,7 +1040,6 @@ fn incompatible_snforge_std_version_warning() {
     assert_stdout_contains(
         output,
         indoc! {r"
-        [..]Updating git repository https://github.com/foundry-rs/starknet-foundry
         [WARNING] Package snforge_std version does not meet the recommended version requirement =0.[..], [..]
         [..]Compiling[..]
         [..]Finished[..]
@@ -1051,23 +1047,23 @@ fn incompatible_snforge_std_version_warning() {
 
         Collected 4 test(s) from steps package
         Running 4 test(s) from src/
-        [PASS] steps::tests::steps_570030 [..]
-        [FAIL] steps::tests::steps_10000005
+        [PASS] steps::tests::steps_much_less_than_10000000 [..]
+        [FAIL] steps::tests::steps_more_than_10000000
 
         Failure data:
             Could not reach the end of the program. RunResources has no remaining steps.
 
-        [FAIL] steps::tests::steps_11250075
+        [FAIL] steps::tests::steps_much_more_than_10000000
 
         Failure data:
             Could not reach the end of the program. RunResources has no remaining steps.
 
-        [PASS] steps::tests::steps_9999990 [..]
+        [PASS] steps::tests::steps_less_than_10000000 [..]
         Tests: 2 passed, 2 failed, 0 skipped, 0 ignored, 0 filtered out
 
         Failures:
-            steps::tests::steps_10000005
-            steps::tests::steps_11250075
+            steps::tests::steps_more_than_10000000
+            steps::tests::steps_much_more_than_10000000
         "},
     );
 }
@@ -1145,9 +1141,9 @@ fn call_nonexistent_selector() {
         output,
         indoc! {r"
         Collected 1 test(s) from nonexistent_selector package
-        Running 1 test(s) from tests/
-        [PASS] nonexistent_selector_integrationtest::test_contract::test_unwrapped_call_contract_syscall (gas: ~103)
         Running 0 test(s) from src/
+        Running 1 test(s) from tests/
+        [PASS] nonexistent_selector_integrationtest::test_contract::test_unwrapped_call_contract_syscall (gas: ~[..])
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
         "},
     );

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1143,7 +1143,7 @@ fn call_nonexistent_selector() {
         Collected 1 test(s) from nonexistent_selector package
         Running 0 test(s) from src/
         Running 1 test(s) from tests/
-        [PASS] nonexistent_selector_integrationtest::test_contract::test_unwrapped_call_contract_syscall (gas: ~[..])
+        [PASS] nonexistent_selector_integrationtest::test_contract::test_unwrapped_call_contract_syscall [..]
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
         "},
     );

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -2,6 +2,8 @@ use super::common::runner::{setup_package, test_runner};
 use indoc::indoc;
 use shared::test_utils::output_assert::assert_stdout_contains;
 
+// TODO(#2806)
+
 #[test]
 fn should_allow_less_than_default() {
     let temp = setup_package("steps");

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -70,10 +70,10 @@ fn should_allow_more_than_10m() {
 
                 Collected 4 test(s) from steps package
                 Running 4 test(s) from src/
-                [PASS] steps::tests::steps_much_less_than_10000000 (gas: ~[..])
-                [PASS] steps::tests::steps_more_than_10000000 (gas: ~[..])
-                [PASS] steps::tests::steps_less_than_10000000 (gas: ~[..])
-                [PASS] steps::tests::steps_much_more_than_10000000 (gas: ~[..])
+                [PASS] steps::tests::steps_much_less_than_10000000 [..]
+                [PASS] steps::tests::steps_more_than_10000000 [..]
+                [PASS] steps::tests::steps_less_than_10000000 [..]
+                [PASS] steps::tests::steps_much_more_than_10000000 [..]
                 Tests: 4 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
             "
         ),
@@ -94,7 +94,7 @@ fn should_default_to_10m() {
 
             Collected 4 test(s) from steps package
             Running 4 test(s) from src/
-            [PASS] steps::tests::steps_much_less_than_10000000 (gas: ~[..])
+            [PASS] steps::tests::steps_much_less_than_10000000 [..]
             [FAIL] steps::tests::steps_much_more_than_10000000
 
             Failure data:
@@ -105,7 +105,7 @@ fn should_default_to_10m() {
             Failure data:
                 Could not reach the end of the program. RunResources has no remaining steps.
 
-            [PASS] steps::tests::steps_less_than_10000000 (gas: ~[..])
+            [PASS] steps::tests::steps_less_than_10000000 [..]
             Tests: 2 passed, 2 failed, 0 skipped, 0 ignored, 0 filtered out
 
             Failures:

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -20,22 +20,22 @@ fn should_allow_less_than_default() {
 
                 Collected 4 test(s) from steps package
                 Running 4 test(s) from src/
-                [FAIL] steps::tests::steps_570030
+                [FAIL] steps::tests::steps_more_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
 
-                [FAIL] steps::tests::steps_11250075
+                [FAIL] steps::tests::steps_less_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
 
-                [FAIL] steps::tests::steps_10000005
+                [FAIL] steps::tests::steps_much_more_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
 
-                [FAIL] steps::tests::steps_9999990
+                [FAIL] steps::tests::steps_much_less_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
@@ -43,10 +43,10 @@ fn should_allow_less_than_default() {
                 Tests: 0 passed, 4 failed, 0 skipped, 0 ignored, 0 filtered out
 
                 Failures:
-                    steps::tests::steps_570030
-                    steps::tests::steps_11250075
-                    steps::tests::steps_10000005
-                    steps::tests::steps_9999990
+                    steps::tests::steps_more_than_10000000
+                    steps::tests::steps_less_than_10000000
+                    steps::tests::steps_much_more_than_10000000
+                    steps::tests::steps_much_less_than_10000000
             "
         ),
     );
@@ -70,10 +70,10 @@ fn should_allow_more_than_10m() {
 
                 Collected 4 test(s) from steps package
                 Running 4 test(s) from src/
-                [PASS] steps::tests::steps_570030 (gas: ~1521)
-                [PASS] steps::tests::steps_10000005 (gas: ~26667)
-                [PASS] steps::tests::steps_9999990 (gas: ~26667)
-                [PASS] steps::tests::steps_11250075 (gas: ~30001)
+                [PASS] steps::tests::steps_much_less_than_10000000 (gas: ~[..])
+                [PASS] steps::tests::steps_more_than_10000000 (gas: ~[..])
+                [PASS] steps::tests::steps_less_than_10000000 (gas: ~[..])
+                [PASS] steps::tests::steps_much_more_than_10000000 (gas: ~[..])
                 Tests: 4 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
             "
         ),
@@ -94,23 +94,23 @@ fn should_default_to_10m() {
 
             Collected 4 test(s) from steps package
             Running 4 test(s) from src/
-            [PASS] steps::tests::steps_570030 (gas: ~1521)
-            [FAIL] steps::tests::steps_10000005
+            [PASS] steps::tests::steps_much_less_than_10000000 (gas: ~[..])
+            [FAIL] steps::tests::steps_much_more_than_10000000
 
             Failure data:
                 Could not reach the end of the program. RunResources has no remaining steps.
 
-            [FAIL] steps::tests::steps_11250075
+            [FAIL] steps::tests::steps_more_than_10000000
 
             Failure data:
                 Could not reach the end of the program. RunResources has no remaining steps.
 
-            [PASS] steps::tests::steps_9999990 (gas: ~26667)
+            [PASS] steps::tests::steps_less_than_10000000 (gas: ~[..])
             Tests: 2 passed, 2 failed, 0 skipped, 0 ignored, 0 filtered out
 
             Failures:
-                steps::tests::steps_10000005
-                steps::tests::steps_11250075
+                steps::tests::steps_much_more_than_10000000
+                steps::tests::steps_more_than_10000000
             "
         ),
     );


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Fix scheduled tests for Scarb `2.9.2` https://github.com/foundry-rs/starknet-foundry/actions/runs/12383672032
- Add `workflow_dispatch` trigger to allow running scheduled tests manually

