### PR TITLE
Update argent class hash to v0.4.0 in `create` docs

### DIFF
--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -39,7 +39,7 @@ Versions of the account contracts:
 | Account Contract | Version | Class Hash                                                                                                                                                          |
 |------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `oz`             | v0.14.0 | [0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6](https://starkscan.co/class/0x00e2eb8f5672af4e6a4e8a8f1b44989685e668489b0a25437733756c5a34a1d6) |
-| `argent`         | v0.3.1  | [0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b](https://starkscan.co/class/0x029927c8af6bccf3f6fda035981e765a7bdbf18a2dc0d630494f8758aa908e2b) |
+| `argent`         | v0.4.0  | [0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f](https://starkscan.co/class/0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f) |
 <!-- TODO(#3118): Uncomment once braavos integration is restored -->
 <!-- | `braavos`        | v1.0.0  | [0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253](https://starkscan.co/class/0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253) | -->
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

In docs we're still mentioning v0.3.1 while calling `sncast create`, while in fact we use v0.4.0

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
