### PR TITLE
Test for multiple writes/reads to the same storage slot

### DIFF
--- a/crates/cheatnet/tests/cheatcodes/mod.rs
+++ b/crates/cheatnet/tests/cheatcodes/mod.rs
@@ -20,6 +20,7 @@ mod precalculate_address;
 mod replace_bytecode;
 mod spy_events;
 mod store;
+mod multiple_writes_same_storage;
 
 pub fn map_entry_address(var_name: &str, key: &[Felt]) -> Felt {
     calculate_variable_address(felt_selector_from_name(var_name).into_(), Some(key))

--- a/crates/cheatnet/tests/cheatcodes/multiple_writes_same_storage.rs
+++ b/crates/cheatnet/tests/cheatcodes/multiple_writes_same_storage.rs
@@ -1,0 +1,46 @@
+use crate::cheatcodes::variable_address;
+use crate::common::assertions::assert_success;
+use crate::common::get_contracts;
+use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::store;
+use starknet_api::core::ContractAddress;
+use starknet_types_core::felt::Felt;
+
+use super::test_environment::TestEnvironment;
+
+trait StoreTrait {
+    fn store(&mut self, target: ContractAddress, storage_address: Felt, value: u128);
+}
+
+impl StoreTrait for TestEnvironment {
+    fn store(&mut self, target: ContractAddress, storage_address: Felt, value: u128) {
+        store(
+            &mut self.cached_state,
+            target,
+            storage_address,
+            Felt::from(value),
+        )
+        .unwrap();
+    }
+}
+
+#[test]
+fn multiple_writes_same_storage() {
+    let mut test_env = TestEnvironment::new();
+    let contracts_data = get_contracts();
+    let hello_class_hash = test_env.declare("HelloStarknet", &contracts_data);
+    let contract_address_write = test_env.deploy_wrapper(&hello_class_hash, &[]);
+    let contract_address_read = test_env.deploy_wrapper(&hello_class_hash, &[]);
+    assert_ne!(contract_address_read, contract_address_write);
+
+    test_env.call_contract(
+        &contract_address_write,
+        "increase_balance",
+        &[Felt::from(420)],
+    );
+    test_env.store(contract_address_write, variable_address("balance"), 450);
+    let write_balance_value = test_env.call_contract(&contract_address_write, "get_balance", &[]);
+    assert_success(write_balance_value, &[Felt::from(450)]);
+
+    let read_balance_value = test_env.call_contract(&contract_address_read, "get_balance", &[]);
+    assert_success(read_balance_value, &[Felt::from(0)]);
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #1559

## Introduced changes

<!-- A brief description of the changes -->
I  modified locally :
`storage_view` field  to map only StorageKey to felt
And created new test case that passes correctly :

* [`crates/cheatnet/tests/cheatcodes/multiple_writes_same_storage.rs`](diffhunk://#diff-e17b72d677be53df13b4896cb6770dc9f012711c5f02ac3e6dd7f7238d8ef32fR1-R46):  test case `multiple_writes_same_storage`. This test ensures that writes to the storage across multiple contracts with same ClassHash and storage key is not possible.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`





