### PR TITLE
Replaced uses: actions/setup-node@v5 → uses: actions/setup-node@v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           cache: 'npm'
           cache-dependency-path: scripts/package-lock.json


### PR DESCRIPTION
Release notes: https://github.com/actions/setup-node/releases/tag/v6.0.0