### PR TITLE
Add short option for `--accounts-file` flag

### DIFF
--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -86,7 +86,7 @@ struct Cli {
     account: Option<String>,
 
     /// Path to the file holding accounts info
-    #[arg(long = "accounts-file")]
+    #[arg(short = 'f', long = "accounts-file")]
     accounts_file_path: Option<Utf8PathBuf>,
 
     /// Path to keystore file; if specified, --account should be a path to starkli JSON account file

--- a/docs/src/appendix/sncast/common.md
+++ b/docs/src/appendix/sncast/common.md
@@ -1,4 +1,5 @@
 # `sncast` common flags
+These flags must be specified directly after the `sncast` command and before the subcommand name.
 
 ## `--profile, -p <PROFILE_NAME>`
 Optional.
@@ -9,7 +10,7 @@ Defaults to `default` (`snfoundry.toml`) and `dev` (`Scarb.toml`).
 ## `--account, -a <ACCOUNT_NAME>`
 Optional.
 
-Account name used to interact with the network, aliased in open zeppelin accounts file.
+Account name used to interact with the network, aliased in the accounts file.
 
 Overrides account from `snfoundry.toml`.
 
@@ -18,7 +19,7 @@ If used with `--keystore`, should be a path to [starkli account JSON file](https
 ## `--accounts-file, -f <PATH_TO_ACCOUNTS_FILE>`
 Optional.
 
-Path to the open zeppelin accounts file holding accounts info. Defaults to `~/.starknet_accounts/starknet_open_zeppelin_accounts.json`.
+Path to the accounts file holding accounts information. Defaults to `~/.starknet_accounts/starknet_open_zeppelin_accounts.json`.
 
 ## `--keystore, -k <PATH_TO_KEYSTORE_FILE>`
 Optional.

--- a/docs/src/appendix/sncast/invoke.md
+++ b/docs/src/appendix/sncast/invoke.md
@@ -5,7 +5,7 @@ Send an invoke transaction to Starknet.
 
 * [`account`](./common.md#--account--a-account_name)
 
-## `--contract-address, -a <CONTRACT_ADDRESS>`
+## `--contract-address, -d <CONTRACT_ADDRESS>`
 Required.
 
 The address of the contract being called in hex (prefixed with '0x') or decimal representation.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Introduced changes

<!-- A brief description of the changes -->

- Added the short flag `-f` for the `--accounts-file`. Although it is [documented](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/common.html#--accounts-file--f-path_to_accounts_file) the option did not exist
- Updated common flags documentation
- Updated incorrect short flag for `contract_address` in the docs

