### PR TITLE
Include `;` at the end of config run if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Forge
+### Forge
 
 #### Changed
 
 - `--detailed-resources` output now includes all gas-related resources
 - `deploy` and `deploy_at` methods on `ContractClass` instance now allow constructor errors to be caught instead of failing immediately. This change diverges from the behavior of the `deploy_syscall` on the network, where such errors cannot be caught.
+
+#### Fixed
+
+- `snforge_scarb_plugin` now correctly generates code in tests with function code starting with `[`
+
 ## [0.55.0] - 2026-01-13
 
-## Forge
+### Forge
 
 #### Changed
 

--- a/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
@@ -121,7 +121,7 @@ fn fuzzer_wrapper_internal(
                     #func_name(#blank_values_for_config_run);
 
                     return;
-                }
+                };
                 #fuzzer_assignments
                 #func_name(#arguments_list);
             }

--- a/crates/snforge-scarb-plugin/src/attributes/test.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/test.rs
@@ -107,7 +107,7 @@ fn test_internal(
                    #if_content
 
                    return;
-               }
+               };
 
                #statements
            }

--- a/crates/snforge-scarb-plugin/src/config_statement.rs
+++ b/crates/snforge-scarb-plugin/src/config_statement.rs
@@ -81,7 +81,7 @@ pub fn append_config_statements(
                 #config_statements
 
                 return;
-            }
+            };
 
             #statements
         }

--- a/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/multiple_attributes.rs
@@ -93,7 +93,7 @@ fn works_with_few_attributes() {
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );
@@ -122,7 +122,7 @@ fn works_with_few_attributes() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -158,7 +158,7 @@ fn works_with_few_attributes() {
                     starknet::testing::cheatcode::<'set_config_fork'>(data.span());
 
                     return;
-                }
+                };
             }
         "#,
     );
@@ -194,7 +194,7 @@ fn works_with_fuzzer() {
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );
@@ -214,7 +214,7 @@ fn works_with_fuzzer() {
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );
@@ -268,7 +268,7 @@ fn works_with_fuzzer_before_test() {
             fn empty_fn(f: felt252) {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );
@@ -292,9 +292,9 @@ fn works_with_fuzzer_before_test() {
         r"
             fn empty_fn__snforge_internal_fuzzer_generated() {
                 if snforge_std::_internals::is_config_run() {
-                empty_fn(snforge_std::fuzzable::Fuzzable::blank());
-                return;
-                }
+                    empty_fn(snforge_std::fuzzable::Fuzzable::blank());
+                    return;
+                };
                 
                 let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
@@ -338,7 +338,7 @@ fn works_with_fuzzer_config_wrapper() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -383,7 +383,7 @@ fn works_with_fuzzer_config_wrapper() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }
     ",
     );
@@ -429,7 +429,7 @@ fn works_with_fuzzer_config_wrapper() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -471,7 +471,7 @@ fn works_with_fuzzer_config_wrapper() {
                     empty_fn(snforge_std::fuzzable::Fuzzable::blank());
 
                     return;
-                }
+                };
                 let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
                 empty_fn(f);
@@ -590,7 +590,7 @@ fn works_with_test_fuzzer_and_test_case() {
                 .serialize(ref data);
                 starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
                 return;
-            }
+            };
             
             core::internal::require_implicit::<System>();
             core::internal::revoke_ap_tracking();
@@ -623,7 +623,7 @@ fn works_with_test_fuzzer_and_test_case() {
             starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
             test_add_one_and_two(snforge_std::fuzzable::Fuzzable::blank());
             return;
-        }
+        };
 
         let _data = snforge_std::fuzzable::Fuzzable::<Span<felt252>>::generate();
         snforge_std::_internals::save_fuzzer_arg(@_data);

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/available_gas.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/available_gas.rs
@@ -24,7 +24,7 @@ fn works_with_empty() {
                     .serialize(ref data);
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
                     return;
-                }
+                };
             }
         ",
     );
@@ -76,7 +76,7 @@ fn work_with_number_some_set() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -107,7 +107,7 @@ fn work_with_number_all_set() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }",
     );
 }
@@ -220,7 +220,7 @@ fn max_permissible_value() {
                     starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/disable_predeployed_contracts.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/disable_predeployed_contracts.rs
@@ -39,7 +39,7 @@ fn works_without_args() {
                     starknet::testing::cheatcode::<'set_config_disable_contracts'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/fork.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/fork.rs
@@ -108,7 +108,7 @@ fn accepts_string() {
                     starknet::testing::cheatcode::<'set_config_fork'>(data.span());
 
                     return;
-                }
+                };
             }
         "#,
     );
