### PR TITLE
fix(std): rename  to  in cheatcode signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2025-04-09
+
+### Forge
+
+#### Changed
+
+- Updated function signatures across snforge_std cheatcodes to use `target: ContractAddress` instead of the incorrect `contract_address: ContractAddress` for consistency and clarity.
+
+- Updated Related Rust test definitions under crates/cheatnet/tests/cheatcodes
+
 ## [0.41.0] - 2025-04-08
 
 ### Forge

--- a/crates/cheatnet/tests/cheatcodes/cheat_block_hash.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_block_hash.rs
@@ -15,24 +15,24 @@ const BLOCK_NUMBER: u64 = 123;
 trait CheatBlockHashTrait {
     fn cheat_block_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         block_number: u64,
         block_hash: Felt,
         span: CheatSpan,
     );
     fn start_cheat_block_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         block_number: u64,
         block_hash: Felt,
     );
-    fn stop_cheat_block_hash(&mut self, contract_address: ContractAddress, block_number: u64);
+    fn stop_cheat_block_hash(&mut self, target: ContractAddress, block_number: u64);
 }
 
 impl CheatBlockHashTrait for TestEnvironment {
     fn cheat_block_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         block_number: u64,
         block_hash: Felt,
         span: CheatSpan,
@@ -42,24 +42,24 @@ impl CheatBlockHashTrait for TestEnvironment {
             Operation::Start(CheatArguments {
                 value: block_hash,
                 span,
-                target: contract_address,
+                target,
             }),
         );
     }
 
     fn start_cheat_block_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         block_number: u64,
         block_hash: Felt,
     ) {
         self.cheatnet_state
-            .start_cheat_block_hash(contract_address, block_number, block_hash);
+            .start_cheat_block_hash(target, block_number, block_hash);
     }
 
-    fn stop_cheat_block_hash(&mut self, contract_address: ContractAddress, block_number: u64) {
+    fn stop_cheat_block_hash(&mut self, target: ContractAddress, block_number: u64) {
         self.cheatnet_state
-            .stop_cheat_block_hash(contract_address, block_number);
+            .stop_cheat_block_hash(target, block_number);
     }
 }
 

