### PR TITLE
Handle requirements check when tools not installed (#3111)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,17 +106,20 @@ jobs:
       - name: nextest partition ${{ matrix.partition }}/8
         run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/8' --archive-file 'nextest-archive-${{ matrix.os }}.tar.zst' e2e
 
-  test-scarb-2-7-1:
-    name: Test scarb 2.7.1
+  test-requirements-check-special-conditions:
+    name: Test requirements check special conditions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+      - uses: software-mansion/setup-universal-sierra-compiler@v1
+
+      - run: cargo test --package forge --features no_scarb_installed --lib compatibility_check::tests::failing_tool_not_installed
+
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: "2.7.1"
-      - uses: software-mansion/setup-universal-sierra-compiler@v1
 
       - run: cargo test --package forge --features scarb_2_7_1 --test main e2e::requirements::test_warning_on_scarb_version_below_recommended
       - run: cargo test --package forge --features scarb_2_7_1 --lib compatibility_check::tests::warning_requirements

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 smoke = []
 scarb_2_7_1 = []
 scarb_since_2_10 = []
+no_scarb_installed = []
 debugging = ["forge_runner/debugging"]
 assert_non_exact_gas = ["test_utils/assert_non_exact_gas"]
 

--- a/crates/forge/src/compatibility_check.rs
+++ b/crates/forge/src/compatibility_check.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result, anyhow};
 use regex::Regex;
 use semver::Version;
+use shared::command::CommandExt;
 use std::cell::RefCell;
 use std::process::Command;
 
@@ -13,6 +14,61 @@ pub struct Requirement<'a> {
     pub helper_text: String,
     pub minimal_version: Version,
     pub minimal_recommended_version: Option<Version>,
+}
+
+impl Requirement<'_> {
+    fn validate_and_get_output(&self) -> (bool, String) {
+        let version = self.get_version();
+        let mut is_valid;
+
+        let output = if let Ok(version) = version {
+            is_valid = version >= self.minimal_version;
+            let is_recommended = self
+                .minimal_recommended_version
+                .as_ref()
+                .is_none_or(|minimal_recommended_version| version >= *minimal_recommended_version);
+
+            let min_version_to_display = self
+                .minimal_recommended_version
+                .as_ref()
+                .unwrap_or(&self.minimal_version);
+
+            if !is_valid {
+                is_valid = false;
+                format!(
+                    "❌ {} Version {} doesn't satisfy minimal {}\n{}",
+                    self.name, version, min_version_to_display, self.helper_text
+                )
+            } else if !is_recommended {
+                format!(
+                    "⚠️  {} Version {} doesn't satisfy minimal recommended {}\n{}",
+                    self.name,
+                    version,
+                    self.minimal_recommended_version.as_ref().unwrap(),
+                    self.helper_text
+                )
+            } else {
+                format!("✅ {} {}", self.name, version)
+            }
+        } else {
+            is_valid = false;
+            format!(
+                "❌ {} is not installed or not added to the PATH\n{}\n",
+                self.name, self.helper_text
+            )
+        };
+
+        (is_valid, output)
+    }
+
+    fn get_version(&self) -> Result<Version> {
+        let version_command_output = self.command.borrow_mut().output_checked()?;
+        let raw_version = String::from_utf8_lossy(&version_command_output.stdout)
+            .trim()
+            .to_string();
+
+        (self.version_parser)(&raw_version)
+    }
 }
 
 pub struct RequirementsChecker<'a> {
