### PR TITLE
Update docs regarding sierra-gas tracking

### DIFF
--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -92,6 +92,7 @@ Enabling this flag will slow down the compilation process, but the built contrac
 Set tracked resource for test execution. Impacts overall test gas cost. Valid values:
 - `cairo-steps` (default): track cairo steps, uses vm `ExecutionResources` (steps, builtins, memory holes) to describe  resources consumed by the test.
 - `sierra-gas` (sierra 1.7.0+ is required): track sierra gas, uses cairo native `CallExecution` (sierra gas consumption) to describe computation resources consumed by the test.
+To learn more about fee calculation formula (and an impact of tracking sierra gas on it) please consult [starknet docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee)
 
 ## `-h`, `--help`
 

--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -87,6 +87,12 @@ Do not activate the `default` feature.
 Build contract artifacts in a separate [starknet contract target](https://docs.swmansion.com/scarb/docs/extensions/starknet/contract-target.html#starknet-contract-target).
 Enabling this flag will slow down the compilation process, but the built contracts will more closely resemble the ones used on real networks. This is set to `true` when using Scarb version less than `2.8.3`.
 
+## `--tracked-resource`
+
+Set tracked resource for test execution. Impacts overall test gas cost. Valid values:
+- `cairo-steps` (default): track cairo steps, uses vm `ExecutionResources` (steps, builtins, memory holes) to describe  resources consumed by the test.
+- `sierra-gas` (sierra 1.7.0+ is required): track sierra gas, uses cairo native `CallExecution` (sierra gas consumption) to describe computation resources consumed by the test.
+
 ## `-h`, `--help`
 
 Print help.

--- a/docs/src/snforge-advanced-features/profiling.md
+++ b/docs/src/snforge-advanced-features/profiling.md
@@ -12,6 +12,11 @@ All you have to do is use the [`--save-trace-data`](../appendix/snforge/test.md#
 $ snforge test --save-trace-data
 ```
 
+> 💡 **Tip**
+>
+> You can choose which resource to track (cairo-steps or sierra-gas) using `--tracked-resource` flag
+> Tracking sierra gas is only available for sierra 1.7.0+
+
 The files with traces will be saved to `snfoundry_trace` directory. Each one of these files can then be used as an input
 for the [cairo-profiler](https://github.com/software-mansion/cairo-profiler).
 

--- a/docs/src/testing/gas-and-resource-estimation.md
+++ b/docs/src/testing/gas-and-resource-estimation.md
@@ -29,10 +29,11 @@ While using the fuzzing feature additional gas statistics will be displayed:
 > Starknet-Foundry uses blob-based gas calculation formula in order to calculate gas usage. 
 > For details on the exact formula, [see the docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee_blob). 
 
-## Resources estimation 
+## Resources Estimation 
 
 It is possible to enable more detailed breakdown of resources, on which the gas calculations are based on.
 Depending on `--tracked-resource`, vm resources or sierra gas will be displayed.
+To learn more about tracked resource flag, see [--tracked-resource](../appendix/snforge/test.md#--tracked-resource).
 
 ### Usage
 In order to run tests with this feature, run the `test` command with the appropriate flag:

--- a/docs/src/testing/gas-and-resource-estimation.md
+++ b/docs/src/testing/gas-and-resource-estimation.md
@@ -29,9 +29,10 @@ While using the fuzzing feature additional gas statistics will be displayed:
 > Starknet-Foundry uses blob-based gas calculation formula in order to calculate gas usage. 
 > For details on the exact formula, [see the docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/#overall_fee_blob). 
 
-## VM Resources estimation 
+## Resources estimation 
 
 It is possible to enable more detailed breakdown of resources, on which the gas calculations are based on.
+Depending on `--tracked-resource`, vm resources or sierra gas will be displayed.
 
 ### Usage
 In order to run tests with this feature, run the `test` command with the appropriate flag:


### PR DESCRIPTION
Related to #2977

This PR stack aims to add support for new resource tracking (sierra-gas) and new gas representation (GasVector triplet instead of single l1 gas value).

-- (https://github.com/foundry-rs/starknet-foundry/pull/3049) Add sierra gas tracking
-- (https://github.com/foundry-rs/starknet-foundry/pull/3050) Run already existing tests with CairoSteps set explicitly
-- (https://github.com/foundry-rs/starknet-foundry/pull/3051) Add support for sierra gas in `--detailed-resources`
-- (https://github.com/foundry-rs/starknet-foundry/pull/3052) Add support for sierra gas in `--save-trace-data`
-- (https://github.com/foundry-rs/starknet-foundry/pull/3053) Add sierra version assertion
-- (https://github.com/foundry-rs/starknet-foundry/pull/3054) Introduce new gas representation
-- (https://github.com/foundry-rs/starknet-foundry/pull/3055) Add gas tests for sierra-gas tracking
--> (This PR) Update docs with sierra-gas related changes
