### PR TITLE
[rust 1.93] fix `clippy::unnecessary-unwrap`

### DIFF
--- a/crates/data-transformer/src/transformer/sierra_abi/data_representation.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/data_representation.rs
@@ -203,8 +203,8 @@ impl CairoSerialize for CalldataEnum {
     // https://docs.starknet.io/architecture-and-concepts/smart-contracts/serialization-of-cairo-types/#serialization_of_enums
     fn serialize(&self, output: &mut BufferWriter) {
         self.position.serialize(output);
-        if self.argument.is_some() {
-            self.argument.as_ref().unwrap().serialize(output);
+        if let Some(arg) = &self.argument {
+            arg.serialize(output);
         }
     }
 }

--- a/crates/sncast/tests/docs_snippets/validation.rs
+++ b/crates/sncast/tests/docs_snippets/validation.rs
@@ -92,8 +92,10 @@ fn test_docs_snippets() {
             .current_dir(tempdir.path());
         let output = snapbox.assert().success();
 
-        if snippet.output.is_some() && !snippet.config.ignored_output {
-            assert_stdout_contains(output, snippet.output.as_ref().unwrap());
+        if let Some(expected_stdout) = &snippet.output
+            && !snippet.config.ignored_output
+        {
+            assert_stdout_contains(output, expected_stdout);
         }
     }
 


### PR DESCRIPTION
fixes clippy::unnecessary-unwrap

☝️ Breaks in the newest stable [Rust toolchain version 1.93.0](https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/), released on January 22, 2026 causing all clippy to fail ([example](https://github.com/foundry-rs/starknet-foundry/actions/runs/21279343150/job/61245391908))

