### PR TITLE
Revert "Increase default `max_steps` limit to `usize::MAX` (#3574)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Forge
 
-#### Changed
-
-- Max steps in tests (configured via the `--max-n-steps` argument) now defaults to `usize::MAX` when not specified (previously 10 million).
-
 ### Cast
 
 #### Fixed

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -12,6 +12,7 @@ use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::cached_state::CachedState;
 use cairo_vm::Felt252;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
+use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use camino::{Utf8Path, Utf8PathBuf};
 use cheatnet::constants as cheatnet_constants;
 use cheatnet::forking::data::ForkData;
@@ -197,12 +198,9 @@ pub fn run_test_case(
     let tracked_resource = TrackedResource::from(runtime_config.tracked_resource);
     let mut context = build_context(&block_info, chain_id, &tracked_resource);
 
-    let max_n_steps = runtime_config
-        .max_n_steps
-        .map_or(usize::MAX, |n| n as usize);
-
-    set_max_steps(&mut context, max_n_steps);
-
+    if let Some(max_n_steps) = runtime_config.max_n_steps {
+        set_max_steps(&mut context, max_n_steps);
+    }
     let mut cached_state = CachedState::new(state_reader);
 
     let hints = hints_by_representation(&casm_program.assembled_cairo_program);
@@ -409,14 +407,20 @@ fn extract_test_case_summary(
                 ui,
             ),
             RunResult::Error(run_error) => {
-                let message = format!(
+                let mut message = format!(
                     "\n    {}\n",
                     run_error
                         .error
                         .to_string()
                         .replace(" Custom Hint Error: ", "\n    ")
                 );
-
+                if let CairoRunError::VirtualMachine(VirtualMachineError::UnfinishedExecution) =
+                    *run_error.error
+                {
+                    message.push_str(
+                        "\n    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps",
+                    );
+                }
                 TestCaseSummary::Failed {
                     name: case.name.clone(),
                     msg: Some(message).map(|msg| {

--- a/crates/forge/tests/data/steps/src/lib.cairo
+++ b/crates/forge/tests/data/steps/src/lib.cairo
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     #[test]
-    fn steps_less_than_10_000_000() {
+    fn steps_less_than_10000000() {
         let mut i = 0;
 
         while i != 550_000 {
@@ -12,21 +12,10 @@ mod tests {
 
 
     #[test]
-    fn steps_more_than_10_000_000() {
+    fn steps_more_than_10000000() {
         let mut i = 0;
 
         while i != 680_000 {
-            i = i + 1;
-            assert(1 + 1 == 2, 'who knows?');
-        }
-    }
-
-    #[test]
-    fn steps_more_than_100_000_000() {
-        let mut i = 0;
-        let target: felt252 = 6_800_000;
-
-        while i != target {
             i = i + 1;
             assert(1 + 1 == 2, 'who knows?');
         }

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -773,11 +773,7 @@ fn with_exit_first() {
         ))
         .unwrap();
 
-    let output = test_runner(&temp)
-        .args(["--max-n-steps", "10000000"])
-        .assert()
-        .code(1);
-
+    let output = test_runner(&temp).assert().code(1);
     assert_stdout_contains(
         output,
         indoc! {r"
@@ -805,11 +801,7 @@ fn with_exit_first() {
 fn with_exit_first_flag() {
     let temp = setup_package("exit_first");
 
-    let output = test_runner(&temp)
-        .arg("--exit-first")
-        .args(["--max-n-steps", "10000000"])
-        .assert()
-        .code(1);
+    let output = test_runner(&temp).arg("--exit-first").assert().code(1);
 
     assert_stdout_contains(
         output,
@@ -936,10 +928,7 @@ fn incompatible_snforge_std_version_warning() {
     scarb_toml["dev-dependencies"]["snforge_std"] = value("0.45.0");
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
 
-    let output = test_runner(&temp)
-        .args(["--max-n-steps", "10000000"])
-        .assert()
-        .failure();
+    let output = test_runner(&temp).assert().failure();
 
     assert_stdout_contains(
         output,
@@ -948,20 +937,19 @@ fn incompatible_snforge_std_version_warning() {
         [..]Compiling[..]
         [..]Finished[..]
 
-        Collected 3 test(s) from steps package
-        Running 3 test(s) from src/
-        [PASS] steps::tests::steps_less_than_10_000_000 [..]
-        [FAIL] steps::tests::steps_more_than_10_000_000
-        [FAIL] steps::tests::steps_more_than_100_000_000
+        Collected 2 test(s) from steps package
+        Running 2 test(s) from src/
+        [PASS] steps::tests::steps_less_than_10000000 [..]
+        [FAIL] steps::tests::steps_more_than_10000000
 
         Failure data:
             Could not reach the end of the program. RunResources has no remaining steps.
+            Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
-        Tests: 1 passed, 2 failed, 0 ignored, 0 filtered out
+        Tests: 1 passed, 1 failed, 0 ignored, 0 filtered out
 
         Failures:
-            steps::tests::steps_more_than_10_000_000
-            steps::tests::steps_more_than_100_000_000
+            steps::tests::steps_more_than_10000000
         "},
     );
 }

--- a/crates/forge/tests/e2e/steps.rs
+++ b/crates/forge/tests/e2e/steps.rs
@@ -20,34 +20,29 @@ fn should_allow_less_than_default() {
                 [..]Compiling[..]
                 [..]Finished[..]
 
-                Collected 3 test(s) from steps package
-                Running 3 test(s) from src/
-                [FAIL] steps::tests::steps_less_than_10_000_000
+                Collected 2 test(s) from steps package
+                Running 2 test(s) from src/
+                [FAIL] steps::tests::steps_less_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
-                [FAIL] steps::tests::steps_more_than_10_000_000
+                [FAIL] steps::tests::steps_more_than_10000000
 
                 Failure data:
                     Could not reach the end of the program. RunResources has no remaining steps.
+                    Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
 
-                [FAIL] steps::tests::steps_more_than_100_000_000
-                
-                Failure data:
-                    Could not reach the end of the program. RunResources has no remaining steps.
-
-                Tests: 0 passed, 3 failed, 0 ignored, 0 filtered out
+                Tests: 0 passed, 2 failed, 0 ignored, 0 filtered out
 
                 Failures:
-                    steps::tests::steps_less_than_10_000_000
-                    steps::tests::steps_more_than_10_000_000
-                    steps::tests::steps_more_than_100_000_000
+                    steps::tests::steps_less_than_10000000
+                    steps::tests::steps_more_than_10000000
             "
         ),
     );
 }
-
 #[test]
 // 10_000_000 is blockifier limit we want to omit
 fn should_allow_more_than_10m() {
@@ -56,7 +51,7 @@ fn should_allow_more_than_10m() {
     let output = test_runner(&temp)
         .args(["--max-n-steps", "15000100"])
         .assert()
-        .code(1);
+        .code(0);
 
     assert_stdout_contains(
         output,
@@ -65,29 +60,20 @@ fn should_allow_more_than_10m() {
                 [..]Compiling[..]
                 [..]Finished[..]
 
-                Collected 3 test(s) from steps package
-                Running 3 test(s) from src/
-                [PASS] steps::tests::steps_more_than_10_000_000 [..]
-                [PASS] steps::tests::steps_less_than_10_000_000 [..]
-                [FAIL] steps::tests::steps_more_than_100_000_000
-
-                Failure data:
-                    Could not reach the end of the program. RunResources has no remaining steps.
-
-                Tests: 2 passed, 1 failed, 0 ignored, 0 filtered out
-
-                Failures:
-                    steps::tests::steps_more_than_100_000_000
+                Collected 2 test(s) from steps package
+                Running 2 test(s) from src/
+                [PASS] steps::tests::steps_more_than_10000000 [..]
+                [PASS] steps::tests::steps_less_than_10000000 [..]
+                Tests: 2 passed, 0 failed, 0 ignored, 0 filtered out
             "
         ),
     );
 }
-
 #[test]
-fn should_default_to_usize_max() {
+fn should_default_to_10m() {
     let temp = setup_package("steps");
 
-    let output = test_runner(&temp).assert().code(0);
+    let output = test_runner(&temp).assert().code(1);
 
     assert_stdout_contains(
         output,
@@ -96,13 +82,19 @@ fn should_default_to_usize_max() {
             [..]Compiling[..]
             [..]Finished[..]
 
-            Collected 3 test(s) from steps package
-            Running 3 test(s) from src/
-            [PASS] steps::tests::steps_less_than_10_000_000 (l1_gas: ~[..], l1_data_gas: ~[..], l2_gas: ~[..])
-            [PASS] steps::tests::steps_more_than_10_000_000 (l1_gas: ~[..], l1_data_gas: ~[..], l2_gas: ~[..])
-            [PASS] steps::tests::steps_more_than_100_000_000 (l1_gas: ~[..], l1_data_gas: ~[..], l2_gas: ~[..])
+            Collected 2 test(s) from steps package
+            Running 2 test(s) from src/
+            [PASS] steps::tests::steps_less_than_10000000 (l1_gas: ~[..], l1_data_gas: ~[..], l2_gas: ~[..])
+            [FAIL] steps::tests::steps_more_than_10000000
 
-            Tests: 3 passed, 0 failed, 0 ignored, 0 filtered out
+            Failure data:
+                Could not reach the end of the program. RunResources has no remaining steps.
+                Suggestion: Consider using the flag `--max-n-steps` to increase allowed limit of steps
+
+            Tests: 1 passed, 1 failed, 0 ignored, 0 filtered out
+
+            Failures:
+                steps::tests::steps_more_than_10000000
             "
         ),
     );

--- a/crates/runtime/src/starknet/context.rs
+++ b/crates/runtime/src/starknet/context.rs
@@ -123,9 +123,9 @@ pub fn build_context(
     context
 }
 
-pub fn set_max_steps(entry_point_ctx: &mut EntryPointExecutionContext, max_n_steps: usize) {
+pub fn set_max_steps(entry_point_ctx: &mut EntryPointExecutionContext, max_n_steps: u32) {
     // override it to omit [`EntryPointExecutionContext::max_steps`] restrictions
-    entry_point_ctx.vm_run_resources = RunResources::new(max_n_steps);
+    entry_point_ctx.vm_run_resources = RunResources::new(max_n_steps as usize);
 }
 
 // We need to be copying those 1:1 for serialization (caching purposes)


### PR DESCRIPTION
This reverts commit b2917504

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
