### PR TITLE
Switch to `get_traceback_entries` provided by `cairo-vm`

### DIFF
--- a/crates/shared/src/vm.rs
+++ b/crates/shared/src/vm.rs
@@ -1,11 +1,9 @@
 use cairo_vm::types::relocatable::Relocatable;
 use cairo_vm::vm::vm_core::VirtualMachine;
-use num_traits::cast::ToPrimitive;
 
 pub trait VirtualMachineExt {
     /// Returns the values (fp, pc) corresponding to each call instruction in the traceback.
     /// Returns the most recent call last.
-    /// TODO(#3170): Use `get_traceback_entries` from [`VirtualMachine`] once it is public.
     fn get_traceback_entries(&self) -> Vec<(Relocatable, Relocatable)>;
 
     /// Return the relocated pc values corresponding to each call instruction in the traceback.
@@ -33,46 +31,11 @@ pub trait VirtualMachineExt {
 }
 
 impl VirtualMachineExt for VirtualMachine {
-    /// implementation adapted from [here](https://github.com/starkware-libs/cairo/blob/795bee8a82ab495ee7f1856209fbc33cfd8c746d/crates/cairo-lang-runner/src/casm_run/mod.rs#L1355)
-    ///
-    /// notable changes:
-    /// - in original code the code returns a vec of (pc, fp) we return a vec of (fp, pc) to comply with [`VirtualMachine`] `get_traceback_entries`
-    /// - removed `println!` calls
     fn get_traceback_entries(&self) -> Vec<(Relocatable, Relocatable)> {
-        let vm = self;
+        let mut entries = VirtualMachine::get_traceback_entries(self);
 
-        let mut fp = vm.get_fp();
-        let mut panic_traceback = vec![(fp, vm.get_pc())];
-        // Fetch the fp and pc traceback entries
-        loop {
-            let ptr_at_offset =
-                |offset: usize| (fp - offset).ok().and_then(|r| vm.get_relocatable(r).ok());
-            // Get return pc.
-            let Some(ret_pc) = ptr_at_offset(1) else {
-                break;
-            };
-            // Get fp traceback.
-            let Some(ret_fp) = ptr_at_offset(2) else {
-                break;
-            };
-            if ret_fp == fp {
-                break;
-            }
-            fp = ret_fp;
-
-            let call_instruction = |offset: usize| -> Option<Relocatable> {
-                let ptr = (ret_pc - offset).ok()?;
-                let inst = vm.get_integer(ptr).ok()?;
-                let inst_short = inst.to_u64()?;
-                (inst_short & 0x7000_0000_0000_0000 == 0x1000_0000_0000_0000).then_some(ptr)
-            };
-            if let Some(call_pc) = call_instruction(1).or_else(|| call_instruction(2)) {
-                panic_traceback.push((fp, call_pc));
-            } else {
-                break;
-            }
-        }
-        panic_traceback.reverse();
-        panic_traceback
+        // The cairo-vm implementation doesn't include the start location, so we add it manually.
+        entries.push((self.get_fp(), self.get_pc()));
+        entries
     }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3170 

## Introduced changes

<!-- A brief description of the changes -->

- Switch to `get_traceback_entries` provided by `cairo-vm` from our own implementation

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
