### PR TITLE
Refactor: add re-usable `clear_events_and_messages_from_reverted_call`

### DIFF
--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -73,6 +73,23 @@ pub(crate) fn update_trace_data(
     );
 }
 
+/// Clears `events` and `l2_to_l1_messages` from a reverted call and all its inner calls that did not fail. 
+pub(crate) fn clear_events_and_messages_from_reverted_call(reverted_call: &mut CallInfo) {
+    let mut stack: Vec<&mut CallInfo> = vec![reverted_call];
+    while let Some(call_info) = stack.pop() {
+        call_info.execution.events.clear();
+        call_info.execution.l2_to_l1_messages.clear();
+        // Add inner calls that did not fail to the stack.
+        // The events and l2_to_l1_messages of the failed calls were already cleared.
+        stack.extend(
+            call_info
+                .inner_calls
+                .iter_mut()
+                .filter(|call_info| !call_info.execution.failed),
+        );
+    }
+}
+
 pub(crate) fn exit_error_call(
     error: &EntryPointExecutionError,
     cheatnet_state: &mut CheatnetState,

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -73,7 +73,7 @@ pub(crate) fn update_trace_data(
     );
 }
 
-/// Clears `events` and `l2_to_l1_messages` from a reverted call and all its inner calls that did not fail. 
+/// Clears `events` and `l2_to_l1_messages` from a reverted call and all its inner calls that did not fail.
 pub(crate) fn clear_events_and_messages_from_reverted_call(reverted_call: &mut CallInfo) {
     let mut stack: Vec<&mut CallInfo> = vec![reverted_call];
     while let Some(call_info) = stack.pop() {

--- a/crates/cheatnet/src/runtime_extensions/native/call.rs
+++ b/crates/cheatnet/src/runtime_extensions/native/call.rs
@@ -12,7 +12,6 @@ use blockifier::execution::syscalls::syscall_base::SyscallHandlerBase;
 use starknet_types_core::felt::Felt;
 
 // Based on https://github.com/software-mansion-labs/sequencer/blob/57447e3e8897d4e7ce7f3ec8d23af58d5b6bf1a7/crates/blockifier/src/execution/syscalls/syscall_base.rs#L435
-#[expect(clippy::mut_mut)]
 pub fn execute_inner_call(
     // region: Modified blockifier code
     syscall_handler_base: &mut SyscallHandlerBase,

--- a/crates/cheatnet/src/runtime_extensions/native/call.rs
+++ b/crates/cheatnet/src/runtime_extensions/native/call.rs
@@ -1,9 +1,9 @@
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::entry_point::{
     ExecuteCallEntryPointExtraOptions, execute_call_entry_point,
 };
+use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::execution_utils::clear_events_and_messages_from_reverted_call;
 use crate::runtime_extensions::native::native_syscall_handler::BaseSyscallResult;
 use crate::state::CheatnetState;
-use blockifier::execution::call_info::CallInfo;
 use blockifier::execution::entry_point::CallEntryPoint;
 use blockifier::execution::syscalls::hint_processor::{
     ENTRYPOINT_FAILED_ERROR, SyscallExecutionError,
@@ -45,20 +45,8 @@ pub fn execute_inner_call(
             .revert(revert_idx, syscall_handler_base.state)?;
 
         // Delete events and l2_to_l1_messages from the reverted call.
-        let reverted_call = &mut syscall_handler_base.inner_calls.last_mut().unwrap();
-        let mut stack: Vec<&mut CallInfo> = vec![reverted_call];
-        while let Some(call_info) = stack.pop() {
-            call_info.execution.events.clear();
-            call_info.execution.l2_to_l1_messages.clear();
-            // Add inner calls that did not fail to the stack.
-            // The events and l2_to_l1_messages of the failed calls were already cleared.
-            stack.extend(
-                call_info
-                    .inner_calls
-                    .iter_mut()
-                    .filter(|call_info| !call_info.execution.failed),
-            );
-        }
+        let reverted_call = syscall_handler_base.inner_calls.last_mut().unwrap();
+        clear_events_and_messages_from_reverted_call(reverted_call);
 
         raw_retdata
             .push(Felt::from_hex(ENTRYPOINT_FAILED_ERROR).map_err(SyscallExecutionError::from)?);


### PR DESCRIPTION
## Stack
- #4116 
- #4117
## Introduced changes

<!-- A brief description of the changes -->

De-duplicates some logic via adding re-usable func (re-used once again in the following PR)

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
