### PR TITLE
Cast default RPC providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- Renamed `--network` flag to `--network-name` in `sncast account delete`
-  with provider command
+- Renamed `--network` flag to `--network-name` in `sncast account delete` command
 
 ## [0.36.0] - 2025-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cast
+
+#### Added
+
+- Default RPC providers under `--network` flag
+
+#### Changed
+
+- Renamed `--network` flag to `--network-name` in `sncast account delete`
+  with provider command
+
 ## [0.36.0] - 2025-01-15
 
 ### Forge

--- a/crates/docs/src/snippet.rs
+++ b/crates/docs/src/snippet.rs
@@ -52,6 +52,10 @@ impl SnippetType {
     }
 }
 
+fn replace_network_default() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize, Serialize, Default)]
 pub struct SnippetConfig {
     #[serde(default)]
@@ -59,8 +63,8 @@ pub struct SnippetConfig {
     pub package_name: Option<String>,
     #[serde(default)]
     pub ignored_output: bool,
-    #[serde(default)]
-    pub not_replace_network: bool,
+    #[serde(default = "replace_network_default")]
+    pub replace_network: bool,
 }
 
 #[derive(Debug)]

--- a/crates/docs/src/snippet.rs
+++ b/crates/docs/src/snippet.rs
@@ -59,6 +59,8 @@ pub struct SnippetConfig {
     pub package_name: Option<String>,
     #[serde(default)]
     pub ignored_output: bool,
+    #[serde(default)]
+    pub not_replace_network: bool,
 }
 
 #[derive(Debug)]

--- a/crates/docs/src/snippet.rs
+++ b/crates/docs/src/snippet.rs
@@ -52,19 +52,24 @@ impl SnippetType {
     }
 }
 
