### PR TITLE
Remove warning in default forge template

### DIFF
--- a/snforge_templates/balance_contract/src/lib.cairo
+++ b/snforge_templates/balance_contract/src/lib.cairo
@@ -11,7 +11,7 @@ pub trait IHelloStarknet<TContractState> {
 /// Simple contract for managing balance.
 #[starknet::contract]
 mod HelloStarknet {
-    use core::starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     struct Storage {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

```
warn: Usage of deprecated feature `"corelib-internal-use"` with no `#[feature("corelib-internal-use")]` attribute. Note: "Use `starknet` directly"
```

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
