### PR TITLE
Remove usage of `SierraVersion::LATEST` constant

### DIFF
--- a/crates/cheatnet/src/constants.rs
+++ b/crates/cheatnet/src/constants.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use blockifier::execution::entry_point::{CallType, ExecutableCallEntryPoint};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
+use cairo_lang_starknet_classes::compiler_version::current_sierra_version_id;
 use conversions::IntoConv;
 use conversions::string::TryFromHexStr;
 use indoc::indoc;
@@ -22,7 +23,7 @@ pub const STRK_CONTRACT_ADDRESS: &str =
 pub const STRK_CLASS_HASH: &str =
     "0x04ad3c1dc8413453db314497945b6903e1c766495a1e60492d44da9c2a986e4b";
 
-// Compiled with starknet-compile, compiler version: 2.10.0
+// Compiled with starknet-compile, compiler version: 2.10.0, Sierra version: 1.7.0
 // See: https://github.com/starknet-io/starkgate-contracts/blob/c787ec8e727c45499700d01e4eacd4cbc23a36ea/src/cairo/strk/erc20_lockable.cairo
 pub const STRK_ERC20_CASM: &str = include_str!("./data/strk_erc20_casm.json");
 
@@ -46,15 +47,15 @@ fn contract_class_no_entrypoints() -> ContractClass {
     let casm_contract_class: CasmContractClass = serde_json::from_str(raw_contract_class)
         .expect("`raw_contract_class` should be valid casm contract class");
 
-    ContractClass::V1((casm_contract_class, SierraVersion::LATEST))
+    ContractClass::V1((casm_contract_class, SierraVersion::default()))
 }
 
 #[must_use]
-pub fn contract_class(raw_casm: &str) -> ContractClass {
+pub fn contract_class(raw_casm: &str, sierra_version: SierraVersion) -> ContractClass {
     let casm_contract_class: CasmContractClass =
         serde_json::from_str(raw_casm).expect("`raw_casm` should be valid casm contract class");
 
-    ContractClass::V1((casm_contract_class, SierraVersion::LATEST))
+    ContractClass::V1((casm_contract_class, sierra_version))
 }
 
 // Creates a state with predeployed account and erc20 used to send transactions during tests.
@@ -102,4 +103,14 @@ pub fn build_test_entry_point() -> ExecutableCallEntryPoint {
         call_type: CallType::Call,
         initial_gas: i64::MAX as u64,
     }
+}
+
+#[must_use]
+pub fn get_current_sierra_version() -> SierraVersion {
+    let version_id = current_sierra_version_id();
+    SierraVersion::new(
+        version_id.major as u64,
+        version_id.minor as u64,
+        version_id.patch as u64,
+    )
 }

--- a/crates/cheatnet/src/forking/state.rs
+++ b/crates/cheatnet/src/forking/state.rs
@@ -248,11 +248,15 @@ impl StateReader for ForkStateReader {
                     "entry_points_by_type": flattened_class.entry_points_by_type
                 });
 
+                let sierra_version =
+                    SierraVersion::extract_from_program(&flattened_class.sierra_program)
+                        .expect("Unable to extract Sierra version from Sierra program");
+
                 match compile_sierra::<String>(&sierra_contract_class, &SierraType::Contract) {
                     Ok(casm_contract_class_raw) => Ok(RunnableCompiledClass::V1(
                         CompiledClassV1::try_from_json_string(
                             &casm_contract_class_raw,
-                            SierraVersion::LATEST,
+                            sierra_version,
                         )
                         .expect("Unable to create RunnableCompiledClass::V1"),
                     )),

--- a/crates/cheatnet/src/predeployment/strk.rs
+++ b/crates/cheatnet/src/predeployment/strk.rs
@@ -7,6 +7,7 @@ use crate::{
     state::ExtendedStateReader,
 };
 use conversions::{felt::FromShortString, string::TryFromHexStr};
+use starknet_api::contract_class::SierraVersion;
 use starknet_api::{core::ContractAddress, state::StorageKey};
 use starknet_types_core::felt::Felt;
 
@@ -27,10 +28,10 @@ pub fn deploy_strk_token(state_reader: &mut ExtendedStateReader) {
         .address_to_class_hash
         .insert(strk_contract_address, strk_class_hash);
 
-    state_reader
-        .dict_state_reader
-        .class_hash_to_class
-        .insert(strk_class_hash, contract_class(STRK_ERC20_CASM));
+    state_reader.dict_state_reader.class_hash_to_class.insert(
+        strk_class_hash,
+        contract_class(STRK_ERC20_CASM, SierraVersion::new(1, 7, 0)),
+    );
 
     let recipient = generate_random_felt();
     let recipient_balance_low_address = map_entry_address("ERC20_balances", &[recipient]);

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/declare.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/declare.rs
@@ -1,3 +1,4 @@
+use crate::constants::get_current_sierra_version;
 use crate::runtime_extensions::forge_runtime_extension::{
     cheatcodes::{CheatcodeError, EnhancedHintError},
     contracts_data::ContractsData,
@@ -8,7 +9,6 @@ use blockifier::state::{errors::StateError, state_api::State};
 use conversions::IntoConv;
 use conversions::serde::serialize::CairoSerialize;
 use starknet::core::types::contract::SierraClass;
-use starknet_api::contract_class::SierraVersion;
 use starknet_api::core::{ClassHash, CompiledClassHash};
 
 #[derive(CairoSerialize)]
@@ -27,9 +27,11 @@ pub fn declare(
         .with_context(|| format!("Failed to get contract artifact for name = {contract_name}."))
         .map_err(EnhancedHintError::from)?;
 
-    let contract_class =
-        CompiledClassV1::try_from_json_string(&contract_artifact.casm, SierraVersion::LATEST)
-            .expect("Failed to read contract class from json");
+    let contract_class = CompiledClassV1::try_from_json_string(
+        &contract_artifact.casm,
+        get_current_sierra_version(),
+    )
+    .expect("Failed to read contract class from json");
     let contract_class = RunnableCompiledClass::V1(contract_class);
 
     let class_hash = *contracts_data


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #3114

## Introduced changes

<!-- A brief description of the changes -->

- Replace all occurrences of `SierraVersion::LATEST` with explicit Sierra version values
