### PR TITLE
Fix fuzzer attribute for generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Added
+
+- A bug that caused `#[fuzzer]` attribute to fail when used with generic structs
+
 ## [0.48.0] - 2025-08-05
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Forge
 
-#### Added
+#### Fixed
 
 - A bug that caused `#[fuzzer]` attribute to fail when used with generic structs
 

--- a/crates/forge/tests/data/fuzzing/tests/generic_struct.cairo
+++ b/crates/forge/tests/data/fuzzing/tests/generic_struct.cairo
@@ -1,0 +1,22 @@
+use snforge_std::fuzzable::Fuzzable;
+
+#[derive(Debug, Drop)]
+struct Price<T> {
+    amount: T,
+}
+
+impl FuzzablePriceU64 of Fuzzable<Price<u64>> {
+    fn blank() -> Price<u64> {
+        Price { amount: 0 }
+    }
+
+    fn generate() -> Price<u64> {
+        Price { amount: Fuzzable::generate() }
+    }
+}
+
+#[fuzzer]
+#[test]
+fn test_generic(price: Price<u64>) {
+    assert(price.amount > 0, 'Wrong price');
+}

--- a/crates/forge/tests/e2e/fuzzing.rs
+++ b/crates/forge/tests/e2e/fuzzing.rs
@@ -36,7 +36,7 @@ fn fuzzing() {
         [PASS] fuzzing::tests::uint128_arg (runs: 256, [..]
         [PASS] fuzzing::tests::uint256_arg (runs: 256, [..]
         Running 0 test(s) from tests/
-        Tests: 12 passed, 1 failed, 0 ignored, 11 filtered out
+        Tests: 12 passed, 1 failed, 0 ignored, 12 filtered out
         Fuzzer seed: [..]
 
         Failures:
@@ -81,7 +81,7 @@ fn fuzzing_set_runs() {
         [PASS] fuzzing::tests::uint128_arg (runs: 10, [..]
         [PASS] fuzzing::tests::uint256_arg (runs: 10, [..]
         Running 0 test(s) from tests/
-        Tests: 12 passed, 1 failed, 0 ignored, 11 filtered out
+        Tests: 12 passed, 1 failed, 0 ignored, 12 filtered out
         Fuzzer seed: [..]
 
         Failures:
@@ -126,7 +126,7 @@ fn fuzzing_set_seed() {
         [PASS] fuzzing::tests::uint128_arg (runs: 256, [..]
         [PASS] fuzzing::tests::uint256_arg (runs: 256, [..]
         Running 0 test(s) from tests/
-        Tests: 12 passed, 1 failed, 0 ignored, 11 filtered out
+        Tests: 12 passed, 1 failed, 0 ignored, 12 filtered out
         Fuzzer seed: 1234
 
         Failures:
@@ -196,7 +196,7 @@ fn fuzzing_exit_first() {
         Failure data:
             0x32202b2062203d3d2032202b2062 ('2 + b == 2 + b')
 
-        Tests: 0 passed, 1 failed, 0 ignored, 22 filtered out
+        Tests: 0 passed, 1 failed, 0 ignored, 23 filtered out
         Interrupted execution of 1 test(s).
 
         Fuzzer seed: [..]
@@ -232,7 +232,7 @@ fn fuzzing_exit_first_single_fail() {
         Failures:
             fuzzing_integrationtest::exit_first_single_fail::exit_first_fails_test
 
-        Tests: 0 passed, 1 failed, 0 ignored, 22 filtered out
+        Tests: 0 passed, 1 failed, 0 ignored, 23 filtered out
         Interrupted execution of 1 test(s).
         "},
     );
@@ -260,7 +260,7 @@ fn fuzzing_multiple_attributes() {
         [PASS] fuzzing_integrationtest::multiple_attributes::with_should_panic (runs: 256, [..])
         [PASS] fuzzing_integrationtest::multiple_attributes::with_available_gas (runs: 50, [..])
         [PASS] fuzzing_integrationtest::multiple_attributes::with_both (runs: 300, [..])
-        Tests: 3 passed, 0 failed, 1 ignored, 20 filtered out
+        Tests: 3 passed, 0 failed, 1 ignored, 21 filtered out
         "},
     );
 }
@@ -286,7 +286,7 @@ fn generate_arg_cheatcode() {
             "`generate_arg` cheatcode: `min_value` must be <= `max_value`, provided values after deserialization: 101 and 100"
 
         [PASS] fuzzing_integrationtest::generate_arg::use_generate_arg_outside_fuzzer (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
-        Tests: 1 passed, 1 failed, 0 ignored, 22 filtered out
+        Tests: 1 passed, 1 failed, 0 ignored, 23 filtered out
         "#},
     );
 }
@@ -317,6 +317,27 @@ fn no_fuzzer_attribute() {
 
         error: could not compile `fuzzing_integrationtest` due to previous error
         [ERROR] Failed to build test artifacts with Scarb: `scarb` exited with error
+        "},
+    );
+}
+
+#[test]
+fn fuzz_generic_struct() {
+    let temp = setup_package("fuzzing");
+
+    let output = test_runner(&temp).arg("test_generic").assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+        [..]Compiling[..]
+        [..]Finished[..]
+
+
+        Collected 1 test(s) from fuzzing package
+        Running 1 test(s) from tests/
+        [PASS] fuzzing_integrationtest::generic_struct::test_generic ([..])
+        Tests: 1 passed, 0 failed, 0 ignored, 24 filtered out
         "},
     );
 }

--- a/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
@@ -7,6 +7,7 @@ use crate::format_ident;
 use crate::utils::{SyntaxNodeUtils, create_single_token, get_statements};
 use cairo_lang_macro::{Diagnostic, Diagnostics, ProcMacroResult, TokenStream, quote};
 use cairo_lang_parser::utils::SimpleParserDatabase;
+use cairo_lang_syntax::node::ast::OptionTypeClause::{Empty, TypeClause};
 use cairo_lang_syntax::node::ast::{FunctionWithBody, Param};
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::with_db::SyntaxNodeWithDb;
@@ -76,11 +77,14 @@ fn fuzzer_wrapper_internal(
         let name = param.name(db).as_syntax_node();
         let name = SyntaxNodeWithDb::new(&name, db);
 
-        let name_type = param.type_clause(db).as_syntax_node();
+        let name_type = match param.type_clause(db) {
+            TypeClause(type_clause) => type_clause.ty(db).as_syntax_node(),
+            Empty(option_type_clause) => option_type_clause.as_syntax_node(),
+        };
         let name_type = SyntaxNodeWithDb::new(&name_type, db);
 
         quote! {
-            let #name #name_type = snforge_std::fuzzable::Fuzzable::generate();
+            let #name = snforge_std::fuzzable::Fuzzable::<#name_type>::generate();
             snforge_std::_internals::save_fuzzer_arg(@#name);
         }
     });

--- a/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
@@ -393,7 +393,7 @@ fn works_with_fuzzer_config_wrapper() {
 
                     return;
                 }
-                let f: felt252 = snforge_std::fuzzable::Fuzzable::generate();
+                let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
                 empty_fn_return_wrapper_actual_body(f);
             }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
@@ -317,7 +317,7 @@ fn config_wrapper_work_with_fn_with_single_param() {
 
                     return;
                 }
-                let f: felt252 = snforge_std::fuzzable::Fuzzable::generate();
+                let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
                 empty_fn_actual_body(f);
             }
@@ -386,9 +386,9 @@ fn config_wrapper_work_with_fn_with_params() {
 
                     return;
                 }
-                let f: felt252 = snforge_std::fuzzable::Fuzzable::generate();
+                let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
-                let u: u32 = snforge_std::fuzzable::Fuzzable::generate();
+                let u = snforge_std::fuzzable::Fuzzable::<u32>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@u);
                 empty_fn_actual_body(f, u);
             }


### PR DESCRIPTION
Reported: https://t.me/starknet_foundry_support/6223

- After migrating to macros V2 the `fuzzer` attribute may generate code that contains syntax errors when using generic types
