### PR TITLE
Run forge integration tests on CI with cargo nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - run: cargo test --release --lib -p forge
 
-  build-test-forge-e2e-nextest-archive:
+  build-test-forge-nextest-archive:
     needs: setup
     runs-on: ${{ matrix.os }}
     strategy:
@@ -65,7 +65,7 @@ jobs:
   test-forge-integration:
     name: Test Forge / Integration Tests
     runs-on: ${{ matrix.os }}
-    needs: [ build-test-forge-e2e-nextest-archive, setup ]
+    needs: [ build-test-forge-nextest-archive, setup ]
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +87,7 @@ jobs:
   test-forge-e2e:
     name: Test Forge / E2E Tests
     runs-on: ${{ matrix.os }}
-    needs: [ build-test-forge-e2e-nextest-archive, setup ]
+    needs: [ build-test-forge-nextest-archive, setup ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
             echo 'matrix_os=["ubuntu-latest","windows-latest"]' >> $GITHUB_OUTPUT
           fi
 
-  test-forge-unit-and-integration:
+  test-forge-unit:
     needs: setup
-    name: Test Forge / Unit and Integration Tests
+    name: Test Forge / Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -40,7 +40,6 @@ jobs:
       - uses: software-mansion/setup-scarb@v1
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - run: cargo test --release --lib -p forge
-      - run: cargo test --release integration -p forge
 
   build-test-forge-e2e-nextest-archive:
     needs: setup
@@ -63,6 +62,28 @@ jobs:
           name: nextest-archive-${{ matrix.os }}
           path: nextest-archive-${{ matrix.os }}.tar.zst
 
+  test-forge-integration:
+    name: Test Forge / Integration Tests
+    runs-on: ${{ matrix.os }}
+    needs: [ build-test-forge-e2e-nextest-archive, setup ]
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [ 1, 2, 3 ]
+        os: ${{ fromJson(needs.setup.outputs.matrix_os) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-scarb@v1
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+      - uses: taiki-e/install-action@nextest
+      - uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive-${{ matrix.os }}
+      - name: nextest partition ${{ matrix.partition }}/3
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ matrix.os }}.tar.zst' integration
+
   test-forge-e2e:
     name: Test Forge / E2E Tests
     runs-on: ${{ matrix.os }}
@@ -70,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+        partition: [ 1, 2, 3 ]
         os: ${{ fromJson(needs.setup.outputs.matrix_os) }}
     steps:
       - name: Extract branch name
@@ -93,14 +114,6 @@ jobs:
         run: echo "REPO_NAME=$(echo ${{ github.event.pull_request.head.repo.full_name }}.git)" >> $GITHUB_ENV
         shell: bash
 
-      - name: Print repo name
-        run: echo 'The repo name is' $REPO_NAME
-        shell: bash
-
-      - name: Get branch name
-        run: echo 'The branch name is' $BRANCH_NAME
-        shell: bash
-
       - name: Install cairo-profiler
         if: runner.os != 'Windows'
         run: |
@@ -119,8 +132,8 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nextest-archive-${{ matrix.os }}
-      - name: nextest partition ${{ matrix.partition }}/8
-        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/8' --archive-file 'nextest-archive-${{ matrix.os }}.tar.zst' e2e
+      - name: nextest partition ${{ matrix.partition }}/3
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ matrix.os }}.tar.zst' e2e
 
   test-requirements-check-special-conditions:
     name: Test requirements check special conditions


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related #3195 

## Introduced changes

<!-- A brief description of the changes -->

- The job `test-forge-unit-and-integration` is currently a bottleneck in the CI process, significantly delaying execution. This change partially fixes the problem by running integration tests with `cargo nextest`
- To avoid increasing the number of necessary workers, the number of partitions for E2E tests has been decreased from 8 to 3 as these jobs are still executed relatively quickly (around 10 minutes each)
- The entire workflow for both Windows and Ubuntu has improved from around [50 minutes](https://github.com/foundry-rs/starknet-foundry/actions/runs/14679406363) to [35 minutes](https://github.com/ddoktorski/starknet-foundry/actions/runs/14679518349)
