### PR TITLE
Fix panics in debugging and gas report for mock calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Signature generation now enforces the low-s rule
 - Fixed a bug that caused a slowdown in test execution
+- Panic that occurred in debug trace and gas report when using mock calls
 
 #### Removed
 


### PR DESCRIPTION
<!-- A brief description of the changes -->

- Ignore mock calls for gas report and debug trace
