### PR TITLE
Fix type conversion in script "deploy" that resulted in max_fee being omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - coverage validation now supports comments in `Scarb.toml`
 
+### Cast
+
+#### Fixed
+
+- Bug resulting in value passed for `max_fee` being ignored in cast scripts when using `deploy` with STRK token
+
 ## [0.36.0] - 2025-01-15
 
 ### Forge

--- a/crates/sncast/src/helpers/fee.rs
+++ b/crates/sncast/src/helpers/fee.rs
@@ -198,22 +198,6 @@ pub enum FeeSettings {
     },
 }
 
-impl From<ScriptFeeSettings> for FeeSettings {
-    fn from(value: ScriptFeeSettings) -> Self {
-        match value {
-            ScriptFeeSettings::Eth { max_fee } => FeeSettings::Eth { max_fee },
-            ScriptFeeSettings::Strk {
-                max_gas,
-                max_gas_unit_price,
-                ..
-            } => FeeSettings::Strk {
-                max_gas,
-                max_gas_unit_price,
-            },
-        }
-    }
-}
-
 pub trait PayableTransaction {
     fn error_message(&self, token: &str, version: &str) -> String;
     fn validate_and_get_token(&self) -> Result<FeeToken>;

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -28,7 +28,6 @@ use sncast::{
     chain_id_to_network_name, get_account, get_block_id, get_chain_id, get_class_hash_by_address,
     get_contract_class, get_default_state_file_name, NumbersFormat, ValidatedWaitParams, WaitForTx,
 };
-use starknet::accounts::ConnectedAccount;
 use starknet::core::types::ContractClass;
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::Provider;
@@ -290,8 +289,6 @@ async fn run_async_command(
         }
 
         Commands::Deploy(deploy) => {
-            let fee_token = deploy.validate_and_get_token()?;
-
             let Deploy {
                 arguments,
                 fee_args,
@@ -309,12 +306,6 @@ async fn run_async_command(
             )
             .await?;
 
-            let fee_settings = fee_args
-                .clone()
-                .fee_token(fee_token)
-                .try_into_fee_settings(&provider, account.block_id())
-                .await?;
-
             // safe to unwrap because "constructor" is a standardized name
             let selector = get_selector_from_name("constructor").unwrap();
 
@@ -328,7 +319,7 @@ async fn run_async_command(
                 &calldata,
                 deploy.salt,
                 deploy.unique,
-                fee_settings,
+                fee_args,
                 deploy.nonce,
                 &account,
                 wait_config,

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -289,6 +289,8 @@ async fn run_async_command(
         }
 
         Commands::Deploy(deploy) => {
+            let fee_token = deploy.validate_and_get_token()?;
+
             let Deploy {
                 arguments,
                 fee_args,
@@ -323,6 +325,7 @@ async fn run_async_command(
                 deploy.nonce,
                 &account,
                 wait_config,
+                fee_token,
             )
             .await
             .map_err(handle_starknet_command_error);

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -84,8 +84,10 @@ pub async fn deploy(
     nonce: Option<Felt>,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
     wait_config: WaitForTx,
+    fee_token: FeeToken,
 ) -> Result<DeployResponse, StarknetCommandError> {
     let fee_settings = fee_args
+        .fee_token(fee_token)
         .try_into_fee_settings(account.provider(), account.block_id())
         .await?;
 

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -80,11 +80,15 @@ pub async fn deploy(
     calldata: &Vec<Felt>,
     salt: Option<Felt>,
     unique: bool,
-    fee_settings: FeeSettings,
+    fee_args: FeeArgs,
     nonce: Option<Felt>,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>,
     wait_config: WaitForTx,
 ) -> Result<DeployResponse, StarknetCommandError> {
+    let fee_settings = fee_args
+        .try_into_fee_settings(account.provider(), account.block_id())
+        .await?;
+
     let salt = extract_or_generate_salt(salt);
     let factory = ContractFactory::new(class_hash, account);
     let result = match fee_settings {

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -161,8 +161,9 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let constructor_calldata = input_reader.read::<Vec<Felt>>()?;
                 let salt = input_reader.read()?;
                 let unique = input_reader.read()?;
-                let fee_args = input_reader.read::<ScriptFeeSettings>()?.into();
+                let fee_args: FeeArgs = input_reader.read::<ScriptFeeSettings>()?.into();
                 let nonce = input_reader.read()?;
+                let fee_token = fee_args.fee_token.clone().unwrap_or_default();
 
                 let deploy_tx_id =
                     generate_deploy_tx_id(class_hash, &constructor_calldata, salt, unique);
@@ -185,6 +186,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                         wait: true,
                         wait_params: self.config.wait_params,
                     },
+                    fee_token,
                 ));
 
                 self.state.maybe_insert_tx_entry(

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -35,7 +35,7 @@ use shared::utils::build_readable_text;
 use sncast::get_nonce;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::SCRIPT_LIB_ARTIFACT_NAME;
-use sncast::helpers::fee::{FeeArgs, FeeSettings, ScriptFeeSettings};
+use sncast::helpers::fee::{FeeArgs, ScriptFeeSettings};
 use sncast::helpers::rpc::RpcArgs;
 use sncast::response::structs::ScriptRunResponse;
 use sncast::state::hashing::{
@@ -161,7 +161,7 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let constructor_calldata = input_reader.read::<Vec<Felt>>()?;
                 let salt = input_reader.read()?;
                 let unique = input_reader.read()?;
-                let fee_args: FeeSettings = input_reader.read::<ScriptFeeSettings>()?.into();
+                let fee_args = input_reader.read::<ScriptFeeSettings>()?.into();
                 let nonce = input_reader.read()?;
 
                 let deploy_tx_id =


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

This came up from #2865 

Conversion from `ScriptFeeSettings` to `FeeSettings` resulted in value for `max_fee` being dropped completely. This conversion was only in cast script "deploy" function.

If deploy was used with Strk token, any value passed to `max_fee` was completely ignored.

Removed the conversion entirely and used correct structure in deploy.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