@@ -33,7 +89,7 @@ impl<'a> RequirementsChecker<'a> {
     }
 
     pub fn check(&self) -> Result<()> {
-        let (validation_output, all_requirements_valid) = self.check_and_prepare_output()?;
+        let (validation_output, all_requirements_valid) = self.check_and_prepare_output();
 
         if self.output_on_success || !all_requirements_valid {
             println!("{validation_output}");
@@ -46,48 +102,19 @@ impl<'a> RequirementsChecker<'a> {
         }
     }
 
-    fn check_and_prepare_output(&self) -> Result<(String, bool)> {
+    fn check_and_prepare_output(&self) -> (String, bool) {
         let mut validation_output = "Checking requirements\n\n".to_string();
         let mut all_valid = true;
 
         for requirement in &self.requirements {
-            let raw_version = get_raw_version(&requirement.name, &requirement.command)?;
-            let version = (requirement.version_parser)(&raw_version)?;
+            let (is_valid, output) = requirement.validate_and_get_output();
 
-            let is_valid = version >= requirement.minimal_version;
-            let is_recommended = requirement
-                .minimal_recommended_version
-                .as_ref()
-                .is_none_or(|minimal_recommended_version| version >= *minimal_recommended_version);
-
-            let min_version_to_display = requirement
-                .minimal_recommended_version
-                .as_ref()
-                .unwrap_or(&requirement.minimal_version);
-
-            let command_output = if !is_valid {
-                all_valid = false;
-                format!(
-                    "❌ {} Version {} doesn't satisfy minimal {}\n{}",
-                    requirement.name, version, min_version_to_display, requirement.helper_text
-                )
-            } else if !is_recommended {
-                format!(
-                    "⚠️  {} Version {} doesn't satisfy minimal recommended {}\n{}",
-                    requirement.name,
-                    version,
-                    requirement.minimal_recommended_version.as_ref().unwrap(),
-                    requirement.helper_text
-                )
-            } else {
-                format!("✅ {} {}", requirement.name, version)
-            };
-
-            validation_output += command_output.as_str();
+            all_valid &= is_valid;
+            validation_output += output.as_str();
             validation_output += "\n";
         }
 
-        Ok((validation_output, all_valid))
+        (validation_output, all_valid)
     }
 }
 
@@ -105,19 +132,13 @@ pub fn create_version_parser<'a>(name: &'a str, pattern: &'a str) -> Box<Version
     })
 }
 
-fn get_raw_version(name: &str, command: &RefCell<Command>) -> Result<String> {
-    let raw_current_version = command
-        .borrow_mut()
-        .output()
-        .with_context(|| format!("Failed to run version command for {name}"))?;
-    Ok(String::from_utf8_lossy(&raw_current_version.stdout)
-        .trim()
-        .to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_fs::{
+        TempDir,
+        fixture::{FileWriteStr, PathChild},
+    };
     use scarb_api::ScarbCommand;
     use universal_sierra_compiler_api::UniversalSierraCompilerCommand;
 
@@ -164,8 +185,7 @@ mod tests {
             ),
         });
 
-        let (validation_output, is_valid) =
-            requirements_checker.check_and_prepare_output().unwrap();
+        let (validation_output, is_valid) = requirements_checker.check_and_prepare_output();
 
         assert!(is_valid);
         assert!(validation_output.contains("✅ Rust"));
@@ -193,8 +213,7 @@ mod tests {
             minimal_recommended_version: None,
         });
 
-        let (validation_output, is_valid) =
-            requirements_checker.check_and_prepare_output().unwrap();
+        let (validation_output, is_valid) = requirements_checker.check_and_prepare_output();
         assert!(!is_valid);
         assert!(validation_output.contains("❌ Rust Version"));
         assert!(validation_output.contains("doesn't satisfy minimal 999.0.0"));
@@ -217,8 +236,7 @@ mod tests {
             ),
         });
 
-        let (validation_output, is_valid) =
-            requirements_checker.check_and_prepare_output().unwrap();
+        let (validation_output, is_valid) = requirements_checker.check_and_prepare_output();
 
         println!("{validation_output}");
         assert!(is_valid);
@@ -242,11 +260,61 @@ mod tests {
             ),
         });
 
