### PR TITLE
Allow comments in coverage validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Fixed
+
+- coverage validation now supports comments is `Scarb.toml` values
+
 ## [0.36.0] - 2025-01-15
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- coverage validation now supports comments is `Scarb.toml` values
+- coverage validation now supports comments in `Scarb.toml`
 
 ## [0.36.0] - 2025-01-15
 

--- a/crates/forge-runner/src/coverage_api.rs
+++ b/crates/forge-runner/src/coverage_api.rs
@@ -17,7 +17,7 @@ const MINIMAL_SCARB_VERSION: Version = Version::new(2, 8, 0);
 const CAIRO_COVERAGE_REQUIRED_ENTRIES: [(&str, &str); 3] = [
     ("unstable-add-statements-functions-debug-info", "true"),
     ("unstable-add-statements-code-locations-debug-info", "true"),
-    ("inlining-strategy", "\"avoid\""),
+    ("inlining-strategy", "avoid"),
 ];
 
 pub fn run_coverage(saved_trace_data_paths: &[PathBuf], coverage_args: &[OsString]) -> Result<()> {
@@ -104,8 +104,16 @@ pub fn can_coverage_be_generated(scarb_metadata: &Metadata) -> Result<()> {
     Ok(())
 }
 
+/// Check if the table contains an entry with the given key and value.
+/// Accepts only bool and string values.
 fn contains_entry_with_value(table: &Table, key: &str, value: &str) -> bool {
-    table
-        .get(key)
-        .is_some_and(|entry| entry.to_string().trim() == value)
+    table.get(key).is_some_and(|entry| {
+        if let Some(entry) = entry.as_bool() {
+            entry.to_string() == value
+        } else if let Some(entry) = entry.as_str() {
+            entry == value
+        } else {
+            false
+        }
+    })
 }

--- a/crates/forge/tests/data/coverage_project/Scarb.toml
+++ b/crates/forge/tests/data/coverage_project/Scarb.toml
@@ -15,6 +15,6 @@ snforge_std = { path = "../../../../../snforge_std" }
 sierra = true
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
+unstable-add-statements-functions-debug-info = true # Comment
 unstable-add-statements-code-locations-debug-info = true
-inlining-strategy= "avoid"
+inlining-strategy= "avoid" # Comment


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->


## Introduced changes

There was an issue where, when validating `Scarb.toml` and calling `.to_string()`, comments were included in the resulting string, causing validation to fail. This PR resolves the issue.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