@@ -161,7 +161,7 @@ fn accepts_inline_config() {
                     starknet::testing::cheatcode::<'set_config_fork'>(data.span());
 
                     return;
-                }
+                };
             }
         "#,
     );
@@ -194,7 +194,7 @@ fn overriding_config_name_first() {
                     starknet::testing::cheatcode::<'set_config_fork'>(data.span());
 
                     return;
-                }
+                };
             }
         "#,
     );
@@ -227,7 +227,7 @@ fn overriding_config_name_second() {
                     starknet::testing::cheatcode::<'set_config_fork'>(data.span());
 
                     return;
-                }
+                };
             }
         "#,
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/fuzzer.rs
@@ -63,7 +63,7 @@ fn config_works_with_runs_only() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -93,7 +93,7 @@ fn config_works_with_seed_only() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -123,7 +123,7 @@ fn config_works_with_both_args() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -153,7 +153,7 @@ fn config_wrapper_work_without_args() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -183,7 +183,7 @@ fn config_wrapper_work_without_args() {
                     empty_fn();
 
                     return;
-                }
+                };
                 empty_fn();
             }
 
@@ -218,7 +218,7 @@ fn config_wrapper_work_with_both_args() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -248,7 +248,7 @@ fn config_wrapper_work_with_both_args() {
                     empty_fn();
 
                     return;
-                }
+                };
                 empty_fn();
             }
 
@@ -286,7 +286,7 @@ fn config_wrapper_work_with_fn_with_single_param() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -316,7 +316,7 @@ fn config_wrapper_work_with_fn_with_single_param() {
                     empty_fn(snforge_std::fuzzable::Fuzzable::blank());
 
                     return;
-                }
+                };
                 let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
                 empty_fn(f);
@@ -355,7 +355,7 @@ fn config_wrapper_work_with_fn_with_params() {
                     starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );
@@ -385,7 +385,7 @@ fn config_wrapper_work_with_fn_with_params() {
                     empty_fn(snforge_std::fuzzable::Fuzzable::blank(), snforge_std::fuzzable::Fuzzable::blank());
 
                     return;
-                }
+                };
                 let f = snforge_std::fuzzable::Fuzzable::<felt252>::generate();
                 snforge_std::_internals::save_fuzzer_arg(@f);
                 let u = snforge_std::fuzzable::Fuzzable::<u32>::generate();
@@ -419,7 +419,7 @@ fn wrapper_handle_attributes() {
                     empty_fn();
 
                     return;
-                }
+                };
                 empty_fn();
             }
 

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/ignore.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/ignore.rs
@@ -37,7 +37,7 @@ fn works_without_args() {
                     starknet::testing::cheatcode::<'set_config_ignore'>(data.span());
 
                     return;
-                }
+                };
             }
         ",
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/internal_config_statement.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/internal_config_statement.rs
@@ -29,7 +29,7 @@ fn appends_config_statement() {
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/should_panic.rs
@@ -24,7 +24,7 @@ fn work_with_empty() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         ",
     );
@@ -52,7 +52,7 @@ fn work_with_expected_string() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         "#,
     );
@@ -80,7 +80,7 @@ fn work_with_expected_string_escaped() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         "#,
     );
@@ -111,7 +111,7 @@ fn work_with_expected_short_string() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         ",
     );
@@ -142,7 +142,7 @@ fn work_with_expected_short_string_escaped() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         ",
     );
@@ -173,7 +173,7 @@ fn work_with_expected_tuple() {
 
                     starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
                     return;
-                }
+                };
             }
         ",
     );

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/test.rs
@@ -32,7 +32,7 @@ fn appends_internal_config_and_executable() {
             fn empty_fn() {
                 if snforge_std::_internals::is_config_run() {
                     return;
-                }
+                };
             }
         ",
     );


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4132 

## Introduced changes

Before:
<img width="1055" height="321" alt="image" src="https://github.com/user-attachments/assets/54dcaa83-09bc-4f8a-b25a-092e6b35bf77" />

After (test fails as intended):
<img width="1032" height="452" alt="image" src="https://github.com/user-attachments/assets/5e1029e9-d7fc-49a7-a386-28421d019f7b" />


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
