### PR TITLE
Use rustup in build matrix workflows

### DIFF
--- a/.github/workflows/_build-binaries.yml
+++ b/.github/workflows/_build-binaries.yml
@@ -48,10 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
+      - name: Setup rust
+        run: |
+          rustup target add ${{ matrix.target }} --toolchain 1.86.0
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:

--- a/.github/workflows/_build-plugin-binaries.yml
+++ b/.github/workflows/_build-plugin-binaries.yml
@@ -68,9 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          target: ${{ matrix.target }}
+      - name: Setup rust
+        run: |
+          rustup target add ${{ matrix.target }} --toolchain 1.86.0
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 

--- a/.github/workflows/_test-binaries.yml
+++ b/.github/workflows/_test-binaries.yml
@@ -35,9 +35,9 @@ jobs:
           # TODO(#3144) Remove
           scarb-version: "2.11.0"
 
-      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
-        with:
-          toolchain: stable
+      - name: Setup rust
+        run: |
+          rustup target add ${{ matrix.target }} --toolchain 1.86.0
 
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Uses rustup directly in build workflows to override the settings from `rust-toolchain.toml`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
