### PR TITLE
Make errors from `deploy` and `deploy_at` of `ContractClass` catchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `--detailed-resources` output now includes all gas-related resources
-- `deploy` and `deploy_at` methods on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where this errors are not revertible and cannot be caught.
-
+- `deploy` and `deploy_at` methods on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where such errors cannot be caught.
 ## [0.55.0] - 2026-01-13
 
 ## Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `--detailed-resources` output now includes all gas-related resources
+- `deploy` method on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where this errors are not revertible and cannot be caught.
 
 ## [0.55.0] - 2026-01-13
 
@@ -21,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimal recommended `Scarb` version is now `2.13.1` (updated from `2.12.2`)
 - `snforge_scarb_plugin` now emits an error if unexpected named args are passed to `#[available_gas]`, `#[fork]`, `#[fuzzer]`, `#[should_panic]` and `#[test_case]` attributes
-- `--detailed-resources` output now includes all gas-related resources
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `--detailed-resources` output now includes all gas-related resources
-- `deploy` method on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where this errors are not revertible and cannot be caught.
+- `deploy` and `deploy_at` methods on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where this errors are not revertible and cannot be caught.
 
 ## [0.55.0] - 2026-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `--detailed-resources` output now includes all gas-related resources
-- `deploy` and `deploy_at` methods on `ContractClass` instance now allow errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where such errors cannot be caught.
+- `deploy` and `deploy_at` methods on `ContractClass` instance now allow constructor errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where such errors cannot be caught.
 ## [0.55.0] - 2026-01-13
 
 ## Forge

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
@@ -156,9 +156,9 @@ pub fn deploy_syscall(
     let raw_retdata = call_info.execution.retdata.0.clone();
     syscall_handler.base.inner_calls.push(call_info);
 
-    // This should be unreachable with the current implementation of `execute_deployment`
-    // This check is kept in case of future changes + to be aligned with revert handling elsewhere.
     if failed && from_cheatcode {
+        // This should be unreachable with the current implementation of `execute_deployment`
+        // This check is kept in case of future changes + to be aligned with revert handling elsewhere.
         return convert_deploy_failure_to_revert(syscall_handler, revert_idx, raw_retdata);
     }
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
@@ -133,7 +133,7 @@ pub fn deploy_syscall(
 
     // Check if this deploy comes from the cheatcode
     // This allows us to make `deploy_syscall` revertible, only when used via the cheatcode
-    let from_cheatcode = cheatnet_state.take_next_deploy_from_cheatcode();
+    let from_cheatcode = cheatnet_state.take_next_syscall_from_cheatcode();
 
     let revert_idx = syscall_handler.base.context.revert_infos.0.len();
 

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
@@ -156,6 +156,8 @@ pub fn deploy_syscall(
     let raw_retdata = call_info.execution.retdata.0.clone();
     syscall_handler.base.inner_calls.push(call_info);
 
+    // This should be unreachable with the current implementation of `execute_deployment`
+    // This check is kept in case of future changes + to be aligned with revert handling elsewhere.
     if failed && from_cheatcode {
         return convert_deploy_failure_to_revert(syscall_handler, revert_idx, raw_retdata);
     }

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/cheated_syscalls.rs
@@ -148,28 +148,19 @@ pub fn deploy_syscall(
         Ok(info) => info,
         Err(EntryPointExecutionError::ExecutionFailed { error_trace }) if from_cheatcode => {
             let panic_data = error_trace.last_retdata.0.clone();
-            return convert_deploy_failure_to_revert(
-                syscall_handler,
-                revert_idx,
-                panic_data,
-            );
+            return convert_deploy_failure_to_revert(syscall_handler, revert_idx, panic_data);
         }
         Err(err) => return Err(err.into()),
     };
     let failed = call_info.execution.failed;
     let raw_retdata = call_info.execution.retdata.0.clone();
     syscall_handler.base.inner_calls.push(call_info);
-    
+
     if failed && from_cheatcode {
-        return convert_deploy_failure_to_revert(
-            syscall_handler,
-            revert_idx,
-            raw_retdata,
-        );
+        return convert_deploy_failure_to_revert(syscall_handler, revert_idx, raw_retdata);
     }
 
-    let constructor_retdata =
-        create_retdata_segment(vm, syscall_handler, &raw_retdata)?;
+    let constructor_retdata = create_retdata_segment(vm, syscall_handler, &raw_retdata)?;
 
     Ok(DeployResponse {
         contract_address: deployed_contract_address,

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -74,6 +74,8 @@ pub(crate) fn update_trace_data(
 }
 
 /// Clears `events` and `l2_to_l1_messages` from a reverted call and all its inner calls that did not fail.
+/// This is part of `execute_inner_call` function in Blockifier.
+/// https://github.com/software-mansion-labs/sequencer/blob/v0.16.0-rc.1/crates/blockifier/src/execution/syscalls/syscall_base.rs#L441-L453
 pub(crate) fn clear_events_and_messages_from_reverted_call(reverted_call: &mut CallInfo) {
     let mut stack: Vec<&mut CallInfo> = vec![reverted_call];
     while let Some(call_info) = stack.pop() {

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -75,7 +75,7 @@ pub(crate) fn update_trace_data(
 
 /// Clears `events` and `l2_to_l1_messages` from a reverted call and all its inner calls that did not fail.
 /// This is part of `execute_inner_call` function in Blockifier.
-/// https://github.com/software-mansion-labs/sequencer/blob/v0.16.0-rc.1/crates/blockifier/src/execution/syscalls/syscall_base.rs#L441-L453
+/// <https://github.com/software-mansion-labs/sequencer/blob/v0.16.0-rc.1/crates/blockifier/src/execution/syscalls/syscall_base.rs#L441-L453>
 pub(crate) fn clear_events_and_messages_from_reverted_call(reverted_call: &mut CallInfo) {
     let mut stack: Vec<&mut CallInfo> = vec![reverted_call];
     while let Some(call_info) = stack.pop() {

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -199,7 +199,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::from_serializable(()))
             }
             // Internal cheatcode to mark next syscall as coming from cheatcode.
-                "set_next_syscall_from_cheatcode" => {
+            "set_next_syscall_from_cheatcode" => {
                 let state = &mut *extended_runtime.extended_runtime.extension.cheatnet_state;
                 state.set_next_syscall_from_cheatcode();
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -199,7 +199,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                 Ok(CheatcodeHandlingResult::from_serializable(()))
             }
             // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
-            "start_cheatcode_deploy" => {
+            "set_next_deploy_from_cheatcode" => {
                 let state = &mut *extended_runtime.extended_runtime.extension.cheatnet_state;
                 state.set_next_deploy_from_cheatcode();
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -198,6 +198,13 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
 
                 Ok(CheatcodeHandlingResult::from_serializable(()))
             }
+            // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
+            "start_cheatcode_deploy" => {
+                let state = &mut *extended_runtime.extended_runtime.extension.cheatnet_state;
+                state.set_next_deploy_from_cheatcode();
+
+                Ok(CheatcodeHandlingResult::from_serializable(()))
+            }
             "precalculate_address" => {
                 let class_hash = input_reader.read()?;
                 let calldata: Vec<_> = input_reader.read()?;

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -198,10 +198,10 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
 
                 Ok(CheatcodeHandlingResult::from_serializable(()))
             }
-            // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
-            "set_next_deploy_from_cheatcode" => {
+            // Internal cheatcode to mark next syscall as coming from cheatcode.
+                "set_next_syscall_from_cheatcode" => {
                 let state = &mut *extended_runtime.extended_runtime.extension.cheatnet_state;
-                state.set_next_deploy_from_cheatcode();
+                state.set_next_syscall_from_cheatcode();
 
                 Ok(CheatcodeHandlingResult::from_serializable(()))
             }

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -240,6 +240,7 @@ pub struct CheatnetState {
     pub detected_messages_to_l1: Vec<MessageToL1>,
     pub deploy_salt_base: u32,
     pub next_deploy_at_address: Option<ContractAddress>,
+    pub next_deploy_from_cheatcode: bool,
     pub block_info: BlockInfo,
     pub trace_data: TraceData,
     pub encountered_errors: EncounteredErrors,
@@ -268,6 +269,7 @@ impl Default for CheatnetState {
             detected_messages_to_l1: vec![],
             deploy_salt_base: 0,
             next_deploy_at_address: None,
+            next_deploy_from_cheatcode: false,
             block_info: SerializableBlockInfo::default().into(),
             trace_data: TraceData {
                 current_call_stack: NotEmptyCallStack::from(test_call),
@@ -341,6 +343,14 @@ impl CheatnetState {
 
     pub fn next_address_for_deployment(&mut self) -> Option<ContractAddress> {
         self.next_deploy_at_address.take()
+    }
+
+    pub fn set_next_deploy_from_cheatcode(&mut self) {
+        self.next_deploy_from_cheatcode = true;
+    }
+
+    pub fn take_next_deploy_from_cheatcode(&mut self) -> bool {
+        std::mem::take(&mut self.next_deploy_from_cheatcode)
     }
 
     #[must_use]

--- a/crates/cheatnet/src/state.rs
+++ b/crates/cheatnet/src/state.rs
@@ -240,7 +240,7 @@ pub struct CheatnetState {
     pub detected_messages_to_l1: Vec<MessageToL1>,
     pub deploy_salt_base: u32,
     pub next_deploy_at_address: Option<ContractAddress>,
-    pub next_deploy_from_cheatcode: bool,
+    pub next_syscall_from_cheatcode: bool,
     pub block_info: BlockInfo,
     pub trace_data: TraceData,
     pub encountered_errors: EncounteredErrors,
@@ -269,7 +269,7 @@ impl Default for CheatnetState {
             detected_messages_to_l1: vec![],
             deploy_salt_base: 0,
             next_deploy_at_address: None,
-            next_deploy_from_cheatcode: false,
+            next_syscall_from_cheatcode: false,
             block_info: SerializableBlockInfo::default().into(),
             trace_data: TraceData {
                 current_call_stack: NotEmptyCallStack::from(test_call),
@@ -345,12 +345,12 @@ impl CheatnetState {
         self.next_deploy_at_address.take()
     }
 
-    pub fn set_next_deploy_from_cheatcode(&mut self) {
-        self.next_deploy_from_cheatcode = true;
+    pub fn set_next_syscall_from_cheatcode(&mut self) {
+        self.next_syscall_from_cheatcode = true;
     }
 
-    pub fn take_next_deploy_from_cheatcode(&mut self) -> bool {
-        std::mem::take(&mut self.next_deploy_from_cheatcode)
+    pub fn take_next_syscall_from_cheatcode(&mut self) -> bool {
+        std::mem::take(&mut self.next_syscall_from_cheatcode)
     }
 
     #[must_use]

--- a/crates/forge/tests/data/contracts/deploy_checker.cairo
+++ b/crates/forge/tests/data/contracts/deploy_checker.cairo
@@ -18,6 +18,7 @@ mod DeployChecker {
 
     #[constructor]
     fn constructor(ref self: ContractState, balance: felt252) -> (ContractAddress, felt252) {
+        assert(balance != 0, 'Initial balance cannot be 0');
         self.balance.write(balance);
         self.caller.write(starknet::get_caller_address());
         (self.caller.read(), balance)

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__handled_error_not_display@2.15.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__handled_error_not_display@2.15.1.snap
@@ -2,7 +2,7 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[PASS] dispatchers_integrationtest::test::test_handle_and_panic (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~576580)
+[PASS] dispatchers_integrationtest::test::test_handle_and_panic (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~583520)
 
 error occurred in contract 'ErrorHandler'
 stack backtrace:

--- a/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__basic@2.15.1.snap
+++ b/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__basic@2.15.1.snap
@@ -2,7 +2,7 @@
 source: crates/forge/tests/e2e/gas_report.rs
 expression: stdout
 ---
-[PASS] simple_package_integrationtest::contract::call_and_invoke (l1_gas: ~0, l1_data_gas: ~192, l2_gas: ~510240)
+[PASS] simple_package_integrationtest::contract::call_and_invoke (l1_gas: ~0, l1_data_gas: ~192, l2_gas: ~513510)
 ╭------------------------+-------+-------+-------+---------+---------╮
 | HelloStarknet Contract |       |       |       |         |         |
 +====================================================================+

--- a/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__multiple_contracts_and_constructor@2.15.1.snap
+++ b/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__multiple_contracts_and_constructor@2.15.1.snap
@@ -2,7 +2,7 @@
 source: crates/forge/tests/e2e/gas_report.rs
 expression: stdout
 ---
-[PASS] simple_package_with_cheats_integrationtest::contract::call_and_invoke_proxy (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~860890)
+[PASS] simple_package_with_cheats_integrationtest::contract::call_and_invoke_proxy (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~867930)
 ╭------------------------+-------+-------+-------+---------+---------╮
 | HelloStarknet Contract |       |       |       |         |         |
 +====================================================================+

--- a/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__recursive_calls@2.15.1.snap
+++ b/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__recursive_calls@2.15.1.snap
@@ -2,7 +2,7 @@
 source: crates/forge/tests/e2e/gas_report.rs
 expression: stdout
 ---
-[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1371590)
+[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1382600)
 ╭-------------------------+-------+--------+--------+---------+---------╮
 | SimpleContract Contract |       |        |        |         |         |
 +=======================================================================+

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1307,7 +1307,7 @@ fn snforge_std_deploy_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(187_730),
+            l2_gas: GasAmount(190_800),
         },
     );
 }
@@ -1392,7 +1392,7 @@ fn contract_keccak_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(1_349_755),
+            l2_gas: GasAmount(1_353_025),
         },
     );
 }
@@ -1444,7 +1444,7 @@ fn storage_write_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(286_080),
+            l2_gas: GasAmount(289_350),
         },
     );
 }
@@ -1498,7 +1498,7 @@ fn multiple_storage_writes_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(393_520),
+            l2_gas: GasAmount(396_790),
         },
     );
 }
@@ -1556,7 +1556,7 @@ fn l1_message_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(29_524),
             l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(289_910),
+            l2_gas: GasAmount(293_180),
         },
     );
 }
@@ -1619,7 +1619,7 @@ fn l1_message_cost_for_proxy_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(29_524),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(550_120),
+            l2_gas: GasAmount(557_260),
         },
     );
 }
@@ -1713,7 +1713,7 @@ fn events_contract_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(467_820),
+            l2_gas: GasAmount(471_090),
         },
     );
 }
@@ -1786,7 +1786,7 @@ fn nested_call_cost_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(288),
-            l2_gas: GasAmount(1_936_402),
+            l2_gas: GasAmount(1_941_892),
         },
     );
 }
