### PR TITLE
Restore interactive prompt in sncast

### DIFF
--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -481,7 +481,10 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !import.silent && result.is_ok() && io::stdout().is_terminal() {
+                let run_interactive_prompt =
+                    !import.silent && result.is_ok() && io::stdout().is_terminal();
+
+                if run_interactive_prompt {
                     if let Some(account_name) =
                         result.as_ref().ok().and_then(|r| r.account_name.clone())
                     {
@@ -517,7 +520,10 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !create.silent && result.is_ok() && io::stdout().is_terminal() {
+                let run_interactive_prompt =
+                    !create.silent && result.is_ok() && io::stdout().is_terminal();
+
+                if run_interactive_prompt {
                     if let Err(err) = prompt_to_add_account_as_default(&account) {
                         eprintln!("Error: Failed to launch interactive prompt: {err}");
                     }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -481,11 +481,7 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !import.silent
-                    && result.is_ok()
-                    && io::stdout().is_terminal()
-                    && import.rpc.network.is_none()
-                {
+                if !import.silent && result.is_ok() && io::stdout().is_terminal() {
                     if let Some(account_name) =
                         result.as_ref().ok().and_then(|r| r.account_name.clone())
                     {
@@ -521,11 +517,7 @@ async fn run_async_command(
                 )
                 .await;
 
-                if !create.silent
-                    && result.is_ok()
-                    && io::stdout().is_terminal()
-                    && create.rpc.network.is_none()
-                {
+                if !create.silent && result.is_ok() && io::stdout().is_terminal() {
                     if let Err(err) = prompt_to_add_account_as_default(&account) {
                         eprintln!("Error: Failed to launch interactive prompt: {err}");
                     }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

Checking if `create.rpc.network.is_none()` successfully disables the interactive prompt, and there's no good reason for that.

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
