### PR TITLE
Use alchemy instead of blast as free provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+
 jobs:
   test-forge-unit:
     name: Test Forge / Unit Tests

--- a/crates/data-transformer/src/transformer/sierra_abi/parsing.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/parsing.rs
@@ -84,7 +84,7 @@ pub fn parse_inline_macro(
             let node_text = token_tree
                 .tokens(db)
                 .elements(db)
-                .map(|token| token.as_syntax_node().get_text(db).to_string())
+                .map(|token| token.as_syntax_node().get_text(db).clone())
                 .collect::<String>();
             split_expressions(&node_text, db)
         }

--- a/crates/debugging/src/tree/ui/display.rs
+++ b/crates/debugging/src/tree/ui/display.rs
@@ -31,14 +31,14 @@ impl NodeDisplay for TestName {
 impl NodeDisplay for ContractName {
     const TAG: &'static str = "contract name";
     fn string_pretty(&self) -> String {
-        self.0.to_string()
+        self.0.clone()
     }
 }
 
 impl NodeDisplay for Selector {
     const TAG: &'static str = "selector";
     fn string_pretty(&self) -> String {
-        self.0.to_string()
+        self.0.clone()
     }
 }
 

--- a/crates/forge/src/new.rs
+++ b/crates/forge/src/new.rs
@@ -6,7 +6,7 @@ use include_dir::{Dir, DirEntry, include_dir};
 use indoc::formatdoc;
 use scarb_api::{ScarbCommand, ensure_scarb_available};
 use semver::Version;
-use shared::consts::FREE_RPC_PROVIDER_URL;
+use shared::consts::free_rpc_provider_url;
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -160,7 +160,7 @@ fn create_snfoundry_manifest(path: &PathBuf) -> Result<()> {
         # block-explorer = "StarkScan"                             # Block explorer service used to display links to transaction details
         # show-explorer-links = true                               # Print links pointing to pages with transaction details in the chosen block explorer
         "#,
-            default_rpc_url = FREE_RPC_PROVIDER_URL,
+            default_rpc_url = free_rpc_provider_url(),
         },
     )?;
 
