### PR TITLE
Handle deploy syscall in outer runtime

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/cheatable_starknet_runtime_extension.rs
+++ b/crates/cheatnet/src/runtime_extensions/cheatable_starknet_runtime_extension.rs
@@ -71,14 +71,6 @@ impl<'a> ExtensionLogic for CheatableStarknetRuntimeExtension<'a> {
                     SyscallSelector::LibraryCall,
                 )
                 .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::Deploy => self
-                .execute_syscall(
-                    syscall_handler,
-                    vm,
-                    cheated_syscalls::deploy_syscall,
-                    SyscallSelector::Deploy,
-                )
-                .map(|()| SyscallHandlingResult::Handled),
             SyscallSelector::GetBlockHash => self
                 .execute_syscall(
                     syscall_handler,
@@ -113,6 +105,7 @@ impl<'a> ExtensionLogic for CheatableStarknetRuntimeExtension<'a> {
                 .map(|()| SyscallHandlingResult::Handled),
             SyscallSelector::DelegateCall
             | SyscallSelector::DelegateL1Handler
+            | SyscallSelector::Deploy
             | SyscallSelector::EmitEvent
             | SyscallSelector::GetBlockNumber
             | SyscallSelector::GetBlockTimestamp

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -276,6 +276,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     CallResult::Failure(CallFailure::Error { msg }) => Err(
                         EnhancedHintError::from(HintError::CustomHint(Box::from(msg.to_string()))),
                     ),
+                    _ => unreachable!(),
                 }
             }
             "read_txt" => {

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -71,6 +71,7 @@ pub fn recover_data(output: CallResult) -> Vec<Felt> {
             CallFailure::Panic { panic_data, .. } => panic_data,
             CallFailure::Error { msg, .. } => panic!("Call failed with message: {msg}"),
         },
+        CallResult::DeploySuccess { .. } => unreachable!(),
     }
 }
 

--- a/crates/debugging/src/trace/collect.rs
+++ b/crates/debugging/src/trace/collect.rs
@@ -117,6 +117,18 @@ impl<'a> Collector<'a> {
                 .expect("call result should be successfully transformed");
                 format_result_message("success", &ret_data)
             }
+            CheatnetCallResult::DeploySuccess {
+                ret_data,
+                contract_address: _contract_address,
+            } => {
+                let ret_data = reverse_transform_output(
+                    ret_data,
+                    abi,
+                    &self.call_trace.entry_point.entry_point_selector.0,
+                )
+                .expect("ret data should be successfully transformed");
+                format_result_message("success", &ret_data)
+            }
             CheatnetCallResult::Failure(failure) => match failure {
                 CallFailure::Panic { panic_data } => {
                     format_result_message("panic", &format_panic_data(panic_data))

--- a/crates/forge/tests/data/contracts/deploy_checker.cairo
+++ b/crates/forge/tests/data/contracts/deploy_checker.cairo
@@ -18,6 +18,7 @@ mod DeployChecker {
 
     #[constructor]
     fn constructor(ref self: ContractState, balance: felt252) -> (ContractAddress, felt252) {
+        assert(balance != 0, 'Initial balance cannot be 0');
         self.balance.write(balance);
         self.caller.write(starknet::get_caller_address());
         (self.caller.read(), balance)


### PR DESCRIPTION
<!-- A brief description of the changes -->

- Handle `deploy_syscall` only in the `CallToBlockifierRuntime`
- Treat all `CairoRun` errors as unrecoverable

This way it allows to to verify in tests that constructor panics in an expected way, but at the same time it will throw a hard error anytime constructor panics in a nested call.
