### PR TITLE
Fix: Change name for plugin artifacts

### DIFF
--- a/.github/workflows/publish_plugin.yml
+++ b/.github/workflows/publish_plugin.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.target }}
+          name: build-plugin-${{ matrix.target }}
           path: ${{ env.OUTPUT_BINARY_PATH }}
           compression-level: 0
 
@@ -148,7 +148,7 @@ jobs:
           set -euxo pipefail
           mkdir -p crates/snforge-scarb-plugin/target/scarb/cairo-plugin
           
-          mv artifacts-dl/build-*/snforge_scarb_plugin_* crates/snforge-scarb-plugin/target/scarb/cairo-plugin/
+          mv artifacts-dl/build-plugin-*/snforge_scarb_plugin_* crates/snforge-scarb-plugin/target/scarb/cairo-plugin/
 
       - name: Publish snforge_scarb_plugin
         if: needs.check-version.outputs.plugin_uploaded == 'false' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

Change name for plugin artifacts so there's no collision when uploading artifacts in release workflow

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
