### PR TITLE
fix outdated doc links

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
@@ -57,7 +57,7 @@ impl<'a> ExtensionLogic for CallToBlockifierExtension<'a> {
             // This is redirected to drop ForgeRuntimeExtension
             // and to enable handling call errors with safe dispatchers in the test code
             // since call errors cannot be handled on real starknet
-            // https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/system-calls-cairo1/#call_contract
+            // https://docs.starknet.io/architecture-and-concepts/smart-contracts/system-calls-cairo1/#call_contract
             DeprecatedSyscallSelector::CallContract => {
                 execute_syscall::<CallContractRequest>(vm, extended_runtime)?;
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/storage.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/storage.rs
@@ -48,7 +48,7 @@ pub fn load(
 
 /// The address after hashing with pedersen, needs to be taken with a specific modulo value (2^251 - 256)
 /// For details see:
-/// <https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-storage/>
+/// <https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-storage>
 #[must_use]
 fn normalize_storage_address(address: Felt) -> Felt {
     let modulus = NonZeroFelt::from_felt_unchecked(Felt::from(2).pow(251_u128) - Felt::from(256));

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/storage.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/storage.rs
@@ -48,7 +48,7 @@ pub fn load(
 
 /// The address after hashing with pedersen, needs to be taken with a specific modulo value (2^251 - 256)
 /// For details see:
-/// <https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/contract-storage>
+/// <https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-storage/>
 #[must_use]
 fn normalize_storage_address(address: Felt) -> Felt {
     let modulus = NonZeroFelt::from_felt_unchecked(Felt::from(2).pow(251_u128) - Felt::from(256));

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -5,7 +5,7 @@ use test_utils::running_tests::run_test_case;
 use test_utils::test_case;
 
 // all calculations are based on formula from
-// https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/fee-mechanism/#overall_fee
+// https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee
 
 #[test]
 fn declare_cost_is_omitted() {


### PR DESCRIPTION
Hey! Fixed broken links in the code that were pointing to outdated Starknet documentation pages. Now all references lead to the correct sections.

### What’s changed:
- Updated links in:
  - `mod.rs`
  - `storage.rs`
  - `gas.rs`

Everything should now resolve properly.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
