### PR TITLE
Restore `range_check` as most costly factor in the corresponding gas test

### DIFF
--- a/crates/forge/tests/data/contracts/gas_checker.cairo
+++ b/crates/forge/tests/data/contracts/gas_checker.cairo
@@ -34,68 +34,9 @@ mod GasChecker {
 
         fn range_check(self: @ContractState) {
             // Felt into ContractAddress conversion uses RangeCheck as implicit argument
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
-            let _x: ContractAddress = 1234.try_into().unwrap();
+            for _ in 0..1000_u16 {
+                let _x: ContractAddress = 1234.try_into().unwrap();
+            }
         }
 
         fn bitwise(self: @ContractState, repetitions: u32) {

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -270,18 +270,17 @@ fn contract_range_check_cost_cairo_steps() {
 
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
-    // TODO: (#4031) Change test that the range check will be most costly factor, not steps
     assert_passed(&result);
     // 96 = cost of deploy (see snforge_std_deploy_cost test)
-    // 6 = cost of 2344 cairo steps (because int(0.0025 * 2344) = 6)
-    // 0 l1_gas + 96 l1_data_gas + 6 * (100 / 0.0025) l2 gas
+    // 43 = cost of 1052 range check builtins (because int(0.04 * 1052) = 43)
+    // 0 l1_gas + 96 l1_data_gas + 43 * (100 / 0.0025) l2 gas
     assert_gas(
         &result,
         "contract_range_check_cost",
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(240_000),
+            l2_gas: GasAmount(1_720_000),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -236,9 +236,6 @@ fn range_check_cost_cairo_steps() {
     );
 }
 
-/// Declare, deploy and function call consume 13 `range_check_builtin`s
-/// `range_check` function consumes 9, so
-/// overall cost will be 22 * range check builtin cost.
 #[test]
 fn contract_range_check_cost_cairo_steps() {
     let test = test_case!(


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4031 

## Introduced changes

<!-- A brief description of the changes -->

- Change test that it uses `range_check` as most costly factor again, not `cairo_steps`

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
