### PR TITLE
Fix `account create` with default name when accounts file is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast utils serialize` command to serialize Cairo expressions into calldata
 - `sncast verify` now supports verifying against [voyager](https://voyager.online/) block explorer.
 
-
 #### Changed
 
 - Improved commands output readability with colors and simplified layout.
 - `sncast verify` no longer defaults to using walnut.
+
+#### Fixed
+
+- Bug where `account create` raised an error if no `--name` was provided and the file specified by `--accounts-file` was empty
 
 #### Removed
 

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -441,9 +441,17 @@ pub fn get_account_data_from_accounts_file(
         .ok_or_else(|| anyhow!("Account = {name} not found under network = {network_name}"))
 }
 
-pub fn read_and_parse_json_file<T: DeserializeOwned>(path: &Utf8PathBuf) -> Result<T> {
+pub fn read_and_parse_json_file<T>(path: &Utf8PathBuf) -> Result<T>
+where
+    T: DeserializeOwned + Default,
+{
     let file_content =
         fs::read_to_string(path).with_context(|| format!("Failed to read a file = {path}"))?;
+
+    if file_content.trim().is_empty() {
+        return Ok(T::default());
+    }
+
     let deserializer = &mut Deserializer::from_str(&file_content);
     serde_path_to_error::deserialize(deserializer).map_err(|err| {
         let path_to_field = err.path().to_string();

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -836,6 +836,31 @@ pub async fn test_happy_case_deployment_fee_message() {
 }
 
 #[tokio::test]
+pub async fn test_happy_case_default_name_generation_when_accounts_file_empty() {
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "test_accounts.json";
+    let accounts_path = temp_dir.path().join(accounts_file);
+    std::fs::File::create(&accounts_path).expect("Failed to create empty accounts file");
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--url",
+        URL,
+        "--class-hash",
+        DEVNET_OZ_CLASS_HASH_CAIRO_0,
+        "--type",
+        "oz",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+
+    snapbox.assert().success();
+}
+
+#[tokio::test]
 pub async fn test_happy_case_accounts_file_empty() {
     let temp_dir = tempdir().expect("Unable to create a temporary directory");
     let accounts_file = "test_accounts.json";


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Fix bug where `account create` raised an error if no `--name` was provided and the file specified by `--accounts-file` was empty. Related with #3379 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