-        let (validation_output, is_valid) =
-            requirements_checker.check_and_prepare_output().unwrap();
+        let (validation_output, is_valid) = requirements_checker.check_and_prepare_output();
 
         assert!(!is_valid);
         assert!(validation_output.contains("❌ Scarb Version"));
         assert!(validation_output.contains("doesn't satisfy minimal 999.0.0"));
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "no_scarb_installed"), ignore)]
+    fn failing_tool_not_installed() {
+        let temp_dir = TempDir::new().unwrap();
+        temp_dir
+            .child(".tool-versions")
+            .write_str("scarb 2.9.9\n")
+            .unwrap();
+
+        let mut requirements_checker = RequirementsChecker::new(true);
+        requirements_checker.add_requirement(Requirement {
+            name: "Scarb".to_string(),
+            command: RefCell::new(
+                ScarbCommand::new()
+                    .arg("--version")
+                    .current_dir(temp_dir.path())
+                    .command(),
+            ),
+            minimal_version: Version::new(2, 8, 5),
+            minimal_recommended_version: Some(Version::new(2, 9, 3)),
+            helper_text: "Follow instructions from https://docs.swmansion.com/scarb/download.html"
+                .to_string(),
+            version_parser: create_version_parser(
+                "Scarb",
+                r"scarb (?<version>[0-9]+.[0-9]+.[0-9]+)",
+            ),
+        });
+        requirements_checker.add_requirement(Requirement {
+            name: "Universal Sierra Compiler".to_string(),
+            command: RefCell::new(UniversalSierraCompilerCommand::new().arg("--version").command()),
+            minimal_version: Version::new(2, 4, 0),
+            minimal_recommended_version: None,
+            helper_text: "Reinstall `snforge` using the same installation method or follow instructions from https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html#universal-sierra-compiler-update".to_string(),
+            version_parser: create_version_parser(
+                "Universal Sierra Compiler",
+                r"universal-sierra-compiler (?<version>[0-9]+.[0-9]+.[0-9]+)",
+            ),
+        });
+
+        let (validation_output, is_valid) = requirements_checker.check_and_prepare_output();
+
+        assert!(!is_valid);
+        assert!(validation_output.contains("❌ Scarb is not installed or not added to the PATH"));
+        assert!(
+            validation_output.contains(
+                "Follow instructions from https://docs.swmansion.com/scarb/download.html"
+            )
+        );
+        assert!(validation_output.contains("✅ Universal Sierra Compiler 2.4.0"));
     }
 }

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -312,10 +312,9 @@ fn check_requirements(
                 command: RefCell::new(ScarbCommand::new().arg("--version").command()),
                 minimal_version: MINIMAL_SCARB_VERSION_FOR_SIERRA_GAS,
                 minimal_recommended_version: None,
-                helper_text: "This version of scarb is the minimum required in order to support sierra gas tracking \
+                helper_text: format!("To track sierra gas, minimal required scarb version is {MINIMAL_SCARB_VERSION_FOR_SIERRA_GAS} \
                 (it comes with sierra >= 1.7.0 support)\n\
-                Follow instructions from https://docs.swmansion.com/scarb/download.html"
-                    .to_string(),
+                Follow instructions from https://docs.swmansion.com/scarb/download.html"),
                 version_parser: create_version_parser("Scarb", r"scarb (?<version>[0-9]+.[0-9]+.[0-9]+)"),
             });
         }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -946,7 +946,7 @@ fn sierra_gas_with_older_scarb() {
         indoc! {r"
         Checking requirements
         [..]Scarb Version [..] doesn't satisfy minimal 2.10.0[..]
-        [..]This version of scarb is the minimum required in order to support sierra gas tracking (it comes with sierra >= 1.7.0 support)[..]
+        [..]To track sierra gas, minimal required scarb version is 2.10.0 (it comes with sierra >= 1.7.0 support)[..]
         [..]Follow instructions from https://docs.swmansion.com/scarb/download.html[..]
         [..]
         [ERROR] Requirements not satisfied


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2807

<!-- A brief description of the changes -->

- Display a formatted message when `--version` command fails instead of
returning an immediate error