### PR TITLE
Prompt to add account to `sncast` config after deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimal supported Scarb version is now `2.9.1`
 
+### Cast
+
+### Fixed
+
+- User is now prompted to save an imported or deployed account in `sncast` config even when using `--network` flag
+
 ## [0.41.0] - 2025-04-08
 
 ### Forge

--- a/crates/sncast/src/helpers/config.rs
+++ b/crates/sncast/src/helpers/config.rs
@@ -4,7 +4,6 @@ use crate::helpers::constants::DEFAULT_ACCOUNTS_FILE;
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
-use shared::consts::FREE_RPC_PROVIDER_URL;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -44,22 +43,19 @@ fn build_default_manifest() -> String {
         # and https://foundry-rs.github.io/starknet-foundry/projects/configuration.html for more information
 
         # [sncast.default]
-        # url = "{default_url}"
+        # url = ""
         # block-explorer = "{default_block_explorer}"
         # wait-params = {{ timeout = {default_wait_timeout}, retry-interval = {default_wait_retry_interval} }}
         # show-explorer-links = {default_show_explorer_links}
         # accounts-file = "{default_accounts_file}"
-        # account = "{default_account}"
-        # keystore = "{default_keystore}"
+        # account = ""
+        # keystore = ""
         "#,
-        default_url = FREE_RPC_PROVIDER_URL,
         default_accounts_file = DEFAULT_ACCOUNTS_FILE,
         default_wait_timeout = default_wait_params.timeout,
         default_wait_retry_interval = default_wait_params.retry_interval,
         default_block_explorer = "StarkScan",
         default_show_explorer_links = show_explorer_links_default(),
-        default_account = "default",
-        default_keystore = ""
     }
 }
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -520,15 +520,6 @@ async fn run_async_command(
                 )
                 .await;
 
-                let run_interactive_prompt =
-                    !create.silent && result.is_ok() && io::stdout().is_terminal();
-
-                if run_interactive_prompt {
-                    if let Err(err) = prompt_to_add_account_as_default(&account) {
-                        eprintln!("Error: Failed to launch interactive prompt: {err}");
-                    }
-                }
-
                 print_command_result("account create", &result, numbers_format, output_format)?;
                 print_block_explorer_link_if_allowed(
                     &result,
@@ -550,7 +541,7 @@ async fn run_async_command(
                 let result = starknet_commands::account::deploy::deploy(
                     &provider,
                     config.accounts_file,
-                    deploy,
+                    &deploy,
                     chain_id,
                     wait_config,
                     &config.account,
@@ -558,6 +549,15 @@ async fn run_async_command(
                     fee_args,
                 )
                 .await;
+
+                let run_interactive_prompt =
+                    !deploy.silent && result.is_ok() && io::stdout().is_terminal();
+
+                if run_interactive_prompt {
+                    if let Err(err) = prompt_to_add_account_as_default(&deploy.name) {
+                        eprintln!("Error: Failed to launch interactive prompt: {err}");
+                    }
+                }
 
                 print_command_result("account deploy", &result, numbers_format, output_format)?;
                 print_block_explorer_link_if_allowed(

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -553,8 +553,12 @@ async fn run_async_command(
                 let run_interactive_prompt =
                     !deploy.silent && result.is_ok() && io::stdout().is_terminal();
 
-                if run_interactive_prompt {
-                    if let Err(err) = prompt_to_add_account_as_default(&deploy.name) {
+                if config.keystore.is_none() && run_interactive_prompt {
+                    if let Err(err) = prompt_to_add_account_as_default(
+                        &deploy
+                            .name
+                            .expect("Must be provided if not using a keystore"),
+                    ) {
                         eprintln!("Error: Failed to launch interactive prompt: {err}");
                     }
                 }

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -53,10 +53,6 @@ pub struct Create {
 
     #[command(flatten)]
     pub rpc: RpcArgs,
-
-    /// If passed, the command will not trigger an interactive prompt to add an account as a default
-    #[arg(long)]
-    pub silent: bool,
 }
 
 pub async fn create(

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -29,7 +29,7 @@ use starknet_types_core::felt::Felt;
 pub struct Deploy {
     /// Name of the account to be deployed
     #[arg(short, long)]
-    pub name: String,
+    pub name: Option<String>,
 
     #[command(flatten)]
     pub fee_args: FeeArgs,
@@ -64,7 +64,10 @@ pub async fn deploy(
         )
         .await
     } else {
-        let account_name = deploy_args.name.clone();
+        let account_name = deploy_args
+            .name
+            .clone()
+            .ok_or_else(|| anyhow!("Required argument `--name` not provided"))?;
         check_account_file_exists(&accounts_file)?;
         deploy_from_accounts_file(
             provider,

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -29,20 +29,24 @@ use starknet_types_core::felt::Felt;
 pub struct Deploy {
     /// Name of the account to be deployed
     #[arg(short, long)]
-    pub name: Option<String>,
+    pub name: String,
 
     #[command(flatten)]
     pub fee_args: FeeArgs,
 
     #[command(flatten)]
     pub rpc: RpcArgs,
+
+    /// If passed, the command will not trigger an interactive prompt to add an account as a default
+    #[arg(long)]
+    pub silent: bool,
 }
 
 #[expect(clippy::too_many_arguments)]
 pub async fn deploy(
     provider: &JsonRpcClient<HttpTransport>,
     accounts_file: Utf8PathBuf,
-    deploy_args: Deploy,
+    deploy_args: &Deploy,
     chain_id: Felt,
     wait_config: WaitForTx,
     account: &str,
@@ -60,9 +64,7 @@ pub async fn deploy(
         )
         .await
     } else {
-        let account_name = deploy_args
-            .name
-            .ok_or_else(|| anyhow!("Required argument `--name` not provided"))?;
+        let account_name = deploy_args.name.clone();
         check_account_file_exists(&accounts_file)?;
         deploy_from_accounts_file(
             provider,

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -57,8 +57,3 @@ If passed, a profile with corresponding name will be added to the local snfoundr
 Optional.
 
 Class hash of a custom openzeppelin account contract declared to the network.
-
-## `--silent`
-Optional.
-
-If passed, the command will not trigger an interactive prompt to add an account as a default

--- a/docs/src/appendix/sncast/account/deploy.md
+++ b/docs/src/appendix/sncast/account/deploy.md
@@ -54,3 +54,8 @@ Maximum L1 data gas for the `deploy_account` transaction. When not used, default
 Optional.
 
 Maximum L1 data gas unit price for the `deploy_account` transaction. When not used, defaults to auto-estimation.
+
+## `--silent`
+Optional.
+
+If passed, the command will not trigger an interactive prompt to add an account as a default


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Changed the logic that prompts user to add account to `sncast` profile, to run after running `account deploy` not `account create`
- Removed some default values placeholders from global config

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
