### PR TITLE
Emit error if parameters without `#[fuzzer]` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Fixed
+
+- `snforge_scarb_plugin` now emits an error when parameters are passed without using the `#[fuzzer]` attribute
+
 ## [0.38.0] - 2025-02-25
 
 ### Forge

--- a/crates/forge/tests/e2e/fuzzing.rs
+++ b/crates/forge/tests/e2e/fuzzing.rs
@@ -310,7 +310,7 @@ fn no_fuzzer_attribute() {
         output,
         indoc! {r"
         error: Plugin diagnostic: #[test] function with parameters must have #[fuzzer] attribute
-         --> [..]tests/no_attribute.cairo:1:1
+         --> [..]no_attribute.cairo:1:1
         #[test]
 
         error: could not compile `fuzzing_integrationtest` due to previous error

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
@@ -1,4 +1,4 @@
-use crate::utils::{assert_diagnostics, assert_output, EMPTY_FN};
+use crate::utils::{assert_diagnostics, assert_output, EMPTY_FN, FN_WITH_SINGLE_FELT252_PARAM};
 use cairo_lang_macro::{Diagnostic, TokenStream};
 use indoc::formatdoc;
 use snforge_scarb_plugin::attributes::test::test;
@@ -50,5 +50,20 @@ fn is_used_once() {
     assert_diagnostics(
         &result,
         &[Diagnostic::error("#[test] can only be used once per item")],
+    );
+}
+
+#[test]
+fn fails_with_params() {
+    let item = TokenStream::new(FN_WITH_SINGLE_FELT252_PARAM.into());
+    let args = TokenStream::new(String::new());
+
+    let result = test(args, item);
+
+    assert_diagnostics(
+        &result,
+        &[Diagnostic::error(
+            "#[test] function with parameters must have #[fuzzer] attribute",
+        )],
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3019

## Introduced changes

<!-- A brief description of the changes -->

- Emit an error if function has the `#[test]` attribute, defined parameters and no `#[fuzzer]` attribute

## Checklist

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [X] Updated relevant documentation
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
