### PR TITLE
Refactor `CallToBlockifierRuntime` and related structs

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -1,18 +1,18 @@
 use super::cairo1_execution::execute_entry_point_call_cairo1;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::deprecated::cairo0_execution::execute_entry_point_call_cairo0;
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{CallResult};
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::execution_utils::{resolve_cheated_data_for_call, update_trace_data, exit_error_call};
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::execution_utils::{exit_error_call, resolve_cheated_data_for_call, update_trace_data};
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallSuccess;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::CheatnetState;
-use crate::runtime_extensions::common::{get_relocated_vm_trace};
-use crate::state::{CheatStatus};
+use crate::runtime_extensions::common::get_relocated_vm_trace;
 #[cfg(feature = "cairo-native")]
 use crate::runtime_extensions::native::execution::execute_entry_point_call_native;
+use crate::state::CheatStatus;
 use blockifier::execution::call_info::{CallExecution, Retdata, StorageAccessTracker};
 use blockifier::execution::contract_class::{RunnableCompiledClass, TrackedResource};
 use blockifier::execution::entry_point::EntryPointRevertInfo;
 use blockifier::execution::execution_utils::update_remaining_gas;
 use blockifier::execution::stack_trace::{
-    Cairo1RevertHeader, extract_trailing_cairo1_revert_trace,
+    extract_trailing_cairo1_revert_trace, Cairo1RevertHeader,
 };
 use blockifier::execution::syscalls::hint_processor::{
     ENTRYPOINT_NOT_FOUND_ERROR, OUT_OF_GAS_ERROR,
@@ -22,8 +22,8 @@ use blockifier::{
     execution::{
         call_info::CallInfo,
         entry_point::{
-            CallEntryPoint, CallType, ConstructorContext, EntryPointExecutionContext,
-            EntryPointExecutionResult, FAULTY_CLASS_HASH, handle_empty_constructor,
+            handle_empty_constructor, CallEntryPoint, CallType, ConstructorContext,
+            EntryPointExecutionContext, EntryPointExecutionResult, FAULTY_CLASS_HASH,
         },
         errors::{EntryPointExecutionError, PreExecutionError},
     },
@@ -36,7 +36,7 @@ use starknet_api::execution_resources::GasAmount;
 use starknet_api::{
     contract_class::EntryPointType,
     core::ClassHash,
-    transaction::{TransactionVersion, fields::Calldata},
+    transaction::{fields::Calldata, TransactionVersion},
 };
 use starknet_types_core::felt::Felt;
 use std::collections::{HashMap, HashSet};
@@ -84,9 +84,9 @@ pub fn execute_call_entry_point(
             u64::default(),
             SyscallUsageMap::default(),
             SyscallUsageMap::default(),
-            CallResult::Success {
+            Ok(CallSuccess {
                 ret_data: ret_data_f252,
-            },
+            }),
             &[],
             vec![],
             vec![],

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -1,5 +1,5 @@
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    AddressOrClassHash, CallResult,
+    AddressOrClassHash, from_error, from_non_error,
 };
 use crate::runtime_extensions::common::sum_syscall_usage;
 use crate::runtime_extensions::forge_runtime_extension::{
@@ -66,7 +66,7 @@ pub(crate) fn update_trace_data(
         call_info.execution.gas_consumed,
         syscall_usage_vm_resources,
         syscall_usage_sierra_gas,
-        CallResult::from_non_error(call_info),
+        from_non_error(call_info),
         &call_info.execution.l2_to_l1_messages,
         signature,
         call_info.execution.events.clone(),
@@ -106,6 +106,6 @@ pub(crate) fn exit_error_call(
     // In case of a revert, clear all events and messages emitted by the current call.
     trace_data.clear_current_call_events_and_messages();
 
-    trace_data.update_current_call_result(CallResult::from_err(error, &identifier));
+    trace_data.update_current_call_result(from_error(error, &identifier));
     trace_data.exit_nested_call();
 }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
@@ -2,18 +2,20 @@ use std::marker::PhantomData;
 
 use crate::state::CheatnetState;
 use blockifier::execution::entry_point::{CallEntryPoint, CallType};
-use blockifier::execution::syscalls::hint_processor::{OUT_OF_GAS_ERROR, SyscallHintProcessor};
+use blockifier::execution::syscalls::hint_processor::{
+    OUT_OF_GAS_ERROR, SyscallHintProcessor, create_retdata_segment,
+};
+use blockifier::execution::syscalls::syscall_base::SyscallResult;
 use blockifier::execution::syscalls::syscall_executor::SyscallExecutor;
 use blockifier::execution::syscalls::vm_syscall_utils::{
-    CallContractRequest, LibraryCallRequest, RevertData, SingleSegmentResponse,
-    SyscallExecutorBaseError, SyscallRequestWrapper, SyscallSelector,
+    CallContractRequest, CallContractResponse, LibraryCallRequest, LibraryCallResponse, RevertData,
+    SelfOrRevert, SingleSegmentResponse, SyscallExecutorBaseError, SyscallRequestWrapper,
+    SyscallSelector,
 };
-use blockifier::execution::{
-    execution_utils::ReadOnlySegment,
-    syscalls::vm_syscall_utils::{SyscallRequest, SyscallResponse, SyscallResponseWrapper},
+use blockifier::execution::syscalls::vm_syscall_utils::{
+    SyscallRequest, SyscallResponse, SyscallResponseWrapper,
 };
 use blockifier::utils::u64_from_usize;
-use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
 use runtime::{ExtendedRuntime, ExtensionLogic, SyscallHandlingResult};
 use starknet_api::contract_class::EntryPointType;
@@ -24,11 +26,10 @@ use starknet_types_core::felt::Felt;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
     AddressOrClassHash, call_entry_point,
 };
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    CallFailure, CallResult,
-};
 
-use super::cheatable_starknet_runtime_extension::CheatableStarknetRuntime;
+use super::cheatable_starknet_runtime_extension::{
+    CheatableStarknetRuntime, CheatableStarknetRuntimeError,
+};
 use conversions::string::TryFromHexStr;
 use runtime::starknet::constants::TEST_ADDRESS;
 
@@ -59,12 +60,12 @@ impl<'a> ExtensionLogic for CallToBlockifierExtension<'a> {
             // This is redirected to drop ForgeRuntimeExtension
             // and to enable executing outer calls in tests as non-revertible.
             SyscallSelector::CallContract => {
-                execute_syscall::<CallContractRequest>(selector, vm, extended_runtime)?;
+                self.execute_syscall(vm, call_contract_syscall, selector, extended_runtime)?;
 
                 Ok(SyscallHandlingResult::Handled)
             }
             SyscallSelector::LibraryCall => {
-                execute_syscall::<LibraryCallRequest>(selector, vm, extended_runtime)?;
+                self.execute_syscall(vm, library_call_syscall, selector, extended_runtime)?;
 
                 Ok(SyscallHandlingResult::Handled)
             }
@@ -105,183 +106,168 @@ impl<'a> ExtensionLogic for CallToBlockifierExtension<'a> {
     }
 }
 
-trait ExecuteCall
-where
-    Self: SyscallRequest,
-{
-    fn execute_call(
-        self,
-        syscall_handler: &mut SyscallHintProcessor,
-        cheatnet_state: &mut CheatnetState,
-        remaining_gas: &mut u64,
-    ) -> CallResult;
-}
-
-impl ExecuteCall for CallContractRequest {
-    fn execute_call(
-        self: CallContractRequest,
-        syscall_handler: &mut SyscallHintProcessor,
-        cheatnet_state: &mut CheatnetState,
-        remaining_gas: &mut u64,
-    ) -> CallResult {
-        let contract_address = self.contract_address;
-
-        let entry_point = CallEntryPoint {
-            class_hash: None,
-            code_address: Some(contract_address),
-            entry_point_type: EntryPointType::External,
-            entry_point_selector: self.function_selector,
-            calldata: self.calldata,
-            storage_address: contract_address,
-            caller_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
-            call_type: CallType::Call,
-            initial_gas: *remaining_gas,
-        };
-
-        call_entry_point(
-            syscall_handler,
-            cheatnet_state,
-            entry_point,
-            &AddressOrClassHash::ContractAddress(contract_address),
-            remaining_gas,
-        )
-    }
-}
-
-impl ExecuteCall for LibraryCallRequest {
-    fn execute_call(
-        self: LibraryCallRequest,
-        syscall_handler: &mut SyscallHintProcessor,
-        cheatnet_state: &mut CheatnetState,
-        remaining_gas: &mut u64,
-    ) -> CallResult {
-        let class_hash = self.class_hash;
-
-        let entry_point = CallEntryPoint {
-            class_hash: Some(class_hash),
-            code_address: None,
-            entry_point_type: EntryPointType::External,
-            entry_point_selector: self.function_selector,
-            calldata: self.calldata,
-            storage_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
-            caller_address: ContractAddress::default(),
-            call_type: CallType::Delegate,
-            initial_gas: *remaining_gas,
-        };
-
-        call_entry_point(
-            syscall_handler,
-            cheatnet_state,
-            entry_point,
-            &AddressOrClassHash::ClassHash(class_hash),
-            remaining_gas,
-        )
-    }
-}
-
-// crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs:677 (execute_syscall)
-fn execute_syscall<Request: ExecuteCall + SyscallRequest>(
-    selector: SyscallSelector,
+fn call_contract_syscall(
+    request: CallContractRequest,
     vm: &mut VirtualMachine,
-    cheatable_starknet_runtime: &mut CheatableStarknetRuntime,
-) -> Result<(), HintError> {
-    // region: Modified blockifier code
-    let syscall_handler = &mut cheatable_starknet_runtime.extended_runtime.hint_handler;
-    let cheatnet_state = &mut *cheatable_starknet_runtime.extension.cheatnet_state;
+    syscall_handler: &mut SyscallHintProcessor,
+    cheatnet_state: &mut CheatnetState,
+    remaining_gas: &mut u64,
+) -> SyscallResult<CallContractResponse> {
+    let contract_address = request.contract_address;
 
-    // Increment, since the selector was peeked into before
-    syscall_handler.syscall_ptr += 1;
-    syscall_handler.increment_syscall_count_by(&selector, 1);
-    // endregion
-
-    let syscall_gas_cost = syscall_handler
-        .get_gas_cost_from_selector(&selector)
-        .map_err(|error| SyscallExecutorBaseError::GasCost { error, selector })?;
-
-    let SyscallRequestWrapper {
-        gas_counter,
-        request,
-    } = SyscallRequestWrapper::<Request>::read(vm, syscall_handler.get_mut_syscall_ptr())?;
-
-    let syscall_gas_cost =
-        syscall_gas_cost.get_syscall_cost(u64_from_usize(request.get_linear_factor_length()));
-    let syscall_base_cost = syscall_handler.get_syscall_base_gas_cost();
-
-    // Sanity check for preventing underflow.
-    assert!(
-        syscall_gas_cost >= syscall_base_cost,
-        "Syscall gas cost must be greater than base syscall gas cost"
-    );
-
-    // Refund `SYSCALL_BASE_GAS_COST` as it was pre-charged.
-    // Note: It is pre-charged by the compiler: https://github.com/starkware-libs/sequencer/blob/v0.15.0-rc.2/crates/blockifier/src/blockifier_versioned_constants.rs#L1057
-    let required_gas = syscall_gas_cost - syscall_base_cost;
-
-    if gas_counter < required_gas {
-        let out_of_gas_error =
-            Felt::from_hex(OUT_OF_GAS_ERROR).map_err(SyscallExecutorBaseError::from)?;
-        let response: SyscallResponseWrapper<SingleSegmentResponse> =
-            SyscallResponseWrapper::Failure {
-                gas_counter,
-                revert_data: RevertData::new_normal(vec![out_of_gas_error]),
-            };
-        response.write(vm, syscall_handler.get_mut_syscall_ptr())?;
-
-        return Ok(());
-    }
-
-    let mut remaining_gas = gas_counter - required_gas;
-
-    // TODO(#3681)
-    syscall_handler.update_revert_gas_with_next_remaining_gas(GasAmount(remaining_gas));
-
-    // region: Modified blockifier code
-    let call_result = request.execute_call(syscall_handler, cheatnet_state, &mut remaining_gas);
-    write_call_response(syscall_handler, vm, remaining_gas, call_result)?;
-    // endregion
-
-    Ok(())
-}
-
-fn write_call_response(
-    syscall_handler: &mut SyscallHintProcessor<'_>,
-    vm: &mut VirtualMachine,
-    gas_counter: u64,
-    call_result: CallResult,
-) -> Result<(), HintError> {
-    let response_wrapper: SyscallResponseWrapper<SingleSegmentResponse> = match call_result {
-        CallResult::Success { ret_data } => {
-            let memory_segment_start_ptr = syscall_handler.read_only_segments.allocate(
-                vm,
-                &ret_data
-                    .clone()
-                    .into_iter()
-                    .map(MaybeRelocatable::Int)
-                    .collect::<Vec<MaybeRelocatable>>(),
-            )?;
-
-            SyscallResponseWrapper::Success {
-                gas_counter,
-                response: SingleSegmentResponse {
-                    segment: ReadOnlySegment {
-                        start_ptr: memory_segment_start_ptr,
-                        length: ret_data.len(),
-                    },
-                },
-            }
-        }
-        CallResult::Failure(failure_type) => match failure_type {
-            CallFailure::Panic { panic_data } => SyscallResponseWrapper::Failure {
-                gas_counter,
-                revert_data: RevertData::new_normal(panic_data),
-            },
-            CallFailure::Error { msg } => {
-                return Err(HintError::CustomHint(Box::from(msg.to_string())));
-            }
-        },
+    let entry_point = CallEntryPoint {
+        class_hash: None,
+        code_address: Some(contract_address),
+        entry_point_type: EntryPointType::External,
+        entry_point_selector: request.function_selector,
+        calldata: request.calldata,
+        storage_address: contract_address,
+        caller_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
+        call_type: CallType::Call,
+        initial_gas: *remaining_gas,
     };
 
-    response_wrapper.write(vm, &mut syscall_handler.syscall_ptr)?;
+    let res = call_entry_point(
+        syscall_handler,
+        cheatnet_state,
+        entry_point,
+        &AddressOrClassHash::ContractAddress(contract_address),
+        remaining_gas,
+    )?;
 
-    Ok(())
+    let segment = create_retdata_segment(vm, syscall_handler, &res.ret_data)?;
+    Ok(CallContractResponse { segment })
+}
+
+fn library_call_syscall(
+    request: LibraryCallRequest,
+    vm: &mut VirtualMachine,
+    syscall_handler: &mut SyscallHintProcessor,
+    cheatnet_state: &mut CheatnetState,
+    remaining_gas: &mut u64,
+) -> SyscallResult<LibraryCallResponse> {
+    let class_hash = request.class_hash;
+
+    let entry_point = CallEntryPoint {
+        class_hash: Some(class_hash),
+        code_address: None,
+        entry_point_type: EntryPointType::External,
+        entry_point_selector: request.function_selector,
+        calldata: request.calldata,
+        storage_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
+        caller_address: ContractAddress::default(),
+        call_type: CallType::Delegate,
+        initial_gas: *remaining_gas,
+    };
+
+    let res = call_entry_point(
+        syscall_handler,
+        cheatnet_state,
+        entry_point,
+        &AddressOrClassHash::ClassHash(class_hash),
+        remaining_gas,
+    )?;
+
+    let segment = create_retdata_segment(vm, syscall_handler, &res.ret_data)?;
+    Ok(LibraryCallResponse { segment })
+}
+
+impl CallToBlockifierExtension<'_> {
+    // crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs:677 (execute_syscall)
+    #[expect(clippy::unused_self)]
+    fn execute_syscall<Request, Response, ExecuteCallback, Error>(
+        &mut self,
+        vm: &mut VirtualMachine,
+        execute_callback: ExecuteCallback,
+        selector: SyscallSelector,
+        extended_runtime: &mut CheatableStarknetRuntime,
+    ) -> Result<(), Error>
+    where
+        Request: SyscallRequest + std::fmt::Debug,
+        Response: SyscallResponse + std::fmt::Debug,
+        Error: CheatableStarknetRuntimeError,
+        ExecuteCallback: FnOnce(
+            Request,
+            &mut VirtualMachine,
+            &mut SyscallHintProcessor<'_>,
+            &mut CheatnetState,
+            &mut u64, // Remaining gas.
+        ) -> Result<Response, Error>,
+    {
+        // region: Modified blockifier code
+        let syscall_handler = &mut extended_runtime.extended_runtime.hint_handler;
+        let cheatnet_state = &mut *extended_runtime.extension.cheatnet_state;
+
+        // Increment, since the selector was peeked into before
+        syscall_handler.syscall_ptr += 1;
+        syscall_handler.increment_syscall_count_by(&selector, 1);
+        // endregion
+
+        let syscall_gas_cost = syscall_handler
+            .get_gas_cost_from_selector(&selector)
+            .map_err(|error| SyscallExecutorBaseError::GasCost { error, selector })?;
+
+        let SyscallRequestWrapper {
+            gas_counter,
+            request,
+        } = SyscallRequestWrapper::<Request>::read(vm, syscall_handler.get_mut_syscall_ptr())?;
+
+        let syscall_gas_cost =
+            syscall_gas_cost.get_syscall_cost(u64_from_usize(request.get_linear_factor_length()));
+        let syscall_base_cost = syscall_handler.get_syscall_base_gas_cost();
+
+        // Sanity check for preventing underflow.
+        assert!(
+            syscall_gas_cost >= syscall_base_cost,
+            "Syscall gas cost must be greater than base syscall gas cost"
+        );
+
+        // Refund `SYSCALL_BASE_GAS_COST` as it was pre-charged.
+        // Note: It is pre-charged by the compiler: https://github.com/starkware-libs/sequencer/blob/v0.15.0-rc.2/crates/blockifier/src/blockifier_versioned_constants.rs#L1057
+        let required_gas = syscall_gas_cost - syscall_base_cost;
+
+        if gas_counter < required_gas {
+            let out_of_gas_error =
+                Felt::from_hex(OUT_OF_GAS_ERROR).map_err(SyscallExecutorBaseError::from)?;
+            let response: SyscallResponseWrapper<SingleSegmentResponse> =
+                SyscallResponseWrapper::Failure {
+                    gas_counter,
+                    revert_data: RevertData::new_normal(vec![out_of_gas_error]),
+                };
+            response.write(vm, syscall_handler.get_mut_syscall_ptr())?;
+
+            return Ok(());
+        }
+
+        let mut remaining_gas = gas_counter - required_gas;
+
+        // TODO(#3681)
+        syscall_handler.update_revert_gas_with_next_remaining_gas(GasAmount(remaining_gas));
+
+        let original_response = execute_callback(
+            request,
+            vm,
+            syscall_handler,
+            cheatnet_state,
+            &mut remaining_gas,
+        );
+
+        let response = match original_response {
+            Ok(response) => SyscallResponseWrapper::Success {
+                gas_counter: remaining_gas,
+                response,
+            },
+            Err(error) => match error.try_extract_revert() {
+                SelfOrRevert::Revert(data) => SyscallResponseWrapper::Failure {
+                    gas_counter: remaining_gas,
+                    revert_data: data,
+                },
+                SelfOrRevert::Original(err) => return Err(err),
+            },
+        };
+
+        response.write(vm, &mut syscall_handler.syscall_ptr)?;
+
+        Ok(())
+    }
 }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -5,6 +5,8 @@ use crate::runtime_extensions::{
     common::create_execute_calldata,
 };
 use blockifier::execution::call_info::ExecutionSummary;
+use blockifier::execution::syscalls::hint_processor::SyscallExecutionError;
+use blockifier::execution::syscalls::vm_syscall_utils::SyscallExecutorBaseError;
 use blockifier::execution::{
     call_info::CallInfo,
     entry_point::{CallType, EntryPointExecutionResult},
@@ -15,6 +17,7 @@ use blockifier::execution::{
     entry_point::CallEntryPoint, syscalls::vm_syscall_utils::SyscallUsageMap,
 };
 use blockifier::state::errors::StateError;
+use cairo_vm::vm::errors::hint_errors::HintError;
 use conversions::{byte_array::ByteArray, serde::serialize::CairoSerialize, string::IntoHexStr};
 use shared::utils::build_readable_text;
 use starknet_api::core::EntryPointSelector;
@@ -31,20 +34,33 @@ pub struct UsedResources {
     pub l1_handler_payload_lengths: Vec<usize>,
 }
 
-/// Enum representing possible call execution result, along with the data
-#[derive(Debug, Clone, CairoSerialize)]
-pub enum CallResult {
-    Success { ret_data: Vec<Felt> },
-    Failure(CallFailure),
+#[derive(Debug, CairoSerialize)]
+pub struct CallSuccess {
+    pub ret_data: Vec<Felt>,
 }
 
-/// Enum representing possible call failure and its type.
-/// `Panic` - Recoverable, meant to be caught by the user.
-/// `Error` - Unrecoverable, equivalent of panic! in rust.
+impl From<CallFailure> for SyscallExecutionError {
+    fn from(value: CallFailure) -> Self {
+        match value {
+            CallFailure::Recoverable { panic_data } => Self::Revert {
+                error_data: panic_data,
+            },
+            CallFailure::Unrecoverable { msg } => Self::SyscallExecutorBase(
+                SyscallExecutorBaseError::Hint(HintError::CustomHint(Box::from(msg.to_string()))),
+            ),
+        }
+    }
+}
+
+pub type CallResult = Result<CallSuccess, CallFailure>;
+
+/// Enum representing a possible call failure and its type.
+/// `Recoverable` - Meant to be caught by the user.
+/// `Unrecoverable` - Equivalent of `panic!` in rust.
 #[derive(Debug, Clone, CairoSerialize)]
 pub enum CallFailure {
-    Panic { panic_data: Vec<Felt> },
-    Error { msg: ByteArray },
+    Recoverable { panic_data: Vec<Felt> },
+    Unrecoverable { msg: ByteArray },
 }
 
 pub enum AddressOrClassHash {
@@ -68,11 +84,11 @@ impl CallFailure {
                 if err_data_str.contains("Failed to deserialize param #")
                     || err_data_str.contains("Input too long for arguments")
                 {
-                    CallFailure::Error {
+                    CallFailure::Unrecoverable {
                         msg: ByteArray::from(err_data_str.as_str()),
                     }
                 } else {
-                    CallFailure::Panic {
+                    CallFailure::Recoverable {
                         panic_data: err_data,
                     }
                 }
@@ -94,7 +110,7 @@ impl CallFailure {
 
                 let panic_data_felts = ByteArray::from(msg.as_str()).serialize_with_magic();
 
-                CallFailure::Panic {
+                CallFailure::Recoverable {
                     panic_data: panic_data_felts,
                 }
             }
@@ -106,21 +122,21 @@ impl CallFailure {
 
                 let panic_data_felts = ByteArray::from(msg.as_str()).serialize_with_magic();
 
-                CallFailure::Panic {
+                CallFailure::Recoverable {
                     panic_data: panic_data_felts,
                 }
             }
             EntryPointExecutionError::StateError(StateError::StateReadError(msg)) => {
-                CallFailure::Error {
+                CallFailure::Unrecoverable {
                     msg: ByteArray::from(msg.as_str()),
                 }
             }
             error => {
                 let error_string = error.to_string();
                 if let Some(panic_data) = try_extract_panic_data(&error_string) {
-                    CallFailure::Panic { panic_data }
+                    CallFailure::Recoverable { panic_data }
                 } else {
-                    CallFailure::Error {
+                    CallFailure::Unrecoverable {
                         msg: ByteArray::from(error_string.as_str()),
                     }
                 }
@@ -129,40 +145,35 @@ impl CallFailure {
     }
 }
 
-impl CallResult {
-    #[must_use]
-    pub fn from_execution_result(
-        result: &EntryPointExecutionResult<CallInfo>,
-        starknet_identifier: &AddressOrClassHash,
-    ) -> Self {
-        match result {
-            Ok(call_info) => Self::from_non_error(call_info),
-            Err(err) => Self::from_err(err, starknet_identifier),
-        }
+pub fn from_execution_result(
+    result: &EntryPointExecutionResult<CallInfo>,
+    starknet_identifier: &AddressOrClassHash,
+) -> Result<CallSuccess, CallFailure> {
+    match result {
+        Ok(call_info) => from_non_error(call_info),
+        Err(err) => from_error(err, starknet_identifier),
+    }
+}
+
+pub fn from_non_error(call_info: &CallInfo) -> Result<CallSuccess, CallFailure> {
+    let return_data = &call_info.execution.retdata.0;
+
+    if call_info.execution.failed {
+        return Err(CallFailure::Recoverable {
+            panic_data: return_data.clone(),
+        });
     }
 
-    #[must_use]
-    pub fn from_non_error(call_info: &CallInfo) -> Self {
-        let return_data = &call_info.execution.retdata.0;
+    Ok(CallSuccess {
+        ret_data: return_data.clone(),
+    })
+}
 
-        if call_info.execution.failed {
-            return CallResult::Failure(CallFailure::Panic {
-                panic_data: return_data.clone(),
-            });
-        }
-
-        CallResult::Success {
-            ret_data: return_data.clone(),
-        }
-    }
-
-    #[must_use]
-    pub fn from_err(
-        err: &EntryPointExecutionError,
-        starknet_identifier: &AddressOrClassHash,
-    ) -> Self {
-        CallResult::Failure(CallFailure::from_execution_error(err, starknet_identifier))
-    }
+pub fn from_error(
+    err: &EntryPointExecutionError,
+    starknet_identifier: &AddressOrClassHash,
+) -> Result<CallSuccess, CallFailure> {
+    Err(CallFailure::from_execution_error(err, starknet_identifier))
 }
 
 pub fn call_l1_handler(
@@ -171,7 +182,7 @@ pub fn call_l1_handler(
     contract_address: &ContractAddress,
     entry_point_selector: EntryPointSelector,
     calldata: &[Felt],
-) -> CallResult {
+) -> Result<CallSuccess, CallFailure> {
     let calldata = create_execute_calldata(calldata);
     let mut remaining_gas = i64::MAX as u64;
     let entry_point = CallEntryPoint {
@@ -201,7 +212,7 @@ pub fn call_entry_point(
     mut entry_point: CallEntryPoint,
     starknet_identifier: &AddressOrClassHash,
     remaining_gas: &mut u64,
-) -> CallResult {
+) -> Result<CallSuccess, CallFailure> {
     let exec_result = non_reverting_execute_call_entry_point(
         &mut entry_point,
         syscall_handler.base.state,
@@ -210,7 +221,7 @@ pub fn call_entry_point(
         remaining_gas,
     );
 
-    let result = CallResult::from_execution_result(&exec_result, starknet_identifier);
+    let result = from_execution_result(&exec_result, starknet_identifier);
 
     if let Ok(call_info) = exec_result {
         syscall_handler.base.inner_calls.push(call_info);

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -45,6 +45,10 @@ impl From<CallFailure> for SyscallExecutionError {
             CallFailure::Recoverable { panic_data } => Self::Revert {
                 error_data: panic_data,
             },
+            // TODO(#3307):
+            // `SyscallExecutorBaseError::Hint` is chosen arbitrary to enable conversion by `try_extract_revert`
+            // in `execute_syscall` function.
+            // Ideally, we should pass the actual received error instead of a string.
             CallFailure::Unrecoverable { msg } => Self::SyscallExecutorBase(
                 SyscallExecutorBaseError::Hint(HintError::CustomHint(Box::from(msg.to_string()))),
             ),

--- a/crates/cheatnet/src/runtime_extensions/cheatable_starknet_runtime_extension.rs
+++ b/crates/cheatnet/src/runtime_extensions/cheatable_starknet_runtime_extension.rs
@@ -4,15 +4,11 @@ use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::
 use crate::state::CheatnetState;
 use anyhow::Result;
 use blockifier::execution::syscalls::hint_processor::OUT_OF_GAS_ERROR;
-use blockifier::execution::syscalls::syscall_base::SyscallResult;
+use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
 use blockifier::execution::syscalls::syscall_executor::SyscallExecutor;
 use blockifier::execution::syscalls::vm_syscall_utils::{
-    RevertData, SyscallExecutorBaseError, SyscallRequest, SyscallRequestWrapper, SyscallResponse,
-    SyscallResponseWrapper, SyscallSelector,
-};
-use blockifier::execution::{
-    common_hints::HintExecutionResult,
-    syscalls::hint_processor::{SyscallExecutionError, SyscallHintProcessor},
+    RevertData, SelfOrRevert, SyscallExecutorBaseError, SyscallRequest, SyscallRequestWrapper,
+    SyscallResponse, SyscallResponseWrapper, SyscallSelector, TryExtractRevert,
 };
 use blockifier::utils::u64_from_usize;
 use cairo_vm::{
@@ -47,70 +43,70 @@ impl<'a> ExtensionLogic for CheatableStarknetRuntimeExtension<'a> {
         // This match must remain exhaustive so that if a new syscall is introduced,
         // we will explicitly add support for it.
         match selector {
-            SyscallSelector::GetExecutionInfo => self
+            SyscallSelector::GetExecutionInfo => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::get_execution_info_syscall,
                     SyscallSelector::GetExecutionInfo,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::CallContract => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::CallContract => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::call_contract_syscall,
                     SyscallSelector::CallContract,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::LibraryCall => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::LibraryCall => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::library_call_syscall,
                     SyscallSelector::LibraryCall,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::Deploy => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::Deploy => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::deploy_syscall,
                     SyscallSelector::Deploy,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::GetBlockHash => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::GetBlockHash => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::get_block_hash_syscall,
                     SyscallSelector::GetBlockHash,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::StorageRead => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::StorageRead => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::storage_read,
                     SyscallSelector::StorageRead,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::StorageWrite => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::StorageWrite => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::storage_write,
                     SyscallSelector::StorageWrite,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
-            SyscallSelector::MetaTxV0 => self
+                .map(|()| SyscallHandlingResult::Handled)?),
+            SyscallSelector::MetaTxV0 => Ok(self
                 .execute_syscall(
                     syscall_handler,
                     vm,
                     cheated_syscalls::meta_tx_v0_syscall,
                     SyscallSelector::MetaTxV0,
                 )
-                .map(|()| SyscallHandlingResult::Handled),
+                .map(|()| SyscallHandlingResult::Handled)?),
             SyscallSelector::DelegateCall
             | SyscallSelector::DelegateL1Handler
             | SyscallSelector::EmitEvent
@@ -171,25 +167,33 @@ pub fn felt_from_ptr_immutable(
     Ok(felt)
 }
 
+pub trait CheatableStarknetRuntimeError: TryExtractRevert + From<SyscallExecutorBaseError> {}
+
+impl<T> CheatableStarknetRuntimeError for T where
+    T: TryExtractRevert + From<SyscallExecutorBaseError>
+{
+}
+
 impl CheatableStarknetRuntimeExtension<'_> {
     // crates/blockifier/src/execution/syscalls/vm_syscall_utils.rs:677 (execute_syscall)
-    fn execute_syscall<Request, Response, ExecuteCallback>(
+    fn execute_syscall<Request, Response, ExecuteCallback, Error>(
         &mut self,
         syscall_handler: &mut SyscallHintProcessor,
         vm: &mut VirtualMachine,
         execute_callback: ExecuteCallback,
         selector: SyscallSelector,
-    ) -> HintExecutionResult
+    ) -> Result<(), Error>
     where
         Request: SyscallRequest + std::fmt::Debug,
         Response: SyscallResponse + std::fmt::Debug,
+        Error: CheatableStarknetRuntimeError,
         ExecuteCallback: FnOnce(
             Request,
             &mut VirtualMachine,
             &mut SyscallHintProcessor<'_>,
             &mut CheatnetState,
             &mut u64, // Remaining gas.
-        ) -> SyscallResult<Response>,
+        ) -> Result<Response, Error>,
     {
         // Increment, since the selector was peeked into before
         syscall_handler.syscall_ptr += 1;
@@ -244,18 +248,19 @@ impl CheatableStarknetRuntimeExtension<'_> {
             self.cheatnet_state,
             &mut remaining_gas,
         );
+
         let response = match original_response {
             Ok(response) => SyscallResponseWrapper::Success {
                 gas_counter: remaining_gas,
                 response,
             },
-            Err(SyscallExecutionError::Revert { error_data: data }) => {
-                SyscallResponseWrapper::Failure {
+            Err(error) => match error.try_extract_revert() {
+                SelfOrRevert::Revert(data) => SyscallResponseWrapper::Failure {
                     gas_counter: remaining_gas,
-                    revert_data: RevertData::new_normal(data),
-                }
-            }
-            Err(error) => return Err(error.into()),
+                    revert_data: data,
+                },
+                SelfOrRevert::Original(err) => return Err(err),
+            },
         };
 
         response.write(vm, &mut syscall_handler.syscall_ptr)?;

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
@@ -37,8 +37,8 @@ impl From<EnhancedHintError> for CheatcodeError {
 impl From<CallFailure> for CheatcodeError {
     fn from(value: CallFailure) -> Self {
         match value {
-            CallFailure::Panic { panic_data } => CheatcodeError::Recoverable(panic_data),
-            CallFailure::Error { msg } => CheatcodeError::Unrecoverable(
+            CallFailure::Recoverable { panic_data } => CheatcodeError::Recoverable(panic_data),
+            CallFailure::Unrecoverable { msg } => CheatcodeError::Unrecoverable(
                 HintError::CustomHint(Box::from(msg.to_string())).into(),
             ),
         }

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -3,10 +3,7 @@ use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::UsedRe
 use crate::runtime_extensions::common::sum_syscall_usage;
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::replace_bytecode::ReplaceBytecodeError;
 use crate::runtime_extensions::{
-    call_to_blockifier_runtime_extension::{
-        CallToBlockifierRuntime,
-        rpc::{CallFailure, CallResult},
-    },
+    call_to_blockifier_runtime_extension::{CallToBlockifierRuntime, rpc::CallFailure},
     common::get_relocated_vm_trace,
     forge_runtime_extension::cheatcodes::{
         CheatcodeError,
@@ -274,15 +271,13 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     from_address,
                     &payload,
                 ) {
-                    CallResult::Success { .. } => {
-                        Ok(CheatcodeHandlingResult::from_serializable(0_u8))
-                    }
-                    CallResult::Failure(CallFailure::Panic { panic_data }) => Ok(
+                    Ok(_) => Ok(CheatcodeHandlingResult::from_serializable(0_u8)),
+                    Err(CallFailure::Recoverable { panic_data }) => Ok(
                         CheatcodeHandlingResult::from_serializable(Err::<(), _>(panic_data)),
                     ),
-                    CallResult::Failure(CallFailure::Error { msg }) => Err(
-                        EnhancedHintError::from(HintError::CustomHint(Box::from(msg.to_string()))),
-                    ),
+                    Err(CallFailure::Unrecoverable { msg }) => Err(EnhancedHintError::from(
+                        HintError::CustomHint(Box::from(msg.to_string())),
+                    )),
                 }
             }
             "read_txt" => {

--- a/crates/cheatnet/src/trace_data.rs
+++ b/crates/cheatnet/src/trace_data.rs
@@ -1,4 +1,6 @@
-use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
+    CallResult, CallSuccess,
+};
 use crate::runtime_extensions::common::sum_syscall_usage;
 use crate::state::CheatedData;
 use blockifier::blockifier_versioned_constants::VersionedConstants;
@@ -202,7 +204,7 @@ impl CallTrace {
             used_syscalls_vm_resources: SyscallUsageMap::default(),
             used_syscalls_sierra_gas: SyscallUsageMap::default(),
             nested_calls: vec![],
-            result: CallResult::Success { ret_data: vec![] },
+            result: Ok(CallSuccess { ret_data: vec![] }),
             vm_trace: None,
             gas_consumed: u64::default(),
             events: vec![],

--- a/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
+++ b/crates/cheatnet/tests/cheatcodes/get_class_hash.rs
@@ -52,7 +52,8 @@ fn get_class_hash_upgrade() {
         &contract_address,
         selector,
         &[hello_starknet_class_hash.into_()],
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         hello_starknet_class_hash,

--- a/crates/cheatnet/tests/cheatcodes/library_call.rs
+++ b/crates/cheatnet/tests/cheatcodes/library_call.rs
@@ -1,7 +1,7 @@
 use crate::cheatcodes::test_environment::TestEnvironment;
 use crate::common::assertions::assert_success;
 use crate::common::get_contracts;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallSuccess;
 use cheatnet::state::CheatSpan;
 use conversions::string::TryFromHexStr;
 use runtime::starknet::constants::TEST_ADDRESS;
@@ -120,7 +120,7 @@ fn global_cheat_works_with_library_call_from_actual_contract() {
 
     let set_class_hash_result =
         test_env.call_contract(&contract_address, "set_class_hash", &[class_hash.into()]);
-    assert!(matches!(set_class_hash_result, CallResult::Success { .. }));
+    assert!(matches!(set_class_hash_result, Ok(CallSuccess { .. })));
 
     test_env
         .cheatnet_state
@@ -149,7 +149,7 @@ fn cheat_with_finite_span_works_with_library_call_from_actual_contract() {
 
     let set_class_hash_result =
         test_env.call_contract(&contract_address, "set_class_hash", &[class_hash.into()]);
-    assert!(matches!(set_class_hash_result, CallResult::Success { .. }));
+    assert!(matches!(set_class_hash_result, Ok(CallSuccess { .. })));
 
     let cheated_caller_address = 123_u8;
 
@@ -181,7 +181,7 @@ fn cheat_with_indefinite_span_works_with_library_call_from_actual_contract() {
 
     let set_class_hash_result =
         test_env.call_contract(&contract_address, "set_class_hash", &[class_hash.into()]);
-    assert!(matches!(set_class_hash_result, CallResult::Success { .. }));
+    assert!(matches!(set_class_hash_result, Ok(CallSuccess { .. })));
 
     let cheated_caller_address = 123_u8;
 

--- a/crates/cheatnet/tests/cheatcodes/load.rs
+++ b/crates/cheatnet/tests/cheatcodes/load.rs
@@ -25,7 +25,9 @@ fn load_simple_state() {
     let class_hash = test_env.declare("HelloStarknet", &contracts_data);
     let contract_address = test_env.deploy_wrapper(&class_hash, &[]);
 
-    test_env.call_contract(&contract_address, "increase_balance", &[Felt::from(420)]);
+    test_env
+        .call_contract(&contract_address, "increase_balance", &[Felt::from(420)])
+        .unwrap();
 
     let balance_value = test_env.load(contract_address, variable_address("balance"));
 
@@ -46,7 +48,9 @@ fn load_state_map_simple_value() {
 
     let map_key = Felt::from(420);
     let inserted_value = Felt::from(69);
-    test_env.call_contract(&contract_address, "insert", &[map_key, inserted_value]);
+    test_env
+        .call_contract(&contract_address, "insert", &[map_key, inserted_value])
+        .unwrap();
 
     let var_address = map_entry_address("values", &[map_key]);
     let map_value = test_env.load(contract_address, var_address);

--- a/crates/cheatnet/tests/cheatcodes/multiple_writes_same_storage.rs
+++ b/crates/cheatnet/tests/cheatcodes/multiple_writes_same_storage.rs
@@ -38,14 +38,18 @@ fn same_storage_access_call_contract() {
     let contract_address_b = test_env.deploy_wrapper(&hello_class_hash, &[]);
     assert_ne!(contract_address_b, contract_address_a);
 
-    test_env.call_contract(&contract_address_a, "increase_balance", &[Felt::from(420)]);
+    test_env
+        .call_contract(&contract_address_a, "increase_balance", &[Felt::from(420)])
+        .unwrap();
     let balance_value_a = test_env.call_contract(&contract_address_a, "get_balance", &[]);
     assert_success(balance_value_a, &[Felt::from(420)]);
 
     let balance_value_b = test_env.call_contract(&contract_address_b, "get_balance", &[]);
     assert_success(balance_value_b, &[Felt::from(0)]);
 
-    test_env.call_contract(&contract_address_b, "increase_balance", &[Felt::from(42)]);
+    test_env
+        .call_contract(&contract_address_b, "increase_balance", &[Felt::from(42)])
+        .unwrap();
 
     let balance_value_b = test_env.call_contract(&contract_address_b, "get_balance", &[]);
     assert_success(balance_value_b, &[Felt::from(42)]);

--- a/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
+++ b/crates/cheatnet/tests/cheatcodes/replace_bytecode.rs
@@ -2,7 +2,7 @@ use crate::{
     cheatcodes::test_environment::TestEnvironment,
     common::{assertions::assert_success, get_contracts, state::create_fork_cached_state_at},
 };
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallSuccess;
 use conversions::string::TryFromHexStr;
 use num_traits::Zero;
 use starknet_api::core::{ClassHash, ContractAddress};
@@ -45,7 +45,7 @@ fn fork() {
 
     assert!(matches!(
         output,
-        CallResult::Success { ret_data, .. } if ret_data != [Felt::zero()],
+        Ok(CallSuccess { ret_data, .. }) if ret_data != [Felt::zero()],
     ));
 
     test_env.replace_class_for_contract(contract, class_hash);

--- a/crates/cheatnet/tests/cheatcodes/spy_events.rs
+++ b/crates/cheatnet/tests/cheatcodes/spy_events.rs
@@ -28,7 +28,9 @@ fn spy_events_zero_offset() {
 
     let contract_address = test_env.deploy("SpyEventsChecker", &[]);
 
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
 
     let events = test_env.get_events(0);
 
@@ -43,7 +45,9 @@ fn spy_events_zero_offset() {
         "Wrong event"
     );
 
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
 
     let length = test_env.get_events(0).len();
     assert_eq!(length, 2, "There should be one more new event");
@@ -55,9 +59,15 @@ fn spy_events_some_offset() {
 
     let contract_address = test_env.deploy("SpyEventsChecker", &[]);
 
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
 
     let events = test_env.get_events(2);
 
@@ -76,7 +86,9 @@ fn spy_events_some_offset() {
         "Wrong event"
     );
 
-    test_env.call_contract(&contract_address, "emit_one_event", &[Felt::from(123)]);
+    test_env
+        .call_contract(&contract_address, "emit_one_event", &[Felt::from(123)])
+        .unwrap();
 
     let length = test_env.get_events(2).len();
     assert_eq!(length, 2, "There should be one more new event");
@@ -89,16 +101,18 @@ fn check_events_order() {
     let spy_events_checker_address = test_env.deploy("SpyEventsChecker", &[]);
     let spy_events_order_checker_address = test_env.deploy("SpyEventsOrderChecker", &[]);
 
-    test_env.call_contract(
-        &spy_events_order_checker_address,
-        "emit_and_call_another",
-        &[
-            Felt::from(123),
-            Felt::from(234),
-            Felt::from(345),
-            spy_events_checker_address.into_(),
-        ],
-    );
+    test_env
+        .call_contract(
+            &spy_events_order_checker_address,
+            "emit_and_call_another",
+            &[
+                Felt::from(123),
+                Felt::from(234),
+                Felt::from(345),
+                spy_events_checker_address.into_(),
+            ],
+        )
+        .unwrap();
 
     let events = test_env.get_events(0);
 
@@ -140,11 +154,13 @@ fn library_call_emits_event() {
     let class_hash = test_env.declare("SpyEventsChecker", &contracts_data);
     let contract_address = test_env.deploy("SpyEventsLibCall", &[]);
 
-    test_env.call_contract(
-        &contract_address,
-        "call_lib_call",
-        &[Felt::from(123), class_hash.into_()],
-    );
+    test_env
+        .call_contract(
+            &contract_address,
+            "call_lib_call",
+            &[Felt::from(123), class_hash.into_()],
+        )
+        .unwrap();
 
     let events = test_env.get_events(0);
 
@@ -194,11 +210,13 @@ fn test_nested_calls() {
     let spy_events_checker_top_proxy_address =
         test_env.deploy_wrapper(&class_hash, &[spy_events_checker_proxy_address.into_()]);
 
-    test_env.call_contract(
-        &spy_events_checker_top_proxy_address,
-        "emit_one_event",
-        &[Felt::from(123)],
-    );
+    test_env
+        .call_contract(
+            &spy_events_checker_top_proxy_address,
+            "emit_one_event",
+            &[Felt::from(123)],
+        )
+        .unwrap();
 
     let events = test_env.get_events(0);
 
@@ -250,11 +268,13 @@ fn use_multiple_spies() {
     // - spy_events_checker_top_proxy_address,
     // - spy_events_checker_proxy_address,
     // - spy_events_checker_address
-    test_env.call_contract(
-        &spy_events_checker_top_proxy_address,
-        "emit_one_event",
-        &[Felt::from(123)],
-    );
+    test_env
+        .call_contract(
+            &spy_events_checker_top_proxy_address,
+            "emit_one_event",
+            &[Felt::from(123)],
+        )
+        .unwrap();
 
     let events1 = test_env.get_events(0);
     let events2 = test_env.get_events(1);
@@ -299,11 +319,13 @@ fn test_emitted_by_emit_events_syscall() {
 
     let contract_address = test_env.deploy("SpyEventsChecker", &[]);
 
-    test_env.call_contract(
-        &contract_address,
-        "emit_event_syscall",
-        &[Felt::from(123), Felt::from(456)],
-    );
+    test_env
+        .call_contract(
+            &contract_address,
+            "emit_event_syscall",
+            &[Felt::from(123), Felt::from(456)],
+        )
+        .unwrap();
 
     let events = test_env.get_events(0);
 
@@ -344,7 +366,8 @@ fn capture_cairo0_event() {
         &contract_address,
         selector,
         &[cairo0_contract_address],
-    );
+    )
+    .unwrap();
 
     let events = cheatnet_state.get_events(0);
 

--- a/crates/cheatnet/tests/common/assertions.rs
+++ b/crates/cheatnet/tests/common/assertions.rs
@@ -1,5 +1,5 @@
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    CallFailure, CallResult,
+    CallFailure, CallResult, CallSuccess,
 };
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::declare::DeclareResult;
 use conversions::byte_array::ByteArray;
@@ -10,7 +10,7 @@ use starknet_types_core::felt::Felt;
 pub fn assert_success(call_contract_output: CallResult, expected_data: &[Felt]) {
     assert!(matches!(
         call_contract_output,
-        CallResult::Success { ret_data, .. }
+        Ok(CallSuccess { ret_data, .. })
         if ret_data == expected_data,
     ));
 }
@@ -19,8 +19,8 @@ pub fn assert_success(call_contract_output: CallResult, expected_data: &[Felt]) 
 pub fn assert_panic(call_contract_output: CallResult, expected_data: &[Felt]) {
     assert!(matches!(
         call_contract_output,
-        CallResult::Failure(
-            CallFailure::Panic { panic_data, .. }
+        Err(
+            CallFailure::Recoverable { panic_data, .. }
         )
         if panic_data == expected_data
     ));
@@ -30,8 +30,8 @@ pub fn assert_panic(call_contract_output: CallResult, expected_data: &[Felt]) {
 pub fn assert_error(call_contract_output: CallResult, expected_data: impl Into<ByteArray>) {
     assert!(matches!(
         call_contract_output,
-        CallResult::Failure(
-            CallFailure::Error { msg, .. }
+        Err(
+            CallFailure::Unrecoverable { msg, .. }
         )
         if msg == expected_data.into(),
     ));

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -13,7 +13,7 @@ use cairo_vm::types::relocatable::Relocatable;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::execution::cheated_syscalls;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::execution::entry_point::non_reverting_execute_call_entry_point;
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    AddressOrClassHash, call_entry_point,
+    AddressOrClassHash, CallSuccess, call_entry_point,
 };
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
     CallFailure, CallResult,
@@ -66,10 +66,10 @@ fn build_syscall_hint_processor<'a>(
 }
 pub fn recover_data(output: CallResult) -> Vec<Felt> {
     match output {
-        CallResult::Success { ret_data, .. } => ret_data,
-        CallResult::Failure(failure_type) => match failure_type {
-            CallFailure::Panic { panic_data, .. } => panic_data,
-            CallFailure::Error { msg, .. } => panic!("Call failed with message: {msg}"),
+        Ok(CallSuccess { ret_data, .. }) => ret_data,
+        Err(failure_type) => match failure_type {
+            CallFailure::Recoverable { panic_data, .. } => panic_data,
+            CallFailure::Unrecoverable { msg, .. } => panic!("Call failed with message: {msg}"),
         },
     }
 }

--- a/crates/cheatnet/tests/starknet/cheat_fork.rs
+++ b/crates/cheatnet/tests/starknet/cheat_fork.rs
@@ -1,6 +1,6 @@
 use crate::common::call_contract;
 use crate::common::state::create_fork_cached_state;
-use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallResult;
+use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::CallSuccess;
 use cheatnet::runtime_extensions::forge_runtime_extension::cheatcodes::storage::selector_from_name;
 use cheatnet::state::CheatnetState;
 use conversions::string::TryFromHexStr;
@@ -30,7 +30,7 @@ fn cheat_caller_address_cairo0_contract(selector: &str) {
         &[],
     );
 
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let caller = &ret_data[0];
@@ -44,7 +44,7 @@ fn cheat_caller_address_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let cheated_caller_address = &ret_data[0];
@@ -58,7 +58,7 @@ fn cheat_caller_address_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let uncheated_caller_address = &ret_data[0];
@@ -84,7 +84,7 @@ fn cheat_block_number_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let block_number = &ret_data[0];
@@ -98,7 +98,7 @@ fn cheat_block_number_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let cheated_block_number = &ret_data[0];
@@ -112,7 +112,7 @@ fn cheat_block_number_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let uncheated_block_number = &ret_data[0];
@@ -138,7 +138,7 @@ fn cheat_block_timestamp_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let block_timestamp = &ret_data[0];
@@ -151,7 +151,7 @@ fn cheat_block_timestamp_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let cheated_block_timestamp = &ret_data[0];
@@ -165,7 +165,7 @@ fn cheat_block_timestamp_cairo0_contract(selector: &str) {
         selector,
         &[],
     );
-    let CallResult::Success { ret_data } = output else {
+    let Ok(CallSuccess { ret_data }) = output else {
         panic!("Wrong call output")
     };
     let uncheated_block_timestamp = &ret_data[0];

--- a/crates/cheatnet/tests/starknet/forking.rs
+++ b/crates/cheatnet/tests/starknet/forking.rs
@@ -46,7 +46,8 @@ fn fork_simple() {
         &contract_address,
         selector,
         &[Felt::from(100)],
-    );
+    )
+    .unwrap();
 
     let selector = selector_from_name("get_balance");
     let output = call_contract(
@@ -188,7 +189,8 @@ fn library_call_on_forked_class_hash() {
         &contract_address,
         selector_from_name("set_balance"),
         &[Felt::from(100)],
-    );
+    )
+    .unwrap();
 
     let output = call_contract(
         &mut cached_fork_state,

--- a/crates/debugging/src/trace/collect.rs
+++ b/crates/debugging/src/trace/collect.rs
@@ -5,7 +5,7 @@ use crate::trace::types::{
 };
 use crate::{Context, Trace};
 use cheatnet::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
-    CallFailure, CallResult as CheatnetCallResult,
+    CallFailure, CallSuccess,
 };
 use cheatnet::trace_data::{CallTrace, CallTraceNode};
 use data_transformer::{reverse_transform_input, reverse_transform_output};
@@ -113,7 +113,7 @@ impl<'a> Collector<'a> {
 
     fn collect_transformed_call_result(&self, abi: &[AbiEntry]) -> TransformedCallResult {
         TransformedCallResult(match &self.call_trace.result {
-            CheatnetCallResult::Success { ret_data } => {
+            Ok(CallSuccess { ret_data }) => {
                 let ret_data = reverse_transform_output(
                     ret_data,
                     abi,
@@ -122,11 +122,13 @@ impl<'a> Collector<'a> {
                 .expect("call result should be successfully transformed");
                 format_result_message("success", &ret_data)
             }
-            CheatnetCallResult::Failure(failure) => match failure {
-                CallFailure::Panic { panic_data } => {
+            Err(failure) => match failure {
+                CallFailure::Recoverable { panic_data } => {
                     format_result_message("panic", &format_panic_data(panic_data))
                 }
-                CallFailure::Error { msg } => format_result_message("error", &msg.to_string()),
+                CallFailure::Unrecoverable { msg } => {
+                    format_result_message("error", &msg.to_string())
+                }
             },
         })
     }

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -52,7 +52,7 @@ impl Contract {
         }
     }
 
-    pub fn from_code_path(name: impl Into<String>, path: &Path) -> Result<Self> {
+    pub fn from_code_path(name: impl Into<String>, path: impl AsRef<Path>) -> Result<Self> {
         let code = fs::read_to_string(path)?;
         Ok(Self {
             name: name.into(),


### PR DESCRIPTION
Towards #3307 & #3837 

## Introduced changes

<!-- A brief description of the changes -->

- Remove our custom logic for writing to VM memory
- Rename `Panic`, `Error` to `Recoverable` and `Unrecoverable`
- Make `CallToBlockifierRuntime` flow similar to other runtimes and Blockifier (e.g. `execute_syscall` function)

