### PR TITLE
Make `panic-backtrace` required in validation

### DIFF
--- a/crates/forge/src/profile_validation/backtrace.rs
+++ b/crates/forge/src/profile_validation/backtrace.rs
@@ -29,10 +29,10 @@ fn check_if_native_disabled(test_args: &TestArgs) -> anyhow::Result<()> {
 
 /// Checks if the runtime profile settings in the provided from [`Metadata`] contain the required entries for backtrace generation.
 fn check_profile(scarb_metadata: &Metadata) -> anyhow::Result<()> {
-    // TODO(#3679): Add `panic-backtrace = true` entry when we decide to bump minimal scarb version to 2.12.
     const BACKTRACE_REQUIRED_ENTRIES: &[(&str, &str)] = &[
         ("unstable-add-statements-functions-debug-info", "true"),
         ("unstable-add-statements-code-locations-debug-info", "true"),
+        ("panic-backtrace", "true"),
     ];
 
     let manifest = get_manifest(scarb_metadata)?;
@@ -48,6 +48,7 @@ fn check_profile(scarb_metadata: &Metadata) -> anyhow::Result<()> {
             [profile.{profile}.cairo]
             unstable-add-statements-functions-debug-info = true
             unstable-add-statements-code-locations-debug-info = true
+            panic-backtrace = true
             ... other entries ...
             ",
             profile = scarb_metadata.current_profile

--- a/crates/forge/src/run_tests/workspace.rs
+++ b/crates/forge/src/run_tests/workspace.rs
@@ -5,7 +5,7 @@ use crate::run_tests::messages::overall_summary::OverallSummaryMessage;
 use crate::run_tests::messages::tests_failure_summary::TestsFailureSummaryMessage;
 use crate::warn::{
     error_if_snforge_std_deprecated_missing, error_if_snforge_std_deprecated_not_compatible,
-    error_if_snforge_std_not_compatible, warn_if_backtrace_without_panic_hint,
+    error_if_snforge_std_not_compatible,
     warn_if_snforge_std_deprecated_does_not_match_package_version,
 };
 use crate::{
@@ -55,8 +55,6 @@ pub async fn run_for_workspace(args: TestArgs, ui: Arc<UI>) -> Result<ExitStatus
         error_if_snforge_std_deprecated_not_compatible(&scarb_metadata)?;
         warn_if_snforge_std_deprecated_does_not_match_package_version(&scarb_metadata, &ui)?;
     }
-
-    warn_if_backtrace_without_panic_hint(&scarb_metadata, &ui);
 
     let artifacts_dir_path =
         target_dir_for_workspace(&scarb_metadata).join(&scarb_metadata.current_profile);

--- a/crates/forge/src/warn.rs
+++ b/crates/forge/src/warn.rs
@@ -1,10 +1,8 @@
 use crate::{MINIMAL_SNFORGE_STD_DEPRECATED_VERSION, MINIMAL_SNFORGE_STD_VERSION};
 use anyhow::{Result, anyhow};
-use forge_runner::backtrace::is_backtrace_enabled;
 use forge_runner::package_tests::with_config_resolved::TestTargetWithResolvedConfig;
 use foundry_ui::UI;
 use foundry_ui::components::warning::WarningMessage;
-use indoc::formatdoc;
 use scarb_api::package_matches_version_requirement;
 use scarb_metadata::Metadata;
 use semver::{Comparator, Op, Version, VersionReq};
@@ -161,38 +159,4 @@ pub fn warn_if_snforge_std_does_not_match_package_version(
         )));
     }
     Ok(())
-}
-
-// TODO(#3679): Remove this function when we decide to bump minimal scarb version to 2.12.
-pub(crate) fn warn_if_backtrace_without_panic_hint(scarb_metadata: &Metadata, ui: &UI) {
-    if is_backtrace_enabled() {
-        let is_panic_backtrace_set = scarb_metadata
-            .compilation_units
-            .iter()
-            .filter(|unit| {
-                unit.target.name.contains("unittest")
-                    || unit.target.name.contains("integrationtest")
-            })
-            .all(|unit| match &unit.compiler_config {
-                serde_json::Value::Object(map) => map
-                    .get("panic_backtrace")
-                    .is_some_and(|v| v == &serde_json::Value::Bool(true)),
-                _ => false,
-            });
-
-        if !is_panic_backtrace_set {
-            let message = formatdoc! {
-                "Scarb version should be 2.12 or higher and `Scarb.toml` should have the following Cairo compiler configuration to get accurate backtrace results:
-
-                [profile.{profile}.cairo]
-                unstable-add-statements-functions-debug-info = true
-                unstable-add-statements-code-locations-debug-info = true
-                panic-backtrace = true # only for scarb 2.12 or higher
-                ... other entries ...
-                ",
-                profile = scarb_metadata.current_profile
-            };
-            ui.println(&WarningMessage::new(message));
-        }
-    }
 }

--- a/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
@@ -20,3 +20,4 @@ test = "snforge test"
 [profile.dev.cairo]
 unstable-add-statements-functions-debug-info = true
 unstable-add-statements-code-locations-debug-info = true
+panic-backtrace = true

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -55,14 +55,6 @@ fn test_backtrace() {
         output,
         indoc! {
            "
-            [WARNING] Scarb version should be 2.12 or higher and `Scarb.toml` should have the following Cairo compiler configuration to get accurate backtrace results:
-
-            [profile.dev.cairo]
-            unstable-add-statements-functions-debug-info = true
-            unstable-add-statements-code-locations-debug-info = true
-            panic-backtrace = true # only for scarb 2.12 or higher
-            ... other entries ...
-
             [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
             
             Failure data:


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3679 

Stack:

  #4009
  #4010
  #4011 
  #4012 

## Introduced changes

<!-- A brief description of the changes -->

- Add panic-backtrace as required in check_profile function for backtrace

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
