### PR TITLE
micro opt: stop emitting __internal_config_statement from test attr

### DIFF
--- a/crates/snforge-scarb-plugin/src/attributes/test.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/test.rs
@@ -2,7 +2,7 @@ use super::{AttributeInfo, ErrorExt, internal_config_statement::InternalConfigSt
 use crate::asserts::assert_is_used_once;
 use crate::common::{has_fuzzer_attribute, has_test_case_attribute};
 use crate::external_inputs::ExternalInput;
-use crate::utils::{create_single_token, process_statements};
+use crate::utils::{create_single_token, get_statements};
 use crate::{
     args::Arguments,
     common::{into_proc_macro_result, with_parsed_values},
@@ -95,12 +95,7 @@ fn test_internal(
 
         let test_func_with_attrs = test_func_with_attrs(&test_func, &called_func, &call_args);
 
-        let statements = func
-            .body(db)
-            .statements(db)
-            .elements(db)
-            .collect::<Vec<_>>();
-        let (statements, if_content) = process_statements(db, &statements);
+        let (statements, if_content) = get_statements(db, func);
 
         Ok(quote!(
             #test_func_with_attrs

--- a/crates/snforge-scarb-plugin/src/attributes/test.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/test.rs
@@ -2,7 +2,7 @@ use super::{AttributeInfo, ErrorExt, internal_config_statement::InternalConfigSt
 use crate::asserts::assert_is_used_once;
 use crate::common::{has_fuzzer_attribute, has_test_case_attribute};
 use crate::external_inputs::ExternalInput;
-use crate::utils::create_single_token;
+use crate::utils::{create_single_token, process_statements};
 use crate::{
     args::Arguments,
     common::{into_proc_macro_result, with_parsed_values},
@@ -81,9 +81,6 @@ fn test_internal(
     let signature = SyntaxNodeWithDb::new(&signature, db);
     let signature = quote! { #signature };
 
-    let body = func.body(db).as_syntax_node();
-    let body = SyntaxNodeWithDb::new(&body, db);
-
     let attributes = func.attributes(db).as_syntax_node();
     let attributes = SyntaxNodeWithDb::new(&attributes, db);
 
@@ -98,13 +95,27 @@ fn test_internal(
 
         let test_func_with_attrs = test_func_with_attrs(&test_func, &called_func, &call_args);
 
+        let statements = func
+            .body(db)
+            .statements(db)
+            .elements(db)
+            .collect::<Vec<_>>();
+        let (statements, if_content) = process_statements(db, &statements);
+
         Ok(quote!(
             #test_func_with_attrs
 
             #attributes
-            #[#internal_config]
             fn #func_ident #signature
-            #body
+            {
+               if snforge_std::_internals::is_config_run() {
+                   #if_content
+
+                   return;
+               }
+
+               #statements
+           }
         ))
     } else {
         Ok(quote!(

--- a/crates/snforge-scarb-plugin/src/utils.rs
+++ b/crates/snforge-scarb-plugin/src/utils.rs
@@ -84,13 +84,7 @@ pub fn get_statements(
         .statements(db)
         .elements(db)
         .collect::<Vec<_>>();
-    process_statements(db, &statements)
-}
 
-pub fn process_statements(
-    db: &SimpleParserDatabase,
-    statements: &[Statement],
-) -> (TokenStream, TokenStream) {
     let if_content = statements.first().and_then(|stmt| {
         // first statement is `if`
         let Statement::Expr(expr) = stmt else {
@@ -139,7 +133,7 @@ pub fn process_statements(
     let statements = if if_content.is_some() {
         &statements[1..]
     } else {
-        statements
+        &statements[..]
     }
     .iter()
     .map(|stmt| stmt.to_token_stream(db))

--- a/crates/snforge-scarb-plugin/src/utils.rs
+++ b/crates/snforge-scarb-plugin/src/utils.rs
@@ -84,7 +84,13 @@ pub fn get_statements(
         .statements(db)
         .elements(db)
         .collect::<Vec<_>>();
+    process_statements(db, &statements)
+}
 
+pub fn process_statements(
+    db: &SimpleParserDatabase,
+    statements: &[Statement],
+) -> (TokenStream, TokenStream) {
     let if_content = statements.first().and_then(|stmt| {
         // first statement is `if`
         let Statement::Expr(expr) = stmt else {
@@ -133,7 +139,7 @@ pub fn get_statements(
     let statements = if if_content.is_some() {
         &statements[1..]
     } else {
-        &statements[..]
+        statements
     }
     .iter()
     .map(|stmt| stmt.to_token_stream(db))

--- a/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
@@ -90,9 +90,10 @@ fn works_with_few_attributes() {
                 core::array::ArrayTrait::span(@arr)
             }
 
-            #[__internal_config_statement]
             fn empty_fn() {
-
+                if snforge_std::_internals::is_config_run() {
+                    return;
+                }
             }
         ",
     );
@@ -107,7 +108,6 @@ fn works_with_few_attributes() {
     assert_output(
         &result,
         "
-            #[__internal_config_statement]
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     let mut data = array![];
@@ -137,7 +137,6 @@ fn works_with_few_attributes() {
     assert_output(
         &result,
         r#"
-            #[__internal_config_statement]
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     let mut data = array![];
@@ -192,9 +191,10 @@ fn works_with_fuzzer() {
                 core::array::ArrayTrait::span(@arr)
             }
 
-            #[__internal_config_statement]
             fn empty_fn() {
-
+                if snforge_std::_internals::is_config_run() {
+                    return;
+                }
             }
         ",
     );
@@ -211,8 +211,11 @@ fn works_with_fuzzer() {
         r"
             #[__fuzzer_config(runs: 123, seed: 321)]
             #[__fuzzer_wrapper]
-            #[__internal_config_statement]
-            fn empty_fn() {}
+            fn empty_fn() {
+                if snforge_std::_internals::is_config_run() {
+                    return;
+                }
+            }
         ",
     );
 }
@@ -262,8 +265,11 @@ fn works_with_fuzzer_before_test() {
 
             #[__fuzzer_config(runs: 123, seed: 321)]
             #[__fuzzer_wrapper]
-            #[__internal_config_statement]
-            fn empty_fn(f: felt252) {}
+            fn empty_fn(f: felt252) {
+                if snforge_std::_internals::is_config_run() {
+                    return;
+                }
+            }
         ",
     );
 
@@ -363,7 +369,6 @@ fn works_with_fuzzer_config_wrapper() {
             }
 
             #[fuzzer]
-            #[__internal_config_statement]
             fn empty_fn(f: felt252) {
                 if snforge_std::_internals::is_config_run() {
                     let mut data = array![];

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
@@ -29,8 +29,11 @@ fn appends_internal_config_and_executable() {
                 core::array::ArrayTrait::span(@arr)
             }
 
-            #[__internal_config_statement]
-            fn empty_fn() {}
+            fn empty_fn() {
+                if snforge_std::_internals::is_config_run() {
+                    return;
+                }
+            }
         ",
     );
 }


### PR DESCRIPTION
The test attr is a hot path, so it may make sense to avoid forcing the expansion to happen twice for every test. The time penalty is not big, but seems easy enough to avoid.

Events breakdown for OZ before / after:

<img width="464" height="222" alt="image" src="https://github.com/user-attachments/assets/6ffd73b5-295a-4376-855a-523f179cfc53" />

<img width="460" height="225" alt="image" src="https://github.com/user-attachments/assets/1772361f-0c8d-40e3-be2b-3fc2389688b3" />
