### PR TITLE
Fix resources from syscalls in nested calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- bug where syscall execution resources from nested calls were being calculated twice
+- Bug where syscall execution resources from nested calls were being calculated twice
 
 ### Cast
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Fixed
+
+- bug where syscall execution resources from nested calls were being calculated twice
+
 ### Cast
 
 #### Changed

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
@@ -127,13 +127,10 @@ pub(crate) fn execute_entry_point_call_cairo1(
             .register_error(class_hash, pcs);
     }
 
-    let mut syscall_usage_vm_resources = SyscallUsageMap::default();
-    let mut syscall_usage_sierra_gas = SyscallUsageMap::default();
-
-    match tracked_resource {
-        TrackedResource::CairoSteps => syscall_usage_vm_resources.clone_from(&syscall_usage),
-        TrackedResource::SierraGas => syscall_usage_sierra_gas.clone_from(&syscall_usage),
-    }
+    let (syscall_usage_vm_resources, syscall_usage_sierra_gas) = match tracked_resource {
+        TrackedResource::CairoSteps => (syscall_usage, SyscallUsageMap::default()),
+        TrackedResource::SierraGas => (SyscallUsageMap::default(), syscall_usage),
+    };
 
     Ok(CallInfoWithExecutionData {
         call_info,

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
@@ -5,12 +5,13 @@ use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::
 };
 use crate::runtime_extensions::cheatable_starknet_runtime_extension::CheatableStarknetRuntimeExtension;
 use crate::runtime_extensions::common::get_relocated_vm_trace;
-use blockifier::execution::contract_class::CompiledClassV1;
+use blockifier::execution::contract_class::{CompiledClassV1, TrackedResource};
 use blockifier::execution::entry_point::ExecutableCallEntryPoint;
 use blockifier::execution::entry_point_execution::{
     ExecutionRunnerMode, VmExecutionContext, finalize_execution,
     initialize_execution_context_with_runner_mode, prepare_call_arguments,
 };
+use blockifier::execution::syscalls::hint_processor::SyscallUsageMap;
 use blockifier::{
     execution::{
         contract_class::EntryPointV1, entry_point::EntryPointExecutionContext,
@@ -93,6 +94,8 @@ pub(crate) fn execute_entry_point_call_cairo1(
     })?;
 
     let trace = get_relocated_vm_trace(&mut runner);
+
+    // Syscall usage here is flat, meaning it only includes syscalls from current call
     let syscall_usage = cheatable_runtime
         .extended_runtime
         .hint_handler
@@ -124,9 +127,19 @@ pub(crate) fn execute_entry_point_call_cairo1(
             .register_error(class_hash, pcs);
     }
 
+    let mut syscall_usage_vm_resources = SyscallUsageMap::default();
+    let mut syscall_usage_sierra_gas = SyscallUsageMap::default();
+
+    match tracked_resource {
+        TrackedResource::CairoSteps => syscall_usage_vm_resources.clone_from(&syscall_usage),
+
+        TrackedResource::SierraGas => syscall_usage_sierra_gas.clone_from(&syscall_usage),
+    }
+
     Ok(CallInfoWithExecutionData {
         call_info,
-        syscall_usage,
+        syscall_usage_vm_resources,
+        syscall_usage_sierra_gas,
         vm_trace: Some(trace),
     })
     // endregion

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cairo1_execution.rs
@@ -132,7 +132,6 @@ pub(crate) fn execute_entry_point_call_cairo1(
 
     match tracked_resource {
         TrackedResource::CairoSteps => syscall_usage_vm_resources.clone_from(&syscall_usage),
-
         TrackedResource::SierraGas => syscall_usage_sierra_gas.clone_from(&syscall_usage),
     }
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
@@ -81,13 +81,11 @@ pub(crate) fn execute_entry_point_call_cairo0(
         n_total_args,
     )?;
 
-    let mut syscall_usage_vm_resources = SyscallUsageMap::default();
-    let mut syscall_usage_sierra_gas = SyscallUsageMap::default();
-
-    match execution_result.tracked_resource {
-        TrackedResource::CairoSteps => syscall_usage_vm_resources.clone_from(&syscall_usage),
-        TrackedResource::SierraGas => syscall_usage_sierra_gas.clone_from(&syscall_usage),
-    }
+    let (syscall_usage_vm_resources, syscall_usage_sierra_gas) =
+        match execution_result.tracked_resource {
+            TrackedResource::CairoSteps => (syscall_usage, SyscallUsageMap::default()),
+            TrackedResource::SierraGas => (SyscallUsageMap::default(), syscall_usage),
+        };
 
     Ok(CallInfoWithExecutionData {
         call_info: execution_result,

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
@@ -7,7 +7,7 @@ use crate::runtime_extensions::deprecated_cheatable_starknet_extension::Deprecat
 use crate::runtime_extensions::deprecated_cheatable_starknet_extension::runtime::{
     DeprecatedExtendedRuntime, DeprecatedStarknetRuntime,
 };
-use blockifier::execution::contract_class::{CompiledClassV0, TrackedResource};
+use blockifier::execution::contract_class::CompiledClassV0;
 use blockifier::execution::deprecated_entry_point_execution::{
     VmExecutionContext, finalize_execution, initialize_execution_context, prepare_call_arguments,
 };
@@ -81,16 +81,10 @@ pub(crate) fn execute_entry_point_call_cairo0(
         n_total_args,
     )?;
 
-    let (syscall_usage_vm_resources, syscall_usage_sierra_gas) =
-        match execution_result.tracked_resource {
-            TrackedResource::CairoSteps => (syscall_usage, SyscallUsageMap::default()),
-            TrackedResource::SierraGas => (SyscallUsageMap::default(), syscall_usage),
-        };
-
     Ok(CallInfoWithExecutionData {
         call_info: execution_result,
-        syscall_usage_vm_resources,
-        syscall_usage_sierra_gas,
+        syscall_usage_vm_resources: syscall_usage,
+        syscall_usage_sierra_gas: SyscallUsageMap::default(),
         vm_trace: None,
     })
     // endregion

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/deprecated/cairo0_execution.rs
@@ -86,7 +86,6 @@ pub(crate) fn execute_entry_point_call_cairo0(
 
     match execution_result.tracked_resource {
         TrackedResource::CairoSteps => syscall_usage_vm_resources.clone_from(&syscall_usage),
-
         TrackedResource::SierraGas => syscall_usage_sierra_gas.clone_from(&syscall_usage),
     }
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -301,7 +301,7 @@ fn call_info_from_pre_execution_error(
     }
 }
 
-/// Recursively collects syscall usage, execution resources, and gas from the nested calls of the given call trace.
+/// Recursively collects execution resources and consumed gas from the nested calls of the given call trace.
 ///
 /// Important note is that it aggregates them from the bottom.
 /// That's because nested calls may use different tracked resources.
@@ -339,7 +339,8 @@ fn collect_resources_and_gas(
         ),
     };
 
-    // We want to add local execution resources and gas only if this is not the very top call.
+    // Here, we add local execution resources and gas consumed by the current call.
+    // We do it only for nested calls (and not for the very top call).
     if !is_top_call {
         accumulated_resources += &local_resources;
         accumulated_gas += local_gas;

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -303,12 +303,12 @@ fn call_info_from_pre_execution_error(
 fn recursively_collect_resources_and_gas(
     trace: &Rc<RefCell<CallTrace>>,
 ) -> (SyscallUsageMap, ExecutionResources, u64) {
-    let trace_ref = trace.borrow();
-    let versioned_constants = VersionedConstants::latest_constants();
-
     let mut aggregated_syscalls = HashMap::new();
     let mut accumulated_resources = ExecutionResources::default();
     let mut accumulated_gas = 0_u64;
+
+    let trace_ref = trace.borrow();
+
     for call in &trace_ref.nested_calls {
         if let CallTraceNode::EntryPointCall(nested_call) = call {
             let (child_syscalls, child_resources, child_gas) =
@@ -321,6 +321,8 @@ fn recursively_collect_resources_and_gas(
 
     let local_syscalls =
         subtract_syscall_usage(trace_ref.used_syscalls.clone(), &aggregated_syscalls);
+
+    let versioned_constants = VersionedConstants::latest_constants();
 
     let (local_resources, local_gas) = match trace_ref.tracked_resource {
         TrackedResource::CairoSteps => (

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -311,7 +311,7 @@ fn collect_resources_and_gas(
 ) -> (ExecutionResources, u64) {
     let mut accumulated_resources = ExecutionResources::default();
     let mut accumulated_gas = 0_u64;
-    let nested_calls_syscalls = get_nested_calls_syscalls(&trace);
+    let nested_calls_syscalls = get_nested_calls_syscalls(trace);
 
     let trace_ref = trace.borrow();
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -2,11 +2,13 @@ use super::cairo1_execution::execute_entry_point_call_cairo1;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::deprecated::cairo0_execution::execute_entry_point_call_cairo0;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{AddressOrClassHash, CallResult};
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::CheatnetState;
-use crate::runtime_extensions::common::{get_relocated_vm_trace, get_syscalls_gas_consumed, sum_syscall_usage};
+use crate::runtime_extensions::common::{get_relocated_vm_trace, get_syscalls_gas_consumed, subtract_syscall_usage, sum_syscall_usage};
+use crate::runtime_extensions::forge_runtime_extension::get_nested_calls_syscalls;
 use crate::state::{CallTrace, CallTraceNode, CheatStatus};
 use blockifier::execution::call_info::{CallExecution, Retdata};
 use blockifier::execution::contract_class::{RunnableCompiledClass, TrackedResource};
 use blockifier::execution::syscalls::hint_processor::{SyscallUsageMap, ENTRYPOINT_NOT_FOUND_ERROR, OUT_OF_GAS_ERROR};
+use blockifier::versioned_constants::VersionedConstants;
 use blockifier::{
     execution::{
         call_info::CallInfo,
@@ -67,12 +69,17 @@ pub fn execute_call_entry_point(
         cheatnet_state.update_cheats(&contract_address);
         cheated_data_
     };
-
+    let tracked_resource = *context
+        .tracked_resource_stack
+        .last()
+        .expect("Unexpected empty tracked resource.");
     // region: Modified blockifier code
     // We skip recursion depth validation here.
-    cheatnet_state
-        .trace_data
-        .enter_nested_call(entry_point.clone(), cheated_data);
+    cheatnet_state.trace_data.enter_nested_call(
+        entry_point.clone(),
+        cheated_data,
+        tracked_resource,
+    );
 
     if let Some(cheat_status) = get_mocked_function_cheat_status(entry_point, cheatnet_state) {
         if let CheatStatus::Cheated(ret_data, _) = (*cheat_status).clone() {
@@ -88,11 +95,9 @@ pub fn execute_call_entry_point(
                 },
                 &[],
                 None,
+                tracked_resource,
             );
-            let tracked_resource = *context
-                .tracked_resource_stack
-                .last()
-                .expect("Unexpected empty tracked resource.");
+
             return Ok(mocked_call_info(
                 entry_point.clone(),
                 ret_data.clone(),
@@ -296,6 +301,61 @@ fn call_info_from_pre_execution_error(
     }
 }
 
+/// Recursively collects execution resources and consumed gas from the nested calls of the given call trace.
+///
+/// Important note is that it aggregates them from the bottom.
+/// That's because nested calls may use different tracked resources.
+fn collect_resources_and_gas(
+    trace: &Rc<RefCell<CallTrace>>,
+    is_top_call: bool,
+) -> (ExecutionResources, u64) {
+    let mut accumulated_resources = ExecutionResources::default();
+    let mut accumulated_gas = 0_u64;
+    let nested_calls_syscalls = get_nested_calls_syscalls(trace);
+
+    let trace_ref = trace.borrow();
+
+    for call in &trace_ref.nested_calls {
+        if let CallTraceNode::EntryPointCall(nested_call) = call {
+            let (nested_calls_resources, nested_calls_gas) =
+                collect_resources_and_gas(nested_call, false);
+            accumulated_resources += &nested_calls_resources;
+            accumulated_gas += nested_calls_gas;
+        }
+    }
+
+    let local_syscalls =
+        subtract_syscall_usage(trace_ref.used_syscalls.clone(), &nested_calls_syscalls);
+
+    let versioned_constants = VersionedConstants::latest_constants();
+    let (local_resources, local_gas) = match trace_ref.tracked_resource {
+        TrackedResource::CairoSteps => (
+            versioned_constants.get_additional_os_syscall_resources(&local_syscalls),
+            0,
+        ),
+        TrackedResource::SierraGas => (
+            ExecutionResources::default(),
+            get_syscalls_gas_consumed(&local_syscalls, versioned_constants),
+        ),
+    };
+
+    // Here, we add local execution resources and gas consumed by the current call.
+    // We do it only for nested calls (and not for the very top call).
+    if !is_top_call {
+        accumulated_resources += &local_resources;
+        accumulated_gas += local_gas;
+    }
+
+    (accumulated_resources, accumulated_gas)
+}
+
+fn calculate_resources_and_gas_from_nested_calls(
+    trace: &Rc<RefCell<CallTrace>>,
+) -> (ExecutionResources, u64) {
+    let (total_resources, total_gas) = collect_resources_and_gas(trace, true);
+    (total_resources, total_gas)
+}
+
 fn remove_syscall_resources_and_exit_non_error_call(
     call_info: &CallInfo,
     syscall_usage: &SyscallUsageMap,
@@ -309,18 +369,28 @@ fn remove_syscall_resources_and_exit_non_error_call(
     let mut resources = call_info.resources.clone();
     let mut gas_consumed = call_info.execution.gas_consumed;
 
-    let nested_syscall_usage_sum =
-        aggregate_nested_syscall_usage(&cheatnet_state.trace_data.current_call_stack.top());
-    let syscall_usage = sum_syscall_usage(nested_syscall_usage_sum, syscall_usage);
-
+    // Remove resources consumed by syscalls from the current call
     match current_tracked_resource {
         TrackedResource::CairoSteps => {
-            resources -= &versioned_constants.get_additional_os_syscall_resources(&syscall_usage);
+            resources -= &versioned_constants.get_additional_os_syscall_resources(syscall_usage);
         }
         TrackedResource::SierraGas => {
-            gas_consumed -= get_syscalls_gas_consumed(&syscall_usage, versioned_constants);
+            gas_consumed -= get_syscalls_gas_consumed(syscall_usage, versioned_constants);
         }
     }
+
+    let nested_syscall_usage_sum =
+        aggregate_nested_syscall_usage(&cheatnet_state.trace_data.current_call_stack.top());
+    let (resources_from_nested_calls, gas_from_nested_calls) =
+        calculate_resources_and_gas_from_nested_calls(
+            &cheatnet_state.trace_data.current_call_stack.top(),
+        );
+
+    // Remove resources consumed by syscalls from nested calls
+    resources -= &resources_from_nested_calls;
+    gas_consumed -= gas_from_nested_calls;
+
+    let syscall_usage = sum_syscall_usage(nested_syscall_usage_sum, syscall_usage);
 
     cheatnet_state.trace_data.exit_nested_call(
         resources,
@@ -329,6 +399,7 @@ fn remove_syscall_resources_and_exit_non_error_call(
         CallResult::from_non_error(call_info),
         &call_info.execution.l2_to_l1_messages,
         vm_trace,
+        current_tracked_resource,
     );
 }
 
@@ -349,6 +420,7 @@ fn exit_error_call(
         CallResult::from_err(error, &identifier),
         &[],
         vm_trace,
+        TrackedResource::default(),
     );
 }
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -67,10 +67,7 @@ pub fn execute_call_entry_point(
         cheatnet_state.update_cheats(&contract_address);
         cheated_data_
     };
-    let tracked_resource = *context
-        .tracked_resource_stack
-        .last()
-        .expect("Unexpected empty tracked resource.");
+
     // region: Modified blockifier code
     // We skip recursion depth validation here.
     cheatnet_state
@@ -93,6 +90,10 @@ pub fn execute_call_entry_point(
                 &[],
                 None,
             );
+            let tracked_resource = *context
+                .tracked_resource_stack
+                .last()
+                .expect("Unexpected empty tracked resource.");
 
             return Ok(mocked_call_info(
                 entry_point.clone(),

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -21,6 +21,7 @@ pub fn sum_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> Syscall
     a
 }
 
+#[must_use]
 pub fn subtract_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> SyscallUsageMap {
     for (key, b_usage) in b {
         a.entry(*key).and_modify(|a_usage| {

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -22,19 +22,6 @@ pub fn sum_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> Syscall
 }
 
 #[must_use]
-pub fn subtract_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> SyscallUsageMap {
-    for (key, b_usage) in b {
-        a.entry(*key).and_modify(|a_usage| {
-            a_usage.call_count -= b_usage.call_count;
-            a_usage.linear_factor -= b_usage.linear_factor;
-        });
-    }
-    a.into_iter()
-        .filter(|(_, usage)| usage.call_count > 0)
-        .collect()
-}
-
-#[must_use]
 pub fn get_syscalls_gas_consumed(
     syscall_usage: &SyscallUsageMap,
     versioned_constants: &VersionedConstants,

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -21,6 +21,18 @@ pub fn sum_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> Syscall
     a
 }
 
+pub fn subtract_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> SyscallUsageMap {
+    for (key, b_usage) in b {
+        a.entry(*key).and_modify(|a_usage| {
+            a_usage.call_count -= b_usage.call_count;
+            a_usage.linear_factor -= b_usage.linear_factor;
+        });
+    }
+    a.into_iter()
+        .filter(|(_, usage)| usage.call_count > 0)
+        .collect()
+}
+
 #[must_use]
 pub fn get_syscalls_gas_consumed(
     syscall_usage: &SyscallUsageMap,

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -21,7 +21,6 @@ pub fn sum_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> Syscall
     a
 }
 
-#[must_use]
 pub fn subtract_syscall_usage(mut a: SyscallUsageMap, b: &SyscallUsageMap) -> SyscallUsageMap {
     for (key, b_usage) in b {
         a.entry(*key).and_modify(|a_usage| {

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -602,7 +602,10 @@ pub fn add_resources_to_top_call(
     }
 }
 
-pub fn update_top_call_resources(runtime: &mut ForgeRuntime) {
+pub fn update_top_call_resources(
+    runtime: &mut ForgeRuntime,
+    top_call_tracked_resource: TrackedResource,
+) {
     // call representing the test code
     let top_call = runtime
         .extended_runtime
@@ -615,12 +618,16 @@ pub fn update_top_call_resources(runtime: &mut ForgeRuntime) {
 
     let all_execution_resources = add_execution_resources(top_call.clone());
     let all_sierra_gas_consumed = add_sierra_gas_resources(&top_call);
-    let nested_calls_syscalls = get_nested_calls_syscalls(&top_call);
+
+    // Below syscall usages are cumulative, meaning they include syscalls from their inner calls.
+    let nested_calls_syscalls_vm_resources = get_nested_calls_syscalls_vm_resources(&top_call);
+    let nested_calls_syscalls_sierra_gas = get_nested_calls_syscalls_sierra_gas(&top_call);
 
     let mut top_call = top_call.borrow_mut();
     top_call.used_execution_resources = all_execution_resources;
     top_call.gas_consumed = all_sierra_gas_consumed;
 
+    // Syscall usage here is flat, meaning it only includes syscalls from current call (in this case the top-level call)
     let top_call_syscalls = runtime
         .extended_runtime
         .extended_runtime
@@ -629,10 +636,27 @@ pub fn update_top_call_resources(runtime: &mut ForgeRuntime) {
         .syscalls_usage
         .clone();
 
-    top_call.used_syscalls = sum_syscall_usage(top_call_syscalls, &nested_calls_syscalls);
+    let mut total_syscalls_vm_resources = nested_calls_syscalls_vm_resources.clone();
+    let mut total_syscalls_sierra_gas = nested_calls_syscalls_sierra_gas.clone();
+
+    // Based on the tracked resource of top call, we add the syscall usage to respective totals.
+    match top_call_tracked_resource {
+        TrackedResource::CairoSteps => {
+            total_syscalls_vm_resources =
+                sum_syscall_usage(total_syscalls_vm_resources, &top_call_syscalls);
+        }
+        TrackedResource::SierraGas => {
+            total_syscalls_sierra_gas =
+                sum_syscall_usage(total_syscalls_sierra_gas, &top_call_syscalls);
+        }
+    }
+
+    top_call.used_syscalls_vm_resources = total_syscalls_vm_resources;
+    top_call.used_syscalls_sierra_gas = total_syscalls_sierra_gas;
 }
 
-pub fn get_nested_calls_syscalls(trace: &Rc<RefCell<CallTrace>>) -> SyscallUsageMap {
+/// Calculates the total syscall usage from nested calls where the tracked resource is Cairo steps.
+pub fn get_nested_calls_syscalls_vm_resources(trace: &Rc<RefCell<CallTrace>>) -> SyscallUsageMap {
     // Only sum 1-level since these include syscalls from inner calls
     trace
         .borrow()
@@ -640,7 +664,20 @@ pub fn get_nested_calls_syscalls(trace: &Rc<RefCell<CallTrace>>) -> SyscallUsage
         .iter()
         .filter_map(CallTraceNode::extract_entry_point_call)
         .fold(SyscallUsageMap::new(), |syscalls, trace| {
-            sum_syscall_usage(syscalls, &trace.borrow().used_syscalls)
+            sum_syscall_usage(syscalls, &trace.borrow().used_syscalls_vm_resources)
+        })
+}
+
+/// Calculates the total syscall usage from nested calls where the tracked resource is Sierra gas.
+pub fn get_nested_calls_syscalls_sierra_gas(trace: &Rc<RefCell<CallTrace>>) -> SyscallUsageMap {
+    // Only sum 1-level since these include syscalls from inner calls
+    trace
+        .borrow()
+        .nested_calls
+        .iter()
+        .filter_map(CallTraceNode::extract_entry_point_call)
+        .fold(SyscallUsageMap::new(), |syscalls, trace| {
+            sum_syscall_usage(syscalls, &trace.borrow().used_syscalls_sierra_gas)
         })
 }
 
@@ -773,7 +810,7 @@ pub fn get_all_used_resources(
 
     let mut execution_resources = top_call.borrow().used_execution_resources.clone();
     let mut sierra_gas_consumed = top_call.borrow().gas_consumed;
-    let top_call_syscalls = top_call.borrow().used_syscalls.clone();
+    let top_call_syscalls = top_call.borrow().get_total_used_syscalls();
 
     match tracked_resource {
         TrackedResource::CairoSteps => {

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -812,19 +812,15 @@ pub fn get_all_used_resources(
     let mut sierra_gas_consumed = top_call.borrow().gas_consumed;
     let top_call_syscalls = top_call.borrow().get_total_used_syscalls();
 
-    match tracked_resource {
-        TrackedResource::CairoSteps => {
-            execution_resources = add_syscall_execution_resources(
-                versioned_constants,
-                &execution_resources,
-                &top_call_syscalls,
-            );
-        }
-        TrackedResource::SierraGas => {
-            sierra_gas_consumed +=
-                get_syscalls_gas_consumed(&top_call_syscalls, versioned_constants);
-        }
-    }
+    execution_resources = add_syscall_execution_resources(
+        versioned_constants,
+        &execution_resources,
+        &top_call.borrow().used_syscalls_vm_resources,
+    );
+    sierra_gas_consumed += get_syscalls_gas_consumed(
+        &top_call.borrow().used_syscalls_sierra_gas,
+        versioned_constants,
+    );
 
     let events = runtime_call_info
         .iter() // This method iterates over inner calls as well

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -615,6 +615,7 @@ pub fn update_top_call_resources(runtime: &mut ForgeRuntime) {
 
     let all_execution_resources = add_execution_resources(top_call.clone());
     let all_sierra_gas_consumed = add_sierra_gas_resources(&top_call);
+    let nested_calls_syscalls = get_nested_calls_syscalls(&top_call);
 
     let mut top_call = top_call.borrow_mut();
     top_call.used_execution_resources = all_execution_resources;
@@ -628,16 +629,19 @@ pub fn update_top_call_resources(runtime: &mut ForgeRuntime) {
         .syscalls_usage
         .clone();
 
+    top_call.used_syscalls = sum_syscall_usage(top_call_syscalls, &nested_calls_syscalls);
+}
+
+pub fn get_nested_calls_syscalls(trace: &Rc<RefCell<CallTrace>>) -> SyscallUsageMap {
     // Only sum 1-level since these include syscalls from inner calls
-    let nested_calls_syscalls = top_call
+    trace
+        .borrow()
         .nested_calls
         .iter()
         .filter_map(CallTraceNode::extract_entry_point_call)
         .fold(SyscallUsageMap::new(), |syscalls, trace| {
             sum_syscall_usage(syscalls, &trace.borrow().used_syscalls)
-        });
-
-    top_call.used_syscalls = sum_syscall_usage(top_call_syscalls, &nested_calls_syscalls);
+        })
 }
 
 // Only top-level is considered relevant since we can't have l1 handlers deeper than 1 level of nesting

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -10,7 +10,7 @@ use crate::runtime_extensions::forge_runtime_extension::cheatcodes::cheat_execut
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spy_events::Event;
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::spy_messages_to_l1::MessageToL1;
 use blockifier::execution::call_info::OrderedL2ToL1Message;
-use blockifier::execution::contract_class::{RunnableCompiledClass, TrackedResource};
+use blockifier::execution::contract_class::RunnableCompiledClass;
 use blockifier::execution::entry_point::CallEntryPoint;
 use blockifier::execution::syscalls::hint_processor::SyscallUsageMap;
 use blockifier::state::errors::StateError::UndeclaredClassHash;
@@ -212,7 +212,6 @@ pub struct CallTrace {
     pub used_syscalls: SyscallUsageMap,
     pub vm_trace: Option<Vec<RelocatedTraceEntry>>,
     pub gas_consumed: u64,
-    pub tracked_resource: TrackedResource,
 }
 
 impl CairoSerialize for CallTrace {
@@ -242,7 +241,6 @@ impl CallTrace {
             result: CallResult::Success { ret_data: vec![] },
             vm_trace: None,
             gas_consumed: u64::default(),
-            tracked_resource: TrackedResource::default(),
         }
     }
 }
@@ -517,15 +515,9 @@ impl CheatnetState {
 }
 
 impl TraceData {
-    pub fn enter_nested_call(
-        &mut self,
-        entry_point: CallEntryPoint,
-        cheated_data: CheatedData,
-        tracked_resource: TrackedResource,
-    ) {
+    pub fn enter_nested_call(&mut self, entry_point: CallEntryPoint, cheated_data: CheatedData) {
         let new_call = Rc::new(RefCell::new(CallTrace {
             entry_point,
-            tracked_resource,
             ..CallTrace::default_successful_call()
         }));
         let current_call = self.current_call_stack.top();
@@ -543,7 +535,6 @@ impl TraceData {
         current_call.borrow_mut().entry_point.class_hash = Some(class_hash);
     }
 
-    #[expect(clippy::too_many_arguments)]
     pub fn exit_nested_call(
         &mut self,
         execution_resources: ExecutionResources,
@@ -552,7 +543,6 @@ impl TraceData {
         result: CallResult,
         l2_to_l1_messages: &[OrderedL2ToL1Message],
         vm_trace: Option<Vec<RelocatedTraceEntry>>,
-        tracked_resource: TrackedResource,
     ) {
         let CallStackElement {
             call_trace: last_call,
@@ -562,7 +552,7 @@ impl TraceData {
         let mut last_call = last_call.borrow_mut();
         last_call.used_execution_resources = execution_resources;
         last_call.gas_consumed = gas_consumed;
-        last_call.tracked_resource = tracked_resource;
+
         last_call.used_syscalls = used_syscalls;
 
         last_call.used_l1_resources.l2_l1_message_sizes = l2_to_l1_messages

--- a/crates/forge-runner/src/build_trace_data.rs
+++ b/crates/forge-runner/src/build_trace_data.rs
@@ -56,7 +56,7 @@ pub fn build_profiler_call_trace(
         entry_point,
         cumulative_resources: build_profiler_execution_resources(
             value.used_execution_resources.clone(),
-            value.used_syscalls.clone(),
+            value.get_total_used_syscalls(),
             value.gas_consumed,
         ),
         used_l1_resources: value.used_l1_resources.clone(),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -337,7 +337,7 @@ pub fn run_test_case(
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
-    update_top_call_resources(&mut forge_runtime);
+    update_top_call_resources(&mut forge_runtime, tracked_resource);
     update_top_call_l1_resources(&mut forge_runtime);
 
     let fuzzer_args = forge_runtime

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1064,18 +1064,18 @@ fn nested_call_cost_cairo_steps() {
 
     assert_passed(&result);
     // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, the number of bitwise and some other builtins should be ~2 lower.
-    // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
+    // int(1121 * 0.16) = 180 = gas cost of bitwise builtins
     // 96 * 3 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
     // ~1 gas for 1 event data
-    // 0 l1_gas + (96 * 3) l1_data_gas + 359 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
+    // 0 l1_gas + (96 * 3) l1_data_gas + 180 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
     assert_gas(
         &result,
         "test_call_other_contract",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(288),
-            l2_gas: GasAmount(14_375_360),
+            l2_gas: GasAmount(7_215_360),
         },
     );
 }
@@ -1138,18 +1138,18 @@ fn nested_call_cost_in_forked_contract_cairo_steps() {
 
     assert_passed(&result);
     // TODO(#3473): Once the bug with duplicated builtins from syscalls in nested calls is fixed, the number of bitwise and some other builtins should be ~2 lower.
-    // int(2242 * 0.16) = 359 = gas cost of bitwise builtins
+    // int(1121 * 0.16) = 180 = gas cost of bitwise builtins
     // 96 * 2 = gas cost of onchain data (deploy cost)
     // ~1 gas for 1 event key
     // ~1 gas for 1 event data
-    // 0 l1_gas + (96 * 2) l1_data_gas + 359 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
+    // 0 l1_gas + (96 * 2) l1_data_gas + 180 * (100 / 0.0025) + 1 * 10240 + 1 * 5120 l2 gas
     assert_gas(
         &result,
         "test_call_other_contract_fork",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(14_375_360),
+            l2_gas: GasAmount(7_215_360),
         },
     );
 }
@@ -1789,15 +1789,15 @@ fn nested_call_cost_sierra_gas() {
     // 10000 = cost of 1 emit event syscall (see `events_cost_sierra_gas` test)
     // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
     // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
-    // 1597317 = reported consumed sierra gas
-    // 0 l1_gas + 288 l1_data_gas + (512000 + 256000 + 10000 + 3 * 142810 + 2 * 87650 + 1597317) l2 gas
+    // 638032 = reported consumed sierra gas
+    // 0 l1_gas + 288 l1_data_gas + (512000 + 256000 + 10000 + 3 * 142810 + 2 * 87650 + 638032) l2 gas
     assert_gas(
         &result,
         "test_call_other_contract",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(288),
-            l2_gas: GasAmount(2_979_047),
+            l2_gas: GasAmount(2_019_762),
         },
     );
 }
@@ -1866,15 +1866,15 @@ fn nested_call_cost_in_forked_contract_sierra_gas() {
     // 10000 = cost of 1 emit event syscall (see `events_cost_sierra_gas` test)
     // 142810 = cost of 1 deploy syscall (see `deploy_syscall_cost_sierra_gas` test)
     // 87650 = cost of 1 call contract syscall (see `contract_keccak_cost_sierra_gas` test)
-    // 1558897 = reported consumed sierra gas
-    // 0 l1_gas + 192 l1_data_gas + (512000 + 256000 + 10000 + 2 * 142810 + 2 * 87650 + 1558897) l2 gas
+    // 599612 = reported consumed sierra gas
+    // 0 l1_gas + 192 l1_data_gas + (512000 + 256000 + 10000 + 2 * 142810 + 2 * 87650 + 599612) l2 gas
     assert_gas(
         &result,
         "test_call_other_contract_fork",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(2_797_817),
+            l2_gas: GasAmount(1_838_532),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1620,15 +1620,15 @@ fn l1_message_cost_for_proxy_sierra_gas() {
     //      -> 1 pedersen costs 4050, 1 range check costs 70
     // 175300 = cost of 2 call contract syscalls (see `multiple_storage_writes_cost_sierra_gas` test)
     // 14170 = cost of 1 SendMessageToL1 syscall (see `l1_message_cost_sierra_gas` test)
-    // 110320 = reported consumed sierra gas
-    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 110320) l2 gas
+    // 90150 = reported consumed sierra gas
+    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 90150) l2 gas
     assert_gas(
         &result,
         "l1_message_cost_for_proxy",
         GasVector {
             l1_gas: GasAmount(29524),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(585_410),
+            l2_gas: GasAmount(565_240),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1620,15 +1620,15 @@ fn l1_message_cost_for_proxy_sierra_gas() {
     //      -> 1 pedersen costs 4050, 1 range check costs 70
     // 175300 = cost of 2 call contract syscalls (see `multiple_storage_writes_cost_sierra_gas` test)
     // 14170 = cost of 1 SendMessageToL1 syscall (see `l1_message_cost_sierra_gas` test)
-    // 90150 = reported consumed sierra gas
-    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 90150) l2 gas
+    // 96150 = reported consumed sierra gas
+    // 29524 l1_gas + (128 + 64) l1_data_gas + (285620 + 175300 + 14170 + 96150) l2 gas
     assert_gas(
         &result,
         "l1_message_cost_for_proxy",
         GasVector {
             l1_gas: GasAmount(29524),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(565_240),
+            l2_gas: GasAmount(571_240),
         },
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3473 

## Introduced changes

Fix bug calculation of resources from nested calls syscalls. The reason of malformed calculations was that during subtracting syscalls' resources in `remove_syscall_resources_and_exit_non_error_call`, they were only from current call and didn't include the ones from nested calls.


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
