### PR TITLE
Add sierra gas resource to trace file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,21 @@ jobs:
       - run: cargo test --package forge --features scarb_2_7_1 --test main e2e::requirements::test_warning_on_scarb_version_below_recommended
       - run: cargo test --package forge --features scarb_2_7_1 --lib compatibility_check::tests::warning_requirements
 
+  # todo(3096): Remove this and the feature as soon as scarb 2.10 is the oldest officially supported version
+  test-scarb-since-2-10:
+    name: Test scarb 2.10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-scarb@v1
+        with:
+          scarb-version: "2.10.1"
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+
+      - run: cargo test --package forge --features scarb_since_2_10 sierra_gas
+
   test-forge-runner:
     name: Test Forge Runner
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new `--tracked-resource` flag, that will change currently tracked resource
   (`cairo-steps` for vm resources - default; `sierra-gas` for sierra gas consumed resources in cairo native)
 
+#### Changed
+- gas is now reported using resource bounds triplet (l1_gas, l1_data_gas and l2_gas)
+- `available_gas` now accepts named arguments denoting resource bounds (eg #[available_gas(l1_gas: 1, l1_data_gas: 2, l2_gas: 3)])
+
 ### Cast
 
 #### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6234,6 +6234,7 @@ dependencies = [
  "scarb-api",
  "semver",
  "shared",
+ "starknet_api",
  "tempfile",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,9 +780,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8925548bb02e41cb71b0aa523744694d63a834cbd9d8a84e4a3646ae678f7"
+checksum = "d4b542cfcdce03448c9db7a2464ec9440c9943785749fc74bf6a1a829fefcea4"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ cairo-lang-test-plugin = "2.11.2"
 cairo-lang-starknet-classes = "2.11.2"
 cairo-lang-parser = "2.11.2"
 cairo-vm = "1.0.2"
-cairo-annotations = "=0.3.0"
+cairo-annotations = "0.3.1"
 dirs = "6.0.0"
 dialoguer = "0.11.0"
 starknet-types-core = { version = "0.1.7", features = ["hash", "prime-bigint"] }

--- a/crates/forge-runner/src/build_trace_data.rs
+++ b/crates/forge-runner/src/build_trace_data.rs
@@ -58,6 +58,7 @@ pub fn build_profiler_call_trace(
         cumulative_resources: build_profiler_execution_resources(
             value.used_execution_resources.clone(),
             value.used_syscalls.clone(),
+            value.gas_consumed,
         ),
         used_l1_resources: value.used_l1_resources.clone(),
         nested_calls: value
@@ -120,6 +121,7 @@ fn build_profiler_call_trace_node(
 pub fn build_profiler_execution_resources(
     execution_resources: ExecutionResources,
     syscall_counter: SyscallCounter,
+    gas_consumed: u64,
 ) -> ProfilerExecutionResources {
     let mut profiler_syscall_counter = HashMap::new();
     for (key, val) in syscall_counter {
@@ -135,6 +137,7 @@ pub fn build_profiler_execution_resources(
                 .map(|(key, value)| (key.to_str_with_suffix().to_owned(), value))
                 .collect(),
         },
+        gas_consumed: Some(gas_consumed),
     }
 }
 

--- a/crates/forge-runner/src/package_tests/with_config.rs
+++ b/crates/forge-runner/src/package_tests/with_config.rs
@@ -1,7 +1,8 @@
 use super::{TestCase, TestTarget};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
 use cheatnet::runtime_extensions::forge_config_extension::config::{
-    Expected, RawForgeConfig, RawForkConfig, RawFuzzerConfig, RawShouldPanicConfig,
+    Expected, RawAvailableGasConfig, RawForgeConfig, RawForkConfig, RawFuzzerConfig,
+    RawShouldPanicConfig,
 };
 use conversions::serde::serialize::SerializeToFeltVec;
 
@@ -13,7 +14,7 @@ pub type TestCaseWithConfig = TestCase<TestCaseConfig>;
 /// see [`super::with_config_resolved::TestCaseResolvedConfig`] for more info
 #[derive(Debug, Clone)]
 pub struct TestCaseConfig {
-    pub available_gas: Option<usize>,
+    pub available_gas: Option<RawAvailableGasConfig>,
     pub ignored: bool,
     pub expected_result: ExpectedTestResult,
     pub fork_config: Option<RawForkConfig>,
@@ -23,7 +24,7 @@ pub struct TestCaseConfig {
 impl From<RawForgeConfig> for TestCaseConfig {
     fn from(value: RawForgeConfig) -> Self {
         Self {
-            available_gas: value.available_gas.map(|v| v.gas),
+            available_gas: value.available_gas,
             ignored: value.ignore.is_some_and(|v| v.is_ignored),
             expected_result: value.should_panic.into(),
             fork_config: value.fork,

--- a/crates/forge-runner/src/package_tests/with_config_resolved.rs
+++ b/crates/forge-runner/src/package_tests/with_config_resolved.rs
@@ -1,6 +1,8 @@
 use super::{TestCase, TestTarget};
 use crate::expected_result::ExpectedTestResult;
-use cheatnet::runtime_extensions::forge_config_extension::config::RawFuzzerConfig;
+use cheatnet::runtime_extensions::forge_config_extension::config::{
+    RawAvailableGasConfig, RawFuzzerConfig,
+};
 use starknet_api::block::BlockNumber;
 use url::Url;
 
@@ -19,7 +21,7 @@ pub struct ResolvedForkConfig {
 ///     fetches block number
 #[derive(Debug, Clone, PartialEq)]
 pub struct TestCaseResolvedConfig {
-    pub available_gas: Option<usize>,
+    pub available_gas: Option<RawAvailableGasConfig>,
     pub ignored: bool,
     pub expected_result: ExpectedTestResult,
     pub fork_config: Option<ResolvedForkConfig>,

--- a/crates/forge-runner/src/printing.rs
+++ b/crates/forge-runner/src/printing.rs
@@ -24,10 +24,7 @@ pub fn print_test_result(
                 test_statistics: FuzzingStatistics { runs },
                 gas_info,
                 ..
-            } => Some(format!(
-                " (runs: {runs}, gas: {{max: ~{}, min: ~{}, mean: ~{:.2}, std deviation: ~{:.2}}})",
-                gas_info.max, gas_info.min, gas_info.mean, gas_info.std_deviation
-            )),
+            } => Some(format!(" (runs: {runs}, {gas_info})",)),
             TestCaseSummary::Failed {
                 fuzzer_args,
                 test_statistics: FuzzingStatistics { runs },
@@ -40,7 +37,10 @@ pub fn print_test_result(
 
     let gas_usage = match any_test_result {
         AnyTestCaseSummary::Single(TestCaseSummary::Passed { gas_info, .. }) => {
-            format!(" (gas: ~{gas_info})")
+            format!(
+                " (l1_gas: ~{}, l1_data_gas: ~{}, l2_gas: ~{})",
+                gas_info.l1_gas, gas_info.l1_data_gas, gas_info.l2_gas
+            )
         }
         _ => String::new(),
     };

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -43,6 +43,7 @@ use hints::{hints_by_representation, hints_to_params};
 use rand::prelude::StdRng;
 use runtime::starknet::context::{build_context, set_max_steps};
 use runtime::{ExtendedRuntime, StarknetRuntime};
+use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
 use std::cell::RefCell;
 use std::default::Default;
@@ -147,7 +148,7 @@ pub(crate) fn run_fuzz_test(
 pub struct RunResultWithInfo {
     pub(crate) run_result: Result<RunResult, Box<CairoRunError>>,
     pub(crate) call_trace: Rc<RefCell<CallTrace>>,
-    pub(crate) gas_used: u128,
+    pub(crate) gas_used: GasVector,
     pub(crate) used_resources: UsedResources,
     pub(crate) encountered_errors: Vec<EncounteredError>,
     pub(crate) fuzzer_args: Vec<String>,
@@ -161,7 +162,10 @@ pub fn run_test_case(
     fuzzer_rng: Option<Arc<Mutex<StdRng>>>,
 ) -> Result<RunResultWithInfo> {
     ensure!(
-        case.config.available_gas != Some(0),
+        case.config
+            .available_gas
+            .as_ref()
+            .is_none_or(|gas| !gas.is_zero()),
         "\n\t`available_gas` attribute was incorrectly configured. Make sure you use scarb >= 2.4.4\n"
     );
 
@@ -312,8 +316,7 @@ pub fn run_test_case(
             value,
             profiling_info: None,
         }),
-        // TODO(#2977) return triplet
-        gas_used: u128::from(gas.l1_gas.0 + gas.l1_data_gas.0),
+        gas_used: gas,
         used_resources,
         call_trace: call_trace_ref,
         encountered_errors,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -13,39 +13,83 @@ use cheatnet::state::{CallTrace as InternalCallTrace, EncounteredError};
 use conversions::byte_array::ByteArray;
 use num_traits::Pow;
 use shared::utils::build_readable_text;
+use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
 use std::cell::RefCell;
+use std::fmt;
 use std::option::Option;
 use std::rc::Rc;
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct GasStatistics {
-    pub min: u128,
-    pub max: u128,
+    pub l1_gas: GasStatisticsComponent,
+    pub l1_data_gas: GasStatisticsComponent,
+    pub l2_gas: GasStatisticsComponent,
+}
+
+impl fmt::Display for GasStatistics {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "(l1_gas: {}, l1_data_gas: {}, l2_gas: {})",
+            self.l1_gas, self.l1_data_gas, self.l2_gas
+        )
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct GasStatisticsComponent {
+    pub min: u64,
+    pub max: u64,
     pub mean: f64,
     pub std_deviation: f64,
 }
 
+impl GasStatisticsComponent {
+    #[must_use]
+    pub fn new(gas_usages: &[u64]) -> Self {
+        let mean = GasStatistics::mean(gas_usages);
+        Self {
+            min: *gas_usages.iter().min().unwrap(),
+            max: *gas_usages.iter().max().unwrap(),
+            mean,
+            std_deviation: GasStatistics::std_deviation(mean, gas_usages),
+        }
+    }
+}
+
+impl fmt::Display for GasStatisticsComponent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{{max: ~{}, min: ~{}, mean: ~{:.2}, std deviation: ~{:.2}}}",
+            self.max, self.min, self.mean, self.std_deviation
+        )
+    }
+}
+
 impl GasStatistics {
     #[must_use]
-    pub fn new(gas_usages: &[u128]) -> Self {
-        let mean = Self::mean(gas_usages);
+    pub fn new(gas_usages: &[GasVector]) -> Self {
+        let l1_gas_values: Vec<u64> = gas_usages.iter().map(|gv| gv.l1_gas.0).collect();
+        let l1_data_gas_values: Vec<u64> = gas_usages.iter().map(|gv| gv.l1_data_gas.0).collect();
+        let l2_gas_values: Vec<u64> = gas_usages.iter().map(|gv| gv.l2_gas.0).collect();
 
         GasStatistics {
-            min: gas_usages.iter().min().copied().unwrap(),
-            max: gas_usages.iter().max().copied().unwrap(),
-            mean,
-            std_deviation: Self::std_deviation(mean, gas_usages),
+            l1_gas: { GasStatisticsComponent::new(l1_gas_values.as_ref()) },
+            l1_data_gas: { GasStatisticsComponent::new(l1_data_gas_values.as_ref()) },
+            l2_gas: { GasStatisticsComponent::new(l2_gas_values.as_ref()) },
         }
     }
 
-    #[expect(clippy::cast_precision_loss)]
-    fn mean(gas_usages: &[u128]) -> f64 {
-        (gas_usages.iter().sum::<u128>() / gas_usages.len() as u128) as f64
+    #[allow(clippy::cast_precision_loss)]
+    fn mean(gas_usages: &[u64]) -> f64 {
+        let sum: f64 = gas_usages.iter().map(|&x| x as f64).sum();
+        sum / gas_usages.len() as f64
     }
 
-    #[expect(clippy::cast_precision_loss)]
-    fn std_deviation(mean: f64, gas_usages: &[u128]) -> f64 {
+    #[allow(clippy::cast_precision_loss)]
+    fn std_deviation(mean: f64, gas_usages: &[u64]) -> f64 {
         let sum_squared_diff = gas_usages
             .iter()
             .map(|&x| (x as f64 - mean).pow(2))
@@ -77,7 +121,7 @@ impl TestType for Fuzzing {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Single;
 impl TestType for Single {
-    type GasInfo = u128;
+    type GasInfo = GasVector;
     type TestStatistics = ();
     type TraceData = VersionedProfilerCallTrace;
 }
@@ -128,8 +172,8 @@ pub enum TestCaseSummary<T: TestType> {
     Skipped {},
 }
 
-#[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
+#[expect(clippy::large_enum_variant)]
 pub enum AnyTestCaseSummary {
     Fuzzing(TestCaseSummary<Fuzzing>),
     Single(TestCaseSummary<Single>),
@@ -190,7 +234,7 @@ impl TestCaseSummary<Fuzzing> {
                 debugging_trace,
             } => {
                 let runs = results.len();
-                let gas_usages: Vec<u128> = results
+                let gas_usages: Vec<GasVector> = results
                     .into_iter()
                     .map(|a| match a {
                         TestCaseSummary::Passed { gas_info, .. } => gas_info,
@@ -202,7 +246,7 @@ impl TestCaseSummary<Fuzzing> {
                     name,
                     msg,
                     arguments,
-                    gas_info: GasStatistics::new(&gas_usages),
+                    gas_info: GasStatistics::new(gas_usages.as_ref()),
                     used_resources: UsedResources::default(),
                     test_statistics: FuzzingStatistics { runs },
                     trace_data: (),
@@ -240,7 +284,7 @@ impl TestCaseSummary<Single> {
         test_case: &TestCaseWithResolvedConfig,
         arguments: Vec<Felt>,
         fuzzer_args: Vec<String>,
-        gas: u128,
+        gas: GasVector,
         used_resources: UsedResources,
         call_trace: &Rc<RefCell<InternalCallTrace>>,
         encountered_errors: &[EncounteredError],
@@ -452,5 +496,82 @@ impl AnyTestCaseSummary {
             AnyTestCaseSummary::Single(TestCaseSummary::Ignored { .. })
                 | AnyTestCaseSummary::Fuzzing(TestCaseSummary::Ignored { .. })
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use starknet_api::execution_resources::GasAmount;
+
+    const FLOAT_ERROR: f64 = 0.01;
+
+    #[test]
+    fn test_mean_basic() {
+        let data = [1, 2, 3, 4, 5];
+        let result = GasStatistics::mean(&data);
+        assert!((result - 3.0).abs() < FLOAT_ERROR);
+    }
+
+    #[test]
+    fn test_mean_single_element() {
+        let data = [42];
+        let result = GasStatistics::mean(&data);
+        assert!((result - 42.0).abs() < FLOAT_ERROR);
+    }
+
+    #[test]
+    fn test_std_deviation_basic() {
+        let data = [1, 2, 3, 4, 5];
+        let mean_value = GasStatistics::mean(&data);
+        let result = GasStatistics::std_deviation(mean_value, &data);
+        assert!((result - 1.414).abs() < FLOAT_ERROR);
+    }
+
+    #[test]
+    fn test_std_deviation_single_element() {
+        let data = [10];
+        let mean_value = GasStatistics::mean(&data);
+        let result = GasStatistics::std_deviation(mean_value, &data);
+        assert!(result.abs() < FLOAT_ERROR);
+    }
+
+    #[test]
+    fn test_gas_statistics_new() {
+        let gas_usages = vec![
+            GasVector {
+                l1_gas: GasAmount(10),
+                l1_data_gas: GasAmount(20),
+                l2_gas: GasAmount(30),
+            },
+            GasVector {
+                l1_gas: GasAmount(20),
+                l1_data_gas: GasAmount(40),
+                l2_gas: GasAmount(60),
+            },
+            GasVector {
+                l1_gas: GasAmount(30),
+                l1_data_gas: GasAmount(60),
+                l2_gas: GasAmount(90),
+            },
+        ];
+
+        let stats = GasStatistics::new(&gas_usages);
+
+        assert_eq!(stats.l1_gas.min, 10);
+        assert_eq!(stats.l1_data_gas.min, 20);
+        assert_eq!(stats.l2_gas.min, 30);
+
+        assert_eq!(stats.l1_gas.max, 30);
+        assert_eq!(stats.l1_data_gas.max, 60);
+        assert_eq!(stats.l2_gas.max, 90);
+
+        assert!((stats.l1_gas.mean - 20.0).abs() < FLOAT_ERROR);
+        assert!((stats.l1_data_gas.mean - 40.0).abs() < FLOAT_ERROR);
+        assert!((stats.l2_gas.mean - 60.0).abs() < FLOAT_ERROR);
+
+        assert!((stats.l1_gas.std_deviation - 8.165).abs() < FLOAT_ERROR);
+        assert!((stats.l1_data_gas.std_deviation - 16.33).abs() < FLOAT_ERROR);
+        assert!((stats.l2_gas.std_deviation - 24.49).abs() < FLOAT_ERROR);
     }
 }

--- a/crates/forge/src/warn.rs
+++ b/crates/forge/src/warn.rs
@@ -14,7 +14,10 @@ pub(crate) fn warn_if_available_gas_used_with_incompatible_scarb_version(
 ) -> Result<()> {
     for test_target in test_targets {
         for case in &test_target.test_cases {
-            if case.config.available_gas == Some(0)
+            if case
+                .config
+                .available_gas
+                .as_ref().is_some_and(cheatnet::runtime_extensions::forge_config_extension::config::RawAvailableGasConfig::is_zero)
                 && ScarbCommand::version().run()?.scarb <= Version::new(2, 4, 3)
             {
                 print_as_warning(&anyhow!(

--- a/crates/forge/test_utils/Cargo.toml
+++ b/crates/forge/test_utils/Cargo.toml
@@ -20,6 +20,7 @@ tempfile.workspace = true
 tokio.workspace = true
 project-root.workspace = true
 semver.workspace = true
+starknet_api.workspace = true
 forge = { path = "../../forge" }
 scarb-api = { path = "../../scarb-api" }
 forge_runner = { path = "../../forge-runner" }

--- a/crates/forge/test_utils/src/runner.rs
+++ b/crates/forge/test_utils/src/runner.rs
@@ -18,6 +18,7 @@ use scarb_api::{
 };
 use semver::Version;
 use shared::command::CommandExt;
+use starknet_api::execution_resources::{GasAmount, GasVector};
 use std::{
     collections::HashMap,
     fs,
@@ -276,7 +277,7 @@ pub fn assert_case_output_contains(
     }));
 }
 
-pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_gas: u128) {
+pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_gas: GasVector) {
     let test_name_suffix = format!("::{test_case_name}");
 
     let result = TestCase::find_test_result(result);
@@ -303,11 +304,20 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
 // This logic is used to assert exact gas values in CI for the minimal supported Scarb version
 // and to assert gas values with a margin in scheduled tests, as values can vary for different Scarb versions
 // FOR LOCAL DEVELOPMENT ALWAYS USE EXACT CALCULATIONS
-fn assert_gas_with_margin(gas: u128, asserted_gas: u128) -> bool {
+fn assert_gas_with_margin(gas: GasVector, asserted_gas: GasVector) -> bool {
     if cfg!(feature = "assert_non_exact_gas") {
-        asserted_gas.abs_diff(gas) <= 10
+        let diff = gas_vector_abs_diff(&gas, &asserted_gas);
+        diff.l1_gas.0 <= 10 && diff.l1_data_gas.0 <= 10 && diff.l2_gas.0 <= 200_000
     } else {
         gas == asserted_gas
+    }
+}
+
+fn gas_vector_abs_diff(a: &GasVector, b: &GasVector) -> GasVector {
+    GasVector {
+        l1_gas: GasAmount(a.l1_gas.0.abs_diff(b.l1_gas.0)),
+        l1_data_gas: GasAmount(a.l1_data_gas.0.abs_diff(b.l1_data_gas.0)),
+        l2_gas: GasAmount(a.l2_gas.0.abs_diff(b.l2_gas.0)),
     }
 }
 

--- a/crates/forge/tests/data/fuzzing/tests/multiple_attributes.cairo
+++ b/crates/forge/tests/data/fuzzing/tests/multiple_attributes.cairo
@@ -1,7 +1,7 @@
 use fuzzing::adder;
 use fuzzing::fib;
 
-#[available_gas(100)]
+#[available_gas(l2_gas: 40000000)]
 #[fuzzer(runs: 50, seed: 123)]
 #[test]
 fn with_available_gas(a: usize) {
@@ -18,7 +18,7 @@ fn with_should_panic(a: u64) {
     assert(b < 0, 'panic message');
 }
 
-#[available_gas(5)]
+#[available_gas(l2_gas: 5)]
 #[should_panic(expected: 'panic message')]
 #[test]
 #[fuzzer(runs: 300)]

--- a/crates/forge/tests/e2e/contract_artifacts.rs
+++ b/crates/forge/tests/e2e/contract_artifacts.rs
@@ -19,9 +19,9 @@ fn unit_and_integration() {
 
     Collected 2 test(s) from unit_and_integration package
     Running 1 test(s) from tests/
-    [PASS] unit_and_integration_integrationtest::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] unit_and_integration_integrationtest::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 1 test(s) from src/
-    [PASS] unit_and_integration::tests::declare_contract_from_lib (gas: [..])
+    [PASS] unit_and_integration::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -41,9 +41,9 @@ fn unit_and_lib_integration() {
 
     Collected 2 test(s) from unit_and_lib_integration package
     Running 1 test(s) from tests/
-    [PASS] unit_and_lib_integration_tests::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] unit_and_lib_integration_tests::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 1 test(s) from src/
-    [PASS] unit_and_lib_integration::tests::declare_contract_from_lib (gas: [..])
+    [PASS] unit_and_lib_integration::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -63,7 +63,7 @@ fn only_integration() {
 
     Collected 1 test(s) from only_integration package
     Running 1 test(s) from tests/
-    [PASS] only_integration_integrationtest::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] only_integration_integrationtest::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 0 test(s) from src/
     Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
@@ -84,7 +84,7 @@ fn only_unit() {
 
     Collected 1 test(s) from only_unit package
     Running 1 test(s) from src/
-    [PASS] only_unit::tests::declare_contract_from_lib (gas: [..])
+    [PASS] only_unit::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -104,7 +104,7 @@ fn only_lib_integration() {
 
     Collected 1 test(s) from only_lib_integration package
     Running 1 test(s) from tests/
-    [PASS] only_lib_integration_tests::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] only_lib_integration_tests::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 0 test(s) from src/
     Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
@@ -129,9 +129,9 @@ fn with_features() {
 
     Collected 2 test(s) from with_features package
     Running 1 test(s) from tests/
-    [PASS] with_features_integrationtest::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] with_features_integrationtest::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 1 test(s) from src/
-    [PASS] with_features::tests::declare_contract_from_lib (gas: [..])
+    [PASS] with_features::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -189,9 +189,9 @@ fn custom_target() {
 
     Collected 2 test(s) from custom_target package
     Running 1 test(s) from tests/
-    [PASS] custom_target_integrationtest::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] custom_target_integrationtest::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 1 test(s) from src/
-    [PASS] custom_target::tests::declare_contract_from_lib (gas: [..])
+    [PASS] custom_target::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -217,9 +217,9 @@ fn custom_target_custom_names() {
 
     Collected 2 test(s) from custom_target_custom_names package
     Running 1 test(s) from tests/
-    [PASS] custom_first::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] custom_first::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Running 1 test(s) from src/
-    [PASS] custom_target_custom_names::tests::declare_contract_from_lib (gas: [..])
+    [PASS] custom_target_custom_names::tests::declare_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );
@@ -242,7 +242,7 @@ fn custom_target_only_integration() {
 
     Collected 1 test(s) from custom_target_only_integration package
     Running 1 test(s) from tests/
-    [PASS] custom_first::tests::declare_and_call_contract_from_lib (gas: [..])
+    [PASS] custom_first::tests::declare_and_call_contract_from_lib (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
     Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
     "},
     );

--- a/crates/forge/tests/e2e/fuzzing.rs
+++ b/crates/forge/tests/e2e/fuzzing.rs
@@ -29,7 +29,7 @@ fn fuzzing() {
 
         [PASS] fuzzing::tests::custom_fuzzer_config (runs: 10, [..]
         [PASS] fuzzing::tests::uint8_arg (runs: 256, [..]
-        [PASS] fuzzing::tests::fuzzed_while_loop (runs: 256, gas: {max: ~[..], min: ~[..], mean: ~[..], std deviation: ~[..]})
+        [PASS] fuzzing::tests::fuzzed_while_loop (runs: 256, [..]
         [PASS] fuzzing::tests::uint16_arg (runs: 256, [..]
         [PASS] fuzzing::tests::uint32_arg (runs: 256, [..]
         [PASS] fuzzing::tests::uint64_arg (runs: 256, [..]
@@ -283,7 +283,7 @@ fn generate_arg_cheatcode() {
         Failure data:
             "`generate_arg` cheatcode: `min_value` must be <= `max_value`, provided values after deserialization: 101 and 100"
 
-        [PASS] fuzzing_integrationtest::generate_arg::use_generate_arg_outside_fuzzer (gas: ~1)
+        [PASS] fuzzing_integrationtest::generate_arg::use_generate_arg_outside_fuzzer (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
         Tests: 1 passed, 1 failed, 0 skipped, 0 ignored, 22 filtered out
         "#},
     );

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -565,8 +565,8 @@ fn with_panic_data_decoding() {
         Failure data:
             (0x7b ('{'), 0x616161 ('aaa'), 0x800000000000011000000000000000000000000000000000000000000000000, 0x98, 0x7c ('|'), 0x95)
 
-        [PASS] panic_decoding_integrationtest::test_panic_decoding::test_simple2 (gas: [..])
-        [PASS] panic_decoding_integrationtest::test_panic_decoding::test_simple (gas: [..])
+        [PASS] panic_decoding_integrationtest::test_panic_decoding::test_simple2 (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
+        [PASS] panic_decoding_integrationtest::test_panic_decoding::test_simple (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         [FAIL] panic_decoding_integrationtest::test_panic_decoding::test_assert_eq
 
         Failure data:
@@ -720,12 +720,12 @@ fn should_panic() {
         Failure data:
             Expected to panic but didn't
 
-        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_no_data (gas: [..])
+        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_no_data (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
 
         Success data:
             0x0 ('')
 
-        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_check_data (gas: [..])
+        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_check_data (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         [FAIL] should_panic_test_integrationtest::should_panic_test::should_panic_not_matching_suffix
 
         Failure data:
@@ -733,8 +733,8 @@ fn should_panic() {
             Actual:    [0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0, 0x546869732077696c6c2070616e6963, 0xf] (This will panic)
             Expected:  [0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0, 0x77696c6c2070616e696363, 0xb] (will panicc)
 
-        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_match_suffix (gas: [..])
-        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_felt_matching (gas: [..])
+        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_match_suffix (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
+        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_felt_matching (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         [FAIL] should_panic_test_integrationtest::should_panic_test::should_panic_felt_with_byte_array
 
         Failure data:
@@ -742,7 +742,7 @@ fn should_panic() {
             Actual:    [0x546869732077696c6c2070616e6963] (This will panic)
             Expected:  [0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0, 0x546869732077696c6c2070616e6963, 0xf] (This will panic)
 
-        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_multiple_messages (gas: [..])
+        [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_multiple_messages (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         [FAIL] should_panic_test_integrationtest::should_panic_test::expected_panic_but_didnt_with_expected
 
         Failure data:
@@ -944,9 +944,12 @@ fn sierra_gas_with_older_scarb() {
     assert_stdout_contains(
         output,
         indoc! {r"
-        [..]Compiling[..]
-        [..]Finished[..]
-        [ERROR] Tracking SierraGas is not supported for sierra <= 1.7.0: Contract version [..] is lower than required minimal sierra version
+        Checking requirements
+        [..]Scarb Version [..] doesn't satisfy minimal 2.10.0[..]
+        [..]This version of scarb is the minimum required in order to support sierra gas tracking (it comes with sierra >= 1.7.0 support)[..]
+        [..]Follow instructions from https://docs.swmansion.com/scarb/download.html[..]
+        [..]
+        [ERROR] Requirements not satisfied
         "},
     );
 }

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -84,7 +84,7 @@ fn should_default_to_10m() {
 
             Collected 2 test(s) from steps package
             Running 2 test(s) from src/
-            [PASS] steps::tests::steps_less_than_10000000 (gas: ~[..])
+            [PASS] steps::tests::steps_less_than_10000000 (l1_gas: ~[..], l1_data_gas: ~[..], l2_gas: ~[..])
             [FAIL] steps::tests::steps_more_than_10000000
 
             Failure data:

--- a/crates/forge/tests/e2e/trace_print.rs
+++ b/crates/forge/tests/e2e/trace_print.rs
@@ -89,7 +89,7 @@ fn trace_info_print() {
         ]
         Call Result: Success: []
         
-        [PASS] trace_info_integrationtest::test_trace::test_trace (gas: [..]
+        [PASS] trace_info_integrationtest::test_trace::test_trace (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
         "},
     );

--- a/crates/forge/tests/integration/available_gas.rs
+++ b/crates/forge/tests/integration/available_gas.rs
@@ -8,6 +8,23 @@ fn correct_available_gas() {
     let test = test_utils::test_case!(indoc!(
         r"
             #[test]
+            #[available_gas(l2_gas: 440000)]
+            fn keccak_cost() {
+                keccak::keccak_u256s_le_inputs(array![1].span());
+            }
+        "
+    ));
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_passed(&result);
+}
+
+#[test]
+fn correct_available_gas_with_unnamed_argument() {
+    let test = test_utils::test_case!(indoc!(
+        r"
+            #[test]
             #[available_gas(11)]
             fn keccak_cost() {
                 keccak::keccak_u256s_le_inputs(array![1].span());
@@ -25,6 +42,28 @@ fn available_gas_exceeded() {
     let test = test_utils::test_case!(indoc!(
         r"
             #[test]
+            #[available_gas(l2_gas: 5)]
+            fn keccak_cost() {
+                keccak::keccak_u256s_le_inputs(array![1].span());
+            }
+        "
+    ));
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_failed(&result);
+    assert_case_output_contains(
+        &result,
+        "keccak_cost",
+        "Test cost exceeded the available gas. Consumed l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~240000",
+    );
+}
+
+#[test]
+fn available_gas_exceeded_with_unnamed_argument() {
+    let test = test_utils::test_case!(indoc!(
+        r"
+            #[test]
             #[available_gas(5)]
             fn keccak_cost() {
                 keccak::keccak_u256s_le_inputs(array![1].span());
@@ -38,7 +77,7 @@ fn available_gas_exceeded() {
     assert_case_output_contains(
         &result,
         "keccak_cost",
-        "Test cost exceeded the available gas. Consumed gas: ~6",
+        "Test cost exceeded the available gas. Consumed l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~240000",
     );
 }
 
@@ -47,7 +86,7 @@ fn available_gas_fuzzing() {
     let test = test_utils::test_case!(indoc!(
         r"
             #[test]
-            #[available_gas(100)]
+            #[available_gas(l2_gas: 40000000)]
             #[fuzzer]
             fn keccak_cost(x: u256) {
                 keccak::keccak_u256s_le_inputs(array![x].span());

--- a/crates/forge/tests/integration/dispatchers.rs
+++ b/crates/forge/tests/integration/dispatchers.rs
@@ -237,8 +237,7 @@ fn handling_bytearray_based_errors() {
             let panic_data = safe_dispatcher.do_a_panic_with_bytearray().unwrap_err();
             let str_err = try_deserialize_bytearray_error(panic_data.span()).expect('wrong format');
             assert(
-                str_err == "This is a very long
- and multiline message that is certain to fill the buffer",
+                str_err == "This is a very long\n and multiline message that is certain to fill the buffer",
                 'wrong string received'
             );
 

--- a/crates/forge/tests/integration/fuzzing.rs
+++ b/crates/forge/tests/integration/fuzzing.rs
@@ -5,6 +5,8 @@ use test_utils::runner::{TestCase, assert_passed};
 use test_utils::running_tests::run_test_case;
 use test_utils::test_case;
 
+const ALLOWED_ERROR: f64 = 0.05;
+
 #[test]
 fn fuzzed_argument() {
     let test = test_case!(indoc!(
@@ -76,8 +78,16 @@ fn fuzzed_while_loop() {
     };
 
     // TODO (#2926)
-    assert_eq!(gas_info.min, 2);
-    assert!(gas_info.max.abs_diff(23) <= 1);
-    assert!((gas_info.mean - 12.).abs() < f64::EPSILON);
-    assert!((gas_info.std_deviation - 6.24).abs() < 0.05);
+    assert_eq!(gas_info.l1_gas.min, 0);
+    assert_eq!(gas_info.l1_gas.max, 0);
+    assert!(gas_info.l1_gas.mean < ALLOWED_ERROR);
+    assert!(gas_info.l1_gas.std_deviation < ALLOWED_ERROR);
+    assert_eq!(gas_info.l1_data_gas.min, 0);
+    assert_eq!(gas_info.l1_data_gas.max, 0);
+    assert!(gas_info.l1_data_gas.mean < ALLOWED_ERROR);
+    assert!(gas_info.l1_data_gas.std_deviation < ALLOWED_ERROR);
+    // different scarbs yield different results here, we do not care about the values that much
+    assert!(gas_info.l2_gas.min < gas_info.l2_gas.max);
+    assert!(gas_info.l2_gas.mean > 0.0);
+    assert!(gas_info.l2_gas.std_deviation > 0.0);
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1,15 +1,20 @@
 use forge_runner::forge_config::ForgeTrackedResource;
 use indoc::indoc;
+use starknet_api::execution_resources::{GasAmount, GasVector};
 use std::path::Path;
 use test_utils::runner::{Contract, assert_gas, assert_passed};
 use test_utils::running_tests::run_test_case;
 use test_utils::test_case;
 
-// all calculations are based on formula from
+// all calculations are based on formulas from
 // https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee
+// important info from this link regarding gas calculations:
+// 1 cairo step = 0.0025 L1 gas = 100 L2 gas
+// 1 sierra gas = 1 l2 gas
+// Costs of syscalls (if provided) are taken from versioned_constants (blockifier)
 
 #[test]
-fn declare_cost_is_omitted() {
+fn declare_cost_is_omitted_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -32,11 +37,23 @@ fn declare_cost_is_omitted() {
 
     assert_passed(&result);
     // 1 = cost of 230 steps (because int(0.0025 * 230) = 1)
-    assert_gas(&result, "declare_cost_is_omitted", 1);
+    //      -> as stated in the top comment, 1 cairo step = 0.0025 L1 gas = 100 L2 gas
+    //         0.0025 * 230 = 0,575 (BUT rounding up to 1, since this is as little as possible)
+    //         since 230 steps = 1 gas, to convert this to l2 gas we need to multiply by 40000 (100/0.0025)
+    // 0 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "declare_cost_is_omitted",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 #[test]
-fn deploy_syscall_cost() {
+fn deploy_syscall_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -64,13 +81,22 @@ fn deploy_syscall_cost() {
     assert_passed(&result);
     // l = 1 (updated contract class)
     // n = 1 (unique contracts updated - in this case it's the new contract address)
-    // ( l + n * 2 ) * felt_size_in_bytes(32) = 96 (total l1 cost)
+    // ( l + n * 2 ) * felt_size_in_bytes(32) = 96 (total l1 data cost)
     // 11 = cost of 2 keccak builtins from constructor (because int(5.12 * 2) = 11)
-    assert_gas(&result, "deploy_syscall_cost", 96 + 11);
+    // 0 l1_gas + 96 l1_data_gas + 11 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "deploy_syscall_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(440_000),
+        },
+    );
 }
 
 #[test]
-fn snforge_std_deploy_cost() {
+fn snforge_std_deploy_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -96,11 +122,20 @@ fn snforge_std_deploy_cost() {
     assert_passed(&result);
     // 96 = gas cost of onchain data (deploy cost)
     // 11 = cost of 2 keccak builtins = 11 (because int(5.12 * 2) = 11)
-    assert_gas(&result, "deploy_cost", 96 + 11);
+    // 0 l1_gas + 96 l1_data_gas + 11 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "deploy_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(440_000),
+        },
+    );
 }
 
 #[test]
-fn keccak_cost() {
+fn keccak_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             #[test]
@@ -114,11 +149,20 @@ fn keccak_cost() {
 
     assert_passed(&result);
     // 6 = cost of 1 keccak builtin (because int(5.12 * 1) = 6)
-    assert_gas(&result, "keccak_cost", 6);
+    // 0 l1_gas + 0 l1_data_gas + 6 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "keccak_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(240_000),
+        },
+    );
 }
 
 #[test]
-fn contract_keccak_cost() {
+fn contract_keccak_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -151,11 +195,20 @@ fn contract_keccak_cost() {
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
     // 26 = cost of 5 keccak builtins (because int(5.12 * 5) = 26)
-    assert_gas(&result, "contract_keccak_cost", 96 + 26);
+    // 0 l1_gas + 96 l1_data_gas + 26 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_keccak_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_040_000),
+        },
+    );
 }
 
 #[test]
-fn range_check_cost() {
+fn range_check_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             #[test]
@@ -169,14 +222,23 @@ fn range_check_cost() {
 
     assert_passed(&result);
     // 1 = cost of 1 range check builtin (because int(0.04 * 1) = 1)
-    assert_gas(&result, "range_check_cost", 1);
+    // 0 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "range_check_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 /// Declare, deploy and function call consume 13 `range_check_builtin`s
 /// `range_check` function consumes 9, so
 /// overall cost will be 22 * range check builtin cost.
 #[test]
-fn contract_range_check_cost() {
+fn contract_range_check_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -209,11 +271,20 @@ fn contract_range_check_cost() {
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
     // 8 = cost of 191 range check builtins (because int(0.04 * 191) = 8)
-    assert_gas(&result, "contract_range_check_cost", 96 + 8);
+    // 0 l1_gas + 96 l1_data_gas + 8 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_range_check_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(320_000),
+        },
+    );
 }
 
 #[test]
-fn bitwise_cost() {
+fn bitwise_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             #[test]
@@ -228,12 +299,21 @@ fn bitwise_cost() {
 
     assert_passed(&result);
     // 1 = cost of 1 bitwise builtin, because int(0.16 * 1) = 1
-    assert_gas(&result, "bitwise_cost", 1);
+    // 0 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "bitwise_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 /// We have to use 6 bitwise operations in the `bitwise` function to exceed steps cost
 #[test]
-fn contract_bitwise_cost() {
+fn contract_bitwise_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -266,11 +346,20 @@ fn contract_bitwise_cost() {
     assert_passed(&result);
     // 96 = cost of deploy l1 cost (see snforge_std_deploy_cost test)
     // 48 = cost of 300 bitwise builtins (because int(0.16 * 300) = 48)
-    assert_gas(&result, "contract_bitwise_cost", 96 + 48);
+    // 0 l1_gas + 96 l1_data_gas + 48 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_bitwise_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_920_000),
+        },
+    );
 }
 
 #[test]
-fn pedersen_cost() {
+fn pedersen_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             #[test]
@@ -285,12 +374,21 @@ fn pedersen_cost() {
 
     assert_passed(&result);
     // 1 = cost of 1 pedersen builtin (because int(0.16 * 1) = 1)
-    assert_gas(&result, "pedersen_cost", 1);
+    // 0 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "pedersen_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 /// We have to use 12 pedersen operations in the `pedersen` function to exceed steps cost
 #[test]
-fn contract_pedersen_cost() {
+fn contract_pedersen_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -323,11 +421,20 @@ fn contract_pedersen_cost() {
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
     // 7 = cost of 86 pedersen builtins (because int(0.08 * 86) = 7)
-    assert_gas(&result, "contract_pedersen_cost", 96 + 7);
+    // 0 l1_gas + 96 l1_data_gas + 7 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_pedersen_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(280_000),
+        },
+    );
 }
 
 #[test]
-fn poseidon_cost() {
+fn poseidon_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             #[test]
@@ -342,12 +449,21 @@ fn poseidon_cost() {
 
     assert_passed(&result);
     // 1 = cost of 1 poseidon builtin (because int(0.08 * 1) = 1)
-    assert_gas(&result, "poseidon_cost", 1);
+    // 0 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "poseidon_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 /// We have to use 12 poseidon operations in the `poseidon` function to exceed steps cost
 #[test]
-fn contract_poseidon_cost() {
+fn contract_poseidon_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -381,11 +497,20 @@ fn contract_poseidon_cost() {
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
     // 13 = cost of 160 poseidon builtins (because int(0.08 * 160) = 13)
-    assert_gas(&result, "contract_poseidon_cost", 96 + 13);
+    // 0 l1_gas + 96 l1_data_gas + 13 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_poseidon_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(520_000),
+        },
+    );
 }
 
 #[test]
-fn ec_op_cost() {
+fn ec_op_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             use core::{ec, ec::{EcPoint, EcPointTrait}};
@@ -402,11 +527,20 @@ fn ec_op_cost() {
 
     assert_passed(&result);
     // 3 = cost of 1 ec_op builtin (because int(2.56 * 1) = 3)
-    assert_gas(&result, "ec_op_cost", 3);
+    // 0 l1_gas + 0 l1_data_gas + 3 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "ec_op_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(120_000),
+        },
+    );
 }
 
 #[test]
-fn contract_ec_op_cost() {
+fn contract_ec_op_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -439,11 +573,20 @@ fn contract_ec_op_cost() {
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
     // 26 = cost of 10 ec_op builtins (because int(2.56 * 10) = 26)
-    assert_gas(&result, "contract_ec_op_cost", 96 + 26);
+    // 0 l1_gas + 96 l1_data_gas + 26 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "contract_ec_op_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_040_000),
+        },
+    );
 }
 
 #[test]
-fn storage_write_cost() {
+fn storage_write_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -478,11 +621,20 @@ fn storage_write_cost() {
     // 96 = gas cost of deployment
     // storage_updates(1) * 2 * 32 = 64
     // storage updates from zero value(1) * 32 = 32 (https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-da-costs-27)
-    assert_gas(&result, "storage_write_cost", 7 + 96 + 64 + 32);
+    // 0 l1_gas + (96 + 64 + 32) l1_data_gas + 7 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "storage_write_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(280_000),
+        },
+    );
 }
 
 #[test]
-fn storage_write_from_test_cost() {
+fn storage_write_from_test_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
         #[starknet::contract]
@@ -512,11 +664,20 @@ fn storage_write_from_test_cost() {
     // n(1) * 2 * 32 = 64
     // m(1) * 2 * 32 = 64
     // storage updates from zero value(1) * 32 = 32 (https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-da-costs-27)
-    assert_gas(&result, "storage_write_from_test_cost", 1 + 64 + 64 + 32);
+    // 0 l1_gas + (64 + 64 + 32) l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "storage_write_from_test_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(160),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 #[test]
-fn multiple_storage_writes_cost() {
+fn multiple_storage_writes_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -557,15 +718,20 @@ fn multiple_storage_writes_cost() {
     // m(1) * 2 * 32 = 64
     // l(1) * 32 = 32
     // storage updates from zero value(1) * 32 = 32 (https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-da-costs-27)
+    // 0 l1_gas + (64 + 64 + 32 + 32) l1_data_gas + 10 * (100 / 0.0025) l2 gas
     assert_gas(
         &result,
         "multiple_storage_writes_cost",
-        10 + 64 + 64 + 32 + 32,
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(400_000),
+        },
     );
 }
 
 #[test]
-fn l1_message_cost() {
+fn l1_message_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -599,11 +765,20 @@ fn l1_message_cost() {
     // 2614 * 0.0025 = 6.535 ~ 7 = gas cost of steps
     // 96 = gas cost of deployment
     // 29524 = gas cost of onchain data
-    assert_gas(&result, "l1_message_cost", 7 + 96 + 29524);
+    // 29524 l1_gas + 96 l1_data_gas + 7 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "l1_message_cost",
+        GasVector {
+            l1_gas: GasAmount(29524),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(280_000),
+        },
+    );
 }
 
 #[test]
-fn l1_message_from_test_cost() {
+fn l1_message_from_test_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
         #[test]
@@ -618,11 +793,20 @@ fn l1_message_from_test_cost() {
     assert_passed(&result);
     // 224 * 0.0025 = 0.56 ~ 1 = gas cost of steps
     // 26764 = gas cost of onchain data
-    assert_gas(&result, "l1_message_from_test_cost", 1 + 26764);
+    // 26764 l1_gas + 0 l1_data_gas + 1 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "l1_message_from_test_cost",
+        GasVector {
+            l1_gas: GasAmount(26764),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(40000),
+        },
+    );
 }
 
 #[test]
-fn l1_message_cost_for_proxy() {
+fn l1_message_cost_for_proxy_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -672,11 +856,20 @@ fn l1_message_cost_for_proxy() {
     // n(2) * 2 * 32 = 128
     // l(2) * 32 = 64
     // 29524 = gas cost of message
-    assert_gas(&result, "l1_message_cost_for_proxy", 14 + 128 + 64 + 29524);
+    // 29524 l1_gas + (128 + 64) l1_data_gas + 14 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "l1_message_cost_for_proxy",
+        GasVector {
+            l1_gas: GasAmount(29524),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(560_000),
+        },
+    );
 }
 
 #[test]
-fn l1_handler_cost() {
+fn l1_handler_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -716,11 +909,20 @@ fn l1_handler_cost() {
     //         + 5000 (1 * 5000, 5000 is gas per counter decrease, ref: https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/src/fee/resources.rs#L364-L368)
     //
     //
-    assert_gas(&result, "l1_handler_cost", 96 + 21 + 15923);
+    // 15923 l1_gas + 96 l1_data_gas + 21 * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "l1_handler_cost",
+        GasVector {
+            l1_gas: GasAmount(15923),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(840_000),
+        },
+    );
 }
 
 #[test]
-fn events_cost() {
+fn events_cost_cairo_steps() {
     let test = test_case!(indoc!(
         r"
             use starknet::syscalls::emit_event_syscall;
@@ -744,14 +946,24 @@ fn events_cost() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
+    // todo(3078): verify gas required be event keys and data
     // 156 range_check_builtin ~= 7
     // 6 gas for 50 event values
     // ~13 gas for 50 event keys
-    assert_gas(&result, "events_cost", 7 + 6 + 13);
+    // 0 l1_gas + 0 l1_data_gas + (7 + 6 + ~13) * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "events_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(1_048_000),
+        },
+    );
 }
 
 #[test]
-fn events_contract_cost() {
+fn events_contract_cost_cairo_steps() {
     let test = test_case!(
         indoc!(
             r#"
@@ -784,5 +996,587 @@ fn events_contract_cost() {
     // 96 = gas cost of onchain data (deploy cost)
     // 6 gas for 50 event values
     // ~13 gas for 50 event keys
-    assert_gas(&result, "event_emission_cost", 11 + 96 + 6 + 13);
+    // 0 l1_gas + 96 l1_data_gas + (11 + 6 + ~13) * (100 / 0.0025) l2 gas
+    assert_gas(
+        &result,
+        "event_emission_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_208_000),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn declare_cost_is_omitted_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::declare;
+            #[test]
+            fn declare_cost_is_omitted() {
+                declare("GasChecker").unwrap();
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 23860 = reported consumed sierra gas
+    // 0 l1_gas + 0 l1_data_gas + 23860 l2 gas
+    assert_gas(
+        &result,
+        "declare_cost_is_omitted",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(23860),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn deploy_syscall_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use core::clone::Clone;
+            use snforge_std::{declare, DeclareResultTrait};
+            use starknet::{SyscallResult, deploy_syscall};
+            #[test]
+            fn deploy_syscall_cost() {
+                let contract = declare("GasConstructorChecker").unwrap().contract_class().clone();
+                let (address, _) = deploy_syscall(contract.class_hash, 0, array![].span(), false).unwrap();
+                assert(address != 0.try_into().unwrap(), 'wrong deployed addr');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasConstructorChecker".to_string(),
+            Path::new("tests/data/contracts/gas_constructor_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // l = 1 (updated contract class)
+    // n = 1 (unique contracts updated - in this case it's the new contract address)
+    // ( l + n * 2 ) * felt_size_in_bytes(32) = 96 (total l1 data cost)
+    //
+    // 20000 = cost of 2 keccak syscall (because 2 * 100 * 100) (from constructor)
+    //      -> 1 keccak syscall costs 100 cairo steps
+    // 142810 = cost of 1 deploy syscall (because 1 * 1132 * 100 + 7 * 4050 + 18 * 70)
+    //      -> 1 deploy syscall costs 1132 cairo steps, 7 pedersen and 18 range check builtins
+    //      -> 1 pedersen costs 4050, 1 range check costs 70
+    // 468864 = reported consumed sierra gas
+    // 0 l1_gas + 96 l1_data_gas + (20000 + 142810 + 468864) l2 gas
+    assert_gas(
+        &result,
+        "deploy_syscall_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(631_674),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn snforge_std_deploy_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[test]
+            fn deploy_cost() {
+                let contract = declare("GasConstructorChecker").unwrap().contract_class();
+                let (address, _) = contract.deploy(@array![]).unwrap();
+                assert(address != 0.try_into().unwrap(), 'wrong deployed addr');
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasConstructorChecker".to_string(),
+            Path::new("tests/data/contracts/gas_constructor_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 20000 = cost of 2 keccak syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 487334 = reported consumed sierra gas
+    // 0 l1_gas + 96 l1_data_gas + (20000 + 142810 + 487334) l2 gas
+    assert_gas(
+        &result,
+        "deploy_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(650_144),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn keccak_cost_sierra_gas() {
+    let test = test_case!(indoc!(
+        r"
+            #[test]
+            fn keccak_cost() {
+                keccak::keccak_u256s_le_inputs(array![1].span());
+            }
+        "
+    ));
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 10000 = cost of 1 keccak syscall (1 * 100 * 100)
+    //      -> 1 keccak syscall costs 100 cairo steps
+    // 56510 = reported consumed sierra gas
+    // 0 l1_gas + 0 l1_data_gas + (10000 + 56510) l2 gas
+    assert_gas(
+        &result,
+        "keccak_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(66510),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn contract_keccak_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn keccak(self: @TContractState, repetitions: u32);
+            }
+            #[test]
+            fn contract_keccak_cost() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.keccak(5);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 50000 = cost of 5 keccak syscall (5 * 100 * 100)
+    //      -> 1 keccak syscall costs 100 cairo steps
+    // 87650 = cost of 1 call contract syscall (because 1 * 866 * 100 + 15 * 70)
+    //      -> 1 call contract syscall costs 866 cairo steps and 15 range check builtins
+    //      -> 1 range check costs 70
+    // 1158935 = reported consumed sierra gas
+    // 0 l1_gas + 96 l1_data_gas + (142810 + 50000 + 87650 + 1158935) l2 gas
+    assert_gas(
+        &result,
+        "contract_keccak_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_439_395),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn contract_range_check_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn range_check(self: @TContractState);
+            }
+            #[test]
+            fn contract_range_check_cost() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.range_check();
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
+    // 129970 = reported consumed sierra gas
+    // 0 l1_gas + 96 l1_data_gas + (142810 + 87650 + 129970) l2 gas
+    assert_gas(
+        &result,
+        "contract_range_check_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(360_430),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn storage_write_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn change_balance(ref self: TContractState, new_balance: u64);
+            }
+            #[test]
+            fn storage_write_cost() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.change_balance(1);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 64 = storage_updates(1) * 2 * 32
+    // 32 = storage updates from zero value(1) * 32 (https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-da-costs-27)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
+    // 10000 = cost of 1 storage write syscall (because 1 * 93 * 100 + 1 * 70 = 9370)
+    //      -> 1 storage write syscall costs 93 cairo steps and 1 range check builtin
+    //      -> 1 range check costs 70
+    //      -> the minimum total cost is `syscall_base_gas_cost`, which is pre-charged by the compiler (atm it is 100 * 100)
+    // 52310 = reported consumed sierra gas
+    // 0 l1_gas + (96 + 64 + 32) l1_data_gas + (142810 + 87650 + 10000 + 52310) l2 gas
+    assert_gas(
+        &result,
+        "storage_write_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(292_770),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn multiple_storage_writes_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn change_balance(ref self: TContractState, new_balance: u64);
+            }
+            #[test]
+            fn multiple_storage_writes_cost() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.change_balance(1);
+                dispatcher.change_balance(1);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 64 = n(1) * 2 * 32
+    // 64 = m(1) * 2 * 32
+    // 32 = l(1) * 32
+    //      -> l = number of class hash updates
+    //      -> n = unique contracts updated
+    //      -> m = unique(!) values updated
+    // 32 = storage updates from zero value(1) * 32 (https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-da-costs-27)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 175300 = cost of 2 call contract syscalls (because 2 * 866 * 100 + 2 * 15 * 70)
+    //      -> 1 call contract syscall costs 866 cairo steps and 15 range check builtins
+    //      -> 1 range check costs 70
+    // 20000 = cost of 2 storage write syscall (because 2 * 93 * 100 + 2 * 70 = 18740)
+    //      -> 1 storage write syscall costs 93 cairo steps and 1 range check builtin
+    //      -> 1 range check costs 70
+    //      -> the minimum total cost is `syscall_base_gas_cost`, which is pre-charged by the compiler (atm it is 100 * 100)
+    // 59790 = reported consumed sierra gas
+    // 0 l1_gas + (64 + 64 + 32 + 32) l1_data_gas + (142810 + 175300 + 20000 + 59790) l2 gas
+    assert_gas(
+        &result,
+        "multiple_storage_writes_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(397_900),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn l1_message_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn send_l1_message(self: @TContractState);
+            }
+            #[test]
+            fn l1_message_cost() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.send_l1_message();
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // todo(2960): verify l2 -> l1 message cost
+    // 29524 = gas cost of l2 -> l1 message
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
+    // 14170 = cost of 1 SendMessageToL1 syscall (because 1 * 141 * 100 + 1 * 70 )
+    //      -> 1 storage write syscall costs 141 cairo steps and 1 range check builtin
+    //      -> 1 range check costs 70
+    // 50870 = reported consumed sierra gas
+    // 29524 l1_gas + 96 l1_data_gas + (142810 + 87650 + 14170 + 50870) l2 gas
+    assert_gas(
+        &result,
+        "l1_message_cost",
+        GasVector {
+            l1_gas: GasAmount(29524),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(295_500),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn l1_message_cost_for_proxy_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasCheckerProxy<TContractState> {
+                fn send_l1_message_from_gas_checker(
+                    self: @TContractState,
+                    address: ContractAddress
+                );
+            }
+            #[test]
+            fn l1_message_cost_for_proxy() {
+                let contract = declare("GasChecker").unwrap().contract_class();
+                let (gas_checker_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let contract = declare("GasCheckerProxy").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@ArrayTrait::new()).unwrap();
+                let dispatcher = IGasCheckerProxyDispatcher { contract_address };
+                dispatcher.send_l1_message_from_gas_checker(gas_checker_address);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker".to_string(),
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "GasCheckerProxy".to_string(),
+            Path::new("tests/data/contracts/gas_checker_proxy.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // todo(2960): verify l2 -> l1 message cost
+    // 29524 = gas cost of l2 -> l1 message
+    // 128 = n(2) * 2 * 32
+    // 64 = l(2) * 32
+    //      -> l = number of class hash updates
+    //      -> n = unique contracts updated
+    // 285620 = cost of 2 deploy syscall (because 2 * 1132 * 100 + 2 * 7 * 4050 + 2 * 18 * 70)
+    //      -> 1 deploy syscall costs 1132 cairo steps, 7 pedersen and 18 range check builtins
+    //      -> 1 pedersen costs 4050, 1 range check costs 70
+    // 175300 = cost of 2 call contract syscalls (see `multiple_storage_writes_cost_sierra_gas` test)
+    // 14170 = cost of 1 SendMessageToL1 syscall (see `l1_message_cost_sierra_gas` test)
+    // 113720 = reported consumed sierra gas
+    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 113720) l2 gas
+    assert_gas(
+        &result,
+        "l1_message_cost_for_proxy",
+        GasVector {
+            l1_gas: GasAmount(29524),
+            l1_data_gas: GasAmount(192),
+            l2_gas: GasAmount(588_810),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn events_cost_sierra_gas() {
+    let test = test_case!(indoc!(
+        r"
+            use starknet::syscalls::emit_event_syscall;
+            #[test]
+            fn events_cost() {
+                let mut keys = array![];
+                let mut values =  array![];
+                let mut i: u32 = 0;
+                while i < 50 {
+                    keys.append('key');
+                    values.append(1);
+                    i += 1;
+                };
+                emit_event_syscall(keys.span(), values.span()).unwrap();
+            }
+        "
+    ));
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+    // 512000 = 50 * 10240
+    //      -> we emit 50 keys, each taking up 1 felt of space
+    //      -> L2 gas cost for event key is 10240 gas/felt
+    // 256000 = 50 * 5120
+    //      -> we emit 50 keys, each having 1 felt of data
+    //      -> L2 gas cost for event data is 5120 gas/felt
+    // 10000 = cost of 1 emit event syscall (because 1 * 61 * 100 + 1 * 70 = 6170)
+    //      -> 1 emit event syscall costs 61 cairo steps and 1 range check builtin
+    //      -> 1 range check costs 70
+    //      -> the minimum total cost is `syscall_base_gas_cost`, which is pre-charged by the compiler (atm it is 100 * 100)
+    // 186880 = reported consumed sierra gas
+    // 0 l1_gas + 0 l1_data_gas + (512000 + 256000 + 10000 + 186880) l2 gas
+    assert_gas(
+        &result,
+        "events_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(0),
+            l2_gas: GasAmount(964_880),
+        },
+    );
+}
+
+#[test]
+#[cfg_attr(not(feature = "scarb_since_2_10"), ignore)]
+fn events_contract_cost_sierra_gas() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use snforge_std::{ declare, ContractClassTrait, DeclareResultTrait };
+            #[starknet::interface]
+            trait IGasChecker<TContractState> {
+                fn emit_event(ref self: TContractState, n_keys_and_vals: u32);
+            }
+            #[test]
+            fn event_emission_cost() {
+                let (contract_address, _) = declare("GasChecker").unwrap().contract_class().deploy(@array![]).unwrap();
+                let dispatcher = IGasCheckerDispatcher { contract_address };
+                dispatcher.emit_event(50);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "GasChecker",
+            Path::new("tests/data/contracts/gas_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+    assert_passed(&result);
+    // 96 = gas cost of onchain data (see `deploy_syscall_cost_sierra_gas` test)
+    // 512000 = event keys cost (see `events_contract_cost_sierra_gas` test)
+    // 256000 = event data cost (see `events_contract_cost_sierra_gas` test)
+    // 10000 = cost of 1 emit event syscall (see `events_contract_cost_sierra_gas` test)
+    // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
+    // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
+    // 230550 = reported consumed sierra gas
+    // 0 l1_gas + 0 l1_data_gas + (512000 + 256000 + 10000 + 142810 + 87650 + 230550) l2 gas
+    assert_gas(
+        &result,
+        "event_emission_cost",
+        GasVector {
+            l1_gas: GasAmount(0),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(1_239_010),
+        },
+    );
 }

--- a/crates/snforge-scarb-plugin/src/attributes/available_gas.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/available_gas.rs
@@ -1,12 +1,14 @@
 use crate::{
     args::Arguments,
     attributes::{AttributeCollector, AttributeInfo, AttributeTypeData},
+    branch,
     cairo_expression::CairoExpression,
     config_statement::extend_with_config_cheatcodes,
     types::{Number, ParseFromExpr},
 };
-use cairo_lang_macro::{Diagnostic, Diagnostics, ProcMacroResult, TokenStream};
+use cairo_lang_macro::{Diagnostic, Diagnostics, ProcMacroResult, Severity, TokenStream};
 use cairo_lang_syntax::node::db::SyntaxGroup;
+use indoc::formatdoc;
 
 pub struct AvailableGasCollector;
 
@@ -24,16 +26,69 @@ impl AttributeCollector for AvailableGasCollector {
         args: Arguments,
         _warns: &mut Vec<Diagnostic>,
     ) -> Result<String, Diagnostics> {
-        let &[arg] = args.unnamed_only::<Self>()?.of_length::<1, Self>()?;
-
-        let gas = Number::parse_from_expr::<Self>(db, arg.1, arg.0.to_string().as_str())?;
-
-        let gas = gas.as_cairo_expression();
-
-        Ok(format!(
-            "snforge_std::_config_types::AvailableGasConfig {{ gas: {gas} }}"
-        ))
+        let expr = branch!(from_resource_bounds(db, &args), from_max_gas(db, &args))?;
+        Ok(expr)
     }
+}
+
+fn from_resource_bounds(db: &dyn SyntaxGroup, args: &Arguments) -> Result<String, Diagnostic> {
+    let named_args = args.named_only::<AvailableGasCollector>()?;
+    let max = u64::MAX;
+
+    let l1_gas = named_args
+        .as_once_optional("l1_gas")?
+        .map(|arg| Number::parse_from_expr::<AvailableGasCollector>(db, arg, "l1_gas"))
+        .transpose()?
+        .unwrap_or(Number(max.into()));
+
+    let l1_data_gas = named_args
+        .as_once_optional("l1_data_gas")?
+        .map(|arg| Number::parse_from_expr::<AvailableGasCollector>(db, arg, "l1_data_gas"))
+        .transpose()?
+        .unwrap_or(Number(max.into()));
+
+    let l2_gas = named_args
+        .as_once_optional("l2_gas")?
+        .map(|arg| Number::parse_from_expr::<AvailableGasCollector>(db, arg, "l2_gas"))
+        .transpose()?
+        .unwrap_or(Number(max.into()));
+
+    l1_gas.validate_in_gas_range::<AvailableGasCollector>("l1_gas")?;
+    l1_data_gas.validate_in_gas_range::<AvailableGasCollector>("l1_data_gas")?;
+    l2_gas.validate_in_gas_range::<AvailableGasCollector>("l2_gas")?;
+
+    let l1_gas_expr = l1_gas.as_cairo_expression();
+    let l1_data_gas_expr = l1_data_gas.as_cairo_expression();
+    let l2_gas_expr = l2_gas.as_cairo_expression();
+
+    Ok(formatdoc!(
+        "
+            snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                 snforge_std::_config_types::AvailableResourceBoundsConfig {{
+                     l1_gas: {l1_gas_expr},
+                     l1_data_gas: {l1_data_gas_expr},
+                     l2_gas: {l2_gas_expr}
+                 }}
+             )
+        "
+    ))
+}
+
+fn from_max_gas(db: &dyn SyntaxGroup, args: &Arguments) -> Result<String, Diagnostic> {
+    let &[arg] = args
+        .unnamed_only::<AvailableGasCollector>()?
+        .of_length::<1, AvailableGasCollector>()?;
+
+    let gas =
+        Number::parse_from_expr::<AvailableGasCollector>(db, arg.1, arg.0.to_string().as_str())?;
+
+    gas.validate_in_gas_range::<AvailableGasCollector>("max_gas")?;
+
+    let gas = gas.as_cairo_expression();
+
+    Ok(format!(
+        "snforge_std::_config_types::AvailableGasConfig::MaxGas({gas})"
+    ))
 }
 
 #[must_use]

--- a/crates/snforge-scarb-plugin/src/types.rs
+++ b/crates/snforge-scarb-plugin/src/types.rs
@@ -51,8 +51,23 @@ impl ParseFromExpr<Expr> for Felt {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct Number(pub(crate) BigInt);
+
+impl Number {
+    pub fn validate_in_gas_range<T: AttributeInfo>(
+        &self,
+        arg_name: &str,
+    ) -> Result<(), Diagnostic> {
+        let max = u64::MAX;
+        if *self > Number(max.into()) {
+            return Err(T::error(format!(
+                "{arg_name} it too large (max permissible value is {max})"
+            )));
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ShortString(pub(crate) String);

--- a/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
@@ -24,7 +24,7 @@ fn works_with_few_attributes() {
     );
 
     let item = result.token_stream;
-    let args = TokenStream::new("(123)".into());
+    let args = TokenStream::new("(l1_gas: 1, l1_data_gas: 2, l2_gas: 3)".into());
 
     let result = available_gas(args, item);
 
@@ -39,9 +39,13 @@ fn works_with_few_attributes() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x7b
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                            l1_gas: 0x1,
+                            l1_data_gas: 0x2,
+                            l2_gas: 0x3
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
@@ -68,9 +72,13 @@ fn works_with_few_attributes() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x7b
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                            l1_gas: 0x1,
+                            l1_data_gas: 0x2,
+                            l2_gas: 0x3
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
@@ -127,9 +135,10 @@ fn works_with_fuzzer() {
 }
 
 #[test]
+#[expect(clippy::too_many_lines)]
 fn works_with_fuzzer_config_wrapper() {
     let item = TokenStream::new(FN_WITH_SINGLE_FELT252_PARAM.into());
-    let args = TokenStream::new("(999)".into());
+    let args = TokenStream::new("(l2_gas: 999)".into());
 
     let result = available_gas(args, item);
 
@@ -142,9 +151,13 @@ fn works_with_fuzzer_config_wrapper() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x3e7
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                            l1_gas: 0xffffffffffffffff,
+                            l1_data_gas: 0xffffffffffffffff,
+                            l2_gas: 0x3e7
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
@@ -180,9 +193,13 @@ fn works_with_fuzzer_config_wrapper() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x3e7
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                            l1_gas: 0xffffffffffffffff,
+                            l1_data_gas: 0xffffffffffffffff,
+                            l2_gas: 0x3e7
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
@@ -219,9 +236,13 @@ fn works_with_fuzzer_config_wrapper() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x3e7
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                            l1_gas: 0xffffffffffffffff,
+                            l1_data_gas: 0xffffffffffffffff,
+                            l2_gas: 0x3e7
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/available_gas.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/available_gas.rs
@@ -4,56 +4,65 @@ use indoc::formatdoc;
 use snforge_scarb_plugin::attributes::available_gas::available_gas;
 
 #[test]
-fn fails_with_empty() {
+fn works_with_empty() {
     let item = TokenStream::new(EMPTY_FN.into());
     let args = TokenStream::new("()".into());
 
     let result = available_gas(args, item);
 
+    assert_output(
+        &result,
+        "
+            fn empty_fn() {
+                if snforge_std::_internals::_is_config_run() {
+                    let mut data = array![];
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                        l1_gas: 0xffffffffffffffff,
+                        l1_data_gas: 0xffffffffffffffff,
+                        l2_gas: 0xffffffffffffffff
+                        }
+                    )
+                    .serialize(ref data);
+                    starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
+                    return;
+                }
+            }
+        ",
+    );
+
     assert_diagnostics(
         &result,
         &[
             Diagnostic::warn("#[available_gas] used with empty argument list. Either remove () or specify some arguments"),
-            Diagnostic::error(
-            "#[available_gas] expected arguments: 1, got: 0",
-        )],
-    );
-}
-
-#[test]
-fn fails_with_more_than_one() {
-    let item = TokenStream::new(EMPTY_FN.into());
-    let args = TokenStream::new("(123,123,123)".into());
-
-    let result = available_gas(args, item);
-
-    assert_diagnostics(
-        &result,
-        &[Diagnostic::error(
-            "#[available_gas] expected arguments: 1, got: 3",
-        )],
+        ],
     );
 }
 
 #[test]
 fn fails_with_non_number_literal() {
     let item = TokenStream::new(EMPTY_FN.into());
-    let args = TokenStream::new(r#"("123")"#.into());
+    let args = TokenStream::new(r#"(l2_gas: "123")"#.into());
 
     let result = available_gas(args, item);
 
     assert_diagnostics(
         &result,
-        &[Diagnostic::error(
-            "#[available_gas] <0> should be number literal",
-        )],
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: #[available_gas] <l2_gas> should be number literal
+                - variant: #[available_gas] can be used with unnamed arguments only
+                Resolve at least one of them
+            "
+        ))],
     );
 }
 
 #[test]
-fn work_with_number() {
+fn work_with_number_some_set() {
     let item = TokenStream::new(EMPTY_FN.into());
-    let args = TokenStream::new("(123)".into());
+    let args = TokenStream::new("(l1_gas: 123)".into());
 
     let result = available_gas(args, item);
 
@@ -66,9 +75,47 @@ fn work_with_number() {
                 if snforge_std::_internals::_is_config_run() {
                     let mut data = array![];
 
-                    snforge_std::_config_types::AvailableGasConfig {
-                        gas: 0x7b
-                    }
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                        l1_gas: 0x7b,
+                        l1_data_gas: 0xffffffffffffffff,
+                        l2_gas: 0xffffffffffffffff
+                        }
+                    )
+                    .serialize(ref data);
+
+                    starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
+
+                    return;
+                }
+            }
+        ",
+    );
+}
+
+#[test]
+fn work_with_number_all_set() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l1_gas: 1, l1_data_gas: 2, l2_gas: 3)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(&result, &[]);
+
+    assert_output(
+        &result,
+        "
+            fn empty_fn() {
+                if snforge_std::_internals::_is_config_run() {
+                    let mut data = array![];
+
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                        l1_gas: 0x1,
+                        l1_data_gas: 0x2,
+                        l2_gas: 0x3
+                        }
+                    )
                     .serialize(ref data);
 
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
@@ -82,20 +129,159 @@ fn work_with_number() {
 
 #[test]
 fn is_used_once() {
-    let item = TokenStream::new(formatdoc!(
-        "
-            #[available_gas]
-            {EMPTY_FN}
-        "
-    ));
-    let args = TokenStream::new("(123)".into());
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l2_gas: 1, l2_gas: 3)".into());
 
     let result = available_gas(args, item);
 
     assert_diagnostics(
         &result,
-        &[Diagnostic::error(
-            "#[available_gas] can only be used once per item",
-        )],
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: <l2_gas> argument was specified 2 times, expected to be used only once
+                - variant: #[available_gas] can be used with unnamed arguments only
+                Resolve at least one of them
+            "
+        ))],
+    );
+}
+
+#[test]
+fn works_with_unnamed_number() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(3)".into());
+
+    let result = available_gas(args, item);
+
+    assert_output(
+        &result,
+        "
+            fn empty_fn() {
+                if snforge_std::_internals::_is_config_run() {
+                    let mut data = array![];
+                    snforge_std::_config_types::AvailableGasConfig::MaxGas(0x3)
+                    .serialize(ref data);
+                    starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
+                    return;
+                }
+            }
+        ",
+    );
+}
+
+// previously if some bonkers number was put into available_gas attribute, test always passed
+// this was because u64 overflow, so now we test with u64::MAX + 1 to make sure it does not happen
+#[test]
+fn handles_number_overflow_unnamed() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(18446744073709551616)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(
+        &result,
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: #[available_gas] can be used with named arguments only
+                - variant: #[available_gas] max_gas it too large (max permissible value is 18446744073709551615)
+                Resolve at least one of them
+            "
+        ))],
+    );
+}
+
+#[test]
+fn handles_number_overflow_l1() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l1_gas: 18446744073709551616)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(
+        &result,
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: #[available_gas] l1_gas it too large (max permissible value is 18446744073709551615)
+                - variant: #[available_gas] can be used with unnamed arguments only
+                Resolve at least one of them
+            "
+        ))],
+    );
+}
+
+#[test]
+fn handles_number_overflow_l1_data() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l1_data_gas: 18446744073709551616)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(
+        &result,
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: #[available_gas] l1_data_gas it too large (max permissible value is 18446744073709551615)
+                - variant: #[available_gas] can be used with unnamed arguments only
+                Resolve at least one of them
+            "
+        ))],
+    );
+}
+
+#[test]
+fn handles_number_overflow_l2() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l2_gas: 18446744073709551616)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(
+        &result,
+        &[Diagnostic::error(formatdoc!(
+            "
+                All options failed
+                - variant: #[available_gas] l2_gas it too large (max permissible value is 18446744073709551615)
+                - variant: #[available_gas] can be used with unnamed arguments only
+                Resolve at least one of them
+            "
+        ))],
+    );
+}
+
+#[test]
+fn max_permissible_value() {
+    let item = TokenStream::new(EMPTY_FN.into());
+    let args = TokenStream::new("(l2_gas: 18446744073709551615)".into());
+
+    let result = available_gas(args, item);
+
+    assert_diagnostics(&result, &[]);
+
+    assert_output(
+        &result,
+        "
+            fn empty_fn() {
+                if snforge_std::_internals::_is_config_run() {
+                    let mut data = array![];
+
+                    snforge_std::_config_types::AvailableGasConfig::MaxResourceBounds(
+                        snforge_std::_config_types::AvailableResourceBoundsConfig {
+                        l1_gas: 0xffffffffffffffff,
+                        l1_data_gas: 0xffffffffffffffff,
+                        l2_gas: 0xffffffffffffffff
+                        }
+                    )
+                    .serialize(ref data);
+
+                    starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
+
+                    return;
+                }
+            }
+        ",
     );
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
@@ -338,7 +338,7 @@ fn config_wrapper_work_with_fn_with_param() {
 fn wrapper_handle_attributes() {
     let item = TokenStream::new(formatdoc!(
         "
-            #[available_gas(1)]
+            #[available_gas(l2_gas: 40000))]
             #[test]
             {EMPTY_FN}
         "
@@ -350,6 +350,7 @@ fn wrapper_handle_attributes() {
     assert_output(
         &result,
         "
+            #[available_gas(l2_gas: 40000))]
             #[test]
             fn empty_fn() { 
                 if snforge_std::_internals::_is_config_run() {
@@ -360,7 +361,6 @@ fn wrapper_handle_attributes() {
                 empty_fn_actual_body(); 
             }
 
-            #[available_gas(1)]
             #[__internal_config_statement]
             fn empty_fn_actual_body() {
             }

--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -87,6 +87,13 @@ Do not activate the `default` feature.
 Build contract artifacts in a separate [starknet contract target](https://docs.swmansion.com/scarb/docs/extensions/starknet/contract-target.html#starknet-contract-target).
 Enabling this flag will slow down the compilation process, but the built contracts will more closely resemble the ones used on real networks. This is set to `true` when using Scarb version less than `2.8.3`.
 
+## `--tracked-resource`
+
+Set tracked resource for test execution. Impacts overall test gas cost. Valid values:
+- `cairo-steps` (default): track cairo steps, uses vm `ExecutionResources` (steps, builtins, memory holes) to describe  resources consumed by the test.
+- `sierra-gas` (sierra 1.7.0+ is required): track sierra gas, uses cairo native `CallExecution` (sierra gas consumption) to describe computation resources consumed by the test.
+To learn more about fee calculation formula (and an impact of tracking sierra gas on it) please consult [starknet docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee)
+
 ## `-h`, `--help`
 
 Print help.

--- a/docs/src/getting-started/first-steps.md
+++ b/docs/src/getting-started/first-steps.md
@@ -50,8 +50,8 @@ $ snforge test
 Collected 2 test(s) from hello_starknet package
 Running 0 test(s) from src/
 Running 2 test(s) from tests/
-[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (gas: ~105)
-[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (gas: ~172)
+[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~360000)
+[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (l1_gas: ~0, l1_data_gas: ~192, l2_gas: ~480000)
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>

--- a/docs/src/snforge-advanced-features/profiling.md
+++ b/docs/src/snforge-advanced-features/profiling.md
@@ -12,6 +12,11 @@ All you have to do is use the [`--save-trace-data`](../appendix/snforge/test.md#
 $ snforge test --save-trace-data
 ```
 
+> 💡 **Tip**
+>
+> You can choose which resource to track (cairo-steps or sierra-gas) using `--tracked-resource` flag
+> Tracking sierra gas is only available for sierra 1.7.0+
+
 The files with traces will be saved to `snfoundry_trace` directory. Each one of these files can then be used as an input
 for the [cairo-profiler](https://github.com/software-mansion/cairo-profiler).
 

--- a/docs/src/testing/contracts.md
+++ b/docs/src/testing/contracts.md
@@ -53,7 +53,7 @@ Running 2 test(s) from tests/
 Failure data:
     (0x50414e4943 ('PANIC'), 0x444159544148 ('DAYTAH'))
 
-[PASS] testing_smart_contracts_handling_errors_integrationtest::handle_panic::handling_string_errors (gas: ~103)
+[PASS] testing_smart_contracts_handling_errors_integrationtest::handle_panic::handling_string_errors (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~280000)
 Running 0 test(s) from src/
 Tests: 1 passed, 1 failed, 0 skipped, 0 ignored, 0 filtered out
 
@@ -97,7 +97,7 @@ Running 2 test(s) from tests/
 Failure data:
     (0x50414e4943 ('PANIC'), 0x444159544148 ('DAYTAH'))
 
-[PASS] testing_smart_contracts_handling_errors_integrationtest::handle_panic::handling_string_errors (gas: ~103)
+[PASS] testing_smart_contracts_handling_errors_integrationtest::handle_panic::handling_string_errors (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~280000)
 Running 0 test(s) from src/
 Tests: 1 passed, 1 failed, 0 skipped, 0 ignored, 0 filtered out
 
@@ -132,7 +132,7 @@ $ snforge test
 Collected 1 test(s) from testing_smart_contracts_safe_dispatcher package
 Running 0 test(s) from src/
 Running 1 test(s) from tests/
-[PASS] testing_smart_contracts_safe_dispatcher_integrationtest::safe_dispatcher::handling_errors (gas: ~103)
+[PASS] testing_smart_contracts_safe_dispatcher_integrationtest::safe_dispatcher::handling_errors (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~280000)
 Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>

--- a/docs/src/testing/gas-and-resource-estimation.md
+++ b/docs/src/testing/gas-and-resource-estimation.md
@@ -11,7 +11,7 @@ please refer to fee mechanism in [Starknet documentation](https://docs.starknet.
 
 When the test passes with no errors, estimated gas is displayed this way:
 ```shell
-[PASS] tests::simple_test (gas: ~1)
+[PASS] tests::simple_test (l1_gas: ~1, l1_data_gas: ~1, l2_gas: ~1)
 ```
 
 This gas calculation is based on the estimated VM resources (that you can [display additionally on demand](#usage)), 
@@ -21,7 +21,7 @@ deployed contracts, storage updates, events and l1 <> l2 messages.
 
 While using the fuzzing feature additional gas statistics will be displayed:
 ```shell
-[PASS] tests::fuzzing_test (runs: 256, gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31})
+[PASS] tests::fuzzing_test (runs: 256, l1_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31}, l1_data_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31}, l2_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31})
 ```
 
 > 📝 **Note**
@@ -29,9 +29,11 @@ While using the fuzzing feature additional gas statistics will be displayed:
 > Starknet-Foundry uses blob-based gas calculation formula in order to calculate gas usage. 
 > For details on the exact formula, [see the docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee_blob). 
 
-## VM Resources estimation 
+## Resources Estimation 
 
 It is possible to enable more detailed breakdown of resources, on which the gas calculations are based on.
+Depending on `--tracked-resource`, vm resources or sierra gas will be displayed.
+To learn more about tracked resource flag, see [--tracked-resource](../appendix/snforge/test.md#--tracked-resource).
 
 ### Usage
 In order to run tests with this feature, run the `test` command with the appropriate flag:
@@ -46,18 +48,18 @@ $ snforge test --detailed-resources
 ```shell
 Collected 2 test(s) from hello_starknet package
 Running 2 test(s) from tests/
-[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (gas: ~105)
+[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~360000)
         steps: 3405
         memory holes: 22
         builtins: (range_check: 77, pedersen: 7)
         syscalls: (CallContract: 2, StorageRead: 1, Deploy: 1)
-        
-[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (gas: ~172)
+
+[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (l1_gas: ~0, l1_data_gas: ~192, l2_gas: ~480000)
         steps: 4535
         memory holes: 15
         builtins: (range_check: 95, pedersen: 7)
         syscalls: (CallContract: 3, StorageRead: 3, Deploy: 1, StorageWrite: 1)
-        
+
 Running 0 test(s) from src/
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```

--- a/docs/src/testing/running-tests.md
+++ b/docs/src/testing/running-tests.md
@@ -13,9 +13,9 @@ $ snforge test
 Collected 3 test(s) from hello_snforge package
 Running 0 test(s) from src/
 Running 3 test(s) from tests/
-[PASS] hello_snforge_integrationtest::test_contract::test_calling (gas: ~1)
-[PASS] hello_snforge_integrationtest::test_contract::test_executing (gas: ~1)
-[PASS] hello_snforge_integrationtest::test_contract::test_calling_another (gas: ~1)
+[PASS] hello_snforge_integrationtest::test_contract::test_calling (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] hello_snforge_integrationtest::test_contract::test_executing (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] hello_snforge_integrationtest::test_contract::test_calling_another (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 3 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>
@@ -37,8 +37,8 @@ $ snforge test calling
 Collected 2 test(s) from hello_snforge package
 Running 0 test(s) from src/
 Running 2 test(s) from tests/
-[PASS] hello_snforge_integrationtest::test_contract::test_calling_another (gas: ~1)
-[PASS] hello_snforge_integrationtest::test_contract::test_calling (gas: ~1)
+[PASS] hello_snforge_integrationtest::test_contract::test_calling_another (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] hello_snforge_integrationtest::test_contract::test_calling (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 1 filtered out
 ```
 </details>
@@ -64,7 +64,7 @@ $ snforge test hello_snforge_integrationtest::test_contract::test_calling --exac
 ```shell
 Collected 1 test(s) from hello_snforge package
 Running 1 test(s) from tests/
-[PASS] hello_snforge_integrationtest::test_contract::test_calling (gas: ~1)
+[PASS] hello_snforge_integrationtest::test_contract::test_calling (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 0 test(s) from src/
 Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, other filtered out
 ```
@@ -114,18 +114,18 @@ $ snforge test --detailed-resources
 ```shell
 Collected 2 test(s) from hello_starknet package
 Running 2 test(s) from tests/
-[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (gas: ~105)
+[PASS] hello_starknet_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~360000)
         steps: 3405
         memory holes: 22
         builtins: (range_check: 77, pedersen: 7)
         syscalls: (CallContract: 2, StorageRead: 1, Deploy: 1)
-        
-[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (gas: ~172)
+
+[PASS] hello_starknet_integrationtest::test_contract::test_increase_balance (l1_gas: ~0, l1_data_gas: ~192, l2_gas: ~480000)
         steps: 4535
         memory holes: 15
         builtins: (range_check: 95, pedersen: 7)
         syscalls: (CallContract: 3, StorageRead: 3, Deploy: 1, StorageWrite: 1)
-        
+
 Running 0 test(s) from src/
 Tests: 2 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```

--- a/docs/src/testing/test-attributes.md
+++ b/docs/src/testing/test-attributes.md
@@ -72,7 +72,19 @@ If the test exceeds the limit, it fails with an appropriate error.
 
 #### Usage
 
-Asserts that the test does not use more than 5 units of gas.
+Asserts that the test does not use more than 5 units of l2 gas:
+
+```rust
+#[available_gas(l2_gas: 5)]
+```
+
+Asserts that the test does not use more than 5 units of l1 gas, l1 data gas and l2 gas each:
+
+```rust
+#[available_gas(l1_gas: 5, l1_data_gas: 5, l2_gas: 5)]
+```
+
+Asserts that the test does not use more than 5 units of gas overall:
 
 ```rust
 #[available_gas(5)]

--- a/docs/src/testing/testing-workspaces.md
+++ b/docs/src/testing/testing-workspaces.md
@@ -48,7 +48,7 @@ $ snforge test
 ```shell
 Collected 3 test(s) from hello_workspaces package
 Running 1 test(s) from src/
-[PASS] hello_workspaces::tests::test_simple (gas: ~1)
+[PASS] hello_workspaces::tests::test_simple (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 2 test(s) from tests/
 [FAIL] hello_workspaces_integrationtest::test_failing::test_failing
 
@@ -83,12 +83,12 @@ $ snforge test --package addition
 ```shell
 Collected 5 test(s) from addition package
 Running 4 test(s) from tests/
-[PASS] addition_integrationtest::nested::test_nested::test_two (gas: ~1)
-[PASS] addition_integrationtest::nested::test_nested::test_two_and_two (gas: ~1)
-[PASS] addition_integrationtest::nested::simple_case (gas: ~1)
-[PASS] addition_integrationtest::nested::contract_test (gas: ~1)
+[PASS] addition_integrationtest::nested::test_nested::test_two (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::test_nested::test_two_and_two (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::simple_case (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::contract_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 1 test(s) from src/
-[PASS] addition::tests::it_works (gas: ~1)
+[PASS] addition::tests::it_works (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>
@@ -106,34 +106,34 @@ $ snforge test --workspace
 ```shell
 Collected 5 test(s) from addition package
 Running 4 test(s) from tests/
-[PASS] addition_integrationtest::nested::test_nested::test_two (gas: ~1)
-[PASS] addition_integrationtest::nested::simple_case (gas: ~1)
-[PASS] addition_integrationtest::nested::test_nested::test_two_and_two (gas: ~1)
-[PASS] addition_integrationtest::nested::contract_test (gas: ~1)
+[PASS] addition_integrationtest::nested::test_nested::test_two (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::simple_case (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::test_nested::test_two_and_two (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] addition_integrationtest::nested::contract_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 1 test(s) from src/
-[PASS] addition::tests::it_works (gas: ~1)
+[PASS] addition::tests::it_works (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 
 
 Collected 6 test(s) from fibonacci package
 Running 2 test(s) from src/
-[PASS] fibonacci::tests::it_works (gas: ~1)
-[PASS] fibonacci::tests::contract_test (gas: ~1)
+[PASS] fibonacci::tests::it_works (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] fibonacci::tests::contract_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 4 test(s) from tests/
 [FAIL] fibonacci_tests::abc::efg::failing_test
 
 Failure data:
     0x0 ('')
 
-[PASS] fibonacci_tests::abc::efg::efg_test (gas: ~1)
-[PASS] fibonacci_tests::lib_test (gas: ~1)
-[PASS] fibonacci_tests::abc::abc_test (gas: ~1)
+[PASS] fibonacci_tests::abc::efg::efg_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] fibonacci_tests::lib_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] fibonacci_tests::abc::abc_test (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 5 passed, 1 failed, 0 skipped, 0 ignored, 0 filtered out
 
 
 Collected 3 test(s) from hello_workspaces package
 Running 1 test(s) from src/
-[PASS] hello_workspaces::tests::test_simple (gas: ~1)
+[PASS] hello_workspaces::tests::test_simple (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 2 test(s) from tests/
 [FAIL] hello_workspaces_integrationtest::test_failing::test_another_failing
 

--- a/docs/src/testing/testing.md
+++ b/docs/src/testing/testing.md
@@ -28,7 +28,7 @@ $ snforge test
 ```shell
 Collected 1 test(s) from first_test package
 Running 1 test(s) from src/
-[PASS] first_test::tests::test_sum (gas: ~1)
+[PASS] first_test::tests::test_sum (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>
@@ -103,11 +103,11 @@ $ snforge test
 ```shell
 Collected 5 test(s) from should_panic_example package
 Running 5 test(s) from src/
-[PASS] should_panic_example::tests::should_panic_felt_matching (gas: ~1)
-[PASS] should_panic_example::tests::should_panic_multiple_messages (gas: ~1)
-[PASS] should_panic_example::tests::should_panic_exact (gas: ~1)
-[PASS] should_panic_example::tests::should_panic_expected_is_substring (gas: ~1)
-[PASS] should_panic_example::tests::should_panic_check_data (gas: ~1)
+[PASS] should_panic_example::tests::should_panic_felt_matching (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] should_panic_example::tests::should_panic_multiple_messages (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] should_panic_example::tests::should_panic_exact (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] should_panic_example::tests::should_panic_expected_is_substring (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
+[PASS] should_panic_example::tests::should_panic_check_data (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Tests: 5 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>

--- a/docs/src/testing/using-cheatcodes.md
+++ b/docs/src/testing/using-cheatcodes.md
@@ -87,7 +87,7 @@ $ snforge test
 Collected 1 test(s) from using_cheatcodes_cheat_address package
 Running 0 test(s) from src/
 Running 1 test(s) from tests/
-[PASS] using_cheatcodes_cheat_address_tests::call_and_invoke (gas: ~239)
+[PASS] using_cheatcodes_cheat_address_tests::call_and_invoke (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~600000)
 Tests: 1 passed, 0 failed, 0 skipped, 0 ignored, 0 filtered out
 ```
 </details>

--- a/snforge_std/src/_config_types.cairo
+++ b/snforge_std/src/_config_types.cairo
@@ -1,6 +1,14 @@
 #[derive(Drop, Serde)]
-pub struct AvailableGasConfig {
-    pub gas: felt252
+pub struct AvailableResourceBoundsConfig {
+    pub l1_gas: felt252,
+    pub l1_data_gas: felt252,
+    pub l2_gas: felt252
+}
+
+#[derive(Drop, Serde)]
+pub enum AvailableGasConfig {
+    MaxGas: felt252,
+    MaxResourceBounds: AvailableResourceBoundsConfig
 }
 
 #[derive(Drop, Serde)]


### PR DESCRIPTION
Related to #2977

This PR stack aims to add support for new resource tracking (sierra-gas) and new gas representation (GasVector triplet instead of single l1 gas value).

-- (https://github.com/foundry-rs/starknet-foundry/pull/3049) Add sierra gas tracking
-- (https://github.com/foundry-rs/starknet-foundry/pull/3050) Run already existing tests with CairoSteps set explicitly
-- (https://github.com/foundry-rs/starknet-foundry/pull/3051) Add support for sierra gas in `--detailed-resources`
--> (This PR) Add support for sierra gas in `--save-trace-data`
-- (https://github.com/foundry-rs/starknet-foundry/pull/3053) Add sierra version assertion
-- (https://github.com/foundry-rs/starknet-foundry/pull/3054) Introduce new gas representation
-- (https://github.com/foundry-rs/starknet-foundry/pull/3055) Add gas tests for sierra-gas tracking
-- (https://github.com/foundry-rs/starknet-foundry/pull/3056) Update docs with sierra-gas related changes
