### PR TITLE
Remove `cairo-lang-runner` from `conversions` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,6 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "blockifier",
- "cairo-lang-runner",
  "cairo-lang-utils",
  "cairo-serde-macros",
  "cairo-vm",

--- a/crates/conversions/Cargo.toml
+++ b/crates/conversions/Cargo.toml
@@ -11,7 +11,6 @@ anyhow.workspace = true
 blockifier.workspace = true
 starknet_api.workspace = true
 starknet-types-core.workspace = true
-cairo-lang-runner.workspace = true
 cairo-lang-utils.workspace = true
 cairo-vm.workspace = true
 starknet.workspace = true

--- a/crates/conversions/src/byte_array.rs
+++ b/crates/conversions/src/byte_array.rs
@@ -1,9 +1,9 @@
 use crate as conversions; // trick for CairoDeserialize macro
 use crate::serde::deserialize::{BufferReadError, BufferReadResult, BufferReader};
 use crate::{serde::serialize::SerializeToFeltVec, string::TryFromHexStr};
-use cairo_lang_runner::short_string::as_cairo_short_string_ex;
 use cairo_lang_utils::byte_array::{BYTE_ARRAY_MAGIC, BYTES_IN_WORD};
 use cairo_serde_macros::{CairoDeserialize, CairoSerialize};
+use conversions::felt::ToShortString;
 use starknet_types_core::felt::Felt;
 use std::fmt;
 
@@ -56,15 +56,88 @@ impl ByteArray {
 
 impl fmt::Display for ByteArray {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let full_words_string = self
+        let words: String = self
             .words
             .iter()
-            .map(|word| as_cairo_short_string_ex(word, BYTES_IN_WORD).unwrap())
-            .collect::<String>();
+            .map(|word| {
+                let word: String = word.to_short_string().map_err(|_| fmt::Error)?;
+                if word.len() != BYTES_IN_WORD {
+                    return Err(fmt::Error)?;
+                }
+                Ok(word)
+            })
+            .collect::<Result<Vec<String>, fmt::Error>>()?
+            .join("");
+        let pending_word = self
+            .pending_word
+            .to_short_string()
+            .map_err(|_| fmt::Error)?;
 
-        let pending_word_string =
-            as_cairo_short_string_ex(&self.pending_word, self.pending_word_len).unwrap();
+        write!(f, "{words}{pending_word}")
+    }
+}
 
-        write!(f, "{full_words_string}{pending_word_string}")
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fmt_empty() {
+        let array = ByteArray::from("");
+        assert_eq!(array.to_string(), "");
+    }
+
+    #[test]
+    fn test_fmt_single_word() {
+        let array = ByteArray::from("Hello");
+        assert_eq!(array.to_string(), "Hello");
+    }
+
+    #[test]
+    fn test_fmt_multiple_words() {
+        let array = ByteArray::from("Hello World! This is a test.");
+        assert_eq!(array.to_string(), "Hello World! This is a test.");
+    }
+
+    #[test]
+    fn test_fmt_with_pending_word() {
+        let array = ByteArray::from("abc");
+        assert_eq!(array.to_string(), "abc");
+    }
+
+    #[test]
+    fn test_fmt_special_chars() {
+        let special_chars = "!@#$%^&*()_+-=[]{}|;:,.<>?";
+        let array = ByteArray::from(special_chars);
+        assert_eq!(array.to_string(), special_chars);
+    }
+
+    #[test]
+    #[should_panic(expected = "a Display implementation returned an error unexpectedly: Error")]
+    fn test_fmt_with_null_bytes() {
+        let with_nulls = "Hello\0World\0Test";
+        let array = ByteArray::from(with_nulls);
+        assert_eq!(array.to_string(), with_nulls);
+    }
+
+    #[test]
+    fn test_fmt_mixed_ascii() {
+        let mixed = "Hello\tWorld\n123 !@#";
+        let array = ByteArray::from(mixed);
+        assert_eq!(array.to_string(), mixed);
+    }
+
+    #[test]
+    fn test_fmt_with_newlines() {
+        let with_newlines = "First line\nSecond line\r\nThird line";
+        let array = ByteArray::from(with_newlines);
+        assert_eq!(array.to_string(), with_newlines);
+    }
+
+    #[test]
+    fn test_fmt_multiple_newlines() {
+        let multiple_newlines = "Line1\n\n\nLine2\n\nLine3";
+        let array = ByteArray::from(multiple_newlines);
+        assert_eq!(array.to_string(), multiple_newlines);
     }
 }

--- a/crates/conversions/tests/e2e/felt.rs
+++ b/crates/conversions/tests/e2e/felt.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests_felt {
-    use cairo_lang_runner::short_string::as_cairo_short_string;
     use cairo_vm::utils::PRIME_STR;
     use conversions::byte_array::ByteArray;
     use conversions::felt::FromShortString;
@@ -87,7 +86,7 @@ mod tests_felt {
     fn test_from_short_string() {
         let felt = Felt::from_short_string("abc").unwrap();
 
-        assert_eq!("abc", &as_cairo_short_string(&felt).unwrap());
+        assert_eq!(felt, Felt::from_hex("0x616263").unwrap());
     }
 
     #[test]


### PR DESCRIPTION
**Stack**:
- #3333
- #3328
- #3327
- #3247
- #3246
- #3245
- #3244
- #3243
- #3242 ⬅
- #3241
- #3240
- #3238


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*