### PR TITLE
Execute `cairo-coverage run` instead of `cairo-coverage`

### DIFF
--- a/crates/forge-runner/src/coverage_api.rs
+++ b/crates/forge-runner/src/coverage_api.rs
@@ -45,6 +45,7 @@ pub fn run_coverage(saved_trace_data_paths: &[PathBuf], coverage_args: &[OsStrin
         .collect();
 
     let mut command = Command::new(coverage);
+    command.arg("run");
 
     if coverage_args.iter().all(|arg| arg != "--output-path") {
         let dir_to_save_coverage = PathBuf::from(COVERAGE_DIR);


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

Running `cairo-coverage` without a subcommand will be deprecated in the next version and will print a warning. To avoid annoying users, this PR ensures Forge is prepared for the upcoming deprecation. It would be nice to include this in `0.38.0`, but it's okay if that doesn't happen.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
