### PR TITLE
Feat: add information about the ability to use --max-n-steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2025-01-27
+
+### Forge
+
+#### Added
+- Added a suggestion for using the `--max-n-steps` flag when the Cairo VM returns the error: `Could not reach the end of the program. RunResources has no remaining steps`.
+
+#### Changed
+- Modified tests to properly display the `--max-n-steps` suggestion when the above error occurs.
+
 ## [0.36.0] - 2025-01-15
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.37.0] - 2025-01-27
-
 ### Forge
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Forge
 
 #### Added
-- Added a suggestion for using the `--max-n-steps` flag when the Cairo VM returns the error: `Could not reach the end of the program. RunResources has no remaining steps`.
 
+- Added a suggestion for using the `--max-n-steps` flag when the Cairo VM returns the error: `Could not reach the end of the program. RunResources has no remaining steps`.
 
 ### Forge
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - Added a suggestion for using the `--max-n-steps` flag when the Cairo VM returns the error: `Could not reach the end of the program. RunResources has no remaining steps`.
 
-#### Changed
-- Modified tests to properly display the `--max-n-steps` suggestion when the above error occurs.
 
 ## [0.36.0] - 2025-01-15
 

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -311,13 +311,16 @@ fn extract_test_case_summary(
                         "\n    {}\n",
                         error.to_string().replace(" Custom Hint Error: ", "\n    ")
                     );
-                    if error.to_string().contains("RunResources has no remaining steps") {
-                        message.push_str("\nSuggestion: Try increasing the steps with --max-n-steps.");
+                    if error
+                        .to_string()
+                        .contains("RunResources has no remaining steps")
+                    {
+                        message
+                            .push_str("\nSuggestion: Try increasing the steps with --max-n-steps.");
                     }
                     TestCaseSummary::Failed {
                         name: case.name.clone(),
-                        msg: Some(message)
-                        .map(|msg| {
+                        msg: Some(message).map(|msg| {
                             add_backtrace_footer(
                                 msg,
                                 contracts_data,
@@ -327,7 +330,7 @@ fn extract_test_case_summary(
                         arguments: args,
                         test_statistics: (),
                     }
-                },
+                }
             }
         }
         // `ForkStateReader.get_block_info`, `get_fork_state_reader, `calculate_used_gas` may return an error

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -315,7 +315,7 @@ fn extract_test_case_summary(
                     if let CairoRunError::VirtualMachine(vm_error) = *error {
                         if let VirtualMachineError::UnfinishedExecution = vm_error {
                             message.push_str(
-                                "\nSuggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps",
+                                "\n    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps",
                             );
                         }
                     }

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -312,12 +312,12 @@ fn extract_test_case_summary(
                         "\n    {}\n",
                         error.to_string().replace(" Custom Hint Error: ", "\n    ")
                     );
-                    if let CairoRunError::VirtualMachine(vm_error) = *error {
-                        if let VirtualMachineError::UnfinishedExecution = vm_error {
-                            message.push_str(
+                    if let CairoRunError::VirtualMachine(VirtualMachineError::UnfinishedExecution) =
+                        *error
+                    {
+                        message.push_str(
                                 "\n    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps",
                             );
-                        }
                     }
                     TestCaseSummary::Failed {
                         name: case.name.clone(),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -306,21 +306,27 @@ fn extract_test_case_summary(
                     versioned_program_path,
                 ),
                 // CairoRunError comes from VirtualMachineError which may come from HintException that originates in TestExecutionSyscallHandler
-                Err(error) => TestCaseSummary::Failed {
-                    name: case.name.clone(),
-                    msg: Some(format!(
+                Err(error) => {
+                    let mut message = format!(
                         "\n    {}\n",
                         error.to_string().replace(" Custom Hint Error: ", "\n    ")
-                    ))
-                    .map(|msg| {
-                        add_backtrace_footer(
-                            msg,
-                            contracts_data,
-                            &result_with_info.encountered_errors,
-                        )
-                    }),
-                    arguments: args,
-                    test_statistics: (),
+                    );
+                    if error.to_string().contains("RunResources has no remaining steps") {
+                        message.push_str("\nSuggestion: Try increasing the steps with --max-n-steps.");
+                    }
+                    TestCaseSummary::Failed {
+                        name: case.name.clone(),
+                        msg: Some(message)
+                        .map(|msg| {
+                            add_backtrace_footer(
+                                msg,
+                                contracts_data,
+                                &result_with_info.encountered_errors,
+                            )
+                        }),
+                        arguments: args,
+                        test_statistics: (),
+                    }
                 },
             }
         }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1052,11 +1052,13 @@ fn incompatible_snforge_std_version_warning() {
 
         Failure data:
             Could not reach the end of the program. RunResources has no remaining steps.
+            Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
         [FAIL] steps::tests::steps_much_more_than_10000000
 
         Failure data:
             Could not reach the end of the program. RunResources has no remaining steps.
+            Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
         [PASS] steps::tests::steps_less_than_10000000 [..]
         Tests: 2 passed, 2 failed, 0 skipped, 0 ignored, 0 filtered out

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -26,21 +26,25 @@ fn should_allow_less_than_default() {
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
                 [FAIL] steps::tests::steps_less_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
                 [FAIL] steps::tests::steps_much_more_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
                 [FAIL] steps::tests::steps_much_less_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
                 Tests: 0 passed, 4 failed, 0 skipped, 0 ignored, 0 filtered out
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2853 

## Introduced changes

<!-- A brief description of the changes -->

- Updated error to suggest using “--max-n-steps” in case of cairo_vm error

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
