### PR TITLE
Remove duplicated resources from `UsedResources`

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -15,11 +15,9 @@ use blockifier::execution::{
     entry_point::CallEntryPoint, syscalls::vm_syscall_utils::SyscallUsageMap,
 };
 use blockifier::state::errors::StateError;
-use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
 use conversions::{byte_array::ByteArray, serde::serialize::CairoSerialize, string::IntoHexStr};
 use shared::utils::build_readable_text;
 use starknet_api::core::EntryPointSelector;
-use starknet_api::execution_resources::GasAmount;
 use starknet_api::{
     contract_class::EntryPointType,
     core::{ClassHash, ContractAddress},
@@ -29,8 +27,6 @@ use starknet_types_core::felt::Felt;
 #[derive(Clone, Debug, Default)]
 pub struct UsedResources {
     pub syscall_usage: SyscallUsageMap,
-    pub execution_resources: ExecutionResources,
-    pub gas_consumed: GasAmount,
     pub execution_summary: ExecutionSummary,
     pub l1_handler_payload_lengths: Vec<usize>,
 }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -42,7 +42,6 @@ use runtime::{
 };
 use scarb_oracle_hint_service::OracleHintService;
 use starknet::signers::SigningKey;
-use starknet_api::execution_resources::GasAmount;
 use starknet_api::{contract_class::EntryPointType::L1Handler, core::ClassHash};
 use starknet_types_core::felt::Felt;
 use std::cell::RefCell;
@@ -785,12 +784,11 @@ pub fn get_all_used_resources(
 
     let l1_handler_payload_lengths = get_l1_handlers_payloads_lengths(&call_info.inner_calls);
 
+    // Syscalls are used only for `--detailed-resources` output.
     let top_call_syscalls = trace.borrow().get_total_used_syscalls();
 
     UsedResources {
         syscall_usage: top_call_syscalls,
-        execution_resources: call_info.resources.clone(),
-        gas_consumed: GasAmount::from(call_info.execution.gas_consumed),
         execution_summary: summary,
         l1_handler_payload_lengths,
     }

--- a/crates/forge-runner/src/gas.rs
+++ b/crates/forge-runner/src/gas.rs
@@ -40,13 +40,17 @@ pub fn calculate_used_gas(
         state: state_resources,
     };
     let computation_resources = ComputationResources {
-        tx_vm_resources: resources.execution_resources.clone(),
+        tx_vm_resources: resources
+            .execution_summary
+            .charged_resources
+            .vm_resources
+            .clone(),
         // OS resources (transaction type related costs) and fee transfer resources are not included
         // as they are not relevant for test execution (see documentation for details):
         // https://github.com/foundry-rs/starknet-foundry/blob/979caf23c5d1085349e253d75682dd0e2527e321/docs/src/testing/gas-and-resource-estimation.md?plain=1#L75
         os_vm_resources: ExecutionResources::default(),
         n_reverted_steps: 0, // TODO(#3681)
-        sierra_gas: resources.gas_consumed,
+        sierra_gas: resources.execution_summary.charged_resources.gas_consumed,
         reverted_sierra_gas: GasAmount::ZERO, // TODO(#3681)
     };
 

--- a/crates/forge-runner/src/messages.rs
+++ b/crates/forge-runner/src/messages.rs
@@ -176,7 +176,9 @@ fn format_detailed_resources(
     };
 
     let syscalls = format_items(&syscall_usage);
-    let vm_resources_output = format_vm_resources(&used_resources.execution_resources);
+
+    let charged_resources = &used_resources.execution_summary.charged_resources;
+    let vm_resources_output = format_vm_resources(&charged_resources.vm_resources);
 
     match tracked_resource {
         ForgeTrackedResource::CairoSteps => {
@@ -191,10 +193,10 @@ fn format_detailed_resources(
                 "
         sierra_gas_consumed: {}
         syscalls: ({syscalls})",
-                used_resources.gas_consumed.0
+                charged_resources.gas_consumed.0
             );
 
-            if used_resources.execution_resources != ExecutionResources::default() {
+            if charged_resources.vm_resources != ExecutionResources::default() {
                 output.push_str(&vm_resources_output);
             }
             output.push('\n');

--- a/crates/forge/test_utils/src/runner.rs
+++ b/crates/forge/test_utils/src/runner.rs
@@ -395,7 +395,9 @@ pub fn assert_builtin(
             AnyTestCaseSummary::Single(case) => match case {
                 TestCaseSummary::Passed { used_resources, .. } => {
                     used_resources
-                        .execution_resources
+                        .execution_summary
+                        .charged_resources
+                        .vm_resources
                         .builtin_instance_counter
                         .get(&builtin)
                         .unwrap_or(&0)


### PR DESCRIPTION
[Refactor only]

We do not need to additionally store VM resources and gas consumed as they are already present in `ExecutionSummary`.
