### PR TITLE
Add custom block explorer in `show-config` tests

### DIFF
--- a/crates/sncast/tests/data/files/correct_snfoundry.toml
+++ b/crates/sncast/tests/data/files/correct_snfoundry.toml
@@ -11,6 +11,7 @@ account = "user3"
 url = "http://127.0.0.1:5055/rpc"
 accounts-file = "../account-file"
 account = "user100"
+block-explorer = "Voyager"
 
 [sncast.profile3]
 url = "http://127.0.0.1:5055/rpc"

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -65,6 +65,7 @@ async fn test_show_config_from_cli_and_snfoundry_toml() {
         Wait Timeout:        300s
         Wait Retry Interval: 5s
         Show Explorer Links: true
+        Block Explorer:      Voyager
     ", URL});
 }
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Displaying custom block explorer from config wasn't tested

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
