### PR TITLE
Display fuzzing output without fractional parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Changed
+
+- Gas values in fuzzing test output are now displayed as whole numbers without fractional parts
+
 ## [0.51.0] - 2025-10-21
 
 ### Forge

--- a/crates/forge-runner/src/gas/stats.rs
+++ b/crates/forge-runner/src/gas/stats.rs
@@ -23,12 +23,20 @@ impl GasStats {
 
 #[expect(clippy::cast_precision_loss)]
 fn mean(values: &[u64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+
     let sum: f64 = values.iter().map(|&x| x as f64).sum();
     sum / values.len() as f64
 }
 
 #[expect(clippy::cast_precision_loss)]
 fn std_deviation(mean: f64, values: &[u64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+
     let sum_squared_diff = values
         .iter()
         .map(|&x| (x as f64 - mean).pow(2))

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -39,7 +39,7 @@ impl fmt::Display for GasStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{{max: ~{}, min: ~{}, mean: ~{:.2}, std deviation: ~{:.2}}}",
+            "{{max: ~{}, min: ~{}, mean: ~{:.0}, std deviation: ~{:.0}}}",
             self.max, self.min, self.mean, self.std_deviation
         )
     }

--- a/docs/src/snforge-advanced-features/fuzz-testing.md
+++ b/docs/src/snforge-advanced-features/fuzz-testing.md
@@ -34,8 +34,8 @@ $ snforge test
 ```shell
 Collected 2 test(s) from fuzz_testing package
 Running 2 test(s) from src/
-[PASS] fuzz_testing::with_parameters::tests::test_sum (runs: 22, gas: {max: ~124, min: ~121, mean: ~123.00, std deviation: ~0.90})
-[PASS] fuzz_testing::basic_example::tests::test_sum (runs: 256, gas: {max: ~124, min: ~121, mean: ~123.00, std deviation: ~0.81})
+[PASS] fuzz_testing::with_parameters::tests::test_sum (runs: 22, (l1_gas: {max: ~0, min: ~0, mean: ~0, std deviation: ~0}, l1_data_gas: {max: ~0, min: ~0, mean: ~0, std deviation: ~0}, l2_gas: {max: ~1888390, min: ~1852630, mean: ~1881888, std deviation: ~9322}))
+[PASS] fuzz_testing::basic_example::tests::test_sum (runs: 256, (l1_gas: {max: ~0, min: ~0, mean: ~0, std deviation: ~0}, l1_data_gas: {max: ~0, min: ~0, mean: ~0, std deviation: ~0}, l2_gas: {max: ~1888390, min: ~1828790, mean: ~1882058, std deviation: ~8807}))
 Tests: 2 passed, 0 failed, 0 ignored, 0 filtered out
 Fuzzer seed: [..]
 ```

--- a/docs/src/testing/gas-and-resource-estimation.md
+++ b/docs/src/testing/gas-and-resource-estimation.md
@@ -21,7 +21,7 @@ storage updates, events and l1 <> l2 messages.
 
 While using the fuzzing feature additional gas statistics will be displayed:
 ```shell
-[PASS] tests::fuzzing_test (runs: 256, l1_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31}, l1_data_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31}, l2_gas: {max: ~126, min: ~1, mean: ~65.00, std deviation: ~37.31})
+[PASS] tests::fuzzing_test (runs: 256, l1_gas: {max: ~126, min: ~1, mean: ~65, std deviation: ~37}, l1_data_gas: {max: ~96, min: ~96, mean: ~96, std deviation: ~0}, l2_gas: {max: ~1888390, min: ~1852630, mean: ~1881888, std deviation: ~9322}})
 ```
 
 > 📝 **Note**


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related #3077

