### PR TITLE
Refactor file gathering logic and update message cancel functionality to show collected files in advance

### DIFF
--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -82,6 +82,40 @@ impl fmt::Display for Verifier {
     }
 }
 
+fn display_files_and_confirm(
+    verifier: &Verifier,
+    files_to_display: Vec<String>,
+    confirm_verification: bool,
+    ui: &UI,
+    artifacts: &HashMap<String, StarknetContractArtifacts>,
+    contract_name: &str,
+) -> Result<()> {
+    // Display files that will be uploaded
+    ui.println(&"The following files will be transferred:");
+    for file_path in files_to_display {
+        ui.println(&file_path);
+    }
+
+    // Ask for confirmation after showing files
+    if !confirm_verification {
+        let prompt_text = format!(
+            "\n\tYou are about to submit the above files to the third-party verifier at {verifier}.\n\n\tImportant: Make sure your project's Scarb.toml does not include sensitive information like private keys.\n\n\tAre you sure you want to proceed? (Y/n)"
+        );
+        let input: String = prompt(prompt_text)?;
+
+        if !input.starts_with('Y') {
+            bail!("Verification aborted");
+        }
+    }
+
+    // Check contract exists after confirmation
+    if !artifacts.contains_key(contract_name) {
+        return Err(anyhow!("Contract named '{contract_name}' was not found"));
+    }
+
+    Ok(())
+}
+
 pub async fn verify(
     args: Verify,
     manifest_path: &Utf8PathBuf,
@@ -117,22 +151,6 @@ pub async fn verify(
     };
     let provider = get_provider(rpc_url.as_str())?;
 
-    // Let's ask confirmation
-    if !confirm_verification {
-        let prompt_text = format!(
-            "\n\tYou are about to submit the entire workspace code to the third-party verifier at {verifier}.\n\n\tImportant: Make sure your project's Scarb.toml does not include sensitive information like private keys.\n\n\tAre you sure you want to proceed? (Y/n)"
-        );
-        let input: String = prompt(prompt_text)?;
-
-        if !input.starts_with('Y') {
-            bail!("Verification aborted");
-        }
-    }
-
-    if !artifacts.contains_key(&contract_name) {
-        return Err(anyhow!("Contract named '{contract_name}' was not found"));
-    }
-
     // Build JSON Payload for the verification request
     // get the parent dir of the manifest path
     let workspace_dir = manifest_path
@@ -166,6 +184,7 @@ pub async fn verify(
         }
     };
 
+    // Create verifier and display files before prompting
     match verifier {
         Verifier::Walnut => {
             if test_files {
@@ -179,12 +198,42 @@ pub async fn verify(
                 &provider,
                 ui,
             )?;
+
+            // Gather and display files
+            let files = walnut.gather_files()?;
+            let files_to_display: Vec<String> =
+                files.iter().map(|(path, _)| format!("  {path}")).collect();
+            display_files_and_confirm(
+                &verifier,
+                files_to_display,
+                confirm_verification,
+                ui,
+                artifacts,
+                &contract_name,
+            )?;
+
             walnut
                 .verify(contract_identifier, contract_name, package, false, ui)
                 .await
         }
         Verifier::Voyager => {
             let voyager = Voyager::new(network, workspace_dir.to_path_buf(), &provider, ui)?;
+
+            // Gather and display files
+            let (_, files) = voyager.gather_files(test_files)?;
+            let files_to_display: Vec<String> = files
+                .iter()
+                .map(|(name, path)| format!("{name}: \n{path}"))
+                .collect();
+            display_files_and_confirm(
+                &verifier,
+                files_to_display,
+                confirm_verification,
+                ui,
+                artifacts,
+                &contract_name,
+            )?;
+
             voyager
                 .verify(contract_identifier, contract_name, package, test_files, ui)
                 .await

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -226,10 +226,8 @@ pub async fn verify(
 
             // Gather and format files for display
             let (_, files) = voyager.gather_files(test_files)?;
-            let files_to_display: Vec<String> = files
-                .iter()
-                .map(|(name, path)| format!("{name}: \n{path}"))
-                .collect();
+            let files_to_display: Vec<String> =
+                files.keys().map(|name| format!("  {name}")).collect();
 
             // Display files and confirm
             display_files_and_confirm(

--- a/crates/sncast/src/starknet_commands/verify/voyager.rs
+++ b/crates/sncast/src/starknet_commands/verify/voyager.rs
@@ -215,7 +215,7 @@ fn longest_common_prefix<P: AsRef<Utf8Path> + Clone>(
 }
 
 impl Voyager<'_> {
-    fn gather_files(
+    pub fn gather_files(
         &self,
         include_test_files: bool,
     ) -> Result<(Utf8PathBuf, HashMap<String, Utf8PathBuf>)> {
@@ -332,11 +332,6 @@ impl<'a> VerificationInterface<'a> for Voyager<'a> {
                     path
                 }
             })?;
-
-        ui.println(&"The following files will be transferred:");
-        for (name, path) in &files {
-            ui.println(&format!("{name}: \n{path}"));
-        }
 
         if selected.manifest_metadata.license.is_none() {
             ui.println(&WarningMessage::new("License not specified in Scarb.toml"));


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3184 

## Introduced changes

<!-- A brief description of the changes -->
- **Refactored file gathering logic**: Introduced a dedicated `gather_files` function for both Voyager and Walnut verification interfaces
- **Improved code organization**: Centralized file discovery logic for better reusability
- **Cleaned up verification output**: Removed file listing output from the Voyager verification process
- **Updated MessageCancel component**: Enhanced message cancellation functionality

## Benefits
- Better code organization and maintainability
- Improved reusability of file gathering logic
- Cleaner verification process output
-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
