### PR TITLE
Support for the verification with class hash (#2906)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--template` flag to `snforge new` command that allows selecting a template for the new project. Possible values are `balance-contract` (default), `cairo-program` and `erc20-contract`
 
+### Cast
+
+#### Changed
+
+- `verify` command now supports the `--class-hash` for Walnut verification
+
 ## [0.40.0] - 2025-03-26
 
 ### Cast

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -637,11 +637,7 @@ async fn run_async_command(
             )
             .expect("Failed to build contract");
             let result = starknet_commands::verify::verify(
-                verify.contract_address,
-                verify.contract_name,
-                verify.verifier,
-                verify.network,
-                verify.confirm_verification,
+                verify,
                 &package_metadata.manifest_path,
                 &artifacts,
             )

--- a/crates/sncast/src/starknet_commands/verify/explorer.rs
+++ b/crates/sncast/src/starknet_commands/verify/explorer.rs
@@ -2,19 +2,29 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use serde::Serialize;
 use sncast::{Network, response::structs::VerifyResponse};
-use starknet_types_core::felt::Felt;
+
+#[derive(Serialize, Debug)]
+#[serde(untagged)]
+pub enum ContractIdentifier {
+    ClassHash { class_hash: String },
+    Address { contract_address: String },
+}
 
 #[derive(Serialize, Debug)]
 pub struct VerificationPayload {
     pub contract_name: String,
-    pub contract_address: String,
+    #[serde(flatten)]
+    pub identifier: ContractIdentifier,
     pub source_code: serde_json::Value,
 }
 
 #[async_trait::async_trait]
 pub trait VerificationInterface {
     fn new(network: Network, workspace_dir: Utf8PathBuf) -> Self;
-    async fn verify(&self, contract_address: Felt, contract_name: String)
-    -> Result<VerifyResponse>;
+    async fn verify(
+        &self,
+        identifier: ContractIdentifier,
+        contract_name: String,
+    ) -> Result<VerifyResponse>;
     fn gen_explorer_url(&self) -> Result<String>;
 }

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, anyhow, bail};
 use camino::Utf8PathBuf;
-use clap::{Args, ValueEnum};
+use clap::{ArgGroup, Args, ValueEnum};
 use promptly::prompt;
 use scarb_api::StarknetContractArtifacts;
 use sncast::{Network, response::structs::VerifyResponse};
@@ -10,15 +10,25 @@ use std::{collections::HashMap, fmt};
 pub mod explorer;
 pub mod walnut;
 
+use explorer::ContractIdentifier;
 use explorer::VerificationInterface;
 use walnut::WalnutVerificationInterface;
 
 #[derive(Args)]
 #[command(about = "Verify a contract through a block explorer")]
