### PR TITLE
Revert "Bump reqwest from 0.12.14 to 0.12.15 (#3178)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,9 +4764,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5653,7 +5653,7 @@ dependencies = [
  "promptly",
  "rand 0.8.5",
  "regex",
- "reqwest 0.12.15",
+ "reqwest 0.12.14",
  "rpassword",
  "runtime",
  "scarb-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ toml = "0.8.20"
 rpassword = "7.3.1"
 promptly = "0.3.1"
 ptree = "0.5.2"
-reqwest = "0.12.15"
+reqwest = "0.12.14"
 fs_extra = "1.3.0"
 openssl = { version = "0.10", features = ["vendored"] }
 toml_edit = "0.22.24"


### PR DESCRIPTION
This reverts commit e7c1721deac9b2ff19c19ede459aed7d7b5f680b.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