--- a/crates/cheatnet/tests/cheatcodes/cheat_block_number.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_block_number.rs
@@ -8,35 +8,24 @@ use starknet_types_core::felt::Felt;
 use super::test_environment::TestEnvironment;
 
 trait CheatBlockNumberTrait {
-    fn cheat_block_number(
-        &mut self,
-        contract_address: ContractAddress,
-        block_number: u64,
-        span: CheatSpan,
-    );
-    fn start_cheat_block_number(&mut self, contract_address: ContractAddress, block_number: u64);
-    fn stop_cheat_block_number(&mut self, contract_address: ContractAddress);
+    fn cheat_block_number(&mut self, target: ContractAddress, block_number: u64, span: CheatSpan);
+    fn start_cheat_block_number(&mut self, target: ContractAddress, block_number: u64);
+    fn stop_cheat_block_number(&mut self, target: ContractAddress);
 }
 
 impl CheatBlockNumberTrait for TestEnvironment {
-    fn cheat_block_number(
-        &mut self,
-        contract_address: ContractAddress,
-        block_number: u64,
-        span: CheatSpan,
-    ) {
+    fn cheat_block_number(&mut self, target: ContractAddress, block_number: u64, span: CheatSpan) {
         self.cheatnet_state
-            .cheat_block_number(contract_address, block_number, span);
+            .cheat_block_number(target, block_number, span);
     }
 
-    fn start_cheat_block_number(&mut self, contract_address: ContractAddress, block_number: u64) {
+    fn start_cheat_block_number(&mut self, target: ContractAddress, block_number: u64) {
         self.cheatnet_state
-            .start_cheat_block_number(contract_address, block_number);
+            .start_cheat_block_number(target, block_number);
     }
 
-    fn stop_cheat_block_number(&mut self, contract_address: ContractAddress) {
-        self.cheatnet_state
-            .stop_cheat_block_number(contract_address);
+    fn stop_cheat_block_number(&mut self, target: ContractAddress) {
+        self.cheatnet_state.stop_cheat_block_number(target);
     }
 }
 

--- a/crates/cheatnet/tests/cheatcodes/cheat_block_timestamp.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_block_timestamp.rs
@@ -9,35 +9,24 @@ use super::test_environment::TestEnvironment;
 const DEFAULT_BLOCK_TIMESTAMP: u64 = 0;
 
 trait CheatBlockTimestampTrait {
-    fn cheat_block_timestamp(
-        &mut self,
-        contract_address: ContractAddress,
-        timestamp: u64,
-        span: CheatSpan,
-    );
-    fn start_cheat_block_timestamp(&mut self, contract_address: ContractAddress, timestamp: u64);
-    fn stop_cheat_block_timestamp(&mut self, contract_address: ContractAddress);
+    fn cheat_block_timestamp(&mut self, target: ContractAddress, timestamp: u64, span: CheatSpan);
+    fn start_cheat_block_timestamp(&mut self, target: ContractAddress, timestamp: u64);
+    fn stop_cheat_block_timestamp(&mut self, target: ContractAddress);
 }
 
 impl CheatBlockTimestampTrait for TestEnvironment {
-    fn cheat_block_timestamp(
-        &mut self,
-        contract_address: ContractAddress,
-        timestamp: u64,
-        span: CheatSpan,
-    ) {
+    fn cheat_block_timestamp(&mut self, target: ContractAddress, timestamp: u64, span: CheatSpan) {
         self.cheatnet_state
-            .cheat_block_timestamp(contract_address, timestamp, span);
+            .cheat_block_timestamp(target, timestamp, span);
     }
 
-    fn start_cheat_block_timestamp(&mut self, contract_address: ContractAddress, timestamp: u64) {
+    fn start_cheat_block_timestamp(&mut self, target: ContractAddress, timestamp: u64) {
         self.cheatnet_state
-            .start_cheat_block_timestamp(contract_address, timestamp);
+            .start_cheat_block_timestamp(target, timestamp);
     }
 
-    fn stop_cheat_block_timestamp(&mut self, contract_address: ContractAddress) {
-        self.cheatnet_state
-            .stop_cheat_block_timestamp(contract_address);
+    fn stop_cheat_block_timestamp(&mut self, target: ContractAddress) {
+        self.cheatnet_state.stop_cheat_block_timestamp(target);
     }
 }
 

--- a/crates/cheatnet/tests/cheatcodes/cheat_caller_address.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_caller_address.rs
@@ -14,38 +14,29 @@ use conversions::string::TryFromHexStr;
 use runtime::starknet::constants::TEST_ADDRESS;
 
 trait CheatCallerAddressTrait {
-    fn cheat_caller_address(
-        &mut self,
-        contract_address: ContractAddress,
-        new_address: u128,
-        span: CheatSpan,
-    );
-    fn start_cheat_caller_address(&mut self, contract_address: ContractAddress, new_address: u128);
-    fn stop_cheat_caller_address(&mut self, contract_address: ContractAddress);
+    fn cheat_caller_address(&mut self, target: ContractAddress, new_address: u128, span: CheatSpan);
+    fn start_cheat_caller_address(&mut self, target: ContractAddress, new_address: u128);
+    fn stop_cheat_caller_address(&mut self, target: ContractAddress);
 }
 
 impl CheatCallerAddressTrait for TestEnvironment {
     fn cheat_caller_address(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         new_address: u128,
         span: CheatSpan,
     ) {
-        self.cheatnet_state.cheat_caller_address(
-            contract_address,
-            ContractAddress::from(new_address),
-            span,
-        );
+        self.cheatnet_state
+            .cheat_caller_address(target, ContractAddress::from(new_address), span);
     }
 
-    fn start_cheat_caller_address(&mut self, contract_address: ContractAddress, new_address: u128) {
+    fn start_cheat_caller_address(&mut self, target: ContractAddress, new_address: u128) {
         self.cheatnet_state
-            .start_cheat_caller_address(contract_address, ContractAddress::from(new_address));
+            .start_cheat_caller_address(target, ContractAddress::from(new_address));
     }
 
-    fn stop_cheat_caller_address(&mut self, contract_address: ContractAddress) {
-        self.cheatnet_state
-            .stop_cheat_caller_address(contract_address);
+    fn stop_cheat_caller_address(&mut self, target: ContractAddress) {
+        self.cheatnet_state.stop_cheat_caller_address(target);
     }
 }
 

--- a/crates/cheatnet/tests/cheatcodes/cheat_execution_info.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_execution_info.rs
@@ -13,23 +13,19 @@ use starknet_types_core::felt::Felt;
 trait CheatTransactionHashTrait {
     fn cheat_transaction_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         transaction_hash: Felt,
         span: CheatSpan,
     );
-    fn start_cheat_transaction_hash(
-        &mut self,
-        contract_address: ContractAddress,
-        transaction_hash: Felt,
-    );
-    fn stop_cheat_transaction_hash(&mut self, contract_address: ContractAddress);
+    fn start_cheat_transaction_hash(&mut self, target: ContractAddress, transaction_hash: Felt);
+    fn stop_cheat_transaction_hash(&mut self, target: ContractAddress);
     fn start_cheat_transaction_hash_global(&mut self, transaction_hash: Felt);
     fn stop_cheat_transaction_hash_global(&mut self);
 }
 impl CheatTransactionHashTrait for TestEnvironment {
     fn cheat_transaction_hash(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         transaction_hash: Felt,
         span: CheatSpan,
     ) {
@@ -38,34 +34,30 @@ impl CheatTransactionHashTrait for TestEnvironment {
         execution_info_mock.tx_info.transaction_hash = Operation::Start(CheatArguments {
             value: transaction_hash,
             span,
-            target: contract_address,
+            target,
         });
 
         self.cheatnet_state
             .cheat_execution_info(execution_info_mock);
     }
 
-    fn start_cheat_transaction_hash(
-        &mut self,
-        contract_address: ContractAddress,
-        transaction_hash: Felt,
-    ) {
+    fn start_cheat_transaction_hash(&mut self, target: ContractAddress, transaction_hash: Felt) {
         let mut execution_info_mock = ExecutionInfoMockOperations::default();
 
         execution_info_mock.tx_info.transaction_hash = Operation::Start(CheatArguments {
             value: transaction_hash,
             span: CheatSpan::Indefinite,
-            target: contract_address,
+            target,
         });
 
         self.cheatnet_state
             .cheat_execution_info(execution_info_mock);
     }
 
-    fn stop_cheat_transaction_hash(&mut self, contract_address: ContractAddress) {
+    fn stop_cheat_transaction_hash(&mut self, target: ContractAddress) {
         let mut execution_info_mock = ExecutionInfoMockOperations::default();
 
-        execution_info_mock.tx_info.transaction_hash = Operation::Stop(contract_address);
+        execution_info_mock.tx_info.transaction_hash = Operation::Stop(target);
 
         self.cheatnet_state
             .cheat_execution_info(execution_info_mock);
@@ -199,11 +191,11 @@ fn cheat_transaction_hash_simple() {
 
 #[test]
 fn start_cheat_execution_info_multiple_times() {
-    fn operation_start<T>(contract_address: ContractAddress, value: T) -> Operation<T> {
+    fn operation_start<T>(target: ContractAddress, value: T) -> Operation<T> {
         Operation::Start(CheatArguments {
             value,
             span: CheatSpan::Indefinite,
-            target: contract_address,
+            target,
         })
     }
 

--- a/crates/cheatnet/tests/cheatcodes/cheat_sequencer_address.rs
+++ b/crates/cheatnet/tests/cheatcodes/cheat_sequencer_address.rs
@@ -10,46 +10,35 @@ use starknet_types_core::felt::Felt;
 trait CheatSequencerAddressTrait {
     fn cheat_sequencer_address(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         sequencer_address: u128,
         span: CheatSpan,
     );
-    fn start_cheat_sequencer_address(
-        &mut self,
-        contract_address: ContractAddress,
-        sequencer_address: u128,
-    );
-    fn stop_cheat_sequencer_address(&mut self, contract_address: ContractAddress);
+    fn start_cheat_sequencer_address(&mut self, target: ContractAddress, sequencer_address: u128);
+    fn stop_cheat_sequencer_address(&mut self, target: ContractAddress);
 }
 
 impl CheatSequencerAddressTrait for TestEnvironment {
     fn cheat_sequencer_address(
         &mut self,
-        contract_address: ContractAddress,
+        target: ContractAddress,
         sequencer_address: u128,
         span: CheatSpan,
     ) {
         self.cheatnet_state.cheat_sequencer_address(
-            contract_address,
+            target,
             ContractAddress::from(sequencer_address),
             span,
         );
     }
 
-    fn start_cheat_sequencer_address(
-        &mut self,
-        contract_address: ContractAddress,
-        sequencer_address: u128,
-    ) {
-        self.cheatnet_state.start_cheat_sequencer_address(
-            contract_address,
-            ContractAddress::from(sequencer_address),
-        );
+    fn start_cheat_sequencer_address(&mut self, target: ContractAddress, sequencer_address: u128) {
+        self.cheatnet_state
+            .start_cheat_sequencer_address(target, ContractAddress::from(sequencer_address));
     }
 
-    fn stop_cheat_sequencer_address(&mut self, contract_address: ContractAddress) {
-        self.cheatnet_state
-            .stop_cheat_sequencer_address(contract_address);
+    fn stop_cheat_sequencer_address(&mut self, target: ContractAddress) {
+        self.cheatnet_state.stop_cheat_sequencer_address(target);
     }
 }
 

--- a/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
+++ b/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
@@ -10,21 +10,13 @@ use starknet_types_core::felt::Felt;
 use tempfile::TempDir;
 
 trait ReplaceBytecodeTrait {
-    fn replace_class_for_contract(
-        &mut self,
-        contract_address: ContractAddress,
-        class_hash: ClassHash,
-    );
+    fn replace_class_for_contract(&mut self, target: ContractAddress, class_hash: ClassHash);
 }
 
 impl ReplaceBytecodeTrait for TestEnvironment {
-    fn replace_class_for_contract(
-        &mut self,
-        contract_address: ContractAddress,
-        class_hash: ClassHash,
-    ) {
+    fn replace_class_for_contract(&mut self, target: ContractAddress, class_hash: ClassHash) {
         self.cheatnet_state
-            .replace_class_for_contract(contract_address, class_hash);
+            .replace_class_for_contract(target, class_hash);
     }
 }
 

--- a/snforge_std/src/cheatcodes.cairo
+++ b/snforge_std/src/cheatcodes.cairo
@@ -39,18 +39,18 @@ pub fn test_address() -> ContractAddress {
 /// An entrypoint that is not present on the deployed contract is also possible to mock.
 /// Note that the function is not meant for mocking internal calls - it works only for contract
 /// entry points.
-/// - `contract_address` - target contract address
+/// - `target` - target contract address
 /// - `function_selector` - hashed name of the target function (can be obtained with `selector!`
 /// macro)
 /// - `ret_data` - data to return by the function `function_selector`
 /// - `n_times` - number of calls to mock the function for
 pub fn mock_call<T, impl TSerde: core::serde::Serde<T>, impl TDestruct: Destruct<T>>(
-    contract_address: ContractAddress, function_selector: felt252, ret_data: T, n_times: u32,
+    target: ContractAddress, function_selector: felt252, ret_data: T, n_times: u32,
 ) {
     assert!(n_times > 0, "cannot mock_call 0 times, n_times argument must be greater than 0");
 
-    let contract_address_felt: felt252 = contract_address.into();
-    let mut inputs = array![contract_address_felt, function_selector];
+    let target_felt: felt252 = target.into();
+    let mut inputs = array![target_felt, function_selector];
 
     CheatSpan::TargetCalls(n_times).serialize(ref inputs);
 
@@ -65,15 +65,15 @@ pub fn mock_call<T, impl TSerde: core::serde::Serde<T>, impl TDestruct: Destruct
 
 /// Mocks contract call to a function of a contract at the given address, indefinitely.
 /// See `mock_call` for comprehensive definition of how it can be used.
-/// - `contract_address` - targeted contracts' address
+/// - `target` - targeted contracts' address
 /// - `function_selector` - hashed name of the target function (can be obtained with `selector!`
 /// macro)
 /// - `ret_data` - data to be returned by the function
 pub fn start_mock_call<T, impl TSerde: core::serde::Serde<T>, impl TDestruct: Destruct<T>>(
-    contract_address: ContractAddress, function_selector: felt252, ret_data: T,
+    target: ContractAddress, function_selector: felt252, ret_data: T,
 ) {
-    let contract_address_felt: felt252 = contract_address.into();
-    let mut inputs = array![contract_address_felt, function_selector];
+    let target_felt: felt252 = target.into();
+    let mut inputs = array![target_felt, function_selector];
 
     CheatSpan::Indefinite.serialize(ref inputs);
 
@@ -87,14 +87,14 @@ pub fn start_mock_call<T, impl TSerde: core::serde::Serde<T>, impl TDestruct: De
 
 /// Cancels the `mock_call` / `start_mock_call` for the function with given name and contract
 /// address.
-/// - `contract_address` - targeted contracts' address
+/// - `target` - targeted contracts' address
 /// - `function_selector` - hashed name of the target function (can be obtained with `selector!`
 /// macro)
-pub fn stop_mock_call(contract_address: ContractAddress, function_selector: felt252) {
-    let contract_address_felt: felt252 = contract_address.into();
+pub fn stop_mock_call(target: ContractAddress, function_selector: felt252) {
+    let target_felt: felt252 = target.into();
     execute_cheatcode_and_deserialize::<
         'stop_mock_call', (),
-    >(array![contract_address_felt, function_selector].span());
+    >(array![target_felt, function_selector].span());
 }
 
 #[derive(Drop, Serde, PartialEq, Debug)]

--- a/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_contract_address.cairo
@@ -4,12 +4,12 @@ use super::{
 
 /// Changes the address of an account which the transaction originates from, for the given contract
 /// address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
+/// - `target` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_account_contract_address(
-    contract_address: ContractAddress, account_contract_address: ContractAddress, span: CheatSpan,
+    target: ContractAddress, account_contract_address: ContractAddress, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -17,7 +17,7 @@ pub fn cheat_account_contract_address(
         .tx_info
         .account_contract_address =
             Operation::Start(
-                CheatArguments { value: account_contract_address, span, target: contract_address },
+                CheatArguments { value: account_contract_address, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -45,24 +45,24 @@ pub fn stop_cheat_account_contract_address_global() {
 }
 
 /// Changes the address of an account which the transaction originates from, for the given
-/// contract_address.
+/// target contract address.
 /// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
 /// - `account_contract_address` - transaction account deployment data to be set
 pub fn start_cheat_account_contract_address(
-    contract_address: ContractAddress, account_contract_address: ContractAddress,
+    target: ContractAddress, account_contract_address: ContractAddress,
 ) {
     cheat_account_contract_address(
-        contract_address, account_contract_address, CheatSpan::Indefinite,
+        target, account_contract_address, CheatSpan::Indefinite,
     );
 }
 
 /// Cancels the `cheat_account_contract_address` / `start_cheat_account_contract_address` for the
-/// given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_account_contract_address(contract_address: ContractAddress) {
+/// given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_account_contract_address(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.account_contract_address = Operation::Stop(contract_address);
+    execution_info.tx_info.account_contract_address = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/account_deployment_data.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/account_deployment_data.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the transaction account deployment data for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
+/// - `target` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `account_deployment_data` - transaction account deployment data to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_account_deployment_data(
-    contract_address: ContractAddress, account_deployment_data: Span<felt252>, span: CheatSpan,
+    target: ContractAddress, account_deployment_data: Span<felt252>, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -16,7 +16,7 @@ pub fn cheat_account_deployment_data(
         .tx_info
         .account_deployment_data =
             Operation::Start(
-                CheatArguments { value: account_deployment_data, span, target: contract_address },
+                CheatArguments { value: account_deployment_data, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -43,22 +43,22 @@ pub fn stop_cheat_account_deployment_data_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction account deployment data for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction account deployment data for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `account_deployment_data` - transaction account deployment data to be set
 pub fn start_cheat_account_deployment_data(
-    contract_address: ContractAddress, account_deployment_data: Span<felt252>,
+    target: ContractAddress, account_deployment_data: Span<felt252>,
 ) {
-    cheat_account_deployment_data(contract_address, account_deployment_data, CheatSpan::Indefinite);
+    cheat_account_deployment_data(target, account_deployment_data, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_account_deployment_data` / `start_cheat_account_deployment_data` for the
-/// given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_account_deployment_data(contract_address: ContractAddress) {
+/// given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_account_deployment_data(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.account_deployment_data = Operation::Stop(contract_address);
+    execution_info.tx_info.account_deployment_data = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/block_number.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/block_number.cairo
@@ -3,18 +3,18 @@ use super::{
 };
 
 /// Changes the block number for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `block_number` - block number to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
-pub fn cheat_block_number(contract_address: ContractAddress, block_number: u64, span: CheatSpan) {
+pub fn cheat_block_number(target: ContractAddress, block_number: u64, span: CheatSpan) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .block_info
         .block_number =
             Operation::Start(
-                CheatArguments { value: block_number, span, target: contract_address },
+                CheatArguments { value: block_number, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -39,19 +39,19 @@ pub fn stop_cheat_block_number_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the block number for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the block number for the given target contract address.
+/// - `target contract address` - instance of `ContractAddress` specifying which contract to cheat
 /// - `block_number` - block number to be set
-pub fn start_cheat_block_number(contract_address: ContractAddress, block_number: u64) {
-    cheat_block_number(contract_address, block_number, CheatSpan::Indefinite);
+pub fn start_cheat_block_number(target: ContractAddress, block_number: u64) {
+    cheat_block_number(target, block_number, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_block_number` / `start_cheat_block_number` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_block_number(contract_address: ContractAddress) {
+/// Cancels the `cheat_block_number` / `start_cheat_block_number` for the given target.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_block_number(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.block_info.block_number = Operation::Stop(contract_address);
+    execution_info.block_info.block_number = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/block_timestamp.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/block_timestamp.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the block timestamp for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `block_timestamp` - block timestamp to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_block_timestamp(
-    contract_address: ContractAddress, block_timestamp: u64, span: CheatSpan,
+    target: ContractAddress, block_timestamp: u64, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -16,7 +16,7 @@ pub fn cheat_block_timestamp(
         .block_info
         .block_timestamp =
             Operation::Start(
-                CheatArguments { value: block_timestamp, span, target: contract_address },
+                CheatArguments { value: block_timestamp, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -41,20 +41,20 @@ pub fn stop_cheat_block_timestamp_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the block timestamp for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the block timestamp for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `block_timestamp` - block timestamp to be set
-pub fn start_cheat_block_timestamp(contract_address: ContractAddress, block_timestamp: u64) {
-    cheat_block_timestamp(contract_address, block_timestamp, CheatSpan::Indefinite);
+pub fn start_cheat_block_timestamp(target: ContractAddress, block_timestamp: u64) {
+    cheat_block_timestamp(target, block_timestamp, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_block_timestamp` / `start_cheat_block_timestamp` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_block_timestamp(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_block_timestamp(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.block_info.block_timestamp = Operation::Stop(contract_address);
+    execution_info.block_info.block_timestamp = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/caller_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/caller_address.cairo
@@ -3,19 +3,19 @@ use super::{
 };
 
 /// Changes the caller address for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `caller_address` - caller address to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_caller_address(
-    contract_address: ContractAddress, caller_address: ContractAddress, span: CheatSpan,
+    target: ContractAddress, caller_address: ContractAddress, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .caller_address =
             Operation::Start(
-                CheatArguments { value: caller_address, span, target: contract_address },
+                CheatArguments { value: caller_address, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -40,22 +40,22 @@ pub fn stop_cheat_caller_address_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the caller address for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the caller address for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `caller_address` - caller address to be set
 pub fn start_cheat_caller_address(
-    contract_address: ContractAddress, caller_address: ContractAddress,
+    target: ContractAddress, caller_address: ContractAddress,
 ) {
-    cheat_caller_address(contract_address, caller_address, CheatSpan::Indefinite);
+    cheat_caller_address(target, caller_address, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_caller_address` / `start_cheat_caller_address` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_caller_address(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_caller_address(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.caller_address = Operation::Stop(contract_address);
+    execution_info.caller_address = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/chain_id.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/chain_id.cairo
@@ -3,17 +3,17 @@ use super::{
 };
 
 /// Changes the transaction chain_id for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `chain_id` - transaction chain_id to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
-pub fn cheat_chain_id(contract_address: ContractAddress, chain_id: felt252, span: CheatSpan) {
+pub fn cheat_chain_id(target: ContractAddress, chain_id: felt252, span: CheatSpan) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
         .chain_id =
-            Operation::Start(CheatArguments { value: chain_id, span, target: contract_address });
+            Operation::Start(CheatArguments { value: chain_id, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -37,19 +37,19 @@ pub fn stop_cheat_chain_id_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction chain_id for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction chain_id for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `chain_id` - transaction chain_id to be set
-pub fn start_cheat_chain_id(contract_address: ContractAddress, chain_id: felt252) {
-    cheat_chain_id(contract_address, chain_id, CheatSpan::Indefinite);
+pub fn start_cheat_chain_id(target: ContractAddress, chain_id: felt252) {
+    cheat_chain_id(target, chain_id, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_chain_id` / `start_cheat_chain_id` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_chain_id(contract_address: ContractAddress) {
+/// Cancels the `cheat_chain_id` / `start_cheat_chain_id` for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_chain_id(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.chain_id = Operation::Stop(contract_address);
+    execution_info.tx_info.chain_id = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/fee_data_availability_mode.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/fee_data_availability_mode.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the transaction fee data availability mode for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
+/// - `target` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `fee_data_availability_mode` - transaction fee data availability mode to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_fee_data_availability_mode(
-    contract_address: ContractAddress, fee_data_availability_mode: u32, span: CheatSpan,
+    target: ContractAddress, fee_data_availability_mode: u32, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -17,7 +17,7 @@ pub fn cheat_fee_data_availability_mode(
         .fee_data_availability_mode =
             Operation::Start(
                 CheatArguments {
-                    value: fee_data_availability_mode, span, target: contract_address,
+                    value: fee_data_availability_mode, span, target,
                 },
             );
 
@@ -45,24 +45,24 @@ pub fn stop_cheat_fee_data_availability_mode_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction fee data availability mode for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction fee data availability mode for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `fee_data_availability_mode` - transaction fee data availability mode to be set
 pub fn start_cheat_fee_data_availability_mode(
-    contract_address: ContractAddress, fee_data_availability_mode: u32,
+    target: ContractAddress, fee_data_availability_mode: u32,
 ) {
     cheat_fee_data_availability_mode(
-        contract_address, fee_data_availability_mode, CheatSpan::Indefinite,
+        target, fee_data_availability_mode, CheatSpan::Indefinite,
     );
 }
 
 /// Cancels the `cheat_fee_data_availability_mode` / `start_cheat_fee_data_availability_mode` for
-/// the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_fee_data_availability_mode(contract_address: ContractAddress) {
+/// the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_fee_data_availability_mode(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.fee_data_availability_mode = Operation::Stop(contract_address);
+    execution_info.tx_info.fee_data_availability_mode = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/max_fee.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/max_fee.cairo
@@ -3,17 +3,17 @@ use super::{
 };
 
 /// Changes the transaction max fee for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `max_fee` - transaction max fee to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
-pub fn cheat_max_fee(contract_address: ContractAddress, max_fee: u128, span: CheatSpan) {
+pub fn cheat_max_fee(target: ContractAddress, max_fee: u128, span: CheatSpan) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
         .max_fee =
-            Operation::Start(CheatArguments { value: max_fee, span, target: contract_address });
+            Operation::Start(CheatArguments { value: max_fee, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -37,19 +37,19 @@ pub fn stop_cheat_max_fee_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction max fee for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction max fee for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `max_fee` - transaction max fee to be set
-pub fn start_cheat_max_fee(contract_address: ContractAddress, max_fee: u128) {
-    cheat_max_fee(contract_address, max_fee, CheatSpan::Indefinite);
+pub fn start_cheat_max_fee(target: ContractAddress, max_fee: u128) {
+    cheat_max_fee(target, max_fee, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_max_fee` / `start_cheat_max_fee` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_max_fee(contract_address: ContractAddress) {
+/// Cancels the `cheat_max_fee` / `start_cheat_max_fee` for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_max_fee(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.max_fee = Operation::Stop(contract_address);
+    execution_info.tx_info.max_fee = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/nonce.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/nonce.cairo
@@ -3,16 +3,16 @@ use super::{
 };
 
 /// Changes the transaction nonce for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `nonce` - transaction nonce to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
-pub fn cheat_nonce(contract_address: ContractAddress, nonce: felt252, span: CheatSpan) {
+pub fn cheat_nonce(target: ContractAddress, nonce: felt252, span: CheatSpan) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
-        .nonce = Operation::Start(CheatArguments { value: nonce, span, target: contract_address });
+        .nonce = Operation::Start(CheatArguments { value: nonce, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -36,19 +36,19 @@ pub fn stop_cheat_nonce_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction nonce for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction nonce for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `nonce` - transaction nonce to be set
-pub fn start_cheat_nonce(contract_address: ContractAddress, nonce: felt252) {
-    cheat_nonce(contract_address, nonce, CheatSpan::Indefinite);
+pub fn start_cheat_nonce(target: ContractAddress, nonce: felt252) {
+    cheat_nonce(target, nonce, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_nonce` / `start_cheat_nonce` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_nonce(contract_address: ContractAddress) {
+/// Cancels the `cheat_nonce` / `start_cheat_nonce` for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_nonce(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.nonce = Operation::Stop(contract_address);
+    execution_info.tx_info.nonce = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/nonce_data_availability_mode.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/nonce_data_availability_mode.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the transaction nonce data availability mode for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contracts to cheat
+/// - `target` - instance of `ContractAddress` specifying which contracts to cheat
 /// - `nonce_data_availability_mode` - transaction nonce data availability mode to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_nonce_data_availability_mode(
-    contract_address: ContractAddress, nonce_data_availability_mode: u32, span: CheatSpan,
+    target: ContractAddress, nonce_data_availability_mode: u32, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -17,7 +17,7 @@ pub fn cheat_nonce_data_availability_mode(
         .nonce_data_availability_mode =
             Operation::Start(
                 CheatArguments {
-                    value: nonce_data_availability_mode, span, target: contract_address,
+                    value: nonce_data_availability_mode, span, target,
                 },
             );
 
@@ -45,24 +45,24 @@ pub fn stop_cheat_nonce_data_availability_mode_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction nonce data availability mode for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction nonce data availability mode for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `nonce_data_availability_mode` - transaction nonce data availability mode to be set
 pub fn start_cheat_nonce_data_availability_mode(
-    contract_address: ContractAddress, nonce_data_availability_mode: u32,
+    target: ContractAddress, nonce_data_availability_mode: u32,
 ) {
     cheat_nonce_data_availability_mode(
-        contract_address, nonce_data_availability_mode, CheatSpan::Indefinite,
+        target, nonce_data_availability_mode, CheatSpan::Indefinite,
     );
 }
 
 /// Cancels the `cheat_nonce_data_availability_mode` / `start_cheat_nonce_data_availability_mode`
-/// for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_nonce_data_availability_mode(contract_address: ContractAddress) {
+/// for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_nonce_data_availability_mode(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.nonce_data_availability_mode = Operation::Stop(contract_address);
+    execution_info.tx_info.nonce_data_availability_mode = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/paymaster_data.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/paymaster_data.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the transaction paymaster data for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `paymaster_data` - transaction paymaster data to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_paymaster_data(
-    contract_address: ContractAddress, paymaster_data: Span<felt252>, span: CheatSpan,
+    target: ContractAddress, paymaster_data: Span<felt252>, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -16,7 +16,7 @@ pub fn cheat_paymaster_data(
         .tx_info
         .paymaster_data =
             Operation::Start(
-                CheatArguments { value: paymaster_data, span, target: contract_address },
+                CheatArguments { value: paymaster_data, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -41,22 +41,22 @@ pub fn stop_cheat_paymaster_data_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction paymaster data for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction paymaster data for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `paymaster_data` - transaction paymaster data to be set
 pub fn start_cheat_paymaster_data(
-    contract_address: ContractAddress, paymaster_data: Span<felt252>,
+    target: ContractAddress, paymaster_data: Span<felt252>,
 ) {
-    cheat_paymaster_data(contract_address, paymaster_data, CheatSpan::Indefinite);
+    cheat_paymaster_data(target, paymaster_data, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_paymaster_data` / `start_cheat_paymaster_data` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_paymaster_data(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_paymaster_data(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.paymaster_data = Operation::Stop(contract_address);
+    execution_info.tx_info.paymaster_data = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/resource_bounds.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/resource_bounds.cairo
@@ -5,12 +5,12 @@ use starknet::ResourcesBounds;
 
 
 /// Changes the transaction resource bounds for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `resource_bounds` - transaction resource bounds to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_resource_bounds(
-    contract_address: ContractAddress, resource_bounds: Span<ResourcesBounds>, span: CheatSpan,
+    target: ContractAddress, resource_bounds: Span<ResourcesBounds>, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -18,7 +18,7 @@ pub fn cheat_resource_bounds(
         .tx_info
         .resource_bounds =
             Operation::Start(
-                CheatArguments { value: resource_bounds, span, target: contract_address },
+                CheatArguments { value: resource_bounds, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -43,22 +43,22 @@ pub fn stop_cheat_resource_bounds_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction resource bounds for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction resource bounds for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `resource_bounds` - transaction resource bounds to be set
 pub fn start_cheat_resource_bounds(
-    contract_address: ContractAddress, resource_bounds: Span<ResourcesBounds>,
+    target: ContractAddress, resource_bounds: Span<ResourcesBounds>,
 ) {
-    cheat_resource_bounds(contract_address, resource_bounds, CheatSpan::Indefinite);
+    cheat_resource_bounds(target, resource_bounds, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_resource_bounds` / `start_cheat_resource_bounds` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_resource_bounds(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_resource_bounds(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.resource_bounds = Operation::Stop(contract_address);
+    execution_info.tx_info.resource_bounds = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/sequencer_address.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/sequencer_address.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the sequencer address for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `sequencer_address` - sequencer address to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_sequencer_address(
-    contract_address: ContractAddress, sequencer_address: ContractAddress, span: CheatSpan,
+    target: ContractAddress, sequencer_address: ContractAddress, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -16,7 +16,7 @@ pub fn cheat_sequencer_address(
         .block_info
         .sequencer_address =
             Operation::Start(
-                CheatArguments { value: sequencer_address, span, target: contract_address },
+                CheatArguments { value: sequencer_address, span, target },
             );
 
     cheat_execution_info(execution_info);
@@ -41,22 +41,22 @@ pub fn stop_cheat_sequencer_address_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the sequencer address for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the sequencer address for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `sequencer_address` - sequencer address to be set
 pub fn start_cheat_sequencer_address(
-    contract_address: ContractAddress, sequencer_address: ContractAddress,
+    target: ContractAddress, sequencer_address: ContractAddress,
 ) {
-    cheat_sequencer_address(contract_address, sequencer_address, CheatSpan::Indefinite);
+    cheat_sequencer_address(target, sequencer_address, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_sequencer_address` / `start_cheat_sequencer_address` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_sequencer_address(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_sequencer_address(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.block_info.sequencer_address = Operation::Stop(contract_address);
+    execution_info.block_info.sequencer_address = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/signature.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/signature.cairo
@@ -3,19 +3,19 @@ use super::{
 };
 
 /// Changes the transaction signature for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `signature` - transaction signature to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_signature(
-    contract_address: ContractAddress, signature: Span<felt252>, span: CheatSpan,
+    target: ContractAddress, signature: Span<felt252>, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
         .signature =
-            Operation::Start(CheatArguments { value: signature, span, target: contract_address });
+            Operation::Start(CheatArguments { value: signature, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -39,19 +39,19 @@ pub fn stop_cheat_signature_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction signature for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction signature for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `signature` - transaction signature to be set
-pub fn start_cheat_signature(contract_address: ContractAddress, signature: Span<felt252>) {
-    cheat_signature(contract_address, signature, CheatSpan::Indefinite);
+pub fn start_cheat_signature(target: ContractAddress, signature: Span<felt252>) {
+    cheat_signature(target, signature, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_signature` / `start_cheat_signature` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_signature(contract_address: ContractAddress) {
+/// Cancels the `cheat_signature` / `start_cheat_signature` for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_signature(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.signature = Operation::Stop(contract_address);
+    execution_info.tx_info.signature = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/tip.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/tip.cairo
@@ -3,16 +3,16 @@ use super::{
 };
 
 /// Changes the transaction tip for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `tip` - transaction tip to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
-pub fn cheat_tip(contract_address: ContractAddress, tip: u128, span: CheatSpan) {
+pub fn cheat_tip(target: ContractAddress, tip: u128, span: CheatSpan) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
-        .tip = Operation::Start(CheatArguments { value: tip, span, target: contract_address });
+        .tip = Operation::Start(CheatArguments { value: tip, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -36,19 +36,19 @@ pub fn stop_cheat_tip_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction tip for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction tip for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `tip` - transaction tip to be set
-pub fn start_cheat_tip(contract_address: ContractAddress, tip: u128) {
-    cheat_tip(contract_address, tip, CheatSpan::Indefinite);
+pub fn start_cheat_tip(target: ContractAddress, tip: u128) {
+    cheat_tip(target, tip, CheatSpan::Indefinite);
 }
 
-/// Cancels the `cheat_tip` / `start_cheat_tip` for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_tip(contract_address: ContractAddress) {
+/// Cancels the `cheat_tip` / `start_cheat_tip` for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_tip(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.tip = Operation::Stop(contract_address);
+    execution_info.tx_info.tip = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/transaction_hash.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/transaction_hash.cairo
@@ -3,12 +3,12 @@ use super::{
 };
 
 /// Changes the transaction hash for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `transaction_hash` - transaction hash to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_transaction_hash(
-    contract_address: ContractAddress, transaction_hash: felt252, span: CheatSpan,
+    target: ContractAddress, transaction_hash: felt252, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
@@ -41,20 +41,20 @@ pub fn stop_cheat_transaction_hash_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction hash for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction hash for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `transaction_hash` - transaction hash to be set
-pub fn start_cheat_transaction_hash(contract_address: ContractAddress, transaction_hash: felt252) {
-    cheat_transaction_hash(contract_address, transaction_hash, CheatSpan::Indefinite);
+pub fn start_cheat_transaction_hash(target: ContractAddress, transaction_hash: felt252) {
+    cheat_transaction_hash(target, transaction_hash, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_transaction_hash` / `start_cheat_transaction_hash` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_transaction_hash(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_transaction_hash(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.transaction_hash = Operation::Stop(contract_address);
+    execution_info.tx_info.transaction_hash = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }

--- a/snforge_std/src/cheatcodes/execution_info/version.cairo
+++ b/snforge_std/src/cheatcodes/execution_info/version.cairo
@@ -2,20 +2,20 @@ use super::{
     ExecutionInfoMock, Operation, CheatArguments, CheatSpan, cheat_execution_info, ContractAddress,
 };
 
-/// Changes the transaction version for the given contract address and span.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction version for the given target contract address and span.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `version` - transaction version to be set
 /// - `span` - instance of `CheatSpan` specifying the number of contract calls with the cheat
 /// applied
 pub fn cheat_transaction_version(
-    contract_address: ContractAddress, version: felt252, span: CheatSpan,
+    target: ContractAddress, version: felt252, span: CheatSpan,
 ) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
     execution_info
         .tx_info
         .version =
-            Operation::Start(CheatArguments { value: version, span, target: contract_address });
+            Operation::Start(CheatArguments { value: version, span, target });
 
     cheat_execution_info(execution_info);
 }
@@ -39,20 +39,20 @@ pub fn stop_cheat_transaction_version_global() {
     cheat_execution_info(execution_info);
 }
 
-/// Changes the transaction version for the given contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to cheat
+/// Changes the transaction version for the given target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to cheat
 /// - `version` - transaction version to be set
-pub fn start_cheat_transaction_version(contract_address: ContractAddress, version: felt252) {
-    cheat_transaction_version(contract_address, version, CheatSpan::Indefinite);
+pub fn start_cheat_transaction_version(target: ContractAddress, version: felt252) {
+    cheat_transaction_version(target, version, CheatSpan::Indefinite);
 }
 
 /// Cancels the `cheat_transaction_version` / `start_cheat_transaction_version` for the given
-/// contract_address.
-/// - `contract_address` - instance of `ContractAddress` specifying which contract to stop cheating
-pub fn stop_cheat_transaction_version(contract_address: ContractAddress) {
+/// target contract address.
+/// - `target` - instance of `ContractAddress` specifying which contract to stop cheating
+pub fn stop_cheat_transaction_version(target: ContractAddress) {
     let mut execution_info: ExecutionInfoMock = Default::default();
 
-    execution_info.tx_info.version = Operation::Stop(contract_address);
+    execution_info.tx_info.version = Operation::Stop(target);
 
     cheat_execution_info(execution_info);
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3180

## Introduced changes

<!-- A brief description of the changes -->

- Replaced `contract_address: ContractAddress` with `target: ContractAddress` in relevant function signatures across the standard library and tests.
- Updated the following locations:
  - `snforge_std/src/cheatcodes.cairo`
  - `snforge_std/src/cheatcodes/execution_info`
  - `crates/cheatnet/tests/cheatcodes`
- Updated `CHANGELOG.md` to reflect the changes.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
