### PR TITLE
Fix #3158: Update clean-cache command name to 'clean cache' in help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--template` flag to `snforge new` command that allows selecting a template for the new project. Possible values are `balance-contract` (default), `cairo-program` and `erc20-contract`
 
+#### Changed
+
+- Renamed the `clean-cache` command to `clean cache` in the help menu to be consistent with the warning message
+
 ### Cast
 
 #### Changed

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -41,7 +41,7 @@ const MINIMAL_SCARB_VERSION_PREBUILT_PLUGIN: Version = Version::new(2, 10, 0);
 const MINIMAL_USC_VERSION: Version = Version::new(2, 0, 0);
 const MINIMAL_SCARB_VERSION_FOR_SIERRA_GAS: Version = Version::new(2, 10, 0);
 
-#[derive(Parser, Debug)]
+#[derive(clap::Parser, Debug)]
 #[command(
     version,
     help_template = "\
@@ -50,8 +50,10 @@ const MINIMAL_SCARB_VERSION_FOR_SIERRA_GAS: Version = Version::new(2, 10, 0);
 Use -h for short descriptions and --help for more details.
 
 {before-help}{usage-heading} {usage}
+{subcommands}
+  \x1b[1mclean cache\x1b[0m         Clean Forge cache directory 
 
-{all-args}{after-help}
+{after-help}
 ",
     after_help = "Read the docs: https://foundry-rs.github.io/starknet-foundry/",
     after_long_help = "\
@@ -72,7 +74,6 @@ Report bugs: https://github.com/foundry-rs/starknet-foundry/issues/new/choose\
 "
 )]
 #[command(about = "snforge - a testing tool for Starknet contracts", long_about = None)]
-#[command(name = "snforge")]
 pub struct Cli {
     #[command(subcommand)]
     subcommand: ForgeSubcommand,
@@ -101,6 +102,7 @@ enum ForgeSubcommand {
         args: CleanArgs,
     },
     /// Clean Forge cache directory
+    #[command(name = "clean-cache", hide = true)]
     CleanCache {},
     /// Check if all `snforge` requirements are installed
     CheckRequirements,


### PR DESCRIPTION
This change makes the command name displayed in the help menu match the recommended format in the warning message, which suggests using 'snforge clean cache' instead.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #
#3158 
## Introduced changes

<!-- A brief description of the changes -->

This PR addresses issue #3158 where there's an inconsistency between the command shown in the help menu (clean-cache) and the recommended command in the warning message (clean cache).

## Checklist

<!-- Make sure all of these are complete -->

- [ x] Linked relevant issue
- [ x] Updated relevant documentation
- [ x] Added relevant tests
- [ x] Performed self-review of the code
- [ x] Added changes to `CHANGELOG.md`