### PR TITLE
Add `SNFORGE_DETERMINISTIC_OUTPUT`; Make snapshot tests deterministic

### DIFF
--- a/crates/forge-runner/src/forge_config.rs
+++ b/crates/forge-runner/src/forge_config.rs
@@ -18,6 +18,7 @@ pub struct ForgeConfig {
 #[derive(Debug, PartialEq)]
 pub struct TestRunnerConfig {
     pub exit_first: bool,
+    pub deterministic_output: bool,
     pub fuzzer_runs: NonZeroU32,
     pub fuzzer_seed: u64,
     pub max_n_steps: Option<u32>,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -135,7 +135,7 @@ pub enum TestCaseSummary<T: TestType> {
     ExcludedFromPartition {},
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 // We allow large enum variant because `Single` is the bigger variant and it is used most often
 #[expect(clippy::large_enum_variant)]
 pub enum AnyTestCaseSummary {

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -135,7 +135,7 @@ pub enum TestCaseSummary<T: TestType> {
     ExcludedFromPartition {},
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 // We allow large enum variant because `Single` is the bigger variant and it is used most often
 #[expect(clippy::large_enum_variant)]
 pub enum AnyTestCaseSummary {

--- a/crates/forge/src/combine_configs.rs
+++ b/crates/forge/src/combine_configs.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 #[expect(clippy::fn_params_excessive_bools)]
 pub fn combine_configs(
     exit_first: bool,
+    deterministic_output: bool,
     fuzzer_runs: Option<NonZeroU32>,
     fuzzer_seed: Option<u64>,
     detailed_resources: bool,
@@ -40,6 +41,7 @@ pub fn combine_configs(
     ForgeConfig {
         test_runner_config: Arc::new(TestRunnerConfig {
             exit_first: exit_first || forge_config_from_scarb.exit_first,
+            deterministic_output,
             fuzzer_runs: fuzzer_runs
                 .or(forge_config_from_scarb.fuzzer_runs)
                 .unwrap_or(NonZeroU32::new(256).unwrap()),
@@ -70,6 +72,7 @@ mod tests {
     fn fuzzer_default_seed() {
         let config = combine_configs(
             false,
+            false,
             None,
             None,
             false,
@@ -86,6 +89,7 @@ mod tests {
             TraceArgs::default(),
         );
         let config2 = combine_configs(
+            false,
             false,
             None,
             None,
@@ -115,6 +119,7 @@ mod tests {
     fn runner_config_default_arguments() {
         let config = combine_configs(
             false,
+            false,
             None,
             None,
             false,
@@ -135,6 +140,7 @@ mod tests {
             ForgeConfig {
                 test_runner_config: Arc::new(TestRunnerConfig {
                     exit_first: false,
+                    deterministic_output: false,
                     fuzzer_runs: NonZeroU32::new(256).unwrap(),
                     fuzzer_seed: config.test_runner_config.fuzzer_seed,
                     max_n_steps: None,
@@ -172,6 +178,7 @@ mod tests {
 
         let config = combine_configs(
             false,
+            false,
             None,
             None,
             false,
@@ -192,6 +199,7 @@ mod tests {
             ForgeConfig {
                 test_runner_config: Arc::new(TestRunnerConfig {
                     exit_first: true,
+                    deterministic_output: false,
                     fuzzer_runs: NonZeroU32::new(1234).unwrap(),
                     fuzzer_seed: 500,
                     max_n_steps: Some(1_000_000),
@@ -233,6 +241,7 @@ mod tests {
         };
         let config = combine_configs(
             true,
+            false,
             Some(NonZeroU32::new(100).unwrap()),
             Some(32),
             true,
@@ -254,6 +263,7 @@ mod tests {
             ForgeConfig {
                 test_runner_config: Arc::new(TestRunnerConfig {
                     exit_first: true,
+                    deterministic_output: false,
                     fuzzer_runs: NonZeroU32::new(100).unwrap(),
                     fuzzer_seed: 32,
                     max_n_steps: Some(1_000_000),

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -1,6 +1,7 @@
 use crate::compatibility_check::{Requirement, RequirementsChecker, create_version_parser};
 use anyhow::Result;
 use camino::Utf8PathBuf;
+use clap::builder::BoolishValueParser;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use derive_more::Display;
 use forge_runner::CACHE_DIR;
@@ -157,6 +158,10 @@ pub struct TestArgs {
     /// Stop executing tests after the first failed test
     #[arg(short = 'x', long)]
     exit_first: bool,
+
+    /// Sort test result outputs by test name, for reproducible outputs (e.g. for snapshot tests).
+    #[arg(long, env = "SNFORGE_DETERMINISTIC_OUTPUT", default_value_t = false, hide = true, value_parser = BoolishValueParser::new())]
+    deterministic_output: bool,
 
     /// Number of fuzzer runs
     #[arg(short = 'r', long)]

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -42,10 +42,7 @@ fn init_logging() -> Option<impl Drop> {
                 .from_env_lossy(),
         );
 
-    let tracing_profile = env::var("SNFORGE_TRACING_PROFILE").ok().is_some_and(|var| {
-        let s = var.as_str();
-        s == "true" || s == "1"
-    });
+    let tracing_profile = shared::env::is_truthy_env("SNFORGE_TRACING_PROFILE", false);
 
     let profile_layer = if tracing_profile {
         let mut path = PathBuf::from(format!(

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -42,7 +42,10 @@ fn init_logging() -> Option<impl Drop> {
                 .from_env_lossy(),
         );
 
-    let tracing_profile = shared::env::is_truthy_env("SNFORGE_TRACING_PROFILE", false);
+    let tracing_profile = env::var("SNFORGE_TRACING_PROFILE").ok().is_some_and(|var| {
+        let s = var.as_str();
+        s == "true" || s == "1"
+    });
 
     let profile_layer = if tracing_profile {
         let mut path = PathBuf::from(format!(

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -103,6 +103,7 @@ impl RunForPackageArgs {
             load_package_config::<ForgeConfigFromScarb>(scarb_metadata, &package.id)?;
         let forge_config = Arc::new(combine_configs(
             args.exit_first,
+            args.deterministic_output,
             args.fuzzer_runs,
             args.fuzzer_seed,
             args.detailed_resources,

--- a/crates/forge/src/run_tests/test_target.rs
+++ b/crates/forge/src/run_tests/test_target.rs
@@ -73,17 +73,23 @@ pub async fn run_for_test_target(
     let mut results = vec![];
     let mut saved_trace_data_paths = vec![];
     let mut interrupted = false;
+    let deterministic_output = forge_config.test_runner_config.deterministic_output;
+
+    let print_test_result = |result: &AnyTestCaseSummary| {
+        let test_result_message = TestResultMessage::new(
+            result,
+            forge_config.output_config.detailed_resources,
+            forge_config.test_runner_config.tracked_resource,
+        );
+        ui.println(&test_result_message);
+    };
 
     while let Some(task) = tasks.next().await {
         let result = task??;
 
-        if should_print_test_result_message(&result) {
-            let test_result_message = TestResultMessage::new(
-                &result,
-                forge_config.output_config.detailed_resources,
-                forge_config.test_runner_config.tracked_resource,
-            );
-            ui.println(&test_result_message);
+        // Skip printing; Print all results at once in a sorted order once they are available
+        if !deterministic_output && should_print_test_result_message(&result) {
+            print_test_result(&result);
         }
 
         let trace_path = maybe_save_trace_and_profile(
@@ -100,6 +106,17 @@ pub async fn run_for_test_target(
         }
 
         results.push(result);
+    }
+
+    if deterministic_output {
+        let mut sorted_results: Vec<_> = results
+            .iter()
+            .filter(|r| should_print_test_result_message(r))
+            .collect();
+        sorted_results.sort_by(|a, b| a.name().unwrap_or("").cmp(b.name().unwrap_or("")));
+        for result in sorted_results {
+            print_test_result(result);
+        }
     }
 
     maybe_generate_coverage(

--- a/crates/forge/src/run_tests/test_target.rs
+++ b/crates/forge/src/run_tests/test_target.rs
@@ -113,7 +113,7 @@ pub async fn run_for_test_target(
             .iter()
             .filter(|r| should_print_test_result_message(r))
             .collect();
-        sorted_results.sort_by(|a, b| a.name().unwrap_or("").cmp(b.name().unwrap_or("")));
+        sorted_results.sort_by_key(|r| r.name().unwrap_or(""));
         for result in sorted_results {
             print_test_result(result);
         }

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -46,6 +46,7 @@ fn snap_test_backtrace() {
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
@@ -59,6 +60,7 @@ fn snap_test_backtrace_without_inlines() {
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
@@ -106,6 +108,7 @@ fn snap_test_backtrace_panic() {
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
@@ -128,6 +131,7 @@ fn snap_test_backtrace_panic_without_optimizations() {
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
@@ -141,6 +145,7 @@ fn snap_test_backtrace_panic_without_inlines() {
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
@@ -154,6 +159,7 @@ fn snap_test_handled_error_not_display() {
     let output = test_runner(&temp)
         .arg("test_handle_and_panic")
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .success();
 

--- a/crates/forge/tests/e2e/common/output.rs
+++ b/crates/forge/tests/e2e/common/output.rs
@@ -1,4 +1,6 @@
 /// Asserts a cleaned `stdout` snapshot using `insta`, filtered for non-deterministic lines.
+/// Additionally, to ensure deterministic snapshots, tests must be run with:
+/// `SNFORGE_DETERMINISTIC_OUTPUT=1`
 /// Uses the current Scarb version as a snapshot suffix.
 #[macro_export]
 macro_rules! assert_cleaned_output {

--- a/crates/forge/tests/e2e/gas_report.rs
+++ b/crates/forge/tests/e2e/gas_report.rs
@@ -11,6 +11,7 @@ fn snap_basic() {
     let output = test_runner(&temp)
         .arg("--gas-report")
         .arg("call_and_invoke")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .code(0);
 
@@ -23,6 +24,7 @@ fn snap_recursive_calls() {
     let output = test_runner(&temp)
         .arg("--gas-report")
         .arg("test_debugging_trace_success")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .code(0);
 
@@ -35,6 +37,7 @@ fn snap_multiple_contracts_and_constructor() {
     let output = test_runner(&temp)
         .arg("--gas-report")
         .arg("call_and_invoke_proxy")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .code(0);
 
@@ -49,6 +52,7 @@ fn snap_fork() {
     let output = test_runner(&temp)
         .arg("--gas-report")
         .arg("test_track_resources")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .code(0);
 

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.14.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.14.0.snap
@@ -2,6 +2,26 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:15:9
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -29,27 +49,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:15:9
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:15:9
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.15.2.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.15.2.snap
@@ -2,6 +2,26 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -29,27 +49,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:13:5
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.16.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.16.0.snap
@@ -2,6 +2,26 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -29,27 +49,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:86:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: (inlined) backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: (inlined) backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:13:5
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.14.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.14.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -22,6 +21,7 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:15:9
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.15.2.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.15.2.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -22,6 +21,7 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.16.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.16.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -22,6 +21,7 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.14.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.14.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:15:9
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.15.2.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.15.2.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.16.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.16.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.14.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.14.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:15:9
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.15.2.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.15.2.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.16.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.16.0.snap
@@ -2,7 +2,6 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
-[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -32,6 +31,7 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+[IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
 Failure data:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.14.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.14.0.snap
@@ -2,6 +2,29 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+Cairo traceback (most recent call last):
+Unknown location (pc=0:50)
+Unknown location (pc=0:207)
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:15:9
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -35,30 +58,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:15:9
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-Cairo traceback (most recent call last):
-Unknown location (pc=0:50)
-Unknown location (pc=0:207)
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:15:9
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.15.2.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.15.2.snap
@@ -2,6 +2,29 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+Cairo traceback (most recent call last):
+Unknown location (pc=0:50)
+Unknown location (pc=0:207)
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -35,30 +58,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-Cairo traceback (most recent call last):
-Unknown location (pc=0:50)
-Unknown location (pc=0:207)
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:13:5
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.16.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.16.0.snap
@@ -2,6 +2,29 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+
+Failure data:
+    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
+Got an exception while executing a hint: Error at pc=0:86:
+Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
+
+Cairo traceback (most recent call last):
+Unknown location (pc=0:50)
+Unknown location (pc=0:207)
+
+
+error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   1: backtrace_vm_error::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -35,30 +58,7 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
-[FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
-
-Failure data:
-    Got an exception while executing a hint: Hint Error: Error at pc=0:280:
-Got an exception while executing a hint: Error at pc=0:86:
-Got an exception while executing a hint: Requested contract address 0x0000000000000000000000000000000000000000000000000000000000000123 is not deployed.
-
-Cairo traceback (most recent call last):
-Unknown location (pc=0:50)
-Unknown location (pc=0:207)
-
-
-error occurred in forked contract with class hash: 0x1a92e0ec431585e5c19b98679e582ebc07d43681ba1cc9c55dcb5ba0ce721a1
-
-error occurred in contract 'OuterContract'
-stack backtrace:
-   0: backtrace_vm_error::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: backtrace_vm_error::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:13:5
-
 
 Failures:
-    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
     backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+    backtrace_vm_error::Test::test_unwrapped_call_contract_syscall

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -148,6 +148,7 @@ fn fork_aliased_decorator() {
                 forge_config: Arc::new(ForgeConfig {
                     test_runner_config: Arc::new(TestRunnerConfig {
                         exit_first: false,
+                        deterministic_output: false,
                         fuzzer_runs: NonZeroU32::new(256).unwrap(),
                         fuzzer_seed: 12345,
                         max_n_steps: None,
@@ -239,6 +240,7 @@ fn fork_aliased_decorator_overrding() {
                 forge_config: Arc::new(ForgeConfig {
                     test_runner_config: Arc::new(TestRunnerConfig {
                         exit_first: false,
+                        deterministic_output: false,
                         fuzzer_runs: NonZeroU32::new(256).unwrap(),
                         fuzzer_seed: 12345,
                         max_n_steps: None,

--- a/crates/forge/tests/utils/running_tests.rs
+++ b/crates/forge/tests/utils/running_tests.rs
@@ -65,6 +65,7 @@ pub fn run_test_case(
             forge_config: Arc::new(ForgeConfig {
                 test_runner_config: Arc::new(TestRunnerConfig {
                     exit_first: false,
+                    deterministic_output: false,
                     fuzzer_runs: NonZeroU32::new(256).unwrap(),
                     fuzzer_seed: 12345,
                     max_n_steps: None,

--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -65,7 +65,7 @@ Run tests for all packages in the workspace.
 
 Number of fuzzer runs.
 
-## `-s`, `--fuzzer-seed` `<FUZZER_SEED>`
+## `-s`, `--fuzzer-seed` `<FUZZER_SEED>`; `SNFORGE_FUZZER_SEED` (environment variable)
 
 Seed for the fuzzer.
 
@@ -149,3 +149,17 @@ Use Scarb dev profile.
 ## `-h`, `--help`
 
 Print help.
+
+## `SNFORGE_BACKTRACE` (environment variable)
+
+True values are `1`.
+
+When enabled, enables backtrace output on test failure. 
+See [Debugging](../../snforge-advanced-features/debugging.md).
+
+## `SNFORGE_DETERMINISTIC_OUTPUT` (environment variable)
+
+True values are `1`, `true`, `t`, `yes`, `y`, and `on`.
+False values are `0`, `false`, `f`, `no`, `n`, and `off`.
+
+When enabled, sorts test result outputs by test name, for reproducible outputs.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4122 

## Stack
- #4148 
- #4158
- #4159


## Introduced changes

<!-- A brief description of the changes -->

- Add internal `SNFORGE_DETERMINISTIC_OUTPUT` env flag to allow ordering test cases by their name
- Use for `snap_` tests

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
