### PR TITLE
Fix #3158: Update clean-cache command name to 'clean cache' in help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--template` flag to `snforge new` command that allows selecting a template for the new project. Possible values are `balance-contract` (default), `cairo-program` and `erc20-contract`
 
+#### Changed
+
+- Renamed the `clean-cache` command to `clean cache` in the help menu to be consistent with the warning message
+
 ### Cast
 
 #### Changed

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -101,6 +101,7 @@ enum ForgeSubcommand {
         args: CleanArgs,
     },
     /// Clean Forge cache directory
+    #[command(name = "clean cache")]
     CleanCache {},
     /// Check if all `snforge` requirements are installed
     CheckRequirements,


### PR DESCRIPTION
This change makes the command name displayed in the help menu match the recommended format in the warning message, which suggests using 'snforge clean cache' instead.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #
#3158 
## Introduced changes

<!-- A brief description of the changes -->

This PR addresses issue #3158 where there's an inconsistency between the command shown in the help menu (clean-cache) and the recommended command in the warning message (clean cache).

## Checklist

<!-- Make sure all of these are complete -->

- [ x] Linked relevant issue
- [ x] Updated relevant documentation
- [ x] Added relevant tests
- [ x] Performed self-review of the code
- [ x] Added changes to `CHANGELOG.md`
