### PR TITLE
Fix `meta_tx_v0` panic with use of `SierraGas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Gas values in fuzzing test output are now displayed as whole numbers without fractional parts
 
+#### Fixed
+
+- A bug that caused `meta_tx_v0` to panic when tracked resources are Sierra gas.
+
 ## [0.51.0] - 2025-10-21
 
 ### Forge

--- a/crates/cheatnet/src/runtime_extensions/common.rs
+++ b/crates/cheatnet/src/runtime_extensions/common.rs
@@ -35,14 +35,15 @@ pub fn get_syscalls_gas_consumed(
                     panic!("Failed to get syscall gas cost for selector {selector:?}")
                 });
 
-            // `linear_factor` is relevant only for `deploy` syscall, for other syscalls it is 0
+            // `linear_factor` is relevant only for `deploy` and `meta_tx_v0` syscalls, for other syscalls it is 0
             // `base_syscall_cost` makes an assert that `linear_factor` is 0
             // Hence to get base cost for `deploy` we use `get_syscall_cost` with 0 as `linear_length`
             // For other syscalls we use `base_syscall_cost`, which is also an additional check that `linear_factor` is always 0 then
-            let base_cost = if let SyscallSelector::Deploy = selector {
-                syscall_gas_cost.get_syscall_cost(0)
-            } else {
-                syscall_gas_cost.base_syscall_cost()
+            let base_cost = match selector {
+                SyscallSelector::Deploy | SyscallSelector::MetaTxV0 => {
+                    syscall_gas_cost.get_syscall_cost(0)
+                }
+                _ => syscall_gas_cost.base_syscall_cost(),
             };
 
             // We want to calculate `base_cost * call_count + linear_cost * linear_factor`

--- a/crates/forge/tests/integration/meta_tx_v0.rs
+++ b/crates/forge/tests/integration/meta_tx_v0.rs
@@ -165,7 +165,7 @@ fn meta_tx_v0_with_cheat_block_hash() {
         .unwrap()
     );
 
-    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
     assert_passed(&result);
 }
 
@@ -236,6 +236,6 @@ fn meta_tx_v0_verify_tx_context_modification() {
         .unwrap()
     );
 
-    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
     assert_passed(&result);
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Fix panic that occur with use of  `meta_tx_v0` syscall and `SierraGas` as tracked resources

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
