### PR TITLE
Fix `TODO` render in docs

### DIFF
--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -30,22 +30,23 @@ Overrides network from `snfoundry.toml`.
 ## `--type, -t <ACCOUNT_TYPE>`
 Optional. Required if `--class-hash` is passed.
 
-<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->                              |
+<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->
 Type of the account. Possible values: `oz`, `argent`, `ready`, `braavos`. Defaults to oz.
 
-<!-- TODO(#3556): Remove warning once we drop Argent account type. -->                              |
+<!-- TODO(#3556): Remove warning once we drop Argent account type. -->
 > ⚠️ **Warning**
 >
 > Argent has rebranded as Ready. The `argent` option is deprecated, please use `ready` instead.
 
 Versions of the account contracts:
 
-| Account Contract | Version | Class Hash                                                                                                                            
-|------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `oz`             | v1.0.0  | [0x05b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564](https://voyager.online/class/0x05b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564) |
-<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->                              |
-| `argent` / `ready`        | v0.4.0  | [0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f](https://voyager.online/class/0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f) |
-| `braavos`        | v1.2.0  | [0x03957f9f5a1cbfe918cedc2015c85200ca51a5f7506ecb6de98a5207b759bf8a](https://voyager.online/class/0x03957f9f5a1cbfe918cedc2015c85200ca51a5f7506ecb6de98a5207b759bf8a) |
+<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->
+
+| Account Contract   | Version | Class Hash                                                                                                                                                            |
+| ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oz`               | v1.0.0  | [0x05b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564](https://voyager.online/class/0x05b4b537eaa2399e3aa99c4e2e0208ebd6c71bc1467938cd52c798c601e43564) |
+| `argent` / `ready` | v0.4.0  | [0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f](https://voyager.online/class/0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f) |
+| `braavos`          | v1.2.0  | [0x03957f9f5a1cbfe918cedc2015c85200ca51a5f7506ecb6de98a5207b759bf8a](https://voyager.online/class/0x03957f9f5a1cbfe918cedc2015c85200ca51a5f7506ecb6de98a5207b759bf8a) |
 
 ## `--salt, -s <SALT>`
 Optional.

--- a/docs/src/appendix/sncast/account/import.md
+++ b/docs/src/appendix/sncast/account/import.md
@@ -17,10 +17,10 @@ Address of the account.
 ## `--type, -t <ACCOUNT_TYPE>`
 Required.
 
-<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->                              |
+<!-- TODO(#3556): Remove `argent` option once we drop Argent account type. -->
 Type of the account. Possible values: `oz`, `argent`, `ready`, `braavos`.
 
-<!-- TODO(#3556): Remove warning once we drop Argent account type. -->                              |
+<!-- TODO(#3556): Remove warning once we drop Argent account type. -->
 > ⚠️ **Warning**
 >
 > Argent has rebranded as Ready. The `argent` option is deprecated, please use `ready` instead.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- There are some wrong rendering TODOS in [docs](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/account/create.html#--type--t-account_type)
<img width="820" height="592" alt="obraz" src="https://github.com/user-attachments/assets/c117fbed-e298-4feb-87f0-aaa189e40260" />


## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
