### PR TITLE
Hide block explorer links when using `Devnet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- Block explorer links are now hidden by default when using `Devnet`. Set `FORCE_SHOW_EXPLORER_LINKS=1` env variable to display them.
+- Block explorer links are now hidden by default when using [`starknet-devnet`](https://github.com/0xSpaceShard/starknet-devnet). Set `SNCAST_FORCE_SHOW_EXPLORER_LINKS=1` env variable to display them.
 
 ## [0.47.0] - 2025-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Max steps in tests (configured via the `--max-n-steps` argument) now defaults to `usize::MAX` when not specified (previously 10 million).
 
+### Cast
+
+#### Fixed
+
+- Block explorer links are now hidden by default when using `Devnet`. Set `FORCE_SHOW_EXPLORER_LINKS=1` env variable to display them.
+
 ## [0.47.0] - 2025-07-28
 
 ### Forge

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -6,6 +6,7 @@ use foundry_ui::UI;
 use shared::consts::RPC_URL_VERSION;
 use shared::verify_and_warn_if_incompatible_rpc_version;
 use starknet::providers::{JsonRpcClient, jsonrpc::HttpTransport};
+use url::Url;
 
 #[derive(Args, Clone, Debug, Default)]
 #[group(required = false, multiple = false)]
@@ -31,20 +32,9 @@ impl RpcArgs {
             )
         }
 
-        let url = if let Some(network) = self.network {
-            let free_provider = FreeProvider::semi_random();
-            network.url(&free_provider)
-        } else {
-            let url = self.url.clone().or_else(|| {
-                if config.url.is_empty() {
-                    None
-                } else {
-                    Some(config.url.clone())
-                }
-            });
-
-            url.context("Either `--network` or `--url` must be provided")?
-        };
+        let url = self
+            .get_url(&config.url)
+            .context("Either `--network` or `--url` must be provided")?;
 
         assert!(!url.is_empty(), "url cannot be empty");
         let provider = get_provider(&url)?;
@@ -55,8 +45,27 @@ impl RpcArgs {
     }
 
     #[must_use]
-    pub fn get_url(&self, config: &CastConfig) -> String {
-        self.url.clone().unwrap_or_else(|| config.url.clone())
+    fn get_url(&self, config_url: &String) -> Option<String> {
+        if let Some(network) = self.network {
+            let free_provider = FreeProvider::semi_random();
+            Some(network.url(&free_provider))
+        } else {
+            self.url.clone().or_else(|| {
+                if config_url.is_empty() {
+                    None
+                } else {
+                    Some(config_url.to_string())
+                }
+            })
+        }
+    }
+
+    #[must_use]
+    pub fn is_localhost(&self, config_url: &String) -> bool {
+        self.get_url(config_url)
+            .and_then(|url_str| Url::parse(&url_str).ok())
+            .and_then(|url| url.host_str().map(str::to_string))
+            .is_some_and(|host| host == "localhost" || host == "127.0.0.1" || host == "::1")
     }
 }
 

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -248,11 +248,11 @@ pub async fn get_account<'a>(
     account: &str,
     accounts_file: &Utf8PathBuf,
     provider: &'a JsonRpcClient<HttpTransport>,
-    keystore: Option<Utf8PathBuf>,
+    keystore: Option<&Utf8PathBuf>,
 ) -> Result<SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>> {
     let chain_id = get_chain_id(provider).await?;
     let account_data = if let Some(keystore) = keystore {
-        get_account_data_from_keystore(account, &keystore)?
+        get_account_data_from_keystore(account, keystore)?
     } else {
         get_account_data_from_accounts_file(account, chain_id, accounts_file)?
     };

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -235,11 +235,13 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
         Commands::Declare(declare) => {
             let provider = declare.rpc.get_provider(&config, ui).await?;
 
+            let rpc = declare.rpc.clone();
+
             let account = get_account(
                 &config.account,
                 &config.accounts_file,
                 &provider,
-                config.keystore,
+                config.keystore.as_ref(),
             )
             .await?;
             let manifest_path = assert_manifest_path_exists()?;
@@ -255,6 +257,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 ui,
             )
             .expect("Failed to build contract");
+
             let result = starknet_commands::declare::declare(
                 declare,
                 &account,
@@ -274,13 +277,8 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 }
             });
 
-            let block_explorer_link = block_explorer_link_if_allowed(
-                &result,
-                provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
-            );
-
+            let block_explorer_link =
+                block_explorer_link_if_allowed(&result, provider.chain_id().await?, &rpc, &config);
             process_command_result("declare", result, ui, block_explorer_link);
 
             Ok(())
@@ -300,7 +298,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 &config.account,
                 &config.accounts_file,
                 &provider,
-                config.keystore,
+                config.keystore.as_ref(),
             )
             .await?;
 
@@ -326,12 +324,8 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             .await
             .map_err(handle_starknet_command_error);
 
-            let block_explorer_link = block_explorer_link_if_allowed(
-                &result,
-                provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
-            );
+            let block_explorer_link =
+                block_explorer_link_if_allowed(&result, provider.chain_id().await?, &rpc, &config);
             process_command_result("deploy", result, ui, block_explorer_link);
 
             Ok(())
@@ -393,7 +387,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 &config.account,
                 &config.accounts_file,
                 &provider,
-                config.keystore,
+                config.keystore.as_ref(),
             )
             .await?;
 
@@ -418,12 +412,8 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             .await
             .map_err(handle_starknet_command_error);
 
-            let block_explorer_link = block_explorer_link_if_allowed(
-                &result,
-                provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
-            );
+            let block_explorer_link =
+                block_explorer_link_if_allowed(&result, provider.chain_id().await?, &rpc, &config);
 
             process_command_result("invoke", result, ui, block_explorer_link);
 

--- a/crates/sncast/src/response/explorer_link.rs
+++ b/crates/sncast/src/response/explorer_link.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use starknet_types_core::felt::Felt;
 
-const FORCE_SHOW_EXPLORER_LINKS_ENV: &str = "FORCE_SHOW_EXPLORER_LINKS";
+const SNCAST_FORCE_SHOW_EXPLORER_LINKS_ENV: &str = "SNCAST_FORCE_SHOW_EXPLORER_LINKS";
 
 // TODO(#3391): This code should be refactored to either use common `Message` trait or be directly
 // included in `sncast` output messages.
@@ -81,7 +81,7 @@ where
 
 #[must_use]
 pub fn is_explorer_link_overridden() -> bool {
-    std::env::var(FORCE_SHOW_EXPLORER_LINKS_ENV)
+    std::env::var(SNCAST_FORCE_SHOW_EXPLORER_LINKS_ENV)
         .map(|value| value == "1")
         .unwrap_or(false)
 }

--- a/crates/sncast/src/response/explorer_link.rs
+++ b/crates/sncast/src/response/explorer_link.rs
@@ -1,8 +1,10 @@
-use crate::helpers::block_explorer::{LinkProvider, Service};
+use crate::helpers::{block_explorer::LinkProvider, configuration::CastConfig, rpc::RpcArgs};
 use foundry_ui::Message;
 use serde::Serialize;
 use serde_json::{Value, json};
 use starknet_types_core::felt::Felt;
+
+const FORCE_SHOW_EXPLORER_LINKS_ENV: &str = "FORCE_SHOW_EXPLORER_LINKS";
 
 // TODO(#3391): This code should be refactored to either use common `Message` trait or be directly
 // included in `sncast` output messages.
@@ -51,26 +53,35 @@ pub enum ExplorerError {
 pub fn block_explorer_link_if_allowed<T>(
     result: &anyhow::Result<T>,
     chain_id: Felt,
-    show_links: bool,
-    explorer: Option<Service>,
+    rpc: &RpcArgs,
+    config: &CastConfig,
 ) -> Option<ExplorerLinksMessage>
 where
     T: OutputLink + Clone,
 {
-    if !show_links {
+    if (!config.show_explorer_links || rpc.is_localhost(&config.url))
+        && !is_explorer_link_overridden()
+    {
         return None;
     }
 
     let Ok(response) = result else {
         return None;
     };
-    let Ok(network) = chain_id.try_into() else {
-        return None;
-    };
 
-    if let Ok(provider) = explorer.unwrap_or_default().as_provider(network) {
-        return Some(ExplorerLinksMessage::new(response, provider));
-    }
+    let network = chain_id.try_into().ok()?;
 
-    None
+    config
+        .block_explorer
+        .unwrap_or_default()
+        .as_provider(network)
+        .ok()
+        .map(|provider| ExplorerLinksMessage::new(response, provider))
+}
+
+#[must_use]
+pub fn is_explorer_link_overridden() -> bool {
+    std::env::var(FORCE_SHOW_EXPLORER_LINKS_ENV)
+        .map(|value| value == "1")
+        .unwrap_or(false)
 }

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -61,7 +61,7 @@ pub struct Create {
 pub async fn create(
     account: &str,
     accounts_file: &Utf8PathBuf,
-    keystore: Option<Utf8PathBuf>,
+    keystore: Option<&Utf8PathBuf>,
     provider: &JsonRpcClient<HttpTransport>,
     chain_id: Felt,
     create: &Create,
@@ -97,7 +97,7 @@ pub async fn create(
         style(estimated_fee_strk).magenta()
     );
 
-    if let Some(keystore) = keystore.clone() {
+    if let Some(keystore) = keystore {
         let account_path = Utf8PathBuf::from(&account);
         if account_path == Utf8PathBuf::default() {
             bail!("Argument `--account` must be passed and be a path when using `--keystore`");
@@ -116,14 +116,14 @@ pub async fn create(
             salt,
             class_hash,
             create.account_type,
-            &keystore,
+            keystore,
             &account_path,
             legacy,
         )?;
 
         let deploy_command = generate_deploy_command_with_keystore(
             account,
-            &keystore,
+            keystore,
             create.rpc.url.as_deref(),
             create.rpc.network.as_ref(),
         );
@@ -145,7 +145,7 @@ pub async fn create(
         &create.rpc,
         account,
         accounts_file,
-        keystore.clone(),
+        keystore.cloned(),
     )?;
 
     Ok(AccountCreateResponse {

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -48,7 +48,7 @@ pub struct Deploy {
 #[expect(clippy::too_many_arguments)]
 pub async fn deploy(
     provider: &JsonRpcClient<HttpTransport>,
-    accounts_file: Utf8PathBuf,
+    accounts_file: &Utf8PathBuf,
     deploy_args: &Deploy,
     chain_id: Felt,
     wait_config: WaitForTx,
@@ -74,7 +74,7 @@ pub async fn deploy(
             .name
             .clone()
             .ok_or_else(|| anyhow!("Required argument `--name` not provided"))?;
-        check_account_file_exists(&accounts_file)?;
+        check_account_file_exists(accounts_file)?;
         deploy_from_accounts_file(
             provider,
             accounts_file,
@@ -160,14 +160,14 @@ async fn deploy_from_keystore(
 
 async fn deploy_from_accounts_file(
     provider: &JsonRpcClient<HttpTransport>,
-    accounts_file: Utf8PathBuf,
+    accounts_file: &Utf8PathBuf,
     name: String,
     chain_id: Felt,
     fee_args: FeeArgs,
     wait_config: WaitForTx,
     ui: &UI,
 ) -> Result<InvokeResponse> {
-    let account_data = get_account_data_from_accounts_file(&name, chain_id, &accounts_file)?;
+    let account_data = get_account_data_from_accounts_file(&name, chain_id, accounts_file)?;
 
     let private_key = SigningKey::from_secret_scalar(account_data.private_key);
 
@@ -348,13 +348,13 @@ where
 }
 
 fn update_account_in_accounts_file(
-    accounts_file: Utf8PathBuf,
+    accounts_file: &Utf8PathBuf,
     account_name: &str,
     chain_id: Felt,
 ) -> Result<()> {
     let network_name = chain_id_to_network_name(chain_id);
 
-    let mut items = load_accounts(&accounts_file)?;
+    let mut items = load_accounts(accounts_file)?;
     items[&network_name][account_name]["deployed"] = serde_json::Value::from(true);
     std::fs::write(accounts_file, serde_json::to_string_pretty(&items).unwrap())
         .context("Failed to write to accounts file")?;

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -250,7 +250,7 @@ pub async fn account(
             let result = starknet_commands::account::create::create(
                 &account,
                 &config.accounts_file,
-                config.keystore,
+                config.keystore.as_ref(),
                 &provider,
                 chain_id,
                 &create,
@@ -261,8 +261,8 @@ pub async fn account(
             let block_explorer_link = block_explorer_link_if_allowed(
                 &result,
                 provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
+                &create.rpc,
+                &config,
             );
 
             process_command_result("account create", result, ui, block_explorer_link);
@@ -278,7 +278,7 @@ pub async fn account(
             let keystore_path = config.keystore.clone();
             let result = starknet_commands::account::deploy::deploy(
                 &provider,
-                config.accounts_file,
+                &config.accounts_file,
                 &deploy,
                 chain_id,
                 wait_config,
@@ -308,8 +308,8 @@ pub async fn account(
             let block_explorer_link = block_explorer_link_if_allowed(
                 &result,
                 provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
+                &deploy.rpc,
+                &config,
             );
             process_command_result("account deploy", result, ui, block_explorer_link);
             Ok(())

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -55,7 +55,7 @@ pub async fn multicall(
                 &config.account,
                 &config.accounts_file,
                 &provider,
-                config.keystore,
+                config.keystore.as_ref(),
             )
             .await?;
             let result =
@@ -65,8 +65,8 @@ pub async fn multicall(
             let block_explorer_link = block_explorer_link_if_allowed(
                 &result,
                 provider.chain_id().await?,
-                config.show_explorer_links,
-                config.block_explorer,
+                &run.rpc,
+                &config,
             );
             process_command_result("multicall run", result, ui, block_explorer_link);
             Ok(())

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -368,7 +368,7 @@ pub fn run(
             &config.account,
             &config.accounts_file,
             provider,
-            config.keystore.clone(),
+            config.keystore.as_ref(),
         ))?)
     };
     let state = StateManager::from(state_file_path)?;

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -87,7 +87,9 @@ fn test_docs_snippets() {
             }
         }
 
-        let snapbox = runner(&args).current_dir(tempdir.path());
+        let snapbox = runner(&args)
+            .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+            .current_dir(tempdir.path());
         let output = snapbox.assert().success();
 
         if snippet.output.is_some() && !snippet.config.ignored_output {

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -88,7 +88,7 @@ fn test_docs_snippets() {
         }
 
         let snapbox = runner(&args)
-            .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+            .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
             .current_dir(tempdir.path());
         let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -9,7 +9,7 @@ use camino::Utf8PathBuf;
 use conversions::string::IntoHexStr;
 use serde_json::{json, to_string_pretty};
 use shared::test_utils::output_assert::{
-    assert_stderr_contains, assert_stdout, assert_stdout_contains,
+    AsOutput, assert_stderr_contains, assert_stdout, assert_stdout_contains,
 };
 use snapbox::assert_matches;
 use sncast::AccountType;
@@ -43,7 +43,9 @@ pub async fn test_happy_case(account_type: &str) {
         account_type,
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
     let output = snapbox.assert().success();
 
     assert_stdout_contains(
@@ -107,7 +109,9 @@ pub async fn test_happy_case_argent_with_deprecation_warning() {
         "argent",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
     let output = snapbox.assert().success();
 
     assert_stdout(
@@ -206,7 +210,9 @@ pub async fn test_happy_case_generate_salt() {
         "oz",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
         Success: Account created
@@ -292,7 +298,9 @@ pub async fn test_happy_case_accounts_file_already_exists() {
         "0x1",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
         Success: Account created
@@ -424,7 +432,9 @@ pub async fn test_happy_case_keystore(account_type: &str) {
         account_type,
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
         Success: Account created
@@ -472,7 +482,9 @@ pub async fn test_happy_case_keystore_argent_with_deprecation_warning() {
         "argent",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
         [WARNING] Argent has rebranded as Ready. The `argent` option for the `--type` flag in `account create` is deprecated, please use `ready` instead.
@@ -676,7 +688,9 @@ pub async fn test_happy_case_keystore_int_format() {
         "oz",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
         Success: Account created
@@ -727,32 +741,45 @@ pub async fn test_happy_case_default_name_generation() {
         "sepolia",
     ];
 
+    let assert_account_created = |id: usize| {
+        runner(&create_args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path())
+        .assert()
+        .stdout_matches(formatdoc! {r"
+            Success: Account created
+
+            Address: 0x0[..]
+            
+            Account successfully created but it needs to be deployed. The estimated deployment fee is [..] STRK. Prefund the account to cover deployment transaction fee
+
+            After prefunding the account, run:
+            sncast --accounts-file accounts.json account deploy --url http://127.0.0.1:5055/rpc --name account-{id}
+
+            To see account creation details, visit:
+            account: [..]
+        ", id = id});
+    };
+
     for i in 0..3 {
-        let snapbox = runner(&create_args).current_dir(tempdir.path());
-        snapbox.assert().stdout_matches(formatdoc! {r"
-        Success: Account created
-
-        Address: 0x0[..]
-        
-        Account successfully created but it needs to be deployed. The estimated deployment fee is [..] STRK. Prefund the account to cover deployment transaction fee
-
-        After prefunding the account, run:
-        sncast --accounts-file accounts.json account deploy --url http://127.0.0.1:5055/rpc --name account-{id}
-
-        To see account creation details, visit:
-        account: [..]
-    ", id = i + 1});
+        assert_account_created(i + 1);
     }
 
     let contents = fs::read_to_string(tempdir.path().join(accounts_file))
         .expect("Unable to read created file");
 
-    assert!(contents.contains("account-1"));
-    assert!(contents.contains("account-2"));
-    assert!(contents.contains("account-3"));
+    assert!(
+        ["account-1", "account-2", "account-3"]
+            .iter()
+            .all(|a| contents.contains(a))
+    );
 
-    let snapbox = runner(&delete_args).current_dir(tempdir.path()).stdin("Y");
-    snapbox.assert().success().stdout_matches(indoc! {r"
+    runner(&delete_args)
+        .current_dir(tempdir.path())
+        .stdin("Y")
+        .assert()
+        .success()
+        .stdout_matches(indoc! {r"
         Success: Account deleted
 
         Account successfully removed
@@ -763,20 +790,7 @@ pub async fn test_happy_case_default_name_generation() {
 
     assert!(!contents_after_delete.contains("account-2"));
 
-    let snapbox = runner(&create_args).current_dir(tempdir.path());
-    snapbox.assert().stdout_matches(indoc! {r"
-        Success: Account created
-
-        Address: 0x0[..]
-        
-        Account successfully created but it needs to be deployed. The estimated deployment fee is [..] STRK. Prefund the account to cover deployment transaction fee
-
-        After prefunding the account, run:
-        sncast --accounts-file accounts.json account deploy --url http://127.0.0.1:5055/rpc --name account-2
-
-        To see account creation details, visit:
-        account: [..]
-    "});
+    assert_account_created(2);
 
     let contents = fs::read_to_string(tempdir.path().join(accounts_file))
         .expect("Unable to read created file");
@@ -993,9 +1007,41 @@ pub async fn test_json_output_format() {
         "my_account",
     ];
 
-    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(temp_dir.path());
     snapbox.assert().stdout_matches(indoc! {r#"
         {"add_profile":"Profile my_account successfully added to [..]/snfoundry.toml","address":"0x[..]","estimated_fee":"[..]","message":"Account successfully created but it needs to be deployed. The estimated deployment fee is [..] STRK. Prefund the account to cover deployment transaction fee/n/nAfter prefunding the account, run:/nsncast --accounts-file accounts.json account deploy --url [..] --name my_account"}
         {"links":"account: https://sepolia.starkscan.co/contract/0x[..]","title":"account creation"}
     "#});
+}
+
+#[tokio::test]
+pub async fn test_no_explorer_links_on_localhost() {
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "accounts.json";
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--url",
+        "http://127.0.0.1:5055/rpc",
+        "--name",
+        "my_account",
+        "--salt",
+        "0x1",
+        "--type",
+        "oz",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+    println!("{}", output.as_stdout());
+    assert!(
+        !output
+            .as_stdout()
+            .contains("To see account creation details, visit:")
+    );
 }

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -44,7 +44,7 @@ pub async fn test_happy_case(account_type: &str) {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
     let output = snapbox.assert().success();
 
@@ -110,7 +110,7 @@ pub async fn test_happy_case_argent_with_deprecation_warning() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
     let output = snapbox.assert().success();
 
@@ -211,7 +211,7 @@ pub async fn test_happy_case_generate_salt() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
@@ -299,7 +299,7 @@ pub async fn test_happy_case_accounts_file_already_exists() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
@@ -433,7 +433,7 @@ pub async fn test_happy_case_keystore(account_type: &str) {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
@@ -483,7 +483,7 @@ pub async fn test_happy_case_keystore_argent_with_deprecation_warning() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
@@ -689,7 +689,7 @@ pub async fn test_happy_case_keystore_int_format() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
 
     snapbox.assert().stdout_matches(formatdoc! {r"
@@ -743,7 +743,7 @@ pub async fn test_happy_case_default_name_generation() {
 
     let assert_account_created = |id: usize| {
         runner(&create_args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path())
         .assert()
         .stdout_matches(formatdoc! {r"
@@ -1008,7 +1008,7 @@ pub async fn test_json_output_format() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(temp_dir.path());
     snapbox.assert().stdout_matches(indoc! {r#"
         {"add_profile":"Profile my_account successfully added to [..]/snfoundry.toml","address":"0x[..]","estimated_fee":"[..]","message":"Account successfully created but it needs to be deployed. The estimated deployment fee is [..] STRK. Prefund the account to cover deployment transaction fee/n/nAfter prefunding the account, run:/nsncast --accounts-file accounts.json account deploy --url [..] --name my_account"}
@@ -1038,7 +1038,7 @@ pub async fn test_no_explorer_links_on_localhost() {
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
     let output = snapbox.assert().success();
-    println!("{}", output.as_stdout());
+
     assert!(
         !output
             .as_stdout()

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -43,7 +43,9 @@ pub async fn test_happy_case(class_hash: &str, account_type: &str) {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let bdg = snapbox.assert();
 
     let hash = get_transaction_hash(&bdg.get_output().stdout);
@@ -79,7 +81,9 @@ pub async fn test_happy_case_max_fee() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let bdg = snapbox.assert();
 
     let hash = get_transaction_hash(&bdg.get_output().stdout);
@@ -115,7 +119,9 @@ pub async fn test_happy_case_add_profile() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert();
 
     let hash = get_transaction_hash(&output.get_output().stdout);
@@ -171,7 +177,9 @@ pub async fn test_valid_class_hash() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
         Success: Account deployed
@@ -201,7 +209,9 @@ pub async fn test_valid_no_max_fee() {
         "my_account",
     ];
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
         Success: Account deployed
@@ -297,7 +307,9 @@ pub async fn test_happy_case_keystore(account_type: &str) {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
 
     snapbox.assert().stdout_matches(indoc! {r"
         Success: Account deployed
@@ -561,7 +573,9 @@ pub async fn test_deploy_keystore_other_args() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     snapbox.assert().stdout_matches(indoc! {r"
         Success: Account deployed
 
@@ -590,7 +604,9 @@ pub async fn test_json_output_format() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     snapbox.assert().stdout_matches(indoc! {r#"
         {"transaction_hash":"0x0[..]"}
         {"links":"transaction: https://sepolia.starkscan.co/tx/0x0[..]","title":"account deployment"}

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -44,7 +44,7 @@ pub async fn test_happy_case(class_hash: &str, account_type: &str) {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let bdg = snapbox.assert();
 
@@ -82,7 +82,7 @@ pub async fn test_happy_case_max_fee() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let bdg = snapbox.assert();
 
@@ -120,7 +120,7 @@ pub async fn test_happy_case_add_profile() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert();
 
@@ -178,7 +178,7 @@ pub async fn test_valid_class_hash() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
@@ -210,7 +210,7 @@ pub async fn test_valid_no_max_fee() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
 
     snapbox.assert().success().stdout_matches(indoc! {r"
@@ -308,7 +308,7 @@ pub async fn test_happy_case_keystore(account_type: &str) {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
 
     snapbox.assert().stdout_matches(indoc! {r"
@@ -574,7 +574,7 @@ pub async fn test_deploy_keystore_other_args() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     snapbox.assert().stdout_matches(indoc! {r"
         Success: Account deployed
@@ -605,7 +605,7 @@ pub async fn test_json_output_format() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     snapbox.assert().stdout_matches(indoc! {r#"
         {"transaction_hash":"0x0[..]"}

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -41,7 +41,7 @@ async fn test_happy_case_human_readable() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
@@ -531,7 +531,7 @@ async fn test_workspaces_package_specified_virtual_fibonacci() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
 
     let output = snapbox.assert().success().get_output().clone();
@@ -596,7 +596,7 @@ async fn test_no_scarb_profile() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(contract_path.path());
     let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -40,7 +40,9 @@ async fn test_happy_case_human_readable() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
     assert_stdout_contains(
@@ -374,7 +376,9 @@ async fn test_json_output_format() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
     assert_stdout_contains(

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -41,7 +41,7 @@ async fn test_happy_case_human_readable() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
@@ -377,7 +377,7 @@ async fn test_json_output_format() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -42,7 +42,7 @@ async fn test_happy_case_human_readable() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -41,7 +41,9 @@ async fn test_happy_case_human_readable() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert().success();
 
     assert_stdout_contains(

--- a/crates/sncast/tests/e2e/multicall/new.rs
+++ b/crates/sncast/tests/e2e/multicall/new.rs
@@ -18,7 +18,9 @@ async fn test_happy_case_file() {
         multicall_toml_file,
     ];
 
-    let snapbox = runner(&args).current_dir(tmp_dir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tmp_dir.path());
     let output = snapbox.assert().success();
 
     assert_stdout_contains(

--- a/crates/sncast/tests/e2e/multicall/new.rs
+++ b/crates/sncast/tests/e2e/multicall/new.rs
@@ -19,7 +19,7 @@ async fn test_happy_case_file() {
     ];
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tmp_dir.path());
     let output = snapbox.assert().success();
 

--- a/crates/sncast/tests/e2e/multicall/run.rs
+++ b/crates/sncast/tests/e2e/multicall/run.rs
@@ -34,7 +34,7 @@ async fn test_happy_case(account: &str) {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args);
+    let snapbox = runner(&args).env("FORCE_SHOW_EXPLORER_LINKS", "1");
     let output = snapbox.assert();
 
     let stderr_str = output.as_stderr();
@@ -77,7 +77,9 @@ async fn test_calldata_ids() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert();
 
     let stderr_str = output.as_stderr();
@@ -258,7 +260,9 @@ async fn test_numeric_inputs() {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).current_dir(tempdir.path());
+    let snapbox = runner(&args)
+        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(tempdir.path());
     let output = snapbox.assert();
 
     let stderr_str = output.as_stderr();

--- a/crates/sncast/tests/e2e/multicall/run.rs
+++ b/crates/sncast/tests/e2e/multicall/run.rs
@@ -34,7 +34,7 @@ async fn test_happy_case(account: &str) {
     ];
     let args = apply_test_resource_bounds_flags(args);
 
-    let snapbox = runner(&args).env("FORCE_SHOW_EXPLORER_LINKS", "1");
+    let snapbox = runner(&args).env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
     let output = snapbox.assert();
 
     let stderr_str = output.as_stderr();
@@ -78,7 +78,7 @@ async fn test_calldata_ids() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert();
 
@@ -261,7 +261,7 @@ async fn test_numeric_inputs() {
     let args = apply_test_resource_bounds_flags(args);
 
     let snapbox = runner(&args)
-        .env("FORCE_SHOW_EXPLORER_LINKS", "1")
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
     let output = snapbox.assert();
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -55,6 +55,7 @@
 * [Inspecting Transactions](starknet/tx-status.md)
 * [Verifying Contracts](starknet/verify.md)
 * [Calldata Transformation](starknet/calldata-transformation.md)
+* [Block Explorers](starknet/block_explorer.md)
 
 ---
 

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -75,6 +75,9 @@ show-explorer-links = true
 
 The `block-explorer` field specifies the block explorer service used to display links to transaction details. 
 
+> 📝 **Note**
+> For details on how block explorers are used in `sncast` and when links are shown, see the [Block Explorers](../starknet/block_explorer.md) section.
+
 | Value     | URL                                    |
 |-----------|----------------------------------------|
 | StarkScan | `https://starkscan.co`          |

