### PR TITLE
Update stale action to v10

### DIFF
--- a/.github/workflows/automate-stale.yml
+++ b/.github/workflows/automate-stale.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Run Stale Bot
         id: stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           # General settings
           days-before-stale: ${{ env.DAYS_BEFORE_STALE }}


### PR DESCRIPTION
Bumped actions/stale from v9 to v10 in .github/workflows/automate-stale.yml.
This keeps the workflow up to date with the latest release.

Proof:https://github.com/actions/stale/releases/tag/v10.0.0