### PR TITLE
remove: completion alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A bug that caused `#[fuzzer]` attribute to fail when used with generic structs
 
+#### Removed
+
+- The `sncast completion` command. Use `sncast completions` instead
+- The `snforge completion` command. Use `snforge completions` instead
+
 ## [0.48.0] - 2025-08-05
 
 ### Forge

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -109,8 +109,6 @@ enum ForgeSubcommand {
     /// Check if all `snforge` requirements are installed
     CheckRequirements,
     /// Generate completions script
-    // TODO(#3560): Remove the `completion` alias
-    #[command(alias = "completion")]
     Completions(Completions),
 }
 
@@ -321,16 +319,6 @@ pub fn main_execution(ui: Arc<UI>) -> Result<ExitStatus> {
         }
         ForgeSubcommand::Completions(completions) => {
             generate_completions(completions.shell, &mut Cli::command())?;
-
-            // TODO(#3560): Remove this warning when the `completion` alias is removed
-            if std::env::args().nth(1).as_deref() == Some("completion") {
-                let message = &WarningMessage::new(
-                    "Command `snforge completion` is deprecated and will be removed in the future. Please use `snforge completions` instead.",
-                );
-
-                // `#` is required since `snforge completions` generates a script and the output is used directly
-                ui.println(&format!("# {}", message.text()));
-            }
 
             Ok(ExitStatus::Success)
         }

--- a/crates/forge/tests/e2e/completions.rs
+++ b/crates/forge/tests/e2e/completions.rs
@@ -26,7 +26,7 @@ fn test_generate_completions_unsupported_shell() {
         std::env::set_var("SHELL", "/bin/unsupported");
     }
 
-    let snapbox = Command::new(snforge_test_bin_path()).arg("completion");
+    let snapbox = Command::new(snforge_test_bin_path()).arg("completions");
 
     let output = snapbox.assert().failure();
 
@@ -38,26 +38,4 @@ fn test_generate_completions_unsupported_shell() {
             "
         ),
     );
-}
-
-#[test]
-fn test_deprecated_alias() {
-    for variant in Shell::value_variants() {
-        let shell = variant.to_string();
-
-        let output = Command::new(snforge_test_bin_path())
-            .arg("completion")
-            .arg(shell.as_str())
-            .assert()
-            .success();
-
-        assert_stdout_contains(
-            output,
-            indoc!(
-                r"
-                # [WARNING] Command `snforge completion` is deprecated and will be removed in the future. Please use `snforge completions` instead.
-                "
-            ),
-        );
-    }
 }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -146,8 +146,6 @@ enum Commands {
     Verify(Verify),
 
     /// Generate completions script
-    // TODO(#3560): Remove the `completion` alias
-    #[command(alias = "completion")]
     Completions(Completions),
 
     /// Utility commands
@@ -485,16 +483,6 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
 
         Commands::Completions(completions) => {
             generate_completions(completions.shell, &mut Cli::command())?;
-
-            // TODO(#3560): Remove this warning when the `completion` alias is removed
-            if std::env::args().nth(1).as_deref() == Some("completion") {
-                let message = &WarningMessage::new(
-                    "Command `sncast completion` is deprecated and will be removed in the future. Please use `sncast completions` instead.",
-                );
-
-                // `#` is required since `sncast completion` generates a script and the output is used directly
-                ui.println(&format!("# {}", message.text()));
-            }
 
             Ok(())
         }

--- a/crates/sncast/tests/e2e/completions.rs
+++ b/crates/sncast/tests/e2e/completions.rs
@@ -39,22 +39,3 @@ fn test_generate_completions_unsupported_shell() {
         ),
     );
 }
-
-#[test]
-fn test_deprecated_alias() {
-    for variant in Shell::value_variants() {
-        let shell = variant.to_string();
-        let args = vec!["completion", shell.as_str()];
-
-        let output = runner(&args).assert().success();
-
-        assert_stdout_contains(
-            output,
-            indoc!(
-                r"
-                # [WARNING] Command `sncast completion` is deprecated and will be removed in the future. Please use `sncast completions` instead.
-                "
-            ),
-        );
-    }
-}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3560 

## Introduced changes

<!-- A brief description of the changes -->

- Removal `completion` alias from `sncast` and `snforge`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
