### PR TITLE
Ignore all `cairo-*` packages in dependabot, use single group for deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,22 +10,11 @@ updates:
     schedule:
       interval: "monthly"
     ignore:
-      - dependency-name: "cairo-lang-*"
+      - dependency-name: "cairo-*"
     groups:
-      reqwest:
+      all-dependencies:
         patterns:
-          - "reqwest*"
-        update-types:
-          - major
-          - minor
-      prod-deps:
-        exclude-patterns:
-          - "reqwest*"
-        dependency-type: production
-      dev-deps:
-        exclude-patterns:
-          - "reqwest*"
-        dependency-type: development
+          - "*"
 
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
