### PR TITLE
Feat(sncast): Allow declaring from precompiled contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Block explorer links are now hidden by default when using [`starknet-devnet`](https://github.com/0xSpaceShard/starknet-devnet). Set `SNCAST_FORCE_SHOW_EXPLORER_LINKS=1` env variable to display them.
 
+#### Added
+
+- `--skip-compile` flag to skip build step and declare precompiled contracts
+
 ## [0.47.0] - 2025-07-28
 
 ### Forge

--- a/crates/sncast/src/helpers/scarb_utils.rs
+++ b/crates/sncast/src/helpers/scarb_utils.rs
@@ -163,6 +163,15 @@ pub fn build_and_load_artifacts(
     build(package, config, default_profile)
         .map_err(|e| anyhow!(format!("Failed to build using scarb; {e}")))?;
 
+    load_artifacts(package, config, ui, default_profile)
+}
+
+pub fn load_artifacts(
+    package: &PackageMetadata,
+    config: &BuildConfig,
+    ui: &UI,
+    default_profile: &str,
+) -> Result<HashMap<String, StarknetContractArtifacts>> {
     let metadata = get_scarb_metadata_with_deps(&config.scarb_toml_path)?;
     let target_dir = target_dir_for_workspace(&metadata);
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -255,7 +255,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 profile: cli.profile.unwrap_or("release".to_string()),
             };
 
-            if declare.source.contract.is_some() {
+            if !declare.skip_compile {
                 artifacts = build_and_load_artifacts(&package_metadata, &build_config, false, ui)
                     .expect("Failed to build contract");
             } else {

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -259,7 +259,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 artifacts = build_and_load_artifacts(&package_metadata, &build_config, false, ui)
                     .expect("Failed to build contract");
             } else {
-                artifacts = load_artifacts(&package_metadata, &build_config, ui, "release")
+                artifacts = load_artifacts(&package_metadata, &build_config, ui, &build_config.profile)
                     .expect("Failed to load artifacts");
             }
 

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -54,7 +54,7 @@ pub struct Source {
     pub contract: Option<String>,
 
     /// Path to compiled contract
-    #[arg(short, long = "contract-path")]
+    #[arg(short, long = "compiled-contract-path")]
     pub path: Option<String>,
 }
 

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -30,7 +30,11 @@ use std::sync::Arc;
 pub struct Declare {
     /// Contract name
     #[arg(short = 'c', long = "contract-name")]
-    pub contract: String,
+    pub contract: Option<String>,
+
+    /// Path to compiled contract
+    #[arg(short, long = "contract-path")]
+    pub path: Option<String>,
 
     #[command(flatten)]
     pub fee_args: FeeArgs,
@@ -55,12 +59,24 @@ pub async fn declare(
     skip_on_already_declared: bool,
     ui: &UI,
 ) -> Result<DeclareResponse, StarknetCommandError> {
-    let contract_artifacts =
-        artifacts
-            .get(&declare.contract)
-            .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
-                data: ByteArray::from(declare.contract.as_str()),
-            }))?;
+    let contract_artifacts;
+    if declare.contract.is_some() {
+        let contract = declare.contract.unwrap();
+        contract_artifacts =
+            artifacts
+                .get(&contract)
+                .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
+                    data: ByteArray::from(contract.as_str()),
+                }))?;
+    } else {
+        let path = declare.path.unwrap();
+        contract_artifacts =
+            artifacts
+                .get(&path)
+                .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
+                    data: ByteArray::from(path.as_str()),
+                }))?;
+    }
 
     let contract_definition: SierraClass = serde_json::from_str(&contract_artifacts.sierra)
         .context("Failed to parse sierra artifact")?;

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -32,10 +32,6 @@ pub struct Declare {
     #[arg(short = 'c', long = "contract-name")]
     pub contract: String,
 
-    /// If passed, compilation is skipped
-    #[arg(long)]
-    pub skip_compile: bool,
-
     #[command(flatten)]
     pub fee_args: FeeArgs,
 
@@ -49,6 +45,10 @@ pub struct Declare {
 
     #[command(flatten)]
     pub rpc: RpcArgs,
+
+    /// If passed, compilation is skipped
+    #[arg(long)]
+    pub skip_compile: bool,
 }
 
 pub async fn declare(

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -28,8 +28,13 @@ use std::sync::Arc;
 #[derive(Args)]
 #[command(about = "Declare a contract to starknet", long_about = None)]
 pub struct Declare {
-    #[command(flatten)]
-    pub source: Source,
+    /// Contract name
+    #[arg(short = 'c', long = "contract-name")]
+    pub contract: Option<String>,
+
+    /// If passed, compilation is skipped
+    #[arg(long)]
+    pub skip_compile: bool,
 
     #[command(flatten)]
     pub fee_args: FeeArgs,
@@ -44,18 +49,6 @@ pub struct Declare {
 
     #[command(flatten)]
     pub rpc: RpcArgs,
-}
-
-#[derive(Args)]
-#[group(required = true, multiple = false)]
-pub struct Source {
-    /// Contract name
-    #[arg(short = 'c', long = "contract-name")]
-    pub contract: Option<String>,
-
-    /// Path to compiled contract
-    #[arg(short, long = "compiled-contract-path")]
-    pub path: Option<String>,
 }
 
 pub async fn declare(

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 pub struct Declare {
     /// Contract name
     #[arg(short = 'c', long = "contract-name")]
-    pub contract: Option<String>,
+    pub contract: String,
 
     /// If passed, compilation is skipped
     #[arg(long)]
@@ -59,24 +59,12 @@ pub async fn declare(
     skip_on_already_declared: bool,
     ui: &UI,
 ) -> Result<DeclareResponse, StarknetCommandError> {
-    let contract_artifacts;
-    if declare.source.contract.is_some() {
-        let contract = declare.source.contract.unwrap();
-        contract_artifacts =
-            artifacts
-                .get(&contract)
-                .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
-                    data: ByteArray::from(contract.as_str()),
-                }))?;
-    } else {
-        let path = declare.source.path.unwrap();
-        contract_artifacts =
-            artifacts
-                .get(&path)
-                .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
-                    data: ByteArray::from(path.as_str()),
-                }))?;
-    }
+    let contract_artifacts =
+        artifacts
+            .get(&declare.contract)
+            .ok_or(StarknetCommandError::ContractArtifactsNotFound(ErrorData {
+                data: ByteArray::from(declare.contract.as_str()),
+            }))?;
 
     let contract_definition: SierraClass = serde_json::from_str(&contract_artifacts.sierra)
         .context("Failed to parse sierra artifact")?;

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -1,4 +1,4 @@
-use crate::starknet_commands::declare::Declare;
+use crate::starknet_commands::declare::{Declare, Source};
 use crate::starknet_commands::{call, declare, deploy, invoke, tx_status};
 use crate::{WaitForTx, get_account};
 use anyhow::{Context, Result, anyhow};