@@ -309,7 +309,7 @@ fn add_fork_config(document: &mut DocumentMut) -> Result<()> {
 
     let mut fork_table = Table::new();
     fork_table.insert("name", Item::Value(Value::from("SEPOLIA_LATEST")));
-    fork_table.insert("url", Item::Value(Value::from(FREE_RPC_PROVIDER_URL)));
+    fork_table.insert("url", Item::Value(Value::from(free_rpc_provider_url())));
 
     let mut block_id_table = Table::new();
     block_id_table.insert("tag", Item::Value(Value::from("latest")));

--- a/crates/forge/tests/e2e/new.rs
+++ b/crates/forge/tests/e2e/new.rs
@@ -7,7 +7,7 @@ use forge::scarb::config::SCARB_MANIFEST_TEMPLATE_CONTENT;
 use indoc::{formatdoc, indoc};
 use regex::Regex;
 use scarb_api::ScarbCommand;
-use shared::consts::FREE_RPC_PROVIDER_URL;
+use shared::consts::free_rpc_provider_url;
 use shared::test_utils::output_assert::assert_stdout_contains;
 use snapbox::assert_matches;
 use snapbox::cmd::Command as SnapboxCommand;
@@ -183,12 +183,13 @@ fn get_expected_manifest_content(template: &Template, validate_snforge_std: bool
 
     let target_contract_entry = "[[target.starknet-contract]]\nsierra = true";
 
+    let free_rpc_provider_url = free_rpc_provider_url();
     let fork_config = if let Template::Erc20Contract = template {
         &formatdoc!(
             r#"
             [[tool.snforge.fork]]
             name = "SEPOLIA_LATEST"
-            url = "{FREE_RPC_PROVIDER_URL}"
+            url = "{free_rpc_provider_url}"
             block_id = {{ tag = "latest" }}
         "#
         )

--- a/crates/scarb-api/src/artifacts.rs
+++ b/crates/scarb-api/src/artifacts.rs
@@ -97,7 +97,7 @@ impl StarknetArtifactsFiles {
             .into_par_iter()
             .map(|(name, path)| {
                 self.compile_artifact_at_path(&path)
-                    .map(|artifact| (name.to_string(), (artifact, path)))
+                    .map(|artifact| (name.clone(), (artifact, path)))
             })
             .collect::<Result<_>>()
     }
@@ -141,7 +141,7 @@ fn unique_artifacts(
     artifact_representations
         .into_iter()
         .flat_map(StarknetArtifactsRepresentation::artifacts)
-        .unique_by(|(name, _)| name.to_string())
+        .unique_by(|(name, _)| name.clone())
         .filter(|(name, _)| !current_artifacts.contains_key(name))
         .collect()
 }

--- a/crates/shared/src/consts.rs
+++ b/crates/shared/src/consts.rs
@@ -1,4 +1,10 @@
 pub const EXPECTED_RPC_VERSION: &str = "0.9.0";
 pub const RPC_URL_VERSION: &str = "v0_9";
 pub const SNFORGE_TEST_FILTER: &str = "SNFORGE_TEST_FILTER";
-pub const FREE_RPC_PROVIDER_URL: &str = "https://starknet-sepolia.public.blastapi.io/rpc/v0_9";
+const ALCHEMY_API_KEY: &str = env!("ALCHEMY_API_KEY");
+
+pub fn free_rpc_provider_url() -> String {
+    format!(
+        "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{ALCHEMY_API_KEY}"
+    )
+}

--- a/crates/shared/src/consts.rs
+++ b/crates/shared/src/consts.rs
@@ -3,6 +3,7 @@ pub const RPC_URL_VERSION: &str = "v0_9";
 pub const SNFORGE_TEST_FILTER: &str = "SNFORGE_TEST_FILTER";
 const ALCHEMY_API_KEY: &str = env!("ALCHEMY_API_KEY");
 
+#[must_use]
 pub fn free_rpc_provider_url() -> String {
     format!(
         "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{ALCHEMY_API_KEY}"

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -70,7 +70,7 @@ impl FreeProvider {
     pub fn mainnet_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {
-                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read api key");
+                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read alchemy api key");
                 format!(
                     "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
                 )
@@ -81,7 +81,7 @@ impl FreeProvider {
     pub fn sepolia_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {
-                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read api key");
+                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to alchemy read api key");
                 format!(
                     "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
                 )

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -69,6 +69,7 @@ impl FreeProvider {
         Self::Alchemy
     }
 
+    #[must_use]
     pub fn mainnet_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {
@@ -79,6 +80,7 @@ impl FreeProvider {
         }
     }
 
+    #[must_use]
     pub fn sepolia_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -9,6 +9,8 @@ use shared::verify_and_warn_if_incompatible_rpc_version;
 use starknet::providers::{JsonRpcClient, jsonrpc::HttpTransport};
 use std::env;
 
+const ALCHEMY_API_KEY: &str = env!("ALCHEMY_API_KEY");
+
 #[derive(Args, Clone, Debug, Default)]
 #[group(required = false, multiple = false)]
 pub struct RpcArgs {
@@ -70,9 +72,8 @@ impl FreeProvider {
     pub fn mainnet_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {
-                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read alchemy api key");
                 format!(
-                    "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
+                    "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{ALCHEMY_API_KEY}"
                 )
             }
         }
@@ -81,9 +82,8 @@ impl FreeProvider {
     pub fn sepolia_rpc(&self) -> String {
         match self {
             FreeProvider::Alchemy => {
-                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to alchemy read api key");
                 format!(
-                    "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
+                    "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{ALCHEMY_API_KEY}"
                 )
             }
         }

--- a/crates/sncast/src/helpers/rpc.rs
+++ b/crates/sncast/src/helpers/rpc.rs
@@ -7,6 +7,7 @@ use foundry_ui::UI;
 use shared::consts::RPC_URL_VERSION;
 use shared::verify_and_warn_if_incompatible_rpc_version;
 use starknet::providers::{JsonRpcClient, jsonrpc::HttpTransport};
+use std::env;
 
 #[derive(Args, Clone, Debug, Default)]
 #[group(required = false, multiple = false)]
@@ -57,13 +58,35 @@ impl RpcArgs {
 }
 
 pub enum FreeProvider {
-    Blast,
+    Alchemy,
 }
 
 impl FreeProvider {
     #[must_use]
     pub fn semi_random() -> Self {
-        Self::Blast
+        Self::Alchemy
+    }
+
+    pub fn mainnet_rpc(&self) -> String {
+        match self {
+            FreeProvider::Alchemy => {
+                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read api key");
+                format!(
+                    "https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
+                )
+            }
+        }
+    }
+
+    pub fn sepolia_rpc(&self) -> String {
+        match self {
+            FreeProvider::Alchemy => {
+                let api_key = env::var("ALCHEMY_API_KEY").expect("Failed to read api key");
+                format!(
+                    "https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/{RPC_URL_VERSION}/{api_key}"
+                )
+            }
+        }
     }
 }
 
@@ -76,12 +99,12 @@ impl Network {
         }
     }
 
-    fn free_mainnet_rpc(_provider: &FreeProvider) -> String {
-        format!("https://starknet-mainnet.public.blastapi.io/rpc/{RPC_URL_VERSION}")
+    fn free_mainnet_rpc(provider: &FreeProvider) -> String {
+        provider.mainnet_rpc()
     }
 
-    fn free_sepolia_rpc(_provider: &FreeProvider) -> String {
-        format!("https://starknet-sepolia.public.blastapi.io/rpc/{RPC_URL_VERSION}")
+    fn free_sepolia_rpc(provider: &FreeProvider) -> String {
+        provider.sepolia_rpc()
     }
 
     async fn devnet_rpc(_provider: &FreeProvider) -> Result<String> {
@@ -111,14 +134,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_mainnet_url_happy_case() {
-        let provider = get_provider(&Network::free_mainnet_rpc(&FreeProvider::Blast)).unwrap();
+        let provider = get_provider(&Network::free_mainnet_rpc(&FreeProvider::Alchemy)).unwrap();
         let spec_version = provider.spec_version().await.unwrap();
         assert!(is_expected_version(&Version::parse(&spec_version).unwrap()));
     }
 
     #[tokio::test]
     async fn test_sepolia_url_happy_case() {
-        let provider = get_provider(&Network::free_sepolia_rpc(&FreeProvider::Blast)).unwrap();
+        let provider = get_provider(&Network::free_sepolia_rpc(&FreeProvider::Alchemy)).unwrap();
         let spec_version = provider.spec_version().await.unwrap();
         assert!(is_expected_version(&Version::parse(&spec_version).unwrap()));
     }

--- a/docs/listings/fork_testing/Scarb.toml
+++ b/docs/listings/fork_testing/Scarb.toml
@@ -18,5 +18,5 @@ test = "snforge test"
 
 [[tool.snforge.fork]]
 name = "SEPOLIA_LATEST"
-url = "https://starknet-sepolia.public.blastapi.io/rpc/v0_7"
+url = "<YOUR_RPC_URL>"
 block_id.tag = "latest"

--- a/docs/listings/fork_testing/tests/explicit/block_hash.cairo
+++ b/docs/listings/fork_testing/tests/explicit/block_hash.cairo
@@ -5,7 +5,7 @@ const CONTRACT_ADDRESS: felt252 =
 
 #[test]
 #[fork(
-    url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
+    url: "<YOUR_RPC_URL>",
     block_hash: 0x0690f8d584b52c2798d76b3346217a516778abee9b1bd8e400beb4f05dd9a4e7,
 )]
 fn test_using_forked_state() {

--- a/docs/listings/fork_testing/tests/explicit/block_number.cairo
+++ b/docs/listings/fork_testing/tests/explicit/block_number.cairo
@@ -6,7 +6,7 @@ const CONTRACT_ADDRESS: felt252 =
     0x0522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716;
 
 #[test]
-#[fork(url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7", block_number: 77864)]
+#[fork(url: "<YOUR_RPC_URL>", block_number: 77864)]
 fn test_using_forked_state() {
     // instantiate the dispatcher
     let dispatcher = IPokemonGalleryDispatcher {

--- a/docs/listings/fork_testing/tests/explicit/block_tag.cairo
+++ b/docs/listings/fork_testing/tests/explicit/block_tag.cairo
@@ -4,7 +4,7 @@ const CONTRACT_ADDRESS: felt252 =
     0x0522dc7cbe288037382a02569af5a4169531053d284193623948eac8dd051716;
 
 #[test]
-#[fork(url: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7", block_tag: latest)]
+#[fork(url: "<YOUR_RPC_URL>", block_tag: latest)]
 fn test_using_forked_state() {
     let dispatcher = IPokemonGalleryDispatcher {
         contract_address: CONTRACT_ADDRESS.try_into().unwrap(),

--- a/docs/listings/map3/snfoundry.toml
+++ b/docs/listings/map3/snfoundry.toml
@@ -1,4 +1,4 @@
 [sncast.default]
 url = "http://127.0.0.1:5050/rpc"
 # [sncast.default]
-# url = "https://starknet-sepolia.public.blastapi.io/rpc/v0_7"
+# url = "<YOUR_RPC_URL>"

--- a/docs/src/snforge-advanced-features/fork-testing.md
+++ b/docs/src/snforge-advanced-features/fork-testing.md
@@ -12,7 +12,6 @@ network and perform actions on top of it.
 ## Test Contract
 
 We will demonstrate fork testing on an example of the `Pokemons` contract deployed on Sepolia network.
-We are going to use a free, open RPC endpoint - [Blast](https://blastapi.io/public-api/starknet).
 
 We first need to define the contract's interface along with all the structures used by its externals:
 ```rust
@@ -77,7 +76,7 @@ the same fork in tests.
 ```toml
 [[tool.snforge.fork]]
 name = "SEPOLIA_LATEST"
-url = "https://starknet-sepolia.public.blastapi.io/rpc/v0_7"
+url = "<YOUR_RPC_URL>"
 block_id.tag = "latest"
 ```
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Change blast to alchemy as rpc provider in sncast, due to blast termination.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
