### PR TITLE
Add `Fuzzable` trait

### DIFF
--- a/snforge_std/src/fuzzable.cairo
+++ b/snforge_std/src/fuzzable.cairo
@@ -57,7 +57,7 @@ pub impl FuzzableU256 of Fuzzable<u256> {
             Fuzzable::<u128>::generate().into(), Fuzzable::<u128>::generate().into()
         ]
             .span();
-        Serde::deserialize(ref serialized).unwrap_or(1)
+        Serde::deserialize(ref serialized).unwrap()
     }
 }
 

--- a/snforge_std/src/fuzzable.cairo
+++ b/snforge_std/src/fuzzable.cairo
@@ -62,7 +62,7 @@ pub impl FuzzableU256 of Fuzzable<u256> {
 }
 
 
-pub impl FuzzableByteArray of Fuzzable<ByteArray> {
+pub impl FuzzableByteArray1000ASCII of Fuzzable<ByteArray> {
     fn blank() -> ByteArray {
         ""
     }

--- a/snforge_std/src/fuzzable.cairo
+++ b/snforge_std/src/fuzzable.cairo
@@ -1,0 +1,84 @@
+pub use super::cheatcodes::generate_arg::generate_arg;
+
+const MAX_FELT: felt252 = 0x800000000000011000000000000000000000000000000000000000000000000;
+
+pub trait Fuzzable<T> {
+    fn blank() -> T;
+    fn generate() -> T;
+}
+
+impl FuzzableFelt of Fuzzable<felt252> {
+    fn blank() -> felt252 {
+        0x0
+    }
+
+    fn generate() -> felt252 {
+        generate_arg(0x0, MAX_FELT)
+    }
+}
+
+mod nums {
+    use super::{Fuzzable, generate_arg};
+    use core::num::traits::{Bounded, One, Zero};
+
+    pub impl FuzzableNum<
+        T, +Zero<T>, +Bounded<T>, +Drop<T>, +Serde<T>, +Into<T, felt252>
+    > of Fuzzable<T> {
+        fn blank() -> T {
+            Zero::<T>::zero()
+        }
+
+        fn generate() -> T {
+            generate_arg(Bounded::<T>::MIN, Bounded::<T>::MAX)
+        }
+    }
+}
+
+pub impl FuzzableU8 = nums::FuzzableNum<u8>;
+pub impl FuzzableU16 = nums::FuzzableNum<u16>;
+pub impl FuzzableU32 = nums::FuzzableNum<u32>;
+pub impl FuzzableU64 = nums::FuzzableNum<u64>;
+pub impl FuzzableU128 = nums::FuzzableNum<u128>;
+
+pub impl FuzzableI8 = nums::FuzzableNum<i8>;
+pub impl FuzzableI16 = nums::FuzzableNum<i16>;
+pub impl FuzzableI32 = nums::FuzzableNum<i32>;
+pub impl FuzzableI64 = nums::FuzzableNum<i64>;
+pub impl FuzzableI128 = nums::FuzzableNum<i128>;
+
+
+pub impl FuzzableU256 of Fuzzable<u256> {
+    fn blank() -> u256 {
+        0
+    }
+
+    fn generate() -> u256 {
+        let mut serialized: Span<felt252> = array![
+            Fuzzable::<u128>::generate().into(), Fuzzable::<u128>::generate().into()
+        ]
+            .span();
+        Serde::deserialize(ref serialized).unwrap_or(1)
+    }
+}
+
+
+pub impl FuzzableByteArray of Fuzzable<ByteArray> {
+    fn blank() -> ByteArray {
+        ""
+    }
+
+    // Generates a random string of length 0 to 1000
+    fn generate() -> ByteArray {
+        let mut ba_len: u32 = generate_arg(0, 1000);
+
+        let mut ba = "";
+        while ba_len > 0 {
+            // Limit only to printable characters with ASCII codes 32-126
+            let letter = Fuzzable::<u8>::generate() % 95;
+            ba.append_byte(letter + 32);
+            ba_len = ba_len - 1;
+        };
+
+        ba
+    }
+}

--- a/snforge_std/src/lib.cairo
+++ b/snforge_std/src/lib.cairo
@@ -123,6 +123,7 @@ pub use cheatcodes::execution_info::account_contract_address::start_cheat_accoun
 
 pub use cheatcodes::generate_random_felt::generate_random_felt;
 
+pub mod fuzzable;
 
 pub mod fs;
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #2051

## Introduced changes

<!-- A brief description of the changes -->

- Added `Fuzzable` trait with implementation for basic types

This PR is part of the stack:

-- Add `generate_arg` cheatcode (https://github.com/foundry-rs/starknet-foundry/pull/2892)
➡️ Add `Fuzzable` trait (https://github.com/foundry-rs/starknet-foundry/pull/2893)
-- Move statements logic to separate function (https://github.com/foundry-rs/starknet-foundry/pull/2894)
-- Add new fuzzer logic to plugin (https://github.com/foundry-rs/starknet-foundry/pull/2895)
-- Add cheatcode to save fuzzer input (https://github.com/foundry-rs/starknet-foundry/pull/2923)
-- Remove old fuzzer logic (https://github.com/foundry-rs/starknet-foundry/pull/2896)
-- Add fuzzer tests with multiple attributes (https://github.com/foundry-rs/starknet-foundry/pull/2898)
-- Update fuzzer documentation and changelog (https://github.com/foundry-rs/starknet-foundry/pull/2899)
