### PR TITLE
fix(sncast): improve calldata serialization logic

### DIFF
--- a/crates/sncast/tests/e2e/calldata_handling.rs
+++ b/crates/sncast/tests/e2e/calldata_handling.rs
@@ -1,0 +1,49 @@
+#[test]
+fn test_no_arguments_with_required_calldata() {
+    // Setup test contract that requires calldata
+    let contract = deploy_contract_requiring_calldata();
+    
+    // Call without --arguments or --calldata
+    let result = sncast()
+        .args(&["call", "--contract", &contract.address, "--function", "requires_args"])
+        .assert()
+        .failure();
+        
+    // Verify we get data transformer error, not provider error
+    assert!(result.stderr().contains("Failed to serialize arguments"));
+}
+
+#[test]
+fn test_both_arguments_and_calldata_provided() {
+    let contract = deploy_contract_requiring_calldata();
+    
+    let result = sncast()
+        .args(&[
+            "call",
+            "--contract", &contract.address,
+            "--function", "requires_args",
+            "--calldata", "1",
+            "--arguments", "2"
+        ])
+        .assert()
+        .failure();
+        
+    assert!(result.stderr().contains("Cannot provide both --calldata and --arguments"));
+}
+
+#[test]
+fn test_invalid_calldata_format() {
+    let contract = deploy_contract_requiring_calldata();
+    
+    let result = sncast()
+        .args(&[
+            "call",
+            "--contract", &contract.address,
+            "--function", "requires_args",
+            "--calldata", "invalid"
+        ])
+        .assert()
+        .failure();
+        
+    assert!(result.stderr().contains("Failed to parse calldata value to felt"));
+} 


### PR DESCRIPTION
- Always use data transformer unless --calldata is provided
- Add better error messages for calldata handling
- Add tests for calldata edge cases

<!-- Reference any GitHub issues resolved by this PR -->

Closes #2760

## Introduced changes

Changes:
- Modified `try_into_calldata` to always use data transformer when `--calldata` is not provided
- Improved error messages for calldata handling failures
- Added tests to verify error cases and empty calldata handling

The change ensures users get clear error messages from the data transformer instead of provider errors when calldata is required but not provided.

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