@@ -128,8 +128,10 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let nonce = input_reader.read()?;
 
                 let declare = Declare {
-                    contract: Some(contract.clone()),
-                    path: None,
+                    source: Source {
+                        contract: Some(contract.clone()),
+                        path: None,
+                    },
                     fee_args,
                     nonce,
                     package: None,

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -128,7 +128,8 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let nonce = input_reader.read()?;
 
                 let declare = Declare {
-                    contract: contract.clone(),
+                    contract: Some(contract.clone()),
+                    path: None,
                     fee_args,
                     nonce,
                     package: None,

--- a/crates/sncast/src/starknet_commands/script/run.rs
+++ b/crates/sncast/src/starknet_commands/script/run.rs
@@ -1,4 +1,4 @@
-use crate::starknet_commands::declare::{Declare, Source};
+use crate::starknet_commands::declare::Declare;
 use crate::starknet_commands::{call, declare, deploy, invoke, tx_status};
 use crate::{WaitForTx, get_account};
 use anyhow::{Context, Result, anyhow};
@@ -128,10 +128,8 @@ impl<'a> ExtensionLogic for CastScriptExtension<'a> {
                 let nonce = input_reader.read()?;
 
                 let declare = Declare {
-                    source: Source {
-                        contract: Some(contract.clone()),
-                        path: None,
-                    },
+                    contract: contract.clone(),
+                    skip_compile: false,
                     fee_args,
                     nonce,
                     package: None,

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -663,8 +663,10 @@ async fn test_deploy_skip_compile() {
 
     // Run `scarb build`
     let output = ScarbCommand::new()
-        .current_dir(tempdir.path())
+        .arg("--profile")
+        .arg("release")
         .arg("build")
+        .current_dir(tempdir.path())
         .command()
         .output()
         .unwrap();

--- a/docs/src/appendix/sncast/declare.md
+++ b/docs/src/appendix/sncast/declare.md
@@ -71,3 +71,8 @@ Optional.
 Name of the package that should be used.
 
 If supplied, a contract from this package will be used. Required if more than one package exists in a workspace.
+
+## `--skip_compile`
+Optional.
+
+If supplied, build step is skipped. Declares precompiled contracts.

--- a/docs/src/starknet/declare.md
+++ b/docs/src/starknet/declare.md
@@ -53,4 +53,29 @@ transaction: https://starkscan.co/search/[..]
 > 💡 **Info**
 > Max fee will be automatically computed if `--max-fee <MAX_FEE>` is not passed.
 
+### Declare from pre-compiled contract
+When an already compiled contract needs to be declared, we can skip the build step by passing the `--skip-compile` flag to the declare command.
 
+```shell
+$ sncast --account my_account \
+    declare \
+	--network sepolia \
+    --contract-name HelloSncast
+    --skip-compile
+```
+
+<details>
+<summary>Output:</summary>
+
+```shell
+Success: Declaration completed
+
+Contract Address: 0x0[..]
+Transaction Hash: 0x0[..]
+
+To see declaration details, visit:
+class: https://starkscan.co/search/[..]
+transaction: https://starkscan.co/search/[..]
+```
+</details>
+<br>


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3587 

## Introduced changes

<!-- A brief description of the changes -->
Currently you can only declare contracts you have source code available. There are use cases where an already compiled contract needs to be declared e.g. to avoid issues with different compiler versions producing different results.
This PR adds a `--skip-compile` flag to `sncast declare`. When the flag is passed, the build step is skipped. 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