--- a/docs/src/starknet/block_explorer.md
+++ b/docs/src/starknet/block_explorer.md
@@ -7,10 +7,25 @@ When you use commands like `sncast deploy`, `sncast declare`, or `sncast account
 
 ## When Are Explorer Links Shown?
 
-* **Public Networks:** Explorer links are enabled by default for public networks (e.g., Sepolia, Mainnet) if the tool can detect a supported explorer for the network.
-* **Devnet:** Explorer links are not shown for localhost or devnet URLs (e.g., `http://localhost:5050/rpc` or `http://127.0.0.1:5050/rpc`). This prevents confusion, as local network transactions are not visible in local explorers.
-* **Disabling Explorer Links:** You can turn off explorer links by setting `show-explorer-links = false` in your `snfoundry.toml` profile. See the [snfoundry.toml appendix](../appendix/snfoundry-toml.md#show-explorer-links) for details.
-* **Environment Variable Override:** You can force explorer links to be shown by setting the environment variable `SNCAST_FORCE_SHOW_EXPLORER_LINKS=1` before running a command.
+### Shown by Default
+
+**Public Networks:** Explorer links are enabled by default for public networks (e.g., Sepolia, Mainnet) if the tool can detect a supported explorer for the network.
+
+### Hidden
+
+**Devnet:** Explorer links are not shown for localhost or devnet URLs (e.g., `http://localhost:5050/rpc` or `http://127.0.0.1:5050/rpc`). This prevents confusion, as local network transactions are not visible in public explorers.
+
+## Disabling Explorer Links
+
+You can turn off explorer links by setting `show-explorer-links = false` in your `snfoundry.toml` profile. See the [snfoundry.toml appendix](../appendix/snfoundry-toml.md#show-explorer-links) for details.
+
+## Environment Variable Override
+
+It's possible to force explorer links to be shown by setting the environment variable `SNCAST_FORCE_SHOW_EXPLORER_LINKS`:
+
+```shell
+$ SNCAST_FORCE_SHOW_EXPLORER_LINKS=1
+```
 
 ## Example Output
 

--- a/docs/src/starknet/block_explorer.md
+++ b/docs/src/starknet/block_explorer.md
@@ -1,0 +1,26 @@
+# Block Explorers
+
+When you use commands like `sncast deploy`, `sncast declare`, or `sncast account create`, `sncast` will display block explorer links in the output if the network supports it. These links allow you to quickly inspect the transaction, contract, or class on a public block explorer such as Starkscan or Voyager.
+
+> 💡 **Tip**
+> If you want to use a specific block explorer, see the [`block-explorer` configuration details](../appendix/snfoundry-toml.md#block-explorer).
+
+## When Are Explorer Links Shown?
+
+* **Public Networks:** Explorer links are enabled by default for public networks (e.g., Sepolia, Mainnet) if the tool can detect a supported explorer for the network.
+* **Devnet:** Explorer links are not shown for localhost or devnet URLs (e.g., `http://localhost:5050/rpc` or `http://127.0.0.1:5050/rpc`). This prevents confusion, as local network transactions are not visible in local explorers.
+* **Disabling Explorer Links:** You can turn off explorer links by setting `show-explorer-links = false` in your `snfoundry.toml` profile. See the [snfoundry.toml appendix](../appendix/snfoundry-toml.md#show-explorer-links) for details.
+* **Environment Variable Override:** You can force explorer links to be shown by setting the environment variable `SNCAST_FORCE_SHOW_EXPLORER_LINKS=1` before running a command.
+
+## Example Output
+
+```shell
+Success: Deployment completed
+
+Contract Address: 0x0...
+Transaction Hash: 0x0...
+
+To see deployment details, visit:
+contract: https://sepolia.starkscan.co/contract/0x0...
+transaction: https://sepolia.starkscan.co/tx/0x0...
+```

--- a/docs/src/starknet/tx-status.md
+++ b/docs/src/starknet/tx-status.md
@@ -28,4 +28,29 @@ Success: Transaction status retrieved
 Finality Status:  Accepted on L1
 Execution Status: Succeeded
 ```
+
 </details>
+
+## Block Explorer Links
+
+When you use commands like `sncast deploy`, `sncast declare`, or `sncast account create`, `sncast` will display block explorer links in the output if the network supports it. These links allow you to quickly inspect the transaction, contract, or class on a public block explorer such as Starkscan or Voyager.
+
+### When Are Explorer Links Shown?
+
+- **Public Networks:** Explorer links are enabled by default for public networks (e.g., Sepolia, Mainnet) if the tool can detect a supported explorer for the network.
+- **Devnet:** Explorer links are not shown for localhost or devnet URLs (e.g., `http://localhost:5050/rpc` or `http://127.0.0.1:5050/rpc`). This prevents confusion, as local networks typically do not have a public explorer.
+- **Disabling Explorer Links:** You can turn off explorer links by setting `show-explorer-links = false` in your `snfoundry.toml` profile. See the [snfoundry.toml appendix](../appendix/snfoundry-toml.md#show-explorer-links) for details.
+- **Environment Variable Override:** You can force explorer links to be shown by setting the environment variable `FORCE_SHOW_EXPLORER_LINKS=1` before running a command. This is useful for testing or custom explorers.
+
+### Example Output
+
+```shell
+Success: Deployment completed
+
+Contract Address: 0x0...
+Transaction Hash: 0x0...
+
+To see deployment details, visit:
+contract: https://sepolia.starkscan.co/contract/0x0...
+transaction: https://sepolia.starkscan.co/tx/0x0...
+```

--- a/docs/src/starknet/tx-status.md
+++ b/docs/src/starknet/tx-status.md
@@ -30,27 +30,3 @@ Execution Status: Succeeded
 ```
 
 </details>
-
-## Block Explorer Links
-
-When you use commands like `sncast deploy`, `sncast declare`, or `sncast account create`, `sncast` will display block explorer links in the output if the network supports it. These links allow you to quickly inspect the transaction, contract, or class on a public block explorer such as Starkscan or Voyager.
-
-### When Are Explorer Links Shown?
-
-- **Public Networks:** Explorer links are enabled by default for public networks (e.g., Sepolia, Mainnet) if the tool can detect a supported explorer for the network.
-- **Devnet:** Explorer links are not shown for localhost or devnet URLs (e.g., `http://localhost:5050/rpc` or `http://127.0.0.1:5050/rpc`). This prevents confusion, as local networks typically do not have a public explorer.
-- **Disabling Explorer Links:** You can turn off explorer links by setting `show-explorer-links = false` in your `snfoundry.toml` profile. See the [snfoundry.toml appendix](../appendix/snfoundry-toml.md#show-explorer-links) for details.
-- **Environment Variable Override:** You can force explorer links to be shown by setting the environment variable `FORCE_SHOW_EXPLORER_LINKS=1` before running a command. This is useful for testing or custom explorers.
-
-### Example Output
-
-```shell
-Success: Deployment completed
-
-Contract Address: 0x0...
-Transaction Hash: 0x0...
-
-To see deployment details, visit:
-contract: https://sepolia.starkscan.co/contract/0x0...
-transaction: https://sepolia.starkscan.co/tx/0x0...
-```


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2488 

## Introduced changes

<!-- A brief description of the changes -->

- Prevent Cast from printing invalid explorer URLs for Devnet transactions by checking if the URL points to localhost or similar.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
