### PR TITLE
Disable voyager provider in `sncast`

### DIFF
--- a/crates/shared/src/consts.rs
+++ b/crates/shared/src/consts.rs
@@ -1,4 +1,4 @@
 pub const EXPECTED_RPC_VERSION: &str = "0.8.1";
 pub const RPC_URL_VERSION: &str = "v0_8";
 pub const SNFORGE_TEST_FILTER: &str = "SNFORGE_TEST_FILTER";
-pub const FREE_RPC_PROVIDER_URL: &str = "https://free-rpc.nethermind.io/sepolia-juno/v0_8";
+pub const FREE_RPC_PROVIDER_URL: &str = "https://starknet-sepolia.public.blastapi.io/rpc/v0_8";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Voyager provider seems to be no longer available. Disabled it so we always use Blast

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
