### PR TITLE
[sncast] Don't require enabling casm compilation in Scarb.toml

### DIFF
--- a/crates/sncast/src/response/errors.rs
+++ b/crates/sncast/src/response/errors.rs
@@ -45,7 +45,7 @@ impl Message for ResponseError {
 pub enum StarknetCommandError {
     #[error(transparent)]
     UnknownError(#[from] anyhow::Error),
-    #[error("Failed to find {} artifact in starknet_artifacts.json file. Please make sure you have specified correct package using `--package` flag and that you have enabled sierra and casm code generation in Scarb.toml.", .0.data)]
+    #[error("Failed to find {} artifact in starknet_artifacts.json file. Please make sure you have specified correct package using `--package` flag.", .0.data)]
     ContractArtifactsNotFound(ErrorData),
     #[error(transparent)]
     WaitForTransactionError(#[from] WaitForTransactionError),

--- a/crates/sncast/tests/data/scripts/declare/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/declare/Scarb.toml
@@ -10,7 +10,6 @@ map1 = { path = "../map_script/contracts" }
 
 [lib]
 sierra = true
-casm = true
 
 [[target.starknet-contract]]
 build-external-contracts = ["map1::Mapa"]

--- a/crates/sncast/tests/data/scripts/map_script/scripts/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/map_script/scripts/Scarb.toml
@@ -10,7 +10,6 @@ map1 = { path = "../contracts" }
 
 [lib]
 sierra = true
-casm = true
 
 [[target.starknet-contract]]
 build-external-contracts = ["map1::Mapa", "map1::Mapa2"]

--- a/crates/sncast/tests/data/scripts/old_sncast_std/scripts/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/old_sncast_std/scripts/Scarb.toml
@@ -9,6 +9,5 @@ sncast_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag =
 
 [lib]
 sierra = true
-casm = true
 
 [[target.starknet-contract]]

--- a/crates/sncast/tests/data/scripts/state_script/scripts/Scarb.toml
+++ b/crates/sncast/tests/data/scripts/state_script/scripts/Scarb.toml
@@ -10,7 +10,6 @@ state = { path = "../contracts" }
 
 [lib]
 sierra = true
-casm = true
 
 [[target.starknet-contract]]
 build-external-contracts = [

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -447,7 +447,7 @@ async fn test_state_file_contains_all_failed_txs() {
         "declare",
         ScriptTransactionStatus::Error,
         vec![
-            "Failed to find Not_this_time artifact in starknet_artifacts.json file. Please make sure you have specified correct package using `--package` flag and that you have enabled sierra and casm code generation in Scarb.toml.",
+            "Failed to find Not_this_time artifact in starknet_artifacts.json file. Please make sure you have specified correct package using `--package` flag.",
         ],
     );
 

--- a/docs/src/starknet/script.md
+++ b/docs/src/starknet/script.md
@@ -324,7 +324,6 @@ map = { path = "../contracts" }
 
 [lib]
 sierra = true
-casm = true
 
 [[target.starknet-contract]]
 build-external-contracts = [


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2621

## Introduced changes

- Update `ContractArtifactsNotFound` error message so it doesn't mention that enabling casm compilation is required
- Remove `casm = true` from couple Scarb.toml in docs, so users aren't misled that it's needed

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
