### PR TITLE
Hide sierra tracking test behind feature flag for older scarb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
 
       - run: cargo test --package forge --features scarb_2_7_1 --test main e2e::requirements::test_warning_on_scarb_version_below_recommended
       - run: cargo test --package forge --features scarb_2_7_1 --lib compatibility_check::tests::warning_requirements
+      - run: cargo test --package forge --features scarb_2_7_1 --test main e2e::running::sierra_gas_with_older_scarb
 
   # todo(3096): Remove this and the feature as soon as scarb 2.10 is the oldest officially supported version
   test-scarb-since-2-10:

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -931,7 +931,7 @@ fn call_nonexistent_selector() {
 }
 
 #[test]
-#[cfg_attr(feature = "scarb_since_2_10", ignore)]
+#[cfg_attr(not(feature = "scarb_2_7_1"), ignore)]
 fn sierra_gas_with_older_scarb() {
     let temp = setup_package("erc20_package");
     let output = test_runner(&temp)


### PR DESCRIPTION
## Introduced changes

<!-- A brief description of the changes -->

- replace feature name for test failing on scheduled

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