+#[command(group(
+    ArgGroup::new("contract_identifier")
+        .required(true)
+        .args(&["class_hash", "contract_address"])
+))]
 pub struct Verify {
+    /// Class hash of a contract to be verified
+    #[arg(short = 'g', long)]
+    pub class_hash: Option<Felt>,
+
     /// Address of a contract to be verified
     #[arg(short = 'd', long)]
-    pub contract_address: Felt,
+    pub contract_address: Option<Felt>,
 
     /// Name of the contract that is being verified
     #[arg(short, long)]
@@ -55,16 +65,14 @@ impl fmt::Display for Verifier {
 }
 
 pub async fn verify(
-    contract_address: Felt,
-    contract_name: String,
-    verifier: Verifier,
-    network: Network,
-    confirm_verification: bool,
+    verify: Verify,
     manifest_path: &Utf8PathBuf,
     artifacts: &HashMap<String, StarknetContractArtifacts>,
 ) -> Result<VerifyResponse> {
+    let verifier = verify.verifier;
+
     // Let's ask confirmation
-    if !confirm_verification {
+    if !verify.confirm_verification {
         let prompt_text = format!(
             "\n\tYou are about to submit the entire workspace code to the third-party verifier at {verifier}.\n\n\tImportant: Make sure your project does not include sensitive information like private keys. The snfoundry.toml file will be uploaded. Keep the keystore outside the project to prevent it from being uploaded.\n\n\tAre you sure you want to proceed? (Y/n)"
         );
@@ -75,6 +83,7 @@ pub async fn verify(
         }
     }
 
+    let contract_name = verify.contract_name;
     if !artifacts.contains_key(&contract_name) {
         return Err(anyhow!("Contract named '{contract_name}' was not found"));
     }
@@ -85,10 +94,24 @@ pub async fn verify(
         .parent()
         .ok_or(anyhow!("Failed to obtain workspace dir"))?;
 
+    let contract_identifier = match (verify.class_hash, verify.contract_address) {
+        (Some(class_hash), None) => ContractIdentifier::ClassHash {
+            class_hash: class_hash.to_fixed_hex_string(),
+        },
+        (None, Some(contract_address)) => ContractIdentifier::Address {
+            contract_address: contract_address.to_fixed_hex_string(),
+        },
+
+        _ => {
+            unreachable!("Exactly one of class_hash or contract_address must be provided.");
+        }
+    };
+
     match verifier {
         Verifier::Walnut => {
-            let walnut = WalnutVerificationInterface::new(network, workspace_dir.to_path_buf());
-            walnut.verify(contract_address, contract_name).await
+            let walnut =
+                WalnutVerificationInterface::new(verify.network, workspace_dir.to_path_buf());
+            walnut.verify(contract_identifier, contract_name).await
         }
     }
 }

--- a/crates/sncast/src/starknet_commands/verify/walnut.rs
+++ b/crates/sncast/src/starknet_commands/verify/walnut.rs
@@ -3,12 +3,11 @@ use camino::Utf8PathBuf;
 use reqwest::StatusCode;
 use sncast::Network;
 use sncast::response::structs::VerifyResponse;
-use starknet_types_core::felt::Felt;
 use std::env;
 use std::ffi::OsStr;
 use walkdir::WalkDir;
 
-use super::explorer::{VerificationInterface, VerificationPayload};
+use super::explorer::{ContractIdentifier, VerificationInterface, VerificationPayload};
 
 pub struct WalnutVerificationInterface {
     network: Network,
@@ -26,7 +25,7 @@ impl VerificationInterface for WalnutVerificationInterface {
 
     async fn verify(
         &self,
-        contract_address: Felt,
+        identifier: ContractIdentifier,
         contract_name: String,
     ) -> Result<VerifyResponse> {
         // Read all files name along with their contents in a JSON format
@@ -57,8 +56,8 @@ impl VerificationInterface for WalnutVerificationInterface {
 
         // Create the JSON payload with "contract name," "address," and "source_code" fields
         let payload = VerificationPayload {
-            contract_name: contract_name.to_string(),
-            contract_address: contract_address.to_string(),
+            contract_name,
+            identifier,
             source_code,
         };
 

--- a/docs/src/appendix/sncast/verify.md
+++ b/docs/src/appendix/sncast/verify.md
@@ -1,8 +1,15 @@
 # `verify`
 Verify Cairo contract on a chosen verification provider.
 
-## `--contract-address, -a <CONTRACT_ADDRESS>`
-Required.
+## `--class-hash, -g <CLASS_HASH>`
+
+Optional. Required if `--contract-address` is not provided.
+
+The class hash of the contract that is to be verified.
+
+## `--contract-address, -d <CONTRACT_ADDRESS>`
+
+Optional. Required if `--class-hash` is not provided.
 
 The address of the contract that is to be verified.
 

--- a/docs/src/starknet/verify.md
+++ b/docs/src/starknet/verify.md
@@ -27,8 +27,8 @@ Then run:
 ```shell
 $ sncast \
     verify \
-    --contract-address 0x0589a8b8bf819b7820cb699ea1f6c409bc012c9b9160106ddc3dacd6a89653cf \
-    --contract-name HelloSncast \
+    --class-hash 0x031966c9fe618bcee61d267750b9d46e3d71469e571e331f35f0ca26efe306dc \
+    --contract-name SimpleBalance \
     --verifier walnut \
     --network sepolia
 ```
@@ -45,8 +45,9 @@ $ sncast \
     Are you sure you want to proceed? (Y/n): Y
 
 command: verify
-message: Contract verification has started. You can check the verification status at the following link: https://api.walnut.dev/v1/verification/77f1d905-fdb4-4280-b7d6-57cd029d1259/status.
+message: Contract verification has started. You can check the verification status at the following link: https://app.walnut.dev/verification/status/77f1d905-fdb4-4280-b7d6-57cd029d1259.
 ```
+
 </details>
 <br>
 


### PR DESCRIPTION
Closes #2668

This PR adds support for `sncast verify --verifier walnut` to use class
hash.

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`

---

**Stack**:
- #3367
- #3366
- #3365
- #3364
- #3363
- #3362
- #3361
- #3360
- #3359
- #3358


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*