### PR TITLE
Use starknet-devnet `v0.4.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  DEVNET_REV: 26292d1f92807090776b470f43b321f150f55ffd # v0.4.1
+  DEVNET_REV: e0613b1028013dfd7ee8239d677e3a544fd808c8 # v0.4.2
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-      - name: Install starknet-devnet-rs on Linux/Macos
+      - name: Install starknet-devnet on Linux/Macos
         if: runner.os != 'Windows'
         run: |
           ./scripts/install_devnet.sh
@@ -279,7 +279,7 @@ jobs:
         if: runner.os == 'Windows' && steps.windows-devnet-cache.outputs.cache-hit != 'true'
         run: |
           $DEVNET_INSTALL_DIR = "${{ github.workspace }}\crates\sncast\tests\utils\devnet"
-          cargo install --git https://github.com/0xSpaceShard/starknet-devnet-rs.git --locked --rev ${{ env.DEVNET_REV }} --root $DEVNET_INSTALL_DIR
+          cargo install --git https://github.com/0xSpaceShard/starknet-devnet.git --locked --rev ${{ env.DEVNET_REV }} --root $DEVNET_INSTALL_DIR
       - uses: software-mansion/setup-scarb@v1
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - name: Run tests

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -112,7 +112,7 @@ jobs:
           scarb-version: ${{ matrix.version }}
       - uses: software-mansion/setup-universal-sierra-compiler@v1
 
-      - name: Install starknet-devnet-rs
+      - name: Install starknet-devnet
         run: ./scripts/install_devnet.sh
 
       - run: cargo test --release -p sncast

--- a/design_documents/transactional_testing/transactional_testing.md
+++ b/design_documents/transactional_testing/transactional_testing.md
@@ -25,7 +25,7 @@ This could be considered as a variant of `cast script`, in a way.
 
 The extending/differentiating factors would be:
 
-- Extra environment-specific functions (for [katana](https://book.dojoengine.org/toolchain/katana/reference.html#custom-methods)/[devnet](https://github.com/0xSpaceShard/starknet-devnet-rs#dumping--loading) - see docs)
+- Extra environment-specific functions (for [katana](https://book.dojoengine.org/toolchain/katana/reference.html#custom-methods)/[devnet](https://0xspaceshard.github.io/starknet-devnet/docs/dump-load-restart) - see docs)
 - Additional RPC functions support (receipts, etc.)
 - Test-like behavior (fail/pass)
 - Idempotent functions, for functionalities that can fail when double-running them (i.e. declare)

--- a/scripts/install_devnet.ps1
+++ b/scripts/install_devnet.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference = "Stop"
 $DEVNET_INSTALL_DIR = Join-Path (git rev-parse --show-toplevel) "crates\sncast\tests\utils\devnet"
 
 $DEVNET_REPO = "https://github.com/0xSpaceShard/starknet-devnet-rs.git"
-$DEVNET_REV = "26292d1f92807090776b470f43b321f150f55ffd" # v0.4.1
+$DEVNET_REV = "e0613b1028013dfd7ee8239d677e3a544fd808c8" # v0.4.2
 
 cargo install --locked --git $DEVNET_REPO --rev $DEVNET_REV --root $DEVNET_INSTALL_DIR --force
 

--- a/scripts/install_devnet.ps1
+++ b/scripts/install_devnet.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = "Stop"
 
 $DEVNET_INSTALL_DIR = Join-Path (git rev-parse --show-toplevel) "crates\sncast\tests\utils\devnet"
 
-$DEVNET_REPO = "https://github.com/0xSpaceShard/starknet-devnet-rs.git"
+$DEVNET_REPO = "https://github.com/0xSpaceShard/starknet-devnet.git"
 $DEVNET_REV = "e0613b1028013dfd7ee8239d677e3a544fd808c8" # v0.4.2
 
 cargo install --locked --git $DEVNET_REPO --rev $DEVNET_REV --root $DEVNET_INSTALL_DIR --force

--- a/scripts/install_devnet.sh
+++ b/scripts/install_devnet.sh
@@ -2,7 +2,7 @@
 set -e
 
 DEVNET_INSTALL_DIR="$(git rev-parse --show-toplevel)/crates/sncast/tests/utils/devnet"
-DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs"
+DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet"
 DEVNET_VER="v0.4.2"
 
 echo "Devnet installation directory: $DEVNET_INSTALL_DIR"

--- a/scripts/install_devnet.sh
+++ b/scripts/install_devnet.sh
@@ -3,7 +3,7 @@ set -e
 
 DEVNET_INSTALL_DIR="$(git rev-parse --show-toplevel)/crates/sncast/tests/utils/devnet"
 DEVNET_REPO="https://github.com/0xSpaceShard/starknet-devnet-rs"
-DEVNET_VER="v0.4.1"
+DEVNET_VER="v0.4.2"
 
 echo "Devnet installation directory: $DEVNET_INSTALL_DIR"
 


### PR DESCRIPTION
## Introduced changes

- This PR is for me to learn and demonstrate how the expected update should be done. It does not introduce a major/breaking Devnet version.
- Replaced occurrences of Devnet v0.4.1 with v0.4.2
- Replaced occurrences of `26292d1f92807090776b470f43b321f150f55ffd` (sha of v0.4.1) with `e0613b1028013dfd7ee8239d677e3a544fd808c8` (sha of v0.4.2).
- Replaced occurrences of `starknet-devnet-rs` with `starknet-devnet` as the repository has been renamed (links currently working due to GitHub's forwarding).
- Updated old link.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
  - No closeable issues I could find
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
  - I did not see this in PR #3150, which I used for reference, but I'd gladly update the changelog if instructed how to.
