### PR TITLE
fix: Replace deprecated #[clap] attributes with #[arg]/#[command] (#3128)

### DIFF
--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -71,7 +71,7 @@ Report bugs: https://github.com/foundry-rs/starknet-foundry/issues/new/choose\
 "
 )]
 #[command(about = "snforge - a testing tool for Starknet contracts", long_about = None)]
-#[clap(name = "snforge")]
+#[command(name = "snforge")]
 pub struct Cli {
     #[command(subcommand)]
     subcommand: ForgeSubcommand,
@@ -205,7 +205,7 @@ pub struct TestArgs {
     tracked_resource: ForgeTrackedResource,
 
     /// Additional arguments for cairo-coverage or cairo-profiler
-    #[clap(last = true)]
+    #[arg(last = true)]
     additional_args: Vec<OsString>,
 }
 

--- a/crates/sncast/src/helpers/fee.rs
+++ b/crates/sncast/src/helpers/fee.rs
@@ -9,15 +9,15 @@ use std::num::{NonZeroU64, NonZeroU128};
 #[derive(Args, Debug, Clone)]
 pub struct FeeArgs {
     /// Max fee for the transaction. If not provided, will be automatically estimated.
-    #[clap(value_parser = parse_non_zero_felt, short, long)]
+    #[arg(value_parser = parse_non_zero_felt, short, long)]
     pub max_fee: Option<NonZeroFelt>,
 
     /// Max gas amount. If not provided, will be automatically estimated.
-    #[clap(value_parser = parse_non_zero_felt, long)]
+    #[arg(value_parser = parse_non_zero_felt, long)]
     pub max_gas: Option<NonZeroFelt>,
 
     /// Max gas price in Fri. If not provided, will be automatically estimated.
-    #[clap(value_parser = parse_non_zero_felt, long)]
+    #[arg(value_parser = parse_non_zero_felt, long)]
     pub max_gas_unit_price: Option<NonZeroFelt>,
 }
 

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -12,11 +12,11 @@ use std::time::UNIX_EPOCH;
 #[group(required = false, multiple = false)]
 pub struct RpcArgs {
     /// RPC provider url address; overrides url from snfoundry.toml
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub url: Option<String>,
 
     /// Use predefined network with a public provider. Note that this option may result in rate limits or other unexpected behavior
-    #[clap(long)]
+    #[arg(long)]
     pub network: Option<Network>,
 }
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -71,49 +71,49 @@ Report bugs: https://github.com/foundry-rs/starknet-foundry/issues/new/choose\
 "
 )]
 #[command(about = "sncast - All-in-one tool for interacting with Starknet smart contracts", long_about = None)]
