### PR TITLE
Cache default value after failed request in `ForkStateReader`

### DIFF
--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -140,7 +140,7 @@ impl StateReader for ForkStateReader {
                     key,
                     Felt::default(),
                 );
-                Ok(Default::default())
+                Ok(Felt::default())
             },
             Err(x) => Err(StateReadError(format!(
                 "Unable to get storage at address: {contract_address:?} and key: {key:?} from fork ({x})"

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -134,7 +134,14 @@ impl StateReader for ForkStateReader {
                 Ok(value_sf)
             }
             Err(ProviderError::Other(boxed)) => other_provider_error(boxed),
-            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(Default::default()),
+            Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                self.cache.borrow_mut().cache_get_storage_at(
+                    contract_address,
+                    key,
+                    Default::default(),
+                );
+                Ok(Default::default())
+            },
             Err(x) => Err(StateReadError(format!(
                 "Unable to get storage at address: {contract_address:?} and key: {key:?} from fork ({x})"
             ))),
@@ -159,6 +166,9 @@ impl StateReader for ForkStateReader {
             }
             Err(ProviderError::Other(boxed)) => other_provider_error(boxed),
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                self.cache
+                    .borrow_mut()
+                    .cache_get_nonce_at(contract_address, Default::default());
                 Ok(Default::default())
             }
             Err(x) => Err(StateReadError(format!(
@@ -184,6 +194,9 @@ impl StateReader for ForkStateReader {
                 Ok(class_hash)
             }
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {
+                self.cache
+                    .borrow_mut()
+                    .cache_get_class_hash_at(contract_address, Default::default());
                 Ok(Default::default())
             }
             Err(ProviderError::Other(boxed)) => other_provider_error(boxed),

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -138,7 +138,7 @@ impl StateReader for ForkStateReader {
                 self.cache.borrow_mut().cache_get_storage_at(
                     contract_address,
                     key,
-                    Default::default(),
+                    Felt::default(),
                 );
                 Ok(Default::default())
             },


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2849

## Introduced changes

<!-- A brief description of the changes -->

Update the logic of `ForkStateReader` - if we receive `StarknetError::ContractNotFound`, we additionaly cache such request.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
