### PR TITLE
Adds serde rename for contract name

### DIFF
--- a/crates/sncast/src/starknet_commands/verify/voyager.rs
+++ b/crates/sncast/src/starknet_commands/verify/voyager.rs
@@ -37,6 +37,7 @@ pub struct Body {
     pub compiler_version: semver::Version,
     pub scarb_version: semver::Version,
     pub project_dir_path: Utf8PathBuf,
+    #[serde(rename = "name")]
     pub contract_name: String,
     pub package_name: String,
     pub license: Option<String>,


### PR DESCRIPTION
Adds `serde(rename = "name")` to the `contract_name` field in the `Body` struct. This is necessary for the Voyager API to correctly deserialize the field after a recent update.
