### PR TITLE
Do not instantiate Program for each test case run separately when fuzzing

### DIFF
--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -176,9 +176,12 @@ fn run_with_fuzzing(
 
         let mut tasks = FuturesUnordered::new();
 
+        let program = case.try_into_program(&casm_program)?;
+
         for _ in 1..=fuzzer_runs.get() {
             tasks.push(run_fuzz_test(
                 case.clone(),
+                program.clone(),
                 casm_program.clone(),
                 forge_config.clone(),
                 versioned_program_path.clone(),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -13,6 +13,7 @@ use blockifier::execution::entry_point_execution::{
 use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::cached_state::CachedState;
 use cairo_vm::Felt252;
+use cairo_vm::types::program::Program;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -75,13 +76,17 @@ pub fn run_test(
         if send.is_closed() {
             return TestCaseSummary::Interrupted {};
         }
-        let run_result = run_test_case(
-            &case,
-            &casm_program,
-            &RuntimeConfig::from(&forge_config.test_runner_config),
-            None,
-            &versioned_program_path,
-        );
+
+        let run_result = case.try_into_program(&casm_program).and_then(|program| {
+            run_test_case(
+                &case,
+                &program,
+                &casm_program,
+                &RuntimeConfig::from(&forge_config.test_runner_config),
+                None,
+                &versioned_program_path,
+            )
+        });
 
         if send.is_closed() {
             return TestCaseSummary::Interrupted {};
@@ -92,8 +97,10 @@ pub fn run_test(
 }
 
 #[tracing::instrument(skip_all, level = "debug")]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run_fuzz_test(
     case: Arc<TestCaseWithResolvedConfig>,
+    program: Program,
     casm_program: Arc<AssembledProgramWithDebugInfo>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
@@ -108,9 +115,9 @@ pub(crate) fn run_fuzz_test(
         if send.is_closed() | fuzzing_send.is_closed() {
             return TestCaseSummary::Interrupted {};
         }
-
         let run_result = run_test_case(
             &case,
+            &program,
             &casm_program,
             &RuntimeConfig::from(&forge_config.test_runner_config),
             Some(rng),
@@ -160,14 +167,14 @@ pub enum RunResult {
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn run_test_case(
     case: &TestCaseWithResolvedConfig,
+    program: &Program,
     casm_program: &AssembledProgramWithDebugInfo,
     runtime_config: &RuntimeConfig,
     fuzzer_rng: Option<Arc<Mutex<StdRng>>>,
     versioned_program_path: &Utf8Path,
 ) -> Result<RunResult> {
-    let program = case.try_into_program(casm_program)?;
     let (call, entry_point) =
-        setup::build_test_call_and_entry_point(&case.test_details, casm_program, &program);
+        setup::build_test_call_and_entry_point(&case.test_details, casm_program, program);
 
     let mut state_reader = ExtendedStateReader {
         dict_state_reader: cheatnet_constants::build_testing_state(),
@@ -200,7 +207,7 @@ pub fn run_test_case(
     } = setup::initialize_execution_context(
         call.clone(),
         &hints,
-        &program,
+        program,
         &mut cached_state,
         &mut context,
     )?;


### PR DESCRIPTION
Correct me if I am wrong, but it seems we recreate the same test case program multiple times when fuzzing. 

When run with `snforge test --workspace --features fuzzing --fuzzer-runs 500 ` on OZ:
Before:  272.79s
After: 208.78s
