### PR TITLE
Fix duplicated syscall resources in nested calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Fixed
+
+- bug where syscall execution resources from nested calls were being calculated twice
+
 ### Cast
 
 #### Removed

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -295,15 +295,12 @@ fn exit_non_error_call(
     cheatnet_state: &mut CheatnetState,
     vm_trace: Option<Vec<RelocatedTraceEntry>>,
 ) {
-    let resources = call_info.resources.clone();
-    let gas_consumed = call_info.execution.gas_consumed;
-
     let nested_syscall_usage_sum =
         aggregate_nested_syscall_usage(&cheatnet_state.trace_data.current_call_stack.top());
     let syscall_usage = sum_syscall_usage(nested_syscall_usage_sum, syscall_usage);
     cheatnet_state.trace_data.exit_nested_call(
-        resources,
-        gas_consumed,
+        call_info.resources.clone(),
+        call_info.execution.gas_consumed,
         syscall_usage,
         CallResult::from_non_error(call_info),
         &call_info.execution.l2_to_l1_messages,

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -644,7 +644,7 @@ pub fn update_top_call_resources(runtime: &mut ForgeRuntime, tracked_resource: &
                 versioned_constants,
                 &all_execution_resources,
                 &top_call_syscalls,
-            )
+            );
         }
         TrackedResource::SierraGas => {
             all_sierra_gas_consumed +=

--- a/crates/forge-runner/src/build_trace_data.rs
+++ b/crates/forge-runner/src/build_trace_data.rs
@@ -82,7 +82,7 @@ pub fn build_profiler_call_trace_with_adjusted_resources(
 ) -> ProfilerCallTrace {
     let versioned_constants = VersionedConstants::latest_constants();
     remove_syscall_resources_from_call_trace(value, tracked_resource, versioned_constants);
-    build_profiler_call_trace(&value, contracts_data, versioned_program_path)
+    build_profiler_call_trace(value, contracts_data, versioned_program_path)
 }
 
 fn build_profiler_call_trace(

--- a/crates/forge-runner/src/build_trace_data.rs
+++ b/crates/forge-runner/src/build_trace_data.rs
@@ -47,7 +47,7 @@ fn remove_syscall_resources_from_call_trace(
     let mut execution_resources = call_trace.used_execution_resources.clone();
     let mut gas_consumed = call_trace.gas_consumed;
 
-    match TrackedResource::CairoSteps {
+    match tracked_resource {
         TrackedResource::CairoSteps => {
             execution_resources -=
                 &versioned_constants.get_additional_os_syscall_resources(&syscall_usage);
@@ -60,7 +60,7 @@ fn remove_syscall_resources_from_call_trace(
     call_trace.used_execution_resources = execution_resources.filter_unused_builtins().clone();
     call_trace.gas_consumed = gas_consumed;
 
-    for nested_call in call_trace.nested_calls.iter_mut() {
+    for nested_call in &mut call_trace.nested_calls {
         match nested_call {
             CallTraceNode::EntryPointCall(nested_call_trace) => {
                 remove_syscall_resources_from_call_trace(

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -350,7 +350,6 @@ pub fn run_test_case(
         .clone();
 
     let transaction_context = get_context(&forge_runtime).tx_context.clone();
-
     let used_resources =
         get_all_used_resources(forge_runtime, &transaction_context, tracked_resource);
     let gas_used = calculate_used_gas(

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -21,8 +21,9 @@ use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::Use
 use cheatnet::runtime_extensions::cheatable_starknet_runtime_extension::CheatableStarknetRuntimeExtension;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::runtime_extensions::forge_runtime_extension::{
-    ForgeExtension, ForgeRuntime, add_resources_to_top_call, get_all_used_resources,
-    update_top_call_l1_resources, update_top_call_resources, update_top_call_vm_trace,
+    ForgeExtension, ForgeRuntime, add_resources_to_top_call, calculate_total_syscall_usage,
+    get_all_used_resources, update_top_call_l1_resources, update_top_call_resources,
+    update_top_call_vm_trace,
 };
 use cheatnet::state::{
     BlockInfoReader, CallTrace, CheatnetState, EncounteredErrors, ExtendedStateReader,
@@ -349,8 +350,14 @@ pub fn run_test_case(
         .clone();
 
     let transaction_context = get_context(&forge_runtime).tx_context.clone();
-    let used_resources =
-        get_all_used_resources(forge_runtime, &transaction_context, tracked_resource);
+    let total_syscalls = calculate_total_syscall_usage(&mut forge_runtime);
+
+    let used_resources = get_all_used_resources(
+        forge_runtime,
+        &transaction_context,
+        tracked_resource,
+        total_syscalls,
+    );
     let gas_used = calculate_used_gas(
         &transaction_context,
         &mut cached_state,

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -21,9 +21,8 @@ use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::Use
 use cheatnet::runtime_extensions::cheatable_starknet_runtime_extension::CheatableStarknetRuntimeExtension;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::runtime_extensions::forge_runtime_extension::{
-    ForgeExtension, ForgeRuntime, add_resources_to_top_call, calculate_total_syscall_usage,
-    get_all_used_resources, update_top_call_l1_resources, update_top_call_resources,
-    update_top_call_vm_trace,
+    ForgeExtension, ForgeRuntime, add_resources_to_top_call, get_all_used_resources,
+    update_top_call_l1_resources, update_top_call_resources, update_top_call_vm_trace,
 };
 use cheatnet::state::{
     BlockInfoReader, CallTrace, CheatnetState, EncounteredErrors, ExtendedStateReader,
@@ -155,6 +154,7 @@ pub struct RunCompleted {
     pub(crate) used_resources: UsedResources,
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
+    pub(crate) tracked_resource: TrackedResource,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -338,7 +338,7 @@ pub fn run_test_case(
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
-    update_top_call_resources(&mut forge_runtime);
+    update_top_call_resources(&mut forge_runtime, &tracked_resource);
     update_top_call_l1_resources(&mut forge_runtime);
 
     let fuzzer_args = forge_runtime
@@ -350,14 +350,9 @@ pub fn run_test_case(
         .clone();
 
     let transaction_context = get_context(&forge_runtime).tx_context.clone();
-    let total_syscalls = calculate_total_syscall_usage(&mut forge_runtime);
 
-    let used_resources = get_all_used_resources(
-        forge_runtime,
-        &transaction_context,
-        tracked_resource,
-        total_syscalls,
-    );
+    let used_resources =
+        get_all_used_resources(forge_runtime, &transaction_context, tracked_resource);
     let gas_used = calculate_used_gas(
         &transaction_context,
         &mut cached_state,
@@ -376,6 +371,7 @@ pub fn run_test_case(
             used_resources,
             encountered_errors,
             fuzzer_args,
+            tracked_resource,
         })),
         Err(error) => RunResult::Error(RunError {
             error: Box::new(error),

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,5 +1,5 @@
 use crate::backtrace::{add_backtrace_footer, get_backtrace, is_backtrace_enabled};
-use crate::build_trace_data::build_profiler_call_trace;
+use crate::build_trace_data::build_profiler_call_trace_with_adjusted_resources;
 use crate::debugging::{TraceVerbosity, build_debugging_trace};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
 use crate::gas::check_available_gas;
@@ -318,6 +318,7 @@ impl TestCaseSummary<Single> {
             used_resources,
             encountered_errors,
             fuzzer_args,
+            tracked_resource,
         }: RunCompleted,
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
@@ -344,11 +345,14 @@ impl TestCaseSummary<Single> {
                         test_statistics: (),
                         gas_info,
                         used_resources,
-                        trace_data: VersionedProfilerCallTrace::V1(build_profiler_call_trace(
-                            &call_trace,
-                            contracts_data,
-                            versioned_program_path,
-                        )),
+                        trace_data: VersionedProfilerCallTrace::V1(
+                            build_profiler_call_trace_with_adjusted_resources(
+                                &call_trace,
+                                contracts_data,
+                                versioned_program_path,
+                                tracked_resource,
+                            ),
+                        ),
                         debugging_trace,
                     };
                     check_available_gas(test_case.config.available_gas, summary, ui)
@@ -381,11 +385,14 @@ impl TestCaseSummary<Single> {
                             test_statistics: (),
                             gas_info,
                             used_resources,
-                            trace_data: VersionedProfilerCallTrace::V1(build_profiler_call_trace(
-                                &call_trace,
-                                contracts_data,
-                                versioned_program_path,
-                            )),
+                            trace_data: VersionedProfilerCallTrace::V1(
+                                build_profiler_call_trace_with_adjusted_resources(
+                                    &call_trace,
+                                    contracts_data,
+                                    versioned_program_path,
+                                    tracked_resource,
+                                ),
+                            ),
                             debugging_trace,
                         }
                     } else {

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1063,7 +1063,6 @@ fn nested_call_cost_cairo_steps() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
-    // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, the number of bitwise and some other builtins should be ~2 lower.
     // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
     // 96 * 3 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
@@ -1137,7 +1136,6 @@ fn nested_call_cost_in_forked_contract_cairo_steps() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
-    // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, the number of bitwise and some other builtins should be ~2 lower.
     // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
     // 96 * 2 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
@@ -1620,8 +1618,8 @@ fn l1_message_cost_for_proxy_sierra_gas() {
     //      -> 1 pedersen costs 4050, 1 range check costs 70
     // 175300 = cost of 2 call contract syscalls (see `multiple_storage_writes_cost_sierra_gas` test)
     // 14170 = cost of 1 SendMessageToL1 syscall (see `l1_message_cost_sierra_gas` test)
-    // 111220 = reported consumed sierra gas
-    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 111220) l2 gas
+    // 97050 = reported consumed sierra gas
+    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 97050) l2 gas
     assert_gas(
         &result,
         "l1_message_cost_for_proxy",

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1075,7 +1075,7 @@ fn nested_call_cost_cairo_steps() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(288),
-            l2_gas: GasAmount(14_375_360),
+            l2_gas: GasAmount(7_215_360),
         },
     );
 }
@@ -1149,7 +1149,7 @@ fn nested_call_cost_in_forked_contract_cairo_steps() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(14_375_360),
+            l2_gas: GasAmount(7_215_360),
         },
     );
 }
@@ -1783,21 +1783,20 @@ fn nested_call_cost_sierra_gas() {
     let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
 
     assert_passed(&result);
-    // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, reported consumed sierra gas should be lower.
     // 512000 = event keys cost (see `events_contract_cost_sierra_gas` test)
     // 256000 = event data cost (see `events_contract_cost_sierra_gas` test)
     // 10000 = cost of 1 emit event syscall (see `events_contract_cost_sierra_gas` test)
     // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
     // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
-    // 1741387 = reported consumed sierra gas
-    // 0 l1_gas + 288 l1_data_gas + (512000 + 256000 + 10000 + 3 * 142810 + 2 * 87650 + 1741387) l2 gas
+    // 639292 = reported consumed sierra gas
+    // 0 l1_gas + 288 l1_data_gas + (512000 + 256000 + 10000 + 3 * 142810 + 2 * 87650 + 639292) l2 gas
     assert_gas(
         &result,
         "test_call_other_contract",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(288),
-            l2_gas: GasAmount(2_980_307),
+            l2_gas: GasAmount(2_021_022),
         },
     );
 }
@@ -1860,21 +1859,20 @@ fn nested_call_cost_in_forked_contract_sierra_gas() {
     let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
 
     assert_passed(&result);
-    // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, reported consumed sierra gas should be lower.
     // 512000 = event keys cost (see `events_contract_cost_sierra_gas` test)
     // 256000 = event data cost (see `events_contract_cost_sierra_gas` test)
     // 10000 = cost of 1 emit event syscall (see `events_contract_cost_sierra_gas` test)
     // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
     // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
-    // 1559797 = reported consumed sierra gas
-    // 0 l1_gas + 192 l1_data_gas + (512000 + 256000 + 10000 + 2 * 142810 + 2 * 87650 + 1559797) l2 gas
+    // 600512 = reported consumed sierra gas
+    // 0 l1_gas + 192 l1_data_gas + (512000 + 256000 + 10000 + 2 * 142810 + 2 * 87650 + 600512) l2 gas
     assert_gas(
         &result,
         "test_call_other_contract_fork",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(2_798_717),
+            l2_gas: GasAmount(1_839_432),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1063,11 +1063,11 @@ fn nested_call_cost_cairo_steps() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
-    // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
+    // int(1121 * 0.16) = 180 = gas cost of bitwise builtins
     // 96 * 3 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
     // ~1 gas for 1 event data
-    // 0 l1_gas + (96 * 3) l1_data_gas + 359 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
+    // 0 l1_gas + (96 * 3) l1_data_gas + 180 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
     assert_gas(
         &result,
         "test_call_other_contract",
@@ -1136,11 +1136,11 @@ fn nested_call_cost_in_forked_contract_cairo_steps() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
-    // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
+    // int(1121 * 0.16) = 180 = gas cost of bitwise builtins
     // 96 * 2 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
     // ~1 gas for 1 event data
-    // 0 l1_gas + (96 * 2) l1_data_gas + 359 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
+    // 0 l1_gas + (96 * 2) l1_data_gas + 180 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
     assert_gas(
         &result,
         "test_call_other_contract_fork",

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1628,7 +1628,7 @@ fn l1_message_cost_for_proxy_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(29524),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(586_310),
+            l2_gas: GasAmount(572_140),
         },
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3473
Closes #3399

## Introduced changes

This PR changes the way we subtract syscall resources. Before, we subtracted them in `execute_call_entry_point`. Now, we do it directly before passing to trace data.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
