### PR TITLE
Fix minor bugs in release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,12 @@ jobs:
             exit 1
           fi
 
+          # Tag is usually created when publishing release from GitHub UI.
+          # Then it triggers this workflow again and we want to exit without error.
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             echo "Release $TAG_NAME already exists - aborting"
-            exit 1
+            echo "versionIsValid=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "versionIsValid=true" >> "$GITHUB_OUTPUT"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,10 @@ VERSION_UNDERSCORED=$(echo "$VERSION" | tr '.' '_')
 
 DIRECTORY="crates/forge/tests/data/forking/.snfoundry_cache"
 OLD_FILE_PATH=$(find "$DIRECTORY" -type f -regex '.*_v[0-9][a-z0-9_-]*\.json')
-NEW_FILE_PATH=$(echo "$OLD_FILE_PATH" | sed -E "s/_v[a-z0-9_-]+\.json$/_v${VERSION_UNDERSCORED}.json/")
+
+# Strip the shortest match of "_v*" starting from the end of the string
+OLD_FILE_PATH_BASE="${OLD_FILE_PATH%_v*}"
+NEW_FILE_PATH="${OLD_FILE_PATH_BASE}_v${VERSION_UNDERSCORED}.json"
 
 mv "$OLD_FILE_PATH" "$NEW_FILE_PATH"
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

- Exit without error if tag already exists to avoid misleading failures in standard release flow (release workflow is triggered again after publishing release and creating a tag)
- Fork cache filenames include two versions (rpc and forge) which was overlooked in the last change. It should now correctly modify the path by stripping only the last `v_*` segment

