### PR TITLE
Migrate all scarb packages to edition = 2024_07

### DIFF
--- a/sncast_std/Scarb.lock
+++ b/sncast_std/Scarb.lock
@@ -4,3 +4,11 @@ version = 1
 [[package]]
 name = "sncast_std"
 version = "0.36.0"
+dependencies = [
+ "snforge_std",
+]
+
+[[package]]
+name = "snforge_std"
+version = "0.27.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.27.0#2d99b7c00678ef0363881ee0273550c44a9263de"

--- a/sncast_std/Scarb.toml
+++ b/sncast_std/Scarb.toml
@@ -1,9 +1,12 @@
 [package]
 name = "sncast_std"
 version = "0.36.0"
-edition = "2023_11"
+edition = "2024_07"
 description = "Library used for writing deployment scripts in Cairo"
 homepage = "https://foundry-rs.github.io/starknet-foundry/starknet/script.html"
 documentation = "https://foundry-rs.github.io/starknet-foundry/appendix/sncast-library.html"
 repository = "https://github.com/foundry-rs/starknet-foundry"
 license-file = "../LICENSE"
+
+[dev-dependencies]
+snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.27.0" }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes
All scarb packages was migrated to edition = 2024_07 

<!-- A brief description of the changes -->
The different scarb packages  in this project were not all in the same edition.  All the scarb packages in this projecte was migrated to edition = 2024_07. Test was run to ensure that the migration was successfully done.

-

## Checklist

<!-- Make sure all of these are complete -->

- [Done ] Updated relevant dependencies
- [ Done] Added relevant tests