-fn replace_network_default() -> bool {
-    true
-}
-
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct SnippetConfig {
-    #[serde(default)]
     pub ignored: bool,
     pub package_name: Option<String>,
-    #[serde(default)]
     pub ignored_output: bool,
-    #[serde(default = "replace_network_default")]
     pub replace_network: bool,
+}
+
+impl Default for SnippetConfig {
+    fn default() -> Self {
+        Self {
+            ignored: false,
+            package_name: None,
+            ignored_output: false,
+            replace_network: true,
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -14,7 +14,7 @@ pub struct RpcArgs {
     #[clap(short, long)]
     pub url: Option<String>,
 
-    /// Use predefined network using public provider. When using this option you may experience rate limits and other unexpected behavior
+    /// Use predefined network with a public provider. Note that this option may result in rate limits or other unexpected behavior
     #[clap(long)]
     pub network: Option<Network>,
 }
@@ -123,7 +123,7 @@ mod tests {
     #[test_case(FreeProvider::Voyager)]
     #[test_case(FreeProvider::Blast)]
     #[tokio::test]
-    async fn test_mainnet_url_works(free_provider: FreeProvider) {
+    async fn test_mainnet_url_happy_case(free_provider: FreeProvider) {
         assert!(call_provider(&Network::free_mainnet_rpc(&free_provider))
             .await
             .is_ok());
@@ -132,7 +132,7 @@ mod tests {
     #[test_case(FreeProvider::Voyager)]
     #[test_case(FreeProvider::Blast)]
     #[tokio::test]
-    async fn test_sepolia_url_works(free_provider: FreeProvider) {
+    async fn test_sepolia_url_happy_case(free_provider: FreeProvider) {
         assert!(call_provider(&Network::free_sepolia_rpc(&free_provider))
             .await
             .is_ok());

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -113,33 +113,26 @@ impl Network {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest::Response;
+    use semver::Version;
+    use shared::rpc::is_expected_version;
+    use starknet::providers::Provider;
     use test_case::test_case;
-
-    async fn call_provider(url: &str) -> Result<Response> {
-        let client = reqwest::Client::new();
-        client
-            .get(url)
-            .send()
-            .await
-            .context("Failed to send request")
-    }
 
     #[test_case(FreeProvider::Voyager)]
     #[test_case(FreeProvider::Blast)]
     #[tokio::test]
     async fn test_mainnet_url_happy_case(free_provider: FreeProvider) {
-        assert!(call_provider(&Network::free_mainnet_rpc(&free_provider))
-            .await
-            .is_ok());
+        let provider = get_provider(&Network::free_sepolia_rpc(&free_provider)).unwrap();
+        let spec_version = provider.spec_version().await.unwrap();
+        assert!(is_expected_version(&Version::parse(&spec_version).unwrap()));
     }
 
     #[test_case(FreeProvider::Voyager)]
     #[test_case(FreeProvider::Blast)]
     #[tokio::test]
     async fn test_sepolia_url_happy_case(free_provider: FreeProvider) {
-        assert!(call_provider(&Network::free_sepolia_rpc(&free_provider))
-            .await
-            .is_ok());
+        let provider = get_provider(&Network::free_sepolia_rpc(&free_provider)).unwrap();
+        let spec_version = provider.spec_version().await.unwrap();
+        assert!(is_expected_version(&Version::parse(&spec_version).unwrap()));
     }
 }

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -1,24 +1,45 @@
-use crate::{get_provider, helpers::configuration::CastConfig};
+use crate::helpers::configuration::CastConfig;
+use crate::{get_provider, Network};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use shared::verify_and_warn_if_incompatible_rpc_version;
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
+use std::env::current_exe;
+use std::time::UNIX_EPOCH;
 
 #[derive(Args, Clone, Debug, Default)]
+#[group(required = false)]
 pub struct RpcArgs {
     /// RPC provider url address; overrides url from snfoundry.toml
     #[clap(short, long)]
     pub url: Option<String>,
+
+    /// Predefined network using public provider
+    #[clap(long)]
+    pub network: Option<Network>,
 }
 
 impl RpcArgs {
-    pub async fn get_provider(
-        &self,
-        config: &CastConfig,
-    ) -> anyhow::Result<JsonRpcClient<HttpTransport>> {
-        let url = self.url.as_ref().unwrap_or(&config.url);
-        let provider = get_provider(url)?;
+    pub async fn get_provider(&self, config: &CastConfig) -> Result<JsonRpcClient<HttpTransport>> {
+        let url = if let Some(network) = self.network {
+            let free_provider = FreeProvider::semi_random();
+            network.url(&free_provider)
+        } else {
+            let url = self.url.clone().or_else(|| {
+                if config.url.is_empty() {
+                    None
+                } else {
+                    Some(config.url.clone())
+                }
+            });
 
-        verify_and_warn_if_incompatible_rpc_version(&provider, &url).await?;
+            url.context("Either `--network` or `--url` must be provided")?
+        };
+
+        assert!(!url.is_empty(), "url cannot be empty");
+        let provider = get_provider(&url)?;
+
+        verify_and_warn_if_incompatible_rpc_version(&provider, url).await?;
 
         Ok(provider)
     }
@@ -26,5 +47,52 @@ impl RpcArgs {
     #[must_use]
     pub fn get_url(&self, config: &CastConfig) -> String {
         self.url.clone().unwrap_or_else(|| config.url.clone())
+    }
+}
+
+fn installation_constant_seed() -> Result<u64> {
+    let executable_path = current_exe()?;
+    let metadata = executable_path.metadata()?;
+    let modified_time = metadata.modified()?;
+    let duration = modified_time.duration_since(UNIX_EPOCH)?;
+
+    Ok(duration.as_secs())
+}
+
+enum FreeProvider {
+    Blast,
+    Voyager,
+}
+
+impl FreeProvider {
+    fn semi_random() -> Self {
+        let seed = installation_constant_seed().unwrap_or(2);
+        if seed % 2 == 0 {
+            return Self::Blast;
+        }
+        Self::Voyager
+    }
+}
+
+impl Network {
+    fn url(self, provider: &FreeProvider) -> String {
+        match self {
+            Network::Mainnet => Self::free_mainnet_rpc(provider),
+            Network::Sepolia => Self::free_sepolia_rpc(provider),
+        }
+    }
+
+    fn free_mainnet_rpc(provider: &FreeProvider) -> String {
+        match provider {
+            FreeProvider::Blast => "https://starknet-mainnet.public.blastapi.io".to_string(),
+            FreeProvider::Voyager => "https://free-rpc.nethermind.io/mainnet-juno".to_string(),
+        }
+    }
+
+    fn free_sepolia_rpc(provider: &FreeProvider) -> String {
+        match provider {
+            FreeProvider::Blast => "https://starknet-sepolia.public.blastapi.io".to_string(),
+            FreeProvider::Voyager => "https://free-rpc.nethermind.io/sepolia-juno".to_string(),
+        }
     }
 }

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -14,7 +14,7 @@ pub struct RpcArgs {
     #[clap(short, long)]
     pub url: Option<String>,
 
-    /// Use predefined network using public provider
+    /// Use predefined network using public provider. When using this option you may experience rate limits and other unexpected behavior
     #[clap(long)]
     pub network: Option<Network>,
 }

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -2,6 +2,7 @@ use crate::helpers::configuration::CastConfig;
 use crate::{get_provider, Network};
 use anyhow::{bail, Context, Result};
 use clap::Args;
+use shared::consts::RPC_URL_VERSION;
 use shared::verify_and_warn_if_incompatible_rpc_version;
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
 use std::env::current_exe;
@@ -89,18 +90,22 @@ impl Network {
     fn free_mainnet_rpc(provider: &FreeProvider) -> String {
         match provider {
             FreeProvider::Blast => {
-                "https://starknet-mainnet.public.blastapi.io/rpc/v0_7".to_string()
+                format!("https://starknet-mainnet.public.blastapi.io/rpc/{RPC_URL_VERSION}")
             }
-            FreeProvider::Voyager => "https://free-rpc.nethermind.io/mainnet-juno".to_string(),
+            FreeProvider::Voyager => {
+                format!("https://free-rpc.nethermind.io/mainnet-juno/{RPC_URL_VERSION}")
+            }
         }
     }
 
     fn free_sepolia_rpc(provider: &FreeProvider) -> String {
         match provider {
             FreeProvider::Blast => {
-                "https://starknet-sepolia.public.blastapi.io/rpc/v0_7".to_string()
+                format!("https://starknet-sepolia.public.blastapi.io/rpc/{RPC_URL_VERSION}")
             }
-            FreeProvider::Voyager => "https://free-rpc.nethermind.io/sepolia-juno".to_string(),
+            FreeProvider::Voyager => {
+                format!("https://free-rpc.nethermind.io/sepolia-juno/{RPC_URL_VERSION}")
+            }
         }
     }
 }

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -14,7 +14,7 @@ pub struct RpcArgs {
     #[clap(short, long)]
     pub url: Option<String>,
 
-    /// Predefined network using public provider
+    /// Use predefined network using public provider
     #[clap(long)]
     pub network: Option<Network>,
 }

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -87,11 +87,10 @@ pub enum Network {
 
 impl Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            Network::Mainnet => "mainnet".to_string(),
-            Network::Sepolia => "sepolia".to_string(),
-        };
-        write!(f, "{str}")
+        match self {
+            Network::Mainnet => write!(f, "mainnet"),
+            Network::Sepolia => write!(f, "sepolia"),
+        }
     }
 }
 

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -31,10 +31,11 @@ use starknet::{
     signers::{LocalWallet, SigningKey},
 };
 use starknet_types_core::felt::Felt;
+use std::collections::HashMap;
+use std::fmt::Display;
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
-use std::{collections::HashMap, fmt::Display};
 use std::{env, fs};
 use thiserror::Error;
 
@@ -82,6 +83,16 @@ pub const SEPOLIA: Felt =
 pub enum Network {
     Mainnet,
     Sepolia,
+}
+
+impl Display for Network {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Network::Mainnet => "mainnet".to_string(),
+            Network::Sepolia => "sepolia".to_string(),
+        };
+        write!(f, "{str}")
+    }
 }
 
 impl TryFrom<Felt> for Network {

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -519,7 +519,6 @@ async fn run_async_command(
                     config.account.clone()
                 };
                 let result = starknet_commands::account::create::create(
-                    create.rpc.get_url(&config),
                     &account,
                     &config.accounts_file,
                     config.keystore,

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -492,7 +492,11 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !import.silent && result.is_ok() && io::stdout().is_terminal() {
+                if !import.silent
+                    && result.is_ok()
+                    && io::stdout().is_terminal()
+                    && import.rpc.network.is_none()
+                {
                     if let Some(account_name) =
                         result.as_ref().ok().and_then(|r| r.account_name.clone())
                     {
@@ -528,7 +532,11 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !create.silent && result.is_ok() && io::stdout().is_terminal() {
+                if !create.silent
+                    && result.is_ok()
+                    && io::stdout().is_terminal()
+                    && create.rpc.network.is_none()
+                {
                     if let Err(err) = prompt_to_add_account_as_default(&account) {
                         eprintln!("Error: Failed to launch interactive prompt: {err}");
                     }

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -347,7 +347,7 @@ fn generate_network_flag(rpc_url: Option<&str>, network: Option<&Network>) -> St
     } else if let Some(network) = network {
         format!("--network {network}",)
     } else {
-        unreachable!()
+        unreachable!("Either `rpc_url` or `network` must be provided.")
     }
 }
 

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -17,7 +17,7 @@ use sncast::helpers::rpc::RpcArgs;
 use sncast::response::structs::AccountCreateResponse;
 use sncast::{
     check_class_hash_exists, check_if_legacy_contract, extract_or_generate_salt, get_chain_id,
-    get_keystore_password, handle_account_factory_error,
+    get_keystore_password, handle_account_factory_error, Network,
 };
 use starknet::accounts::{
     AccountDeploymentV1, AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory,
@@ -44,7 +44,7 @@ pub struct Create {
     pub salt: Option<Felt>,
 
     /// If passed, a profile with provided name and corresponding data will be created in snfoundry.toml
-    #[clap(long)]
+    #[clap(long, conflicts_with = "network")]
     pub add_profile: Option<String>,
 
     /// Custom contract class hash of declared contract
@@ -61,7 +61,6 @@ pub struct Create {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn create(
-    rpc_url: String,
     account: &str,
     accounts_file: &Utf8PathBuf,
     keystore: Option<Utf8PathBuf>,
@@ -112,24 +111,38 @@ pub async fn create(
             legacy,
         )?;
 
-        let deploy_command = generate_deploy_command_with_keystore(account, &keystore, &rpc_url);
+        let deploy_command = generate_deploy_command_with_keystore(
+            account,
+            &keystore,
+            create.rpc.url.as_deref(),
+            create.rpc.network.as_ref(),
+        );
         message.push_str(&deploy_command);
     } else {
         write_account_to_accounts_file(account, accounts_file, chain_id, account_json.clone())?;
 
-        let deploy_command = generate_deploy_command(accounts_file, &rpc_url, account);
+        let deploy_command = generate_deploy_command(
+            accounts_file,
+            create.rpc.url.as_deref(),
+            create.rpc.network.as_ref(),
+            account,
+        );
         message.push_str(&deploy_command);
     }
 
     if add_profile.is_some() {
-        let config = CastConfig {
-            url: rpc_url,
-            account: account.into(),
-            accounts_file: accounts_file.into(),
-            keystore,
-            ..Default::default()
-        };
-        add_created_profile_to_configuration(create.add_profile.as_deref(), &config, None)?;
+        if let Some(url) = &create.rpc.url {
+            let config = CastConfig {
+                url: url.clone(),
+                account: account.into(),
+                accounts_file: accounts_file.into(),
+                keystore,
+                ..Default::default()
+            };
+            add_created_profile_to_configuration(create.add_profile.as_deref(), &config, None)?;
+        } else {
+            unreachable!("Conflicting arguments should be handled in clap");
+        }
     }
 
     Ok(AccountCreateResponse {
@@ -328,7 +341,22 @@ fn write_account_to_file(
     Ok(())
 }
 
-fn generate_deploy_command(accounts_file: &Utf8PathBuf, rpc_url: &str, account: &str) -> String {
+fn generate_network_flag(rpc_url: Option<&str>, network: Option<&Network>) -> String {
+    if let Some(rpc_url) = rpc_url {
+        format!("--url {rpc_url}")
+    } else if let Some(network) = network {
+        format!("--network {network}",)
+    } else {
+        unreachable!()
+    }
+}
+
+fn generate_deploy_command(
+    accounts_file: &Utf8PathBuf,
+    rpc_url: Option<&str>,
+    network: Option<&Network>,
+    account: &str,
+) -> String {
     let accounts_flag = if accounts_file
         .to_string()
         .contains("starknet_accounts/starknet_open_zeppelin_accounts.json")
@@ -338,19 +366,24 @@ fn generate_deploy_command(accounts_file: &Utf8PathBuf, rpc_url: &str, account: 
         format!(" --accounts-file {accounts_file}")
     };
 
+    let network_flag = generate_network_flag(rpc_url, network);
+
     format!(
         "\n\nAfter prefunding the address, run:\n\
-        sncast{accounts_flag} account deploy --url {rpc_url} --name {account} --fee-token strk"
+        sncast{accounts_flag} account deploy {network_flag} --name {account} --fee-token strk"
     )
 }
 
 fn generate_deploy_command_with_keystore(
     account: &str,
     keystore: &Utf8PathBuf,
-    rpc_url: &str,
+    rpc_url: Option<&str>,
+    network: Option<&Network>,
 ) -> String {
+    let network_flag = generate_network_flag(rpc_url, network);
+
     format!(
         "\n\nAfter prefunding the address, run:\n\
-        sncast --account {account} --keystore {keystore} account deploy --url {rpc_url} --fee-token strk"
+        sncast --account {account} --keystore {keystore} account deploy {network_flag} --fee-token strk"
     )
 }

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -347,7 +347,7 @@ fn generate_network_flag(rpc_url: Option<&str>, network: Option<&Network>) -> St
     } else if let Some(network) = network {
         format!("--network {network}",)
     } else {
-        unreachable!("Either `rpc_url` or `network` must be provided.")
+        unreachable!("Either `--rpc_url` or `--network` must be provided.")
     }
 }
 

--- a/crates/sncast/src/starknet_commands/account/import.rs
+++ b/crates/sncast/src/starknet_commands/account/import.rs
@@ -57,7 +57,7 @@ pub struct Import {
 
     /// If passed, a profile with the provided name and corresponding data will be created in snfoundry.toml
     #[allow(clippy::struct_field_names)]
-    #[clap(long)]
+    #[clap(long, conflicts_with = "network")]
     pub add_profile: Option<String>,
 
     #[clap(flatten)]
@@ -156,13 +156,17 @@ pub async fn import(
     write_account_to_accounts_file(&account_name, accounts_file, chain_id, account_json.clone())?;
 
     if import.add_profile.is_some() {
-        let config = CastConfig {
-            url: import.rpc.url.clone().unwrap_or_default(),
-            account: account_name.clone(),
-            accounts_file: accounts_file.into(),
-            ..Default::default()
-        };
-        add_created_profile_to_configuration(import.add_profile.as_deref(), &config, None)?;
+        if let Some(url) = &import.rpc.url {
+            let config = CastConfig {
+                url: url.clone(),
+                account: account_name.clone(),
+                accounts_file: accounts_file.into(),
+                ..Default::default()
+            };
+            add_created_profile_to_configuration(import.add_profile.as_deref(), &config, None)?;
+        } else {
+            unreachable!("Conflicting arguments should be handled in clap");
+        }
     }
 
     Ok(AccountImportResponse {

--- a/crates/sncast/tests/data/files/correct_snfoundry.toml
+++ b/crates/sncast/tests/data/files/correct_snfoundry.toml
@@ -31,3 +31,7 @@ accounts-file = "/path/to/account.json"
 account = "user1"
 wait-params = { timeout = 500, retry-interval = 10 }
 show-explorer-links = false
+
+[sncast.no_url]
+accounts-file = "../account-file"
+account = "user1"

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -9,7 +9,6 @@ use docs::utils::{
     update_scarb_toml_dependencies,
 };
 use docs::validation::{extract_snippets_from_directory, extract_snippets_from_file};
-use itertools::Itertools;
 use shared::test_utils::output_assert::assert_stdout_contains;
 
 #[test]

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -9,6 +9,7 @@ use docs::utils::{
     update_scarb_toml_dependencies,
 };
 use docs::validation::{extract_snippets_from_directory, extract_snippets_from_file};
+use itertools::Itertools;
 use shared::test_utils::output_assert::assert_stdout_contains;
 
 #[test]
@@ -55,6 +56,14 @@ fn test_docs_snippets() {
 
         args.insert(0, "--accounts-file");
         args.insert(1, target_accounts_json_path.to_str().unwrap());
+
+        if !snippet.config.not_replace_network {
+            let network_pos = args.iter().position(|arg| *arg == "--network");
+            if let Some(network_pos) = network_pos {
+                args[network_pos] = "--url";
+                args[network_pos + 1] = "http://127.0.0.1:5055";
+            }
+        }
 
         let snapbox = runner(&args).current_dir(tempdir.path());
         let output = snapbox.assert().success();

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -56,7 +56,7 @@ fn test_docs_snippets() {
         args.insert(0, "--accounts-file");
         args.insert(1, target_accounts_json_path.to_str().unwrap());
 
-        if !snippet.config.not_replace_network {
+        if snippet.config.replace_network {
             let network_pos = args.iter().position(|arg| *arg == "--network");
             if let Some(network_pos) = network_pos {
                 args[network_pos] = "--url";

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -64,6 +64,9 @@ fn test_docs_snippets() {
             }
         }
 
+        dbg!(&snippet);
+        dbg!(&args);
+
         let snapbox = runner(&args).current_dir(tempdir.path());
         let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -244,6 +244,35 @@ pub async fn test_happy_case_accounts_file_already_exists() {
 }
 
 #[tokio::test]
+pub async fn test_add_profile_with_network() {
+    let tempdir = tempdir().expect("Failed to create a temporary directory");
+    let accounts_file = "accounts.json";
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--network",
+        "sepolia",
+        "--name",
+        "my_account",
+        "--add-profile",
+        "my_account",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+        error: the argument '--network <NETWORK>' cannot be used with '--add-profile <ADD_PROFILE>'
+    "},
+    );
+}
+
+#[tokio::test]
 pub async fn test_profile_already_exists() {
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None).unwrap();
     let accounts_file = "accounts.json";

--- a/crates/sncast/tests/e2e/account/delete.rs
+++ b/crates/sncast/tests/e2e/account/delete.rs
@@ -13,7 +13,7 @@ pub fn test_no_accounts_in_network() {
         "delete",
         "--name",
         "user99",
-        "--network",
+        "--network-name",
         "my-custom-network",
     ];
 
@@ -68,7 +68,7 @@ pub fn test_delete_abort() {
         "delete",
         "--name",
         "user3",
-        "--network",
+        "--network-name",
         "custom-network",
     ];
 
@@ -99,7 +99,7 @@ pub fn test_happy_case() {
         "delete",
         "--name",
         "user3",
-        "--network",
+        "--network-name",
         "custom-network",
     ];
 
@@ -150,7 +150,7 @@ pub fn test_happy_case_with_yes_flag() {
         "delete",
         "--name",
         "user3",
-        "--network",
+        "--network-name",
         "custom-network",
         "--yes",
     ];
@@ -167,7 +167,7 @@ pub fn test_happy_case_with_yes_flag() {
 }
 
 #[test]
-pub fn test_accept_only_url_or_network() {
+pub fn test_accept_only_one_network_type_argument() {
     let accounts_file_name = "temp_accounts.json";
     let temp_dir = create_tempdir_with_accounts_file(accounts_file_name, true);
 
@@ -180,7 +180,7 @@ pub fn test_accept_only_url_or_network() {
         URL,
         "--name",
         "user3",
-        "--network",
+        "--network-name",
         "custom-network",
     ];
 
@@ -190,7 +190,7 @@ pub fn test_accept_only_url_or_network() {
     assert_stderr_contains(
         output,
         indoc! {r"
-            error: the argument '--url <URL>' cannot be used with '--network <NETWORK>'
+            error: the argument '--url <URL>' cannot be used with '--network-name <NETWORK_NAME>'
         "},
     );
 }

--- a/crates/sncast/tests/e2e/account/import.rs
+++ b/crates/sncast/tests/e2e/account/import.rs
@@ -719,7 +719,7 @@ pub async fn test_happy_case_default_name_generation() {
         "delete",
         "--name",
         "account-2",
-        "--network",
+        "--network-name",
         "alpha-sepolia",
     ];
 

--- a/crates/sncast/tests/e2e/account/import.rs
+++ b/crates/sncast/tests/e2e/account/import.rs
@@ -275,6 +275,43 @@ pub async fn test_happy_case_add_profile() {
 }
 
 #[tokio::test]
+pub async fn test_add_profile_with_network_arg() {
+    let tempdir = tempdir().expect("Failed to create a temporary directory");
+    let accounts_file = "accounts.json";
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "import",
+        "--network",
+        "sepolia",
+        "--name",
+        "my_account_import",
+        "--address",
+        "0x1",
+        "--private-key",
+        "0x2",
+        "--class-hash",
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
+        "--type",
+        "oz",
+        "--add-profile",
+        "my_account_import",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+        error: the argument '--network <NETWORK>' cannot be used with '--add-profile <ADD_PROFILE>'
+    "},
+    );
+}
+
+#[tokio::test]
 pub async fn test_detect_deployed() {
     let tempdir = tempdir().expect("Unable to create a temporary directory");
     let accounts_file = "accounts.json";

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -36,6 +36,32 @@ async fn test_happy_case_from_sncast_config() {
 }
 
 #[tokio::test]
+async fn test_happy_case_predefined_network() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None).unwrap();
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "--profile",
+        "no_url",
+        "call",
+        "--network",
+        "sepolia",
+        "--contract-address",
+        "0x0",
+        "--function",
+        "doesnotmatter",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        "Error: An error occurred in the called contract[..]Requested contract address [..] is not deployed[..]"
+    );
+}
+
+#[tokio::test]
 async fn test_happy_case_from_cli_no_scarb() {
     let args = vec![
         "--accounts-file",

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -62,6 +62,60 @@ async fn test_happy_case_predefined_network() {
 }
 
 #[tokio::test]
+async fn test_url_with_network_args() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None).unwrap();
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "--profile",
+        "no_url",
+        "call",
+        "--network",
+        "sepolia",
+        "--url",
+        URL,
+        "--contract-address",
+        "0x0",
+        "--function",
+        "doesnotmatter",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        "error: the argument '--network <NETWORK>' cannot be used with '--url <URL>'",
+    );
+}
+
+#[tokio::test]
+async fn test_network_with_url_defined_in_config_toml() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None).unwrap();
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "--profile",
+        "default",
+        "call",
+        "--network",
+        "sepolia",
+        "--contract-address",
+        "0x0",
+        "--function",
+        "doesnotmatter",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        "Error: The argument '--network' cannot be used when `url` is defined in `snfoundry.toml` for the active profile"
+    );
+}
+
+#[tokio::test]
 async fn test_happy_case_from_cli_no_scarb() {
     let args = vec![
         "--accounts-file",

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -19,7 +19,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with a public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -16,6 +16,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--type, -t <ACCOUNT_TYPE>`
 Optional. Required if `--class-hash` is passed.
 

--- a/docs/src/appendix/sncast/account/delete.md
+++ b/docs/src/appendix/sncast/account/delete.md
@@ -16,7 +16,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with a public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/account/delete.md
+++ b/docs/src/appendix/sncast/account/delete.md
@@ -13,10 +13,17 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
-## `--network`
+## `--network <NETWORK>`
 Optional.
 
-Network in `accounts-file` associated with the account. By default, the network of RPC node.
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
+## `--network-name`
+Optional.
+
+Network in `accounts-file` associated with the account. By default, the network passed as `--network` of RPC node.
 
 ## `--yes`
 Optional.

--- a/docs/src/appendix/sncast/account/deploy.md
+++ b/docs/src/appendix/sncast/account/deploy.md
@@ -13,6 +13,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--max-fee, -m <MAX_FEE>`
 Optional.
 

--- a/docs/src/appendix/sncast/account/deploy.md
+++ b/docs/src/appendix/sncast/account/deploy.md
@@ -16,7 +16,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with a public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/account/import.md
+++ b/docs/src/appendix/sncast/account/import.md
@@ -26,6 +26,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--class-hash, -c <CLASS_HASH>`
 Optional.
 

--- a/docs/src/appendix/sncast/account/import.md
+++ b/docs/src/appendix/sncast/account/import.md
@@ -29,7 +29,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/call.md
+++ b/docs/src/appendix/sncast/call.md
@@ -18,6 +18,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--calldata, -c <CALLDATA>`
 Optional.
 

--- a/docs/src/appendix/sncast/call.md
+++ b/docs/src/appendix/sncast/call.md
@@ -21,7 +21,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/declare.md
+++ b/docs/src/appendix/sncast/declare.md
@@ -17,6 +17,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--max-fee, -m <MAX_FEE>`
 Optional.
 

--- a/docs/src/appendix/sncast/declare.md
+++ b/docs/src/appendix/sncast/declare.md
@@ -20,7 +20,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/deploy.md
+++ b/docs/src/appendix/sncast/deploy.md
@@ -17,6 +17,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--constructor-calldata, -c <CONSTRUCTOR_CALLDATA>`
 Optional.
 

--- a/docs/src/appendix/sncast/deploy.md
+++ b/docs/src/appendix/sncast/deploy.md
@@ -20,7 +20,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/invoke.md
+++ b/docs/src/appendix/sncast/invoke.md
@@ -31,7 +31,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/invoke.md
+++ b/docs/src/appendix/sncast/invoke.md
@@ -28,6 +28,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--max-fee, -m <MAX_FEE>`
 Optional.
 

--- a/docs/src/appendix/sncast/multicall/run.md
+++ b/docs/src/appendix/sncast/multicall/run.md
@@ -18,6 +18,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--max-fee, -m <MAX_FEE>`
 Optional.
 

--- a/docs/src/appendix/sncast/multicall/run.md
+++ b/docs/src/appendix/sncast/multicall/run.md
@@ -21,7 +21,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/script/run.md
+++ b/docs/src/appendix/sncast/script/run.md
@@ -17,6 +17,13 @@ Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
 
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.
+
 ## `--package <NAME>`
 Optional.
 

--- a/docs/src/appendix/sncast/script/run.md
+++ b/docs/src/appendix/sncast/script/run.md
@@ -20,7 +20,7 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.
 

--- a/docs/src/appendix/sncast/show_config.md
+++ b/docs/src/appendix/sncast/show_config.md
@@ -7,3 +7,10 @@ Optional.
 Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
+
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.

--- a/docs/src/appendix/sncast/show_config.md
+++ b/docs/src/appendix/sncast/show_config.md
@@ -11,6 +11,6 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.

--- a/docs/src/appendix/sncast/tx-status.md
+++ b/docs/src/appendix/sncast/tx-status.md
@@ -14,3 +14,10 @@ Optional.
 Starknet RPC node url address.
 
 Overrides url from `snfoundry.toml`.
+
+## `--network <NETWORK>`
+Optional.
+
+Use predefined network using public provider
+
+Possible values: `mainnet`, `sepolia`.

--- a/docs/src/appendix/sncast/tx-status.md
+++ b/docs/src/appendix/sncast/tx-status.md
@@ -18,6 +18,6 @@ Overrides url from `snfoundry.toml`.
 ## `--network <NETWORK>`
 Optional.
 
-Use predefined network using public provider
+Use predefined network with public provider
 
 Possible values: `mainnet`, `sepolia`.

--- a/docs/src/development/shell-snippets.md
+++ b/docs/src/development/shell-snippets.md
@@ -11,7 +11,7 @@ To configure a snippet, you need to add a comment block right before it. The com
 ```shell
 $ sncast \
     account create \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --name my_first_account
 ```
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -107,6 +107,12 @@ Install Scarb
 asdf install scarb latest
 ```
 
+Set a version globally (in your ~/.tool-versions file):
+
+```shell
+asdf global scarb latest
+```
+
 To verify that Scarb was installed, run
 
 ```shell
@@ -127,6 +133,12 @@ Install Starknet Foundry
 
 ```shell
 asdf install starknet-foundry latest
+```
+
+Set a version globally (in your ~/.tool-versions file):
+
+```shell
+asdf global starknet-foundry latest
 ```
 
 To verify that Starknet Foundry was installed, run

--- a/docs/src/starknet/account-import.md
+++ b/docs/src/starknet/account-import.md
@@ -74,7 +74,7 @@ To import an account into the file holding the accounts info (`~/.starknet_accou
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name account_123 \
     --address 0x1 \
     --private-key 0x2 \
@@ -91,7 +91,7 @@ If you don't want to pass the private key in the command (because of safety aspe
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name account_123 \
     --address 0x1 \
     --type oz
@@ -113,7 +113,7 @@ To import Argent account, set the `--type` flag to `argent`.
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name account_argent \
     --address 0x1 \
     --private-key 0x2 \
@@ -127,7 +127,7 @@ To import Braavos account, set the `--type` flag to `braavos`.
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name account_braavos \
     --address 0x1 \
     --private-key 0x2 \
@@ -141,7 +141,7 @@ To import OpenZeppelin account, set the `--type` flag to `oz` or  `open_zeppelin
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name account_oz \
     --address 0x1 \
     --private-key 0x2 \

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -1,12 +1,14 @@
 # Creating And Deploying Accounts
 
-Account is required to perform interactions with Starknet (only calls can be done without it). Starknet Foundry `sncast` supports
+Account is required to perform interactions with Starknet (only calls can be done without it). Starknet Foundry `sncast`
+supports
 entire account management flow with the `sncast account create` and `sncast account deploy` commands.
 
 Difference between those two commands is that the first one creates account information (private key, address and more)
 and the second one deploys it to the network. After deployment, account can be used to interact with Starknet.
 
-To remove an account from the accounts file, you can use  `sncast account delete`. Please note this only removes the account information stored locally - this will not remove the account from Starknet.
+To remove an account from the accounts file, you can use  `sncast account delete`. Please note this only removes the
+account information stored locally - this will not remove the account from Starknet.
 
 > 💡 **Info**
 > Accounts creation and deployment is supported for
@@ -25,7 +27,7 @@ Do the following to start interacting with the Starknet:
 ```shell
 $ sncast \
     account create \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --name new_account
 ```
 
@@ -42,6 +44,7 @@ message: Account successfully created. Prefund generated address with at least <
 To see account creation details, visit:
 account: https://sepolia.starkscan.co/contract/[..]
 ```
+
 </details>
 <br>
 
@@ -51,12 +54,16 @@ See more advanced use cases below or jump directly to the section [here](#advanc
 
 #### Prefund generated address with tokens
 
-To deploy an account in the next step, you need to prefund it with either STRK or an equivalent amount of ETH tokens (read more about them [here](https://docs.starknet.io/architecture-and-concepts/economics-of-starknet/)).
-You can do it both by sending tokens from another starknet account or by bridging them with [StarkGate](https://starkgate.starknet.io/).
+To deploy an account in the next step, you need to prefund it with either STRK or an equivalent amount of ETH tokens (
+read more about them [here](https://docs.starknet.io/architecture-and-concepts/economics-of-starknet/)).
+You can do it both by sending tokens from another starknet account or by bridging them
+with [StarkGate](https://starkgate.starknet.io/).
 
- >💡 **Info**
-> When deploying on a Sepolia test network, you can also fund your account with artificial tokens via the [Starknet Faucet](https://starknet-faucet.vercel.app)
->![image](images/starknet-faucet-sepolia.png)
+> 💡 **Info**
+> When deploying on a Sepolia test network, you can also fund your account with artificial tokens via
+> the [Starknet Faucet](https://starknet-faucet.vercel.app)
+> ![image](images/starknet-faucet-sepolia.png)
+
 #### Deploy account with the `sncast account deploy` command
 
 <!-- TODO(#2736) -->
@@ -64,7 +71,7 @@ You can do it both by sending tokens from another starknet account or by bridgin
 ```shell
 $ sncast \
     account deploy \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
 	--name new_account \
 	--max-fee 9999999999999
 ```
@@ -79,23 +86,26 @@ transaction_hash: [..]
 To see invocation details, visit:
 transaction: https://sepolia.starkscan.co/tx/[..]
 ```
+
 </details>
 <br>
 
 For a detailed CLI description, see [account deploy command reference](../appendix/sncast/account/deploy.md).
 
-
 ## Managing Accounts
 
-If you created an account with `sncast account create` it by default it will be saved in `~/.starknet_accounts/starknet_open_zeppelin_accounts.json` file which we call `default accounts file` in the following sections.
+If you created an account with `sncast account create` it by default it will be saved in
+`~/.starknet_accounts/starknet_open_zeppelin_accounts.json` file which we call `default accounts file` in the following
+sections.
 
 ### [`account import`](../appendix/sncast/account/import.md)
 
 To import an account to the `default accounts file`, use the `account import` command.
+
 ```shell
 $ sncast \
     account import \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --name my_imported_account \
     --address 0x3a0bcb72428d8056cc7c2bbe5168ddfc844db2737dda3b4c67ff057691177e1 \
     --private-key 0x2 \
@@ -103,6 +113,7 @@ $ sncast \
 ```
 
 ### [`account list`](../appendix/sncast/account/list.md)
+
 List all accounts saved in `accounts file`, grouped based on the networks they are defined on.
 
 <!-- TODO(#2736) -->
@@ -133,6 +144,7 @@ Available accounts (at [..]):
   deployed: true
   type: OpenZeppelin
 ```
+
 </details>
 <br>
 
@@ -141,7 +153,8 @@ There is also possibility to show private keys with the `--display-private-keys`
 
 ### [`account delete`](../appendix/sncast/account/delete.md)
 
-Delete an account from `accounts-file` and its associated Scarb profile. If you pass this command, you will be asked to confirm the deletion.
+Delete an account from `accounts-file` and its associated Scarb profile. If you pass this command, you will be asked to
+confirm the deletion.
 
 ```shell
 $ sncast account delete \
@@ -153,15 +166,17 @@ $ sncast account delete \
 
 #### Custom Account Contract
 
-By default, `sncast` creates/deploys an account using [OpenZeppelin's account contract class hash](https://starkscan.co/class/0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6).
-It is possible to create an account using custom openzeppelin, argent or braavos contract declared to starknet. This can be achieved
+By default, `sncast` creates/deploys an account
+using [OpenZeppelin's account contract class hash](https://starkscan.co/class/0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6).
+It is possible to create an account using custom openzeppelin, argent or braavos contract declared to starknet. This can
+be achieved
 with `--class-hash` flag:
 
 ```shell
 $ sncast \
     account create \
     --name new_account_2 \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --class-hash 0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6
     --type oz
 ```
@@ -173,7 +188,7 @@ Instead of random generation, salt can be specified with `--salt`.
 ```shell
 $ sncast \
     account create \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --name another_account_3 \
     --salt 0x1
 ```
@@ -182,9 +197,9 @@ $ sncast \
 
 ##### Specifying [`--accounts-file`](../appendix/sncast/account/create.md#create)
 
-Account information such as `private_key`, `class_hash`, `address` etc. will be saved to the file specified by `--accounts-file` argument, 
+Account information such as `private_key`, `class_hash`, `address` etc. will be saved to the file specified by
+`--accounts-file` argument,
 if not provided, the `default accounts file` will be used.
-
 
 ##### Specifying [`--add-profile`](../appendix/sncast/account/create.md#--add-profile-name)
 
@@ -194,7 +209,8 @@ Simply use the `--profile` argument followed by the account name in subsequent r
 
 #### Using Keystore and Starkli Account
 
-Accounts created and deployed with [starkli](https://book.starkli.rs/accounts#accounts) can be used by specifying the [`--keystore` argument](../appendix/sncast/common.md#--keystore--k-path_to_keystore_file).
+Accounts created and deployed with [starkli](https://book.starkli.rs/accounts#accounts) can be used by specifying the [
+`--keystore` argument](../appendix/sncast/common.md#--keystore--k-path_to_keystore_file).
 
 > 💡 **Info**
 > When passing the `--keystore` argument, `--account` argument must be a path to the starkli account JSON file.
@@ -206,13 +222,14 @@ $ sncast \
     --keystore keystore.json \
     --account account.json  \
     declare \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --contract-name my_contract \
 ```
 
 #### Creating an Account With Starkli-Style Keystore
 
-It is possible to create an openzeppelin account with keystore in a similar way [starkli](https://book.starkli.rs/accounts#accounts) does.
+It is possible to create an openzeppelin account with keystore in a similar
+way [starkli](https://book.starkli.rs/accounts#accounts) does.
 
 <!-- Snippets is ignored, because typing password for keystore uses interactive mode -->
 <!-- { "ignored": true } -->
@@ -221,7 +238,8 @@ $ sncast \
     --keystore my_key.json \
     --account my_account.json \
     account create \
-    --url http://127.0.0.1:5050 
+    --network sncast
 ```
 
-The command above will generate a keystore file containing the private key, as well as an account file containing the openzeppelin account info that can later be used with starkli.
+The command above will generate a keystore file containing the private key, as well as an account file containing the
+openzeppelin account info that can later be used with starkli.

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -146,7 +146,7 @@ Delete an account from `accounts-file` and its associated Scarb profile. If you 
 ```shell
 $ sncast account delete \
     --name new_account \
-    --network alpha-sepolia
+    --network-name alpha-sepolia
 ```
 
 ### Advanced Use Cases
@@ -188,8 +188,8 @@ if not provided, the `default accounts file` will be used.
 
 ##### Specifying [`--add-profile`](../appendix/sncast/account/create.md#--add-profile-name)
 
-When the `--add-profile` flag is used, you won't need to include the `--url` or `--accounts-file` parameters 
-(the latter being necessary if your account information was stored in a custom file).
+When the `--add-profile` flag is used, the [profile](../projects/configuration.md#defining-profiles-in-snfoundrytoml)
+is automatically created for the account.
 Simply use the `--profile` argument followed by the account name in subsequent requests.
 
 #### Using Keystore and Starkli Account

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -54,8 +54,7 @@ See more advanced use cases below or jump directly to the section [here](#advanc
 
 #### Prefund generated address with tokens
 
-To deploy an account in the next step, you need to prefund it with either STRK or an equivalent amount of ETH tokens (
-read more about them [here](https://docs.starknet.io/architecture-and-concepts/economics-of-starknet/)).
+To deploy an account in the next step, you need to prefund it with either STRK or an equivalent amount of ETH tokens (read more about them [here](https://docs.starknet.io/architecture-and-concepts/economics-of-starknet/)).
 You can do it both by sending tokens from another starknet account or by bridging them
 with [StarkGate](https://starkgate.starknet.io/).
 

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -238,7 +238,7 @@ $ sncast \
     --keystore my_key.json \
     --account my_account.json \
     account create \
-    --network sncast
+    --network sepolia
 ```
 
 The command above will generate a keystore file containing the private key, as well as an account file containing the

--- a/docs/src/starknet/call.md
+++ b/docs/src/starknet/call.md
@@ -19,7 +19,7 @@ For a detailed CLI description, see the [call command reference](../appendix/snc
 ```shell
 $ sncast \
   call \
-  --url http://127.0.0.1:5055 \
+  --network sepolia \
   --contract-address 0x522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716 \
   --function "balance_of" \
   --arguments '0x0554d15a839f0241ba465bb176d231730c01cf89cdcb95fe896c51d4a6f4bb8f'
@@ -44,7 +44,7 @@ You can call a contract at the specific block by passing `--block-id` argument.
 
 ```shell
 $ sncast call \
-  --url http://127.0.0.1:5055 \
+  --network sepolia \
   --contract-address 0x522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716 \
   --function "balance_of" \
   --arguments '0x0554d15a839f0241ba465bb176d231730c01cf89cdcb95fe896c51d4a6f4bb8f' \

--- a/docs/src/starknet/calldata-transformation.md
+++ b/docs/src/starknet/calldata-transformation.md
@@ -15,7 +15,7 @@ A default form of calldata passed to commands requiring it is a series of hex-en
 
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x05075f6d418f7c53c6cdc21cbb5aca2b69c83b6fbcc8256300419a9f101c8b77 \
     --function tuple_fn \
     --calldata 0x10 0x3 0x0 \
@@ -41,7 +41,7 @@ We can write the same command as above, but with arguments:
 
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x05075f6d418f7c53c6cdc21cbb5aca2b69c83b6fbcc8256300419a9f101c8b77 \
     --function tuple_fn \
     --arguments '(0x10, 3, hello_sncast::data_transformer_contract::Enum::One)' \
@@ -86,7 +86,7 @@ Numeric types (primitives and `felt252`) can be paseed with type suffix specifie
 
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x05075f6d418f7c53c6cdc21cbb5aca2b69c83b6fbcc8256300419a9f101c8b77 \
     --function complex_fn \
     --arguments \
@@ -109,7 +109,7 @@ Alternatively, you can continue the single quote for multiple lines.
 
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x05075f6d418f7c53c6cdc21cbb5aca2b69c83b6fbcc8256300419a9f101c8b77 \
     --function complex_fn \
     --arguments 'array![array![1, 2], array![3, 4, 5], array![6]],
@@ -131,7 +131,7 @@ true,
 
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x05075f6d418f7c53c6cdc21cbb5aca2b69c83b6fbcc8256300419a9f101c8b77 \
     --function nested_struct_fn \
     --arguments \

--- a/docs/src/starknet/declare.md
+++ b/docs/src/starknet/declare.md
@@ -22,7 +22,7 @@ Then run:
 ```shell
 $ sncast --account my_account \
     declare \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --contract-name HelloSncast
 ```
 
@@ -45,7 +45,7 @@ transaction: https://starkscan.co/search/[..]
 > Contract name is a part after the `mod` keyword in your contract file. It may differ from package name defined in `Scarb.toml` file.
 
 > 📝 **Note**
-> In the above example we supply `sncast` with `--account` and `--url` flags. If `snfoundry.toml` is present, and has
+> In the above example we supply `sncast` with `--account` and `--network` flags. If `snfoundry.toml` is present, and has
 > the properties set, values provided using these flags will override values from `snfoundry.toml`. Learn more about `snfoundry.toml`
 > configuration [here](../projects/configuration.md#sncast).
 

--- a/docs/src/starknet/deploy.md
+++ b/docs/src/starknet/deploy.md
@@ -18,7 +18,7 @@ After [declaring your contract](./declare.md), you can deploy it the following w
 $ sncast \
     --account my_account \
     deploy \
-    --url http://127.0.0.1:5055/rpc \
+    --network sepolia \
     --class-hash 0x0227f52a4d2138816edf8231980d5f9e6e0c8a3deab45b601a1fcee3d4427b02
 ```
 

--- a/docs/src/starknet/invoke.md
+++ b/docs/src/starknet/invoke.md
@@ -22,7 +22,7 @@ For detailed CLI description, see [invoke command reference](../appendix/sncast/
 $ sncast \
   --account my_account \
   invoke \
-  --url http://127.0.0.1:5055 \
+  --network sepolia \
   --contract-address 0x522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716 \
   --function "add" \
   --arguments 'pokemons::model::PokemonData {'\

--- a/docs/src/starknet/script.md
+++ b/docs/src/starknet/script.md
@@ -260,7 +260,7 @@ To run the script, do:
 ```shell
 $ sncast \
   script run my_script
-  --url https://starknet-sepolia.public.blastapi.io/rpc/v0_7
+  --network sepolia
 ```
 
 <details>
@@ -340,7 +340,7 @@ To run the script, do:
 $ sncast \
   --account example_user \
   script run map_script \
-  --url https://starknet-sepolia.public.blastapi.io/rpc/v0_7
+  --network sepolia
 ```
 
 <details>
@@ -368,7 +368,7 @@ and only `call` functions are being executed (as they do not change the network 
 $ sncast \
   --account example_user \
   script run map_script \
-  --url https://starknet-sepolia.public.blastapi.io/rpc/v0_7
+  --network sepolia
 ```
 
 <details>
@@ -393,7 +393,7 @@ whereas, when we run the same script once again with `--no-state-file` flag set,
 $ sncast \
   --account example_user \
   script run map_script \
-  --url https://starknet-sepolia.public.blastapi.io/rpc/v0_7 \
+  --network sepolia \
   --no-state-file
 ```
 

--- a/docs/src/starknet/sncast-overview.md
+++ b/docs/src/starknet/sncast-overview.md
@@ -33,7 +33,7 @@ Let's use `sncast` to call a contract's function:
 <!-- { "ignored": true } -->
 ```shell
 $ sncast call \
-    --url http://127.0.0.1:5055 \
+    --network sepolia \
     --contract-address 0x522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716 \
     --function "pokemon" \
     --arguments '"Charizard"' \
@@ -89,7 +89,7 @@ Let's invoke a transaction and wait for it to be `ACCEPTED_ON_L2`.
 $ sncast --account my_account \
     --wait \
     deploy \
-	--url http://127.0.0.1:5055 \
+	--network sepolia \
     --class-hash 0x0227f52a4d2138816edf8231980d5f9e6e0c8a3deab45b601a1fcee3d4427b02 \
     --fee-token strk
 ```

--- a/docs/src/starknet/sncast-overview.md
+++ b/docs/src/starknet/sncast-overview.md
@@ -55,6 +55,13 @@ response: [0x0, 0x0, 0x43686172697a617264, 0x9, 0x0, 0x0, 0x41a78e741e5af2fec34b
 
 ### Network and RPC Providers
 
+### Network and RPC Providers
+
+When providing `--network` flag, `sncast` will randomly select on of the free RPC providers.
+When using free provider you may experience rate limits and other unexpected behavior.
+
+If using `sncast` extensively, we recommend getting access to a dedicated RPC node and providing its URL to sncast with
+`--url` flag.
 
 ### Arguments
 

--- a/docs/src/starknet/sncast-overview.md
+++ b/docs/src/starknet/sncast-overview.md
@@ -51,7 +51,9 @@ response: [0x0, 0x0, 0x43686172697a617264, 0x9, 0x0, 0x0, 0x41a78e741e5af2fec34b
 <br>
 
 > 📝 **Note**
-> In the above example we supply `sncast` with `--account` and `--url` flags. If `snfoundry.toml` is present, and have these properties set, values provided using these flags will override values from `snfoundry.toml`. Learn more about `snfoundry.toml` configuration [here](../projects/configuration.md#sncast).
+> In the above example we supply `sncast` with `--account` flag. If `snfoundry.toml` is present, and have this property set, value provided using this flags will override value from `snfoundry.toml`. Learn more about `snfoundry.toml` configuration [here](../projects/configuration.md#sncast).
+
+### Network and RPC Providers
 
 
 ### Arguments

--- a/docs/src/starknet/sncast-overview.md
+++ b/docs/src/starknet/sncast-overview.md
@@ -55,8 +55,6 @@ response: [0x0, 0x0, 0x43686172697a617264, 0x9, 0x0, 0x0, 0x41a78e741e5af2fec34b
 
 ### Network and RPC Providers
 
-### Network and RPC Providers
-
 When providing `--network` flag, `sncast` will randomly select on of the free RPC providers.
 When using free provider you may experience rate limits and other unexpected behavior.
 

--- a/docs/src/starknet/tx-status.md
+++ b/docs/src/starknet/tx-status.md
@@ -16,7 +16,7 @@ You can track the details about the execution and finality status of a transacti
 $ sncast \
  tx-status \
  0x07d2067cd7675f88493a9d773b456c8d941457ecc2f6201d2fe6b0607daadfd1 \
- --url https://starknet-sepolia.public.blastapi.io
+ --network sepolia
 ```
 
 <details>

--- a/docs/src/starknet/verify.md
+++ b/docs/src/starknet/verify.md
@@ -23,7 +23,7 @@ First, ensure that you have created a `Scarb.toml` file for your contract (it sh
 
 Then run:
 
-<!-- { "ignored_output": true, "not_replace_network": true } -->
+<!-- { "ignored_output": true, "replace_network": false } -->
 ```shell
 $ sncast \
     verify \

--- a/docs/src/starknet/verify.md
+++ b/docs/src/starknet/verify.md
@@ -23,7 +23,7 @@ First, ensure that you have created a `Scarb.toml` file for your contract (it sh
 
 Then run:
 
-<!-- { "ignored_output": true } -->
+<!-- { "ignored_output": true, "not_replace_network": true } -->
 ```shell
 $ sncast \
     verify \


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2708 

## Introduced changes

<!-- A brief description of the changes -->

- Added default RPC providers to `sncast` under `--network` flag
- Breaking: renamed `--network` flag to `--network-name` in `sncast account delete` and `sncast account import` due to conflict with the added flag 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
