### PR TITLE
Fix `incompatible_snforge_std_version_warning` test

### DIFF
--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -926,7 +926,6 @@ fn incompatible_snforge_std_version_warning() {
         .parse::<DocumentMut>()
         .unwrap();
     scarb_toml["dev-dependencies"]["snforge_std"] = value("0.45.0");
-    scarb_toml["dev-dependencies"]["snforge_scarb_plugin"] = value("0.45.0");
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
 
     let output = test_runner(&temp).assert().failure();


### PR DESCRIPTION
Failed run: https://github.com/foundry-rs/starknet-foundry/actions/runs/16243351331

- It fails because starting with Scarb `2.11.0` there was introduced a mechanism that allows a Cairo package to re-export a procedural macro from its dependencies