### PR TITLE
Make test `simple_package_with_git_dependency` pass locally

### DIFF
--- a/crates/forge/tests/e2e/common/runner.rs
+++ b/crates/forge/tests/e2e/common/runner.rs
@@ -237,7 +237,12 @@ pub(crate) fn get_remote_url() -> String {
             .output_checked()
             .unwrap();
 
-        String::from_utf8(output.stdout).unwrap().trim().to_string()
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .trim()
+            .strip_prefix("https://github.com/")
+            .unwrap()
+            .to_string()
     }
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #
<img width="412" alt="image" src="https://github.com/user-attachments/assets/fbb3a17f-dcef-40da-a229-d3b148ba5c4d" />

In local environment, this test failed bcs remote_url variable resulted in `https://github.com/foundry-rs/starknet-foundry.git` and for this reason, git path was `https://github.com/https://github.com/foundry-rs/starknet-foundry.git`. It works when it is stripped to `<repo_owner>/<repo_name>.git`. 

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