@@ -1861,7 +1861,7 @@ fn nested_call_cost_in_forked_contract_sierra_gas() {
         GasVector {
             l1_gas: GasAmount(0),
             l1_data_gas: GasAmount(192),
-            l2_gas: GasAmount(1_808_492),
+            l2_gas: GasAmount(1_812_052),
         },
     );
 }

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -69,7 +69,7 @@ impl ContractClassImpl of ContractClassTrait {
         let salt: felt252 = execute_cheatcode_and_deserialize::<'get_salt'>(array![].span());
 
         // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
-        // This allows `deploy` cheatcode to be revertible and thus catchable at test level (unlike `deploy_syscall`).
+        // This allows `deploy_syscall` to be handled differently when coming from cheatcode.
         execute_cheatcode_and_deserialize::<'start_cheatcode_deploy', ()>(array![].span());
 
         starknet::syscalls::deploy_syscall(

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -70,7 +70,7 @@ impl ContractClassImpl of ContractClassTrait {
 
         // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
         // This allows `deploy_syscall` to be handled differently when coming from cheatcode.
-        execute_cheatcode_and_deserialize::<'start_cheatcode_deploy', ()>(array![].span());
+        execute_cheatcode_and_deserialize::<'set_next_deploy_from_cheatcode', ()>(array![].span());
 
         starknet::syscalls::deploy_syscall(
             *self.class_hash, salt, constructor_calldata.span(), false,

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -69,7 +69,7 @@ impl ContractClassImpl of ContractClassTrait {
         let salt: felt252 = execute_cheatcode_and_deserialize::<'get_salt'>(array![].span());
 
         // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
-        // This allows `deploy` cheatcode to be revertable and thus catchable at test level (unlike `deploy_syscall`).
+        // This allows `deploy` cheatcode to be revertible and thus catchable at test level (unlike `deploy_syscall`).
         execute_cheatcode_and_deserialize::<'start_cheatcode_deploy', ()>(array![].span());
 
         starknet::syscalls::deploy_syscall(

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -68,6 +68,10 @@ impl ContractClassImpl of ContractClassTrait {
     ) -> SyscallResult<(ContractAddress, Span<felt252>)> {
         let salt: felt252 = execute_cheatcode_and_deserialize::<'get_salt'>(array![].span());
 
+        // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
+        // This allows `deploy` cheatcode to be revertable and thus catchable at test level (unlike `deploy_syscall`).
+        execute_cheatcode_and_deserialize::<'start_cheatcode_deploy', ()>(array![].span());
+
         starknet::syscalls::deploy_syscall(
             *self.class_hash, salt, constructor_calldata.span(), false,
         )

--- a/snforge_std/src/cheatcodes/contract_class.cairo
+++ b/snforge_std/src/cheatcodes/contract_class.cairo
@@ -70,7 +70,7 @@ impl ContractClassImpl of ContractClassTrait {
 
         // Internal cheatcode to mark next `deploy_syscall` as coming from cheatcode.
         // This allows `deploy_syscall` to be handled differently when coming from cheatcode.
-        execute_cheatcode_and_deserialize::<'set_next_deploy_from_cheatcode', ()>(array![].span());
+        execute_cheatcode_and_deserialize::<'set_next_syscall_from_cheatcode', ()>(array![].span());
 
         starknet::syscalls::deploy_syscall(
             *self.class_hash, salt, constructor_calldata.span(), false,


### PR DESCRIPTION
## Stack
- #4116 
- #4117

<!-- Reference any GitHub issues resolved by this PR -->

Closes #3992

## Introduced changes

<!-- A brief description of the changes -->

When `deploy_syscall` is executed in the context of `ContractClass::deploy` `ContractClass::deploy_at` cheatcodes, deployment will be **reverted** instead of resulting in hard error.

This diverges with how `deploy_syscall` behaves on real network: https://community.starknet.io/t/starknet-v0-13-4-pre-release-notes/115257#p-2358763-catching-errors-12 

This is done intentionally to allow catching and testing deployment errors.
 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
