### PR TITLE
docs: add color guidelines for sncast output formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,4 +51,4 @@ Please follow these rules when creating outputs for `sncast`:
 - Keep your message concise and to the point
 - When displaying config, use `key: value` format
 - If the executed command has a natural successor-command, display it as hint in the output. For example, the output of `declare` command should include a hint to use `deploy` command next.
-<!-- TODO(#2859): Add bullet point about colors used for text when displaying fees, addresses and hashes -->
+- When displaying fees, addresses and hashes, use the following colors: green for fees, blue for addresses, and yellow for transaction hashes


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Added clear guidelines for color usage in sncast output formatting.
This establishes a consistent color scheme for displaying:
- Fees (green)
- Addresses (blue)
- Transaction hashes (yellow)


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
