### PR TITLE
Remove fixed toolchain in build workflows

### DIFF
--- a/.github/workflows/_build-binaries.yml
+++ b/.github/workflows/_build-binaries.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup rust
         run: |
-          rustup target add ${{ matrix.target }} --toolchain 1.86.0
+          rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:

--- a/.github/workflows/_build-plugin-binaries.yml
+++ b/.github/workflows/_build-plugin-binaries.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Setup rust
         run: |
-          rustup target add ${{ matrix.target }} --toolchain 1.86.0
+          rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 

--- a/.github/workflows/_test-binaries.yml
+++ b/.github/workflows/_test-binaries.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Setup rust
         run: |
-          rustup target add ${{ matrix.target }} --toolchain 1.86.0
+          rustup target add ${{ matrix.target }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Follow up to #3518 

Currently build workflows fail because they don't have targets for the default toolchain installed. Example run: https://github.com/foundry-rs/starknet-foundry/actions/runs/16157074684/job/45601646514