-#[clap(name = "sncast")]
+#[command(name = "sncast")]
 #[expect(clippy::struct_excessive_bools)]
 struct Cli {
     /// Profile name in snfoundry.toml config file
-    #[clap(short, long)]
+    #[arg(short, long)]
     profile: Option<String>,
 
     /// Account to be used for contract declaration;
     /// When using keystore (`--keystore`), this should be a path to account file
     /// When using accounts file, this should be an account name
-    #[clap(short = 'a', long)]
+    #[arg(short = 'a', long)]
     account: Option<String>,
 
     /// Path to the file holding accounts info
-    #[clap(long = "accounts-file")]
+    #[arg(long = "accounts-file")]
     accounts_file_path: Option<Utf8PathBuf>,
 
     /// Path to keystore file; if specified, --account should be a path to starkli JSON account file
-    #[clap(short, long)]
+    #[arg(short, long)]
     keystore: Option<Utf8PathBuf>,
 
     /// If passed, values will be displayed as integers
-    #[clap(long, conflicts_with = "hex_format")]
+    #[arg(long, conflicts_with = "hex_format")]
     int_format: bool,
 
     /// If passed, values will be displayed as hex
-    #[clap(long, conflicts_with = "int_format")]
+    #[arg(long, conflicts_with = "int_format")]
     hex_format: bool,
 
     /// If passed, output will be displayed in json format
-    #[clap(short, long)]
+    #[arg(short, long)]
     json: bool,
 
     /// If passed, command will wait until transaction is accepted or rejected
-    #[clap(short = 'w', long)]
+    #[arg(short = 'w', long)]
     wait: bool,
 
     /// Adjusts the time after which --wait assumes transaction was not received or rejected
-    #[clap(long)]
+    #[arg(long)]
     wait_timeout: Option<u16>,
 
     /// Adjusts the time between consecutive attempts to fetch transaction by --wait flag
-    #[clap(long)]
+    #[arg(long)]
     wait_retry_interval: Option<u8>,
 
     #[command(subcommand)]
@@ -160,11 +160,11 @@ enum Commands {
 #[group(multiple = false)]
 pub struct Arguments {
     /// Arguments of the called function serialized as a series of felts
-    #[clap(short, long, value_delimiter = ' ', num_args = 1..)]
+    #[arg(short, long, value_delimiter = ' ', num_args = 1..)]
     pub calldata: Option<Vec<String>>,
 
     // Arguments of the called function as a comma-separated string of Cairo expressions
-    #[clap(long)]
+    #[arg(long)]
     pub arguments: Option<String>,
 }
 

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -32,30 +32,30 @@ use std::str::FromStr;
 #[command(about = "Create an account with all important secrets")]
 pub struct Create {
     /// Type of the account
-    #[clap(value_enum, short = 't', long = "type", value_parser = AccountType::from_str, default_value_t = AccountType::OpenZeppelin)]
+    #[arg(value_enum, short = 't', long = "type", value_parser = AccountType::from_str, default_value_t = AccountType::OpenZeppelin)]
     pub account_type: AccountType,
 
     /// Account name under which account information is going to be saved
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub name: Option<String>,
 
     /// Salt for the address
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub salt: Option<Felt>,
 
     /// If passed, a profile with provided name and corresponding data will be created in snfoundry.toml
-    #[clap(long, conflicts_with = "network")]
+    #[arg(long, conflicts_with = "network")]
     pub add_profile: Option<String>,
 
     /// Custom contract class hash of declared contract
-    #[clap(short, long, requires = "account_type")]
+    #[arg(short, long, requires = "account_type")]
     pub class_hash: Option<Felt>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 
     /// If passed, the command will not trigger an interactive prompt to add an account as a default
-    #[clap(long)]
+    #[arg(long)]
     pub silent: bool,
 }
 

--- a/crates/sncast/src/starknet_commands/account/delete.rs
+++ b/crates/sncast/src/starknet_commands/account/delete.rs
@@ -16,18 +16,18 @@ use sncast::{chain_id_to_network_name, get_chain_id};
     .multiple(false)))]
 pub struct Delete {
     /// Name of the account to be deleted
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub name: String,
 
     /// Assume "yes" as answer to confirmation prompt and run non-interactively
-    #[clap(long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     pub yes: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 
     /// Literal name of the network used in accounts file
-    #[clap(long)]
+    #[arg(long)]
     pub network_name: Option<String>,
 }
 

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -28,13 +28,13 @@ use starknet_types_core::felt::Felt;
 #[command(about = "Deploy an account to the Starknet")]
 pub struct Deploy {
     /// Name of the account to be deployed
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub name: Option<String>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub fee_args: FeeArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/account/import.rs
+++ b/crates/sncast/src/starknet_commands/account/import.rs
@@ -24,42 +24,42 @@ use starknet_types_core::felt::Felt;
 #[command(about = "Add an account to the accounts file")]
 pub struct Import {
     /// Name of the account to be imported
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub name: Option<String>,
 
     /// Address of the account
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub address: Felt,
 
     /// Type of the account
-    #[clap(short = 't', long = "type", value_parser = AccountType::from_str)]
+    #[arg(short = 't', long = "type", value_parser = AccountType::from_str)]
     pub account_type: AccountType,
 
     /// Class hash of the account
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub class_hash: Option<Felt>,
 
     /// Account private key
-    #[clap(long, group = "private_key_input")]
+    #[arg(long, group = "private_key_input")]
     pub private_key: Option<Felt>,
 
     /// Path to the file holding account private key
-    #[clap(long = "private-key-file", group = "private_key_input")]
+    #[arg(long = "private-key-file", group = "private_key_input")]
     pub private_key_file_path: Option<Utf8PathBuf>,
 
     /// Salt for the address
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub salt: Option<Felt>,
 
     /// If passed, a profile with the provided name and corresponding data will be created in snfoundry.toml
-    #[clap(long, conflicts_with = "network")]
+    #[arg(long, conflicts_with = "network")]
     pub add_profile: Option<String>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 
     /// If passed, the command will not trigger an interactive prompt to add an account as a default
-    #[clap(long)]
+    #[arg(long)]
     pub silent: bool,
 }
 

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -27,7 +27,7 @@ pub mod list;
 #[derive(Args)]
 #[command(about = "Creates and deploys an account to the Starknet")]
 pub struct Account {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: Commands,
 }
 

--- a/crates/sncast/src/starknet_commands/call.rs
+++ b/crates/sncast/src/starknet_commands/call.rs
@@ -13,23 +13,23 @@ use starknet_types_core::felt::Felt;
 #[command(about = "Call a contract instance on Starknet", long_about = None)]
 pub struct Call {
     /// Address of the called contract (hex)
-    #[clap(short = 'd', long)]
+    #[arg(short = 'd', long)]
     pub contract_address: Felt,
 
     /// Name of the contract function to be called
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub function: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub arguments: Arguments,
 
     /// Block identifier on which call should be performed.
     /// Possible values: pending, latest, block hash (0x prefixed string)
     /// and block number (u64)
-    #[clap(short, long, default_value = "pending")]
+    #[arg(short, long, default_value = "pending")]
     pub block_id: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -28,21 +28,21 @@ use std::sync::Arc;
 #[command(about = "Declare a contract to starknet", long_about = None)]
 pub struct Declare {
     /// Contract name
-    #[clap(short = 'c', long = "contract-name")]
+    #[arg(short = 'c', long = "contract-name")]
     pub contract: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub fee_args: FeeArgs,
 
     /// Nonce of the transaction. If not provided, nonce will be set automatically
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub nonce: Option<Felt>,
 
     /// Specifies scarb package to be used
-    #[clap(long)]
+    #[arg(long)]
     pub package: Option<String>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -20,28 +20,28 @@ use starknet_types_core::felt::Felt;
 #[command(about = "Deploy a contract on Starknet")]
 pub struct Deploy {
     /// Class hash of contract to deploy
-    #[clap(short = 'g', long)]
+    #[arg(short = 'g', long)]
     pub class_hash: Felt,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub arguments: DeployArguments,
 
     /// Salt for the address
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub salt: Option<Felt>,
 
     /// If true, salt will be modified with an account address
-    #[clap(long)]
+    #[arg(long)]
     pub unique: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub fee_args: FeeArgs,
 
     /// Nonce of the transaction. If not provided, nonce will be set automatically
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub nonce: Option<Felt>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 
@@ -49,11 +49,11 @@ pub struct Deploy {
 #[group(multiple = false)]
 pub struct DeployArguments {
     /// Arguments of the called function serialized as a series of felts
-    #[clap(short, long, value_delimiter = ' ', num_args = 1..)]
+    #[arg(short, long, value_delimiter = ' ', num_args = 1..)]
     pub constructor_calldata: Option<Vec<String>>,
 
     // Arguments of the called function as a comma-separated string of Cairo expressions
-    #[clap(long)]
+    #[arg(long)]
     pub arguments: Option<String>,
 }
 

--- a/crates/sncast/src/starknet_commands/invoke.rs
+++ b/crates/sncast/src/starknet_commands/invoke.rs
@@ -19,24 +19,24 @@ use starknet_types_core::felt::Felt;
 #[command(about = "Invoke a contract on Starknet")]
 pub struct Invoke {
     /// Address of contract to invoke
-    #[clap(short = 'd', long)]
+    #[arg(short = 'd', long)]
     pub contract_address: Felt,
 
     /// Name of the function to invoke
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub function: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub arguments: Arguments,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub fee_args: FeeArgs,
 
     /// Nonce of the transaction. If not provided, nonce will be set automatically
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub nonce: Option<Felt>,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -9,7 +9,7 @@ use run::Run;
 #[derive(Args)]
 #[command(about = "Execute multiple calls at once", long_about = None)]
 pub struct Multicall {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: Commands,
 }
 

--- a/crates/sncast/src/starknet_commands/multicall/new.rs
+++ b/crates/sncast/src/starknet_commands/multicall/new.rs
@@ -13,7 +13,7 @@ pub struct New {
     pub output_path: Option<Utf8PathBuf>,
 
     /// If the file specified in output-path exists, this flag decides if it is going to be overwritten
-    #[clap(short = 'o', long = "overwrite")]
+    #[arg(short = 'o', long = "overwrite")]
     pub overwrite: bool,
 }
 

--- a/crates/sncast/src/starknet_commands/multicall/run.rs
+++ b/crates/sncast/src/starknet_commands/multicall/run.rs
@@ -22,13 +22,13 @@ use std::collections::HashMap;
 #[command(about = "Execute a multicall from a .toml file", long_about = None)]
 pub struct Run {
     /// Path to the toml file with declared operations
-    #[clap(short = 'p', long = "path")]
+    #[arg(short = 'p', long = "path")]
     pub path: Utf8PathBuf,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub fee_args: FeeArgs,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/script/mod.rs
+++ b/crates/sncast/src/starknet_commands/script/mod.rs
@@ -7,7 +7,7 @@ pub mod run;
 
 #[derive(Args)]
 pub struct Script {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     pub command: Commands,
 }
 

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -65,14 +65,14 @@ pub struct Run {
     pub script_name: String,
 
     /// Specifies scarb package to be used
-    #[clap(long)]
+    #[arg(long)]
     pub package: Option<String>,
 
     /// Do not use the state file
-    #[clap(long)]
+    #[arg(long)]
     pub no_state_file: bool,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/show_config.rs
+++ b/crates/sncast/src/starknet_commands/show_config.rs
@@ -11,7 +11,7 @@ use starknet::providers::jsonrpc::HttpTransport;
 #[derive(Args)]
 #[command(about = "Show current configuration being used", long_about = None)]
 pub struct ShowConfig {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/tx_status.rs
+++ b/crates/sncast/src/starknet_commands/tx_status.rs
@@ -13,7 +13,7 @@ pub struct TxStatus {
     /// Hash of the transaction
     pub transaction_hash: Felt,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub rpc: RpcArgs,
 }
 

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -17,27 +17,27 @@ use walnut::WalnutVerificationInterface;
 #[command(about = "Verify a contract through a block explorer")]
 pub struct Verify {
     /// Address of a contract to be verified
-    #[clap(short = 'd', long)]
+    #[arg(short = 'd', long)]
     pub contract_address: Felt,
 
     /// Name of the contract that is being verified
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub contract_name: String,
 
     /// Block explorer to use for the verification
-    #[clap(short, long, value_enum, default_value_t = Verifier::Walnut)]
+    #[arg(short, long, value_enum, default_value_t = Verifier::Walnut)]
     pub verifier: Verifier,
 
     /// The network on which block explorer will do the verification
-    #[clap(short, long, value_enum)]
+    #[arg(short, long, value_enum)]
     pub network: Network,
 
     /// Assume "yes" as answer to confirmation prompt and run non-interactively
-    #[clap(long, default_value = "false")]
+    #[arg(long, default_value = "false")]
     pub confirm_verification: bool,
 
     /// Specifies scarb package to be used
-    #[clap(long)]
+    #[arg(long)]
     pub package: Option<String>,
 }
 


### PR DESCRIPTION
Closes #3127

This PR updates deprecated `#[clap(...)]` attributes to their modern
equivalents in `clap` 4.x.
The current codebase still uses outdated syntax that has been deprecated
since version 4.0.
By making this update, we ensure compatibility with future versions and
maintain code quality.

`cargo check --features clap/deprecated `fixed now.

![Pasted Graphic
74](https://github.com/user-attachments/assets/f70d703d-7d30-432e-b74b-cc94c62d71dc)

<!-- Make sure all of these are complete -->

- [X] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`

---

**Stack**:
- #3360
- #3359
- #3358


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*