### PR TITLE
Add `generate_arg` cheatcode

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/fuzzer.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/fuzzer.rs
@@ -1,0 +1,38 @@
+use anyhow::ensure;
+use num_bigint::RandBigInt;
+use rand::prelude::StdRng;
+use starknet_types_core::felt::Felt;
+use std::sync::{Arc, Mutex};
+
+pub(crate) fn generate_arg(
+    fuzzer_rng: Option<Arc<Mutex<StdRng>>>,
+    min_value: Felt,
+    max_value: Felt,
+) -> anyhow::Result<Felt> {
+    let min_big_int = if min_value > (Felt::MAX + Felt::from(i128::MIN)) && min_value > max_value {
+        // Negative value x is serialized as P + x, where P is the STARK prime number
+        // hence to deserialize and get the actual x we need to subtract P (== Felt::MAX + 1)
+        min_value.to_bigint() - Felt::MAX.to_bigint() - 1
+    } else {
+        min_value.to_bigint()
+    };
+
+    let max_big_int = max_value.to_bigint();
+
+    ensure!(
+        min_big_int <= max_big_int,
+        format!("`generate_arg` cheatcode: `min_value` must be <= `max_value`, provided values after deserialization: {min_big_int} and {max_big_int}")
+    );
+
+    let value = if let Some(fuzzer_rng) = fuzzer_rng {
+        fuzzer_rng
+            .lock()
+            .unwrap()
+            .gen_bigint_range(&min_big_int, &(max_big_int + 1))
+    } else {
+        // `generate_arg` cheatcode can be also used outside the fuzzer context
+        rand::thread_rng().gen_bigint_range(&min_big_int, &(max_big_int + 1))
+    };
+
+    Ok(Felt::from(value))
+}

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/fuzzer.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/fuzzer.rs
@@ -27,7 +27,7 @@ pub(crate) fn generate_arg(
     let value = if let Some(fuzzer_rng) = fuzzer_rng {
         fuzzer_rng
             .lock()
-            .unwrap()
+            .expect("Failed to acquire lock on fuzzer_rng")
             .gen_bigint_range(&min_big_int, &(max_big_int + 1))
     } else {
         // `generate_arg` cheatcode can be also used outside the fuzzer context

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -481,8 +481,8 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 generate_random_felt(),
             )),
             "generate_arg" => {
-                let min_value: Felt = input_reader.read()?;
-                let max_value: Felt = input_reader.read()?;
+                let min_value = input_reader.read()?;
+                let max_value = input_reader.read()?;
 
                 Ok(CheatcodeHandlingResult::from_serializable(
                     fuzzer::generate_arg(self.fuzzer_rng.clone(), min_value, max_value)?,

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -203,6 +203,7 @@ pub fn run_test_case(
     let forge_extension = ForgeExtension {
         environment_variables: runtime_config.environment_variables,
         contracts_data: runtime_config.contracts_data,
+        fuzzer_rng: None,
     };
 
     let mut forge_runtime = ExtendedRuntime {

--- a/snforge_std/src/cheatcodes.cairo
+++ b/snforge_std/src/cheatcodes.cairo
@@ -8,6 +8,7 @@ pub mod storage;
 pub mod execution_info;
 pub mod message_to_l1;
 pub mod generate_random_felt;
+pub mod generate_arg;
 
 /// Enum used to specify how long the target should be cheated for.
 #[derive(Copy, Drop, Serde, PartialEq, Clone, Debug)]

--- a/snforge_std/src/cheatcodes/generate_arg.cairo
+++ b/snforge_std/src/cheatcodes/generate_arg.cairo
@@ -1,0 +1,8 @@
+use super::super::_cheatcode::execute_cheatcode_and_deserialize;
+
+// Generates a random number that is used for creating data for fuzz tests
+pub fn generate_arg<T, +Serde<T>, +Drop<T>, +Into<T, felt252>>(min_value: T, max_value: T) -> T {
+    execute_cheatcode_and_deserialize::<
+        'generate_arg'
+    >(array![min_value.into(), max_value.into()].span())
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #2051

## Introduced changes

<!-- A brief description of the changes -->

- Added a cheatcode for generating random number that is used for creating data for fuzz tests

This PR is part of the stack:

➡️ Add `generate_arg` cheatcode (https://github.com/foundry-rs/starknet-foundry/pull/2892)
-- Add `Fuzzable` trait (https://github.com/foundry-rs/starknet-foundry/pull/2893)
-- Move statements logic to separate function (https://github.com/foundry-rs/starknet-foundry/pull/2894)
-- Add new fuzzer logic to plugin (https://github.com/foundry-rs/starknet-foundry/pull/2895)
-- Add cheatcode to save fuzzer input (https://github.com/foundry-rs/starknet-foundry/pull/2923)
-- Remove old fuzzer logic (https://github.com/foundry-rs/starknet-foundry/pull/2896)
-- Add fuzzer tests with multiple attributes (https://github.com/foundry-rs/starknet-foundry/pull/2898)
-- Update fuzzer documentation and changelog (https://github.com/foundry-rs/starknet-foundry/pull/2899)
