### PR TITLE
Run schedule_compile_raw_sierra_at_path preemptively on another thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8317,7 +8317,6 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "num-bigint",
- "rayon",
  "serde",
  "serde_json",
  "shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "packages_validation",
  "project-root",
  "rand 0.8.5",
+ "rayon",
  "regex",
  "scarb-api",
  "scarb-metadata",
@@ -8312,9 +8313,11 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 name = "universal-sierra-compiler-api"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "num-bigint",
+ "rayon",
  "serde",
  "serde_json",
  "shared",
@@ -8322,6 +8325,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "uv-once-map",
  "which",
 ]
 
@@ -8380,6 +8384,17 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uv-once-map"
+version = "0.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ccfda7f4d0c25f0c69c0658e57b1e0fc8082d70dd3362e8cec31f8f564a762"
+dependencies = [
+ "dashmap",
+ "futures",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ snapbox = "0.6.23"
 scarb-ui = "0.1.7"
 semver = "1.0.27"
 bimap = "0.6.3"
-primitive-types = {  version =  "0.14.0", features = ["serde"] }
+primitive-types = { version = "0.14.0", features = ["serde"] }
 shellexpand = "3.1.0"
 toml = "0.9.8"
 rpassword = "7.3.1"
@@ -131,3 +131,4 @@ tracing-chrome = "0.7.2"
 tracing-log = "0.2.0"
 comfy-table = "7"
 insta = { version = "1.46.0", features = ["filters"] }
+uv-once-map = "0"

--- a/crates/forge-runner/src/running/with_config.rs
+++ b/crates/forge-runner/src/running/with_config.rs
@@ -15,7 +15,7 @@ use cairo_lang_sierra::{
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use std::{collections::HashMap, sync::Arc};
-use universal_sierra_compiler_api::compile_raw_sierra_at_path;
+use universal_sierra_compiler_api::blocking_get_compiled_raw_sierra_at_path;
 
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn test_target_with_config(
@@ -38,7 +38,7 @@ pub fn test_target_with_config(
     let funcs = by_id!(funcs);
     let type_declarations = by_id!(type_declarations);
 
-    let casm_program = Arc::new(compile_raw_sierra_at_path(
+    let casm_program = Arc::new(blocking_get_compiled_raw_sierra_at_path(
         test_target_raw.sierra_program_path.as_std_path(),
     )?);
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -58,6 +58,7 @@ chrono.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 tracing-chrome.workspace = true
+rayon.workspace = true
 
 [[bin]]
 name = "snforge"

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -29,6 +29,7 @@ use forge_runner::forge_config::{
 use scarb_api::ScarbCommand;
 use scarb_api::metadata::metadata_for_dir;
 use shared::test_utils::node_url::node_rpc_url;
+use universal_sierra_compiler_api::schedule_compile_raw_sierra_at_path;
 
 #[test]
 fn fork_simple_decorator() {
@@ -128,6 +129,10 @@ fn fork_aliased_decorator() {
     let raw_test_targets =
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
 
+    for test_target in &raw_test_targets {
+        schedule_compile_raw_sierra_at_path(test_target.sierra_program_path.as_ref()).unwrap();
+    }
+
     let ui = Arc::new(UI::default());
     let result = rt
         .block_on(run_for_package(
@@ -217,6 +222,10 @@ fn fork_aliased_decorator_overrding() {
 
     let raw_test_targets =
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
+
+    for test_target in &raw_test_targets {
+        schedule_compile_raw_sierra_at_path(test_target.sierra_program_path.as_ref()).unwrap();
+    }
 
     let ui = Arc::new(UI::default());
     let result = rt

--- a/crates/forge/tests/utils/running_tests.rs
+++ b/crates/forge/tests/utils/running_tests.rs
@@ -21,6 +21,7 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
+use universal_sierra_compiler_api::schedule_compile_raw_sierra_at_path;
 
 #[must_use]
 pub fn run_test_case(
@@ -45,6 +46,10 @@ pub fn run_test_case(
     let rt = Runtime::new().expect("Could not instantiate Runtime");
     let raw_test_targets =
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
+
+    for test_target in &raw_test_targets {
+        schedule_compile_raw_sierra_at_path(test_target.sierra_program_path.as_ref()).unwrap();
+    }
 
     let ui = Arc::new(UI::default());
     rt.block_on(run_for_package(

--- a/crates/universal-sierra-compiler-api/Cargo.toml
+++ b/crates/universal-sierra-compiler-api/Cargo.toml
@@ -16,5 +16,4 @@ tracing.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
 uv-once-map.workspace = true
-rayon.workspace = true
 anyhow.workspace = true

--- a/crates/universal-sierra-compiler-api/Cargo.toml
+++ b/crates/universal-sierra-compiler-api/Cargo.toml
@@ -15,3 +15,6 @@ cairo-lang-starknet-classes.workspace = true
 tracing.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
+uv-once-map.workspace = true
+rayon.workspace = true
+anyhow.workspace = true

--- a/crates/universal-sierra-compiler-api/src/lib.rs
+++ b/crates/universal-sierra-compiler-api/src/lib.rs
@@ -8,10 +8,14 @@
 use crate::command::{USCError, USCInternalCommand};
 use crate::compile::{CompilationError, SierraType, compile_sierra, compile_sierra_at_path};
 use crate::representation::RawCasmProgram;
+use anyhow::bail;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use serde_json::Value;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::OnceLock;
+use tracing::trace_span;
+use uv_once_map::OnceMap;
 
 mod command;
 mod compile;
@@ -37,12 +41,63 @@ pub fn compile_raw_sierra(sierra_json: &Value) -> Result<RawCasmProgram, Compila
     serde_json::from_str(&json).map_err(CompilationError::Deserialization)
 }
 
-/// Compiles Sierra JSON file at the given path of a raw program into [`RawCasmProgram`].
-pub fn compile_raw_sierra_at_path(
+static SIERRA_RAW_COMPILATION_DATA_LOADER: OnceLock<
+    OnceMap<PathBuf, Result<RawCasmProgram, CompilationErrorString>>,
+> = OnceLock::new();
+
+// We need a cloneable error type for the `OnceMap` to work.
+#[derive(Clone)]
+struct CompilationErrorString(String);
+
+/// Starts a compilation of Sierra JSON file at the given path into [`RawCasmProgram`].
+/// This is a fire and forget operation. It neither blocks the thread, nor waits for compilation
+/// to finish in any way.
+/// The compilation will happen on another thread.
+pub fn schedule_compile_raw_sierra_at_path(sierra_file_path: &Path) -> anyhow::Result<()> {
+    let cell = SIERRA_RAW_COMPILATION_DATA_LOADER.get_or_init(OnceMap::default);
+    let path = sierra_file_path.to_path_buf();
+
+    if cell.register(path.clone()) {
+        rayon::spawn(move || {
+            let span = trace_span!("compile_raw_sierra_at_path");
+            let result = {
+                let _g = span.enter();
+                compile_sierra_at_path(&path, SierraType::Raw).and_then(|json| {
+                    serde_json::from_str(&json).map_err(CompilationError::Deserialization)
+                })
+            };
+            match result {
+                Ok(program) => {
+                    cell.done(path, Ok(program));
+                }
+                Err(e) => {
+                    cell.done(path, Err(CompilationErrorString(e.to_string())));
+                }
+            }
+        });
+    }
+
+    Ok(())
+}
+
+/// Waits in a blocking manner for a compilation of Sierra JSON file at the given path to finish.
+/// Returns the raw program compiled into [`RawCasmProgram`].
+/// Panics unless `schedule_compile_raw_sierra_at_path` has been called before.
+pub fn blocking_get_compiled_raw_sierra_at_path(
     sierra_file_path: &Path,
-) -> Result<RawCasmProgram, CompilationError> {
-    let json = compile_sierra_at_path(sierra_file_path, SierraType::Raw)?;
-    serde_json::from_str(&json).map_err(CompilationError::Deserialization)
+) -> anyhow::Result<RawCasmProgram> {
+    let cell = SIERRA_RAW_COMPILATION_DATA_LOADER.get_or_init(OnceMap::default);
+    let path = sierra_file_path.to_path_buf();
+    let span = trace_span!("waiting_for_compiled_raw_sierra_at_path");
+    let result = {
+        let _g = span.enter();
+        cell.wait_blocking(&path)
+            .expect("schedule_compile_raw_sierra_at_path must be called first")
+    };
+    match result {
+        Ok(metadata) => Ok(metadata),
+        Err(e) => bail!(e.0),
+    }
 }
 
 /// Creates a `universal-sierra-compiler --version` command.


### PR DESCRIPTION
On cairo-contracts:

Before:
```
Time (mean ± σ):     46.300 s ±  1.312 s    [User: 275.481 s, System: 22.427 s]  Range (min … max):   45.293 s … 48.290 s    5 runs
```
<img width="840" height="1033" alt="image" src="https://github.com/user-attachments/assets/31d5827a-8e76-4619-b482-ab63d68a6cfe" />

After: 
```
Time (mean ± σ):     36.926 s ±  2.170 s    [User: 279.394 s, System: 28.798 s]  Range (min … max):   35.337 s … 40.697 s    5 runs
```
<img width="844" height="1023" alt="image" src="https://github.com/user-attachments/assets/5166c6d7-5dc8-4334-a558-1a4a1e0dabea" />
