### PR TITLE
Fixing Broken Documentation Link

### DIFF
--- a/design_documents/transactional_testing/transactional_testing.md
+++ b/design_documents/transactional_testing/transactional_testing.md
@@ -25,7 +25,7 @@ This could be considered as a variant of `cast script`, in a way.
 
 The extending/differentiating factors would be:
 
-- Extra environment-specific functions (for [katana](https://book.dojoengine.org/toolchain/katana/reference.html#custom-methods)/[devnet](https://github.com/0xSpaceShard/starknet-devnet-rs#dumping--loading) - see docs)
+- Extra environment-specific functions (for [katana](https://book.dojoengine.org/toolchain/katana)/[devnet](https://github.com/0xSpaceShard/starknet-devnet-rs#dumping--loading) - see docs)
 - Additional RPC functions support (receipts, etc.)
 - Test-like behavior (fail/pass)
 - Idempotent functions, for functionalities that can fail when double-running them (i.e. declare)


### PR DESCRIPTION
The previous link led to a 404 error, meaning users could not access the referenced documentation.
The corrected link directs to the main Katana toolchain page, ensuring accurate reference material.
This change was necessary because the "reference" section does not exist in Katana's documentation, making the previous link invalid.


