### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/_build-binaries-native.yml
+++ b/.github/workflows/_build-binaries-native.yml
@@ -58,13 +58,13 @@ jobs:
     steps:
       - name: Checkout with ref
         if: inputs.ref != ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Checkout default
         if: inputs.ref == ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup rust
         run: |

--- a/.github/workflows/_build-binaries.yml
+++ b/.github/workflows/_build-binaries.yml
@@ -52,13 +52,13 @@ jobs:
     steps:
       - name: Checkout with ref
         if: inputs.ref != ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Checkout default
         if: inputs.ref == ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup rust
         run: |

--- a/.github/workflows/_build-plugin-binaries.yml
+++ b/.github/workflows/_build-plugin-binaries.yml
@@ -74,13 +74,13 @@ jobs:
     steps:
       - name: Checkout with ref
         if: inputs.ref != ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Checkout default
         if: inputs.ref == ''
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup rust
         run: |

--- a/.github/workflows/_publish-plugin.yml
+++ b/.github/workflows/_publish-plugin.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       plugin_uploaded: ${{ steps.check-uploaded.outputs.plugin_uploaded }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check version
         id: check-uploaded
         run: |
@@ -44,7 +44,7 @@ jobs:
     env:
       SCARB_REGISTRY_AUTH_TOKEN: ${{ inputs.prod_registry == true && secrets.SCARB_REGISTRY_AUTH_TOKEN || secrets.DEV_SCARB_REGISTRY_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: software-mansion/setup-scarb@v1
 

--- a/.github/workflows/_test-binaries.yml
+++ b/.github/workflows/_test-binaries.yml
@@ -32,7 +32,7 @@ jobs:
             os: macos-14-large
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
 
       - name: Setup rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
     name: Test Forge / Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - run: cargo test --profile ci --lib -p forge
 
   build-test-forge-nextest-archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           setup-scarb: 'false'
@@ -47,7 +47,7 @@ jobs:
   build-test-forge-nextest-archive-native:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           install-llvm: 'true'
@@ -74,7 +74,7 @@ jobs:
       matrix:
         partition: [ 1, 2, 3 ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
         with:
@@ -94,7 +94,7 @@ jobs:
       matrix:
         partition: [ 1, 2, 3 ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
         with:
@@ -141,7 +141,7 @@ jobs:
         run: |
           curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
@@ -192,7 +192,7 @@ jobs:
         run: |
           curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
@@ -211,7 +211,7 @@ jobs:
     name: Test plugin across different scarb versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         # No setup scarb action is used because we want to install multiple versions of scarb through asdf
         with:
@@ -223,7 +223,7 @@ jobs:
     name: Test requirements check special conditions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           setup-scarb: 'false'
@@ -240,7 +240,7 @@ jobs:
     name: Test Forge Runner
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - run: cargo test --profile ci -p forge_runner
 
@@ -248,7 +248,7 @@ jobs:
     name: Test Cheatnet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - name: Run Cheatnet tests
         run: cargo test --profile ci -p cheatnet
@@ -257,7 +257,7 @@ jobs:
     name: Test Data Transformer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - name: Run Data Transformer tests
         run: cargo test --profile ci -p data-transformer
@@ -266,7 +266,7 @@ jobs:
     name: Test Forge Scarb Plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - name: Run Forge Scarb Plugin tests
         working-directory: crates/snforge-scarb-plugin
@@ -276,7 +276,7 @@ jobs:
     name: Test Forge Scarb Plugin Deprecated
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - name: Run Forge Scarb Plugin tests
         working-directory: crates/snforge-scarb-plugin-deprecated
@@ -286,7 +286,7 @@ jobs:
     name: Test Cast
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
       - uses: ./.github/actions/setup-tools
       - name: Run tests
@@ -299,7 +299,7 @@ jobs:
     name: Test Conversions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           setup-scarb: 'false'
@@ -311,7 +311,7 @@ jobs:
     name: Test Shared
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           setup-scarb: 'false'
@@ -322,14 +322,14 @@ jobs:
     name: Test Scarb Api
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - run: cargo test --profile ci -p scarb-api
 
   scarbfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
       - name: Check cairo files format
         run: |
@@ -346,7 +346,7 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
@@ -369,7 +369,7 @@ jobs:
       # Make sure CI fails on all warnings - including Clippy lints.
       RUSTFLAGS: "-Dwarnings"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
         with:
           install-llvm: 'true'
@@ -391,7 +391,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.4.52
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools
       - name: Install mdBook
         run: |
@@ -415,6 +415,6 @@ jobs:
     name: Check typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: typos-action
         uses: crate-ci/typos@v1.31.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
       - name: Install sitemap CLI
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       nightly_version: ${{ steps.version.outputs.nightly_version }}
       nightly_branch: ${{ steps.version.outputs.nightly_branch }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Configure Git for committing
         run: |
@@ -147,7 +147,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.SNFOUNDRY_NIGHTLIES_CONTENTS_WRITE }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.nightly_branch }}
 
@@ -215,7 +215,7 @@ jobs:
     if: always() && needs.prepare.result == 'success'
     needs: [ prepare, create-release ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Delete nightly branch
         run: |
           git push origin -d ${{ needs.prepare.outputs.nightly_branch }}

--- a/.github/workflows/publish-std.yml
+++ b/.github/workflows/publish-std.yml
@@ -39,7 +39,7 @@ jobs:
       snforge_std_deprecated_uploaded: ${{ steps.check-uploaded.outputs.snforge_std_deprecated_uploaded }}
       sncast_std_uploaded: ${{ steps.check-uploaded.outputs.sncast_std_uploaded }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check version
         id: check-uploaded
         run: |
@@ -67,7 +67,7 @@ jobs:
     env:
       SCARB_REGISTRY_AUTH_TOKEN: ${{ inputs.prod_registry == true && secrets.SCARB_REGISTRY_AUTH_TOKEN || secrets.DEV_SCARB_REGISTRY_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       versionIsValid: ${{ steps.validVersion.outputs.versionIsValid }}
       version: ${{ steps.validVersion.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v5
         with:
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ test-binary, verify-version ]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -22,7 +22,7 @@ jobs:
       versions: ${{ steps.get_versions.outputs.versions }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
         with:
           tool_versions: |
@@ -45,7 +45,7 @@ jobs:
         version: ${{ fromJSON(needs.get-scarb-versions.outputs.versions) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
       - uses: software-mansion/setup-scarb@v1
@@ -82,7 +82,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: echo "REPO_NAME=$(echo ${{ github.event.pull_request.head.repo.full_name }}.git)" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
       - uses: software-mansion/setup-scarb@v1
@@ -111,7 +111,7 @@ jobs:
         version: ${{ fromJSON(needs.get-scarb-versions.outputs.versions) }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
       - uses: software-mansion/setup-scarb@v1
@@ -141,7 +141,7 @@ jobs:
     outputs:
       version: ${{ steps.validVersion.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Get version from Cargo.toml
         id: lookupVersion


### PR DESCRIPTION
Routine update of checkout action to the latest stable version (v6).

https://github.com/actions/checkout/releases/tag/v6.0.0