### PR TITLE
Fix Voyager verification payload and contract file resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug with invalid function name mappings for functions with `#[test]` attribute
 
+### Cast
+
+#### Fixed
+
+- `sncast verify --verifier voyager` now sends the expected contract file metadata and correctly handles standard and virtual Scarb workspaces
+- `sncast verify --verifier voyager` now strips `dev-dependencies` from uploaded `Scarb.toml` manifests before remote compilation
+
 ## [0.57.0] - 2026-02-24
 
 ### Forge

--- a/crates/sncast/src/starknet_commands/verify/voyager.rs
+++ b/crates/sncast/src/starknet_commands/verify/voyager.rs
@@ -38,11 +38,13 @@ pub struct Body {
     pub compiler_version: semver::Version,
     pub scarb_version: semver::Version,
     pub project_dir_path: Utf8PathBuf,
-    #[serde(rename = "name")]
-    pub contract_name: String,
+    pub name: String,
+    pub contract_file: String,
+    #[serde(rename = "contract-name")]
+    pub serialized_contract_name: String,
     pub package_name: String,
     pub build_tool: String,
-    pub license: Option<String>,
+    pub license: String,
     pub files: HashMap<String, String>,
 }
 
@@ -213,6 +215,234 @@ fn longest_common_prefix<P: AsRef<Utf8Path> + Clone>(
     longest_prefix.to_path_buf()
 }
 
+fn select_package(metadata: &Metadata, package: Option<&str>) -> Result<PackageMetadata> {
+    let mut workspace_packages: Vec<PackageMetadata> = metadata
+        .packages
+        .iter()
+        .filter(|&package_meta| metadata.workspace.members.contains(&package_meta.id))
+        .cloned()
+        .collect();
+
+    if workspace_packages.len() > 1 {
+        match package {
+            Some(package_name) => workspace_packages
+                .into_iter()
+                .find(|p| p.name == package_name)
+                .ok_or(anyhow!(
+                    "Package {package_name} not found in scarb metadata"
+                )),
+            None => Err(anyhow!(
+                "More than one package found in scarb metadata - specify package using --package flag"
+            )),
+        }
+    } else {
+        workspace_packages
+            .pop()
+            .ok_or(anyhow!("No packages found in scarb metadata"))
+    }
+}
+
+fn prepare_project_dir_path() -> Utf8PathBuf {
+    Utf8PathBuf::from(".")
+}
+
+fn build_files_payload(files: &HashMap<String, Utf8PathBuf>) -> Result<HashMap<String, String>> {
+    files
+        .iter()
+        .map(|(name, path)| -> Result<(String, String)> {
+            let mut contents = fs::read_to_string(path.as_path())?;
+            if is_scarb_manifest(name) {
+                contents = filter_scarb_toml_content(&contents);
+            }
+            Ok((name.clone(), contents))
+        })
+        .try_collect()
+}
+
+fn build_request_body(
+    cairo_version: semver::Version,
+    scarb_version: semver::Version,
+    contract_name: &str,
+    selected: &PackageMetadata,
+    prefix: &Utf8Path,
+    files: &HashMap<String, Utf8PathBuf>,
+) -> Result<Body> {
+    let contract_file = find_contract_file(files, &selected.root, contract_name, prefix)?;
+
+    Ok(Body {
+        compiler_version: cairo_version,
+        scarb_version,
+        project_dir_path: prepare_project_dir_path(),
+        name: contract_name.to_string(),
+        contract_file: contract_file.clone(),
+        serialized_contract_name: serialized_contract_name(&contract_file),
+        package_name: selected.name.clone(),
+        build_tool: "scarb".to_string(),
+        license: normalize_license(selected.manifest_metadata.license.as_deref()),
+        files: build_files_payload(files)?,
+    })
+}
+
+fn serialized_contract_name(contract_file: &str) -> String {
+    contract_file.to_string()
+}
+
+fn normalize_license(license: Option<&str>) -> String {
+    license.unwrap_or("NONE").to_string()
+}
+
+fn is_scarb_manifest(path: &str) -> bool {
+    path == "Scarb.toml" || path.ends_with("/Scarb.toml")
+}
+
+fn filter_scarb_toml_content(content: &str) -> String {
+    let mut lines = Vec::new();
+    let mut in_dev_dependencies = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("[dev-dependencies]") {
+            in_dev_dependencies = true;
+            lines.push("# [dev-dependencies] section removed for remote compilation");
+            continue;
+        }
+
+        if trimmed.starts_with('[') && !trimmed.starts_with("[dev-dependencies]") {
+            if in_dev_dependencies {
+                lines.push("");
+            }
+            in_dev_dependencies = false;
+            lines.push(line);
+            continue;
+        }
+
+        if in_dev_dependencies {
+            continue;
+        }
+
+        lines.push(line);
+    }
+
+    lines.join("\n")
+}
+
+fn find_contract_file_path(
+    files: &HashMap<String, Utf8PathBuf>,
+    package_root: &Utf8Path,
+    contract_name: &str,
+) -> Result<Utf8PathBuf> {
+    if let Some(contract_file) = find_contract_by_pattern(files, package_root, contract_name) {
+        return Ok(contract_file);
+    }
+
+    for path in [
+        format!("src/{}.cairo", contract_name.to_lowercase()),
+        format!(
+            "src/{}/{}.cairo",
+            contract_name.to_lowercase(),
+            contract_name.to_lowercase()
+        ),
+        format!("src/systems/{}.cairo", contract_name.to_lowercase()),
+        format!("src/contracts/{}.cairo", contract_name.to_lowercase()),
+    ] {
+        let full_path = package_root.join(path);
+        if full_path.exists() {
+            return Ok(full_path);
+        }
+    }
+
+    for path in ["src/lib.cairo", "src/main.cairo"] {
+        let full_path = package_root.join(path);
+        if full_path.exists() {
+            return Ok(full_path);
+        }
+    }
+
+    files
+        .values()
+        .filter(|path| path.starts_with(package_root))
+        .find(|path| path.extension() == Some(CAIRO_EXT))
+        .cloned()
+        .ok_or(anyhow!(
+            "No Cairo source files found for package {}",
+            package_root
+        ))
+}
+
+fn find_contract_file(
+    files: &HashMap<String, Utf8PathBuf>,
+    package_root: &Utf8Path,
+    contract_name: &str,
+    prefix: &Utf8Path,
+) -> Result<String> {
+    let contract_file_path = find_contract_file_path(files, package_root, contract_name)?;
+    let contract_file = contract_file_path
+        .strip_prefix(prefix)
+        .map_err(|_| anyhow!("Couldn't strip {prefix} from {contract_file_path}"))?;
+    Ok(contract_file.to_string())
+}
+
+fn find_contract_by_pattern(
+    files: &HashMap<String, Utf8PathBuf>,
+    package_root: &Utf8Path,
+    contract_name: &str,
+) -> Option<Utf8PathBuf> {
+    files
+        .values()
+        .filter(|path| path.starts_with(package_root))
+        .filter(|path| path.extension() == Some(CAIRO_EXT))
+        .find_map(|path| match fs::read_to_string(path) {
+            Ok(contents) if contains_contract_definition(&contents, contract_name) => {
+                Some(path.clone())
+            }
+            _ => None,
+        })
+}
+
+fn contains_contract_definition(content: &str, contract_name: &str) -> bool {
+    let lines: Vec<&str> = content.lines().collect();
+
+    for (index, line) in lines.iter().enumerate() {
+        if !line.trim().starts_with("#[starknet::contract]") {
+            continue;
+        }
+
+        let end_index = std::cmp::min(index + 5, lines.len());
+        for next_line in lines.iter().skip(index + 1).take(end_index - (index + 1)) {
+            let next_line = next_line.trim();
+            if next_line.is_empty() || next_line.starts_with("//") {
+                continue;
+            }
+
+            if let Some(module_name) = extract_module_name(next_line) {
+                if module_name == contract_name {
+                    return true;
+                }
+                break;
+            }
+        }
+    }
+
+    false
+}
+
+fn extract_module_name(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let without_pub = trimmed
+        .strip_prefix("pub ")
+        .map_or(trimmed, |rest| rest.trim());
+
+    without_pub
+        .strip_prefix("mod ")
+        .and_then(|rest| {
+            rest.trim()
+                .split(|c: char| c == '{' || c.is_whitespace())
+                .next()
+        })
+        .filter(|name| !name.is_empty())
+        .map(ToString::to_string)
+}
+
 impl Voyager<'_> {
     pub fn gather_files(
         &self,
@@ -290,69 +520,23 @@ impl<'a> VerificationInterface<'a> for Voyager<'a> {
 
         let cairo_version = self.metadata.app_version_info.cairo.version.clone();
         let scarb_version = self.metadata.app_version_info.version.clone();
-
-        let mut workspace_packages: Vec<PackageMetadata> = self
-            .metadata
-            .packages
-            .iter()
-            .filter(|&package_meta| self.metadata.workspace.members.contains(&package_meta.id))
-            .cloned()
-            .collect();
-
-        let selected = (if workspace_packages.len() > 1 {
-            match package {
-                Some(ref package_name) => workspace_packages
-                    .into_iter()
-                    .find(|p| p.name == *package_name)
-                    .ok_or(anyhow!(
-                        "Package {package_name} not found in scarb metadata"
-                    )),
-                None => Err(anyhow!(
-                    "More than one package found in scarb metadata - specify package using --package flag"
-                )),
-            }
-        } else {
-            workspace_packages
-                .pop()
-                .ok_or(anyhow!("No packages found in scarb metadata"))
-        })?;
+        let selected = select_package(&self.metadata, package.as_deref())?;
 
         let (prefix, files) = self.gather_files(test_files)?;
-        let project_dir_path = self
-            .metadata
-            .workspace
-            .root
-            .strip_prefix(prefix)
-            // backend expects this: "." for cwd
-            .map(|path| {
-                if path.as_str().is_empty() {
-                    Utf8Path::new(".")
-                } else {
-                    path
-                }
-            })?;
 
         if selected.manifest_metadata.license.is_none() {
             ui.print_warning(WarningMessage::new("License not specified in Scarb.toml"));
         }
 
         let client = reqwest::Client::new();
-        let body = Body {
-            compiler_version: cairo_version,
+        let body = build_request_body(
+            cairo_version,
             scarb_version,
-            project_dir_path: project_dir_path.to_path_buf(),
-            contract_name: contract_name.clone(),
-            license: selected.manifest_metadata.license.clone(),
-            package_name: selected.name,
-            build_tool: "scarb".to_string(),
-            files: files
-                .iter()
-                .map(|(name, path)| -> Result<(String, String)> {
-                    let contents = fs::read_to_string(path.as_path())?;
-                    Ok((name.clone(), contents))
-                })
-                .try_collect()?,
-        };
+            &contract_name,
+            &selected,
+            &prefix,
+            &files,
+        )?;
 
         let url = format!(
             "{}{}/{:#066x}",
@@ -393,5 +577,125 @@ impl<'a> VerificationInterface<'a> for Voyager<'a> {
                 Network::Devnet => Err(ExplorerError::DevnetNotSupported.into()),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        contains_contract_definition, filter_scarb_toml_content, find_contract_file,
+        find_contract_file_path, is_scarb_manifest, normalize_license, prepare_project_dir_path,
+        serialized_contract_name,
+    };
+    use camino::{Utf8Path, Utf8PathBuf};
+    use std::collections::HashMap;
+    use walkdir::WalkDir;
+
+    fn contract_fixture_path(path: &str) -> Utf8PathBuf {
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/contracts")
+            .join(path)
+    }
+
+    fn fixture_files(root: &Utf8Path) -> HashMap<String, Utf8PathBuf> {
+        WalkDir::new(root)
+            .into_iter()
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_type().is_file())
+            .map(|entry| Utf8PathBuf::try_from(entry.into_path()).expect("utf-8 test path"))
+            .map(|path| (path.as_str().to_string(), path))
+            .collect()
+    }
+
+    #[test]
+    fn test_contract_file_detection_matches_contract_module() {
+        let contents = r#"
+#[starknet::contract]
+pub mod MatchingContract {
+}
+
+#[starknet::contract]
+mod OtherContract {
+}
+"#;
+
+        assert!(contains_contract_definition(contents, "MatchingContract"));
+        assert!(contains_contract_definition(contents, "OtherContract"));
+        assert!(!contains_contract_definition(contents, "MissingContract"));
+    }
+
+    #[test]
+    fn test_contract_file_map_fixture_resolves_to_src_lib_cairo() {
+        let package_root = contract_fixture_path("map");
+        let files = fixture_files(&package_root);
+
+        let contract_file_path =
+            find_contract_file_path(&files, &package_root, "Map").expect("contract file");
+        let contract_file =
+            find_contract_file(&files, &package_root, "Map", &package_root).expect("relative path");
+
+        assert_eq!(contract_file_path, package_root.join("src/lib.cairo"));
+        assert_eq!(contract_file, "src/lib.cairo");
+    }
+
+    #[test]
+    fn test_contract_file_virtual_workspace_resolves_to_workspace_relative_path() {
+        let workspace_root = contract_fixture_path("virtual_workspace");
+        let package_root = workspace_root.join("crates/cast_fibonacci");
+        let files = fixture_files(&workspace_root);
+
+        let contract_file =
+            find_contract_file(&files, &package_root, "FibonacciContract", &workspace_root)
+                .expect("relative contract file");
+
+        assert_eq!(contract_file, "crates/cast_fibonacci/src/lib.cairo");
+    }
+
+    #[test]
+    fn test_project_dir_path_is_dot() {
+        assert_eq!(prepare_project_dir_path(), Utf8PathBuf::from("."));
+    }
+
+    #[test]
+    fn test_serialized_contract_name_mirrors_contract_file() {
+        assert_eq!(
+            serialized_contract_name("src/lib.cairo"),
+            "src/lib.cairo".to_string()
+        );
+    }
+
+    #[test]
+    fn test_normalize_license_defaults_to_none() {
+        assert_eq!(normalize_license(None), "NONE".to_string());
+        assert_eq!(normalize_license(Some("MIT")), "MIT".to_string());
+    }
+
+    #[test]
+    fn test_filter_scarb_toml_content_removes_dev_dependencies_only() {
+        let manifest = r#"[package]
+name = "map"
+
+[dependencies]
+starknet = "2.0.0"
+
+[dev-dependencies]
+snforge_std = "0.43.0"
+
+[scripts]
+test = "snforge test"
+"#;
+
+        let filtered = filter_scarb_toml_content(manifest);
+
+        assert!(!filtered.contains("snforge_std"));
+        assert!(filtered.contains("[dependencies]"));
+        assert!(filtered.contains("[scripts]"));
+    }
+
+    #[test]
+    fn test_is_scarb_manifest_matches_only_manifest_paths() {
+        assert!(is_scarb_manifest("Scarb.toml"));
+        assert!(is_scarb_manifest("crates/cast_fibonacci/Scarb.toml"));
+        assert!(!is_scarb_manifest("Scarb.lock"));
     }
 }

--- a/crates/sncast/src/starknet_commands/verify/voyager.rs
+++ b/crates/sncast/src/starknet_commands/verify/voyager.rs
@@ -364,8 +364,7 @@ fn find_contract_file_path(
         .find(|path| path.extension() == Some(CAIRO_EXT))
         .cloned()
         .ok_or(anyhow!(
-            "No Cairo source files found for package {}",
-            package_root
+            "No Cairo source files found for package {package_root}"
         ))
 }
 
@@ -609,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_contract_file_detection_matches_contract_module() {
-        let contents = r#"
+        let contents = r"
 #[starknet::contract]
 pub mod MatchingContract {
 }
@@ -617,7 +616,7 @@ pub mod MatchingContract {
 #[starknet::contract]
 mod OtherContract {
 }
-"#;
+";
 
         assert!(contains_contract_definition(contents, "MatchingContract"));
         assert!(contains_contract_definition(contents, "OtherContract"));

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -4,11 +4,42 @@ use crate::helpers::constants::{
 use crate::helpers::fixtures::copy_directory_to_tempdir;
 use crate::helpers::runner::runner;
 use indoc::formatdoc;
-use serde_json::json;
+use serde_json::{Value, json};
 use shared::test_utils::output_assert::assert_stderr_contains;
 use starknet_types_core::felt::Felt;
+use std::fs;
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+#[derive(Clone, Copy)]
+struct ExpectedVoyagerPayload<'a> {
+    name: &'a str,
+    package_name: &'a str,
+    contract_file: &'a str,
+}
+
+fn parse_request_body(req: &Request) -> Option<Value> {
+    std::str::from_utf8(&req.body)
+        .ok()
+        .and_then(|body| serde_json::from_str(body).ok())
+}
+
+fn matches_voyager_payload(req: &Request, expected: ExpectedVoyagerPayload<'_>) -> bool {
+    let Some(body) = parse_request_body(req) else {
+        return false;
+    };
+
+    body.get("name").and_then(Value::as_str) == Some(expected.name)
+        && body.get("package_name").and_then(Value::as_str) == Some(expected.package_name)
+        && body.get("contract_file").and_then(Value::as_str) == Some(expected.contract_file)
+        && body.get("contract-name").and_then(Value::as_str) == Some(expected.contract_file)
+        && body.get("project_dir_path").and_then(Value::as_str) == Some(".")
+        && body.get("license").and_then(Value::as_str) == Some("NONE")
+        && body
+            .get("files")
+            .and_then(Value::as_object)
+            .is_some_and(|files| files.contains_key(expected.contract_file))
+}
 
 #[tokio::test]
 async fn test_happy_case_contract_address() {
@@ -36,9 +67,15 @@ async fn test_happy_case_contract_address() {
 
     let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
 
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
+        .and(move |req: &Request| matches_voyager_payload(req, expected))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)
         .mount(&mock_server)
@@ -81,9 +118,15 @@ async fn test_happy_case_class_hash() {
 
     let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
 
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
+        .and(move |req: &Request| matches_voyager_payload(req, expected))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)
         .mount(&mock_server)
@@ -139,9 +182,15 @@ async fn test_happy_case_with_confirm_verification_flag() {
 
     let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
 
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
+        .and(move |req: &Request| matches_voyager_payload(req, expected))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)
         .mount(&mock_server)
@@ -388,9 +437,15 @@ async fn test_virtual_workspaces() {
 
     let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "FibonacciContract",
+        package_name: "cast_fibonacci",
+        contract_file: "crates/cast_fibonacci/src/lib.cairo",
+    };
 
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
+        .and(move |req: &Request| matches_voyager_payload(req, expected))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)
         .mount(&mock_server)
@@ -423,6 +478,94 @@ async fn test_virtual_workspaces() {
 }
 
 #[tokio::test]
+async fn test_uploaded_scarb_toml_removes_dev_dependencies() {
+    let contract_path = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/map");
+    let manifest_path = contract_path.path().join("Scarb.toml");
+    let manifest = fs::read_to_string(&manifest_path).expect("Failed to read test Scarb.toml");
+    fs::write(
+        &manifest_path,
+        format!(
+            "{manifest}\n[dev-dependencies]\nsnforge_std = \"0.43.0\"\n\n[scripts]\ncheck = \"scarb check\"\n"
+        ),
+    )
+    .expect("Failed to write test Scarb.toml");
+
+    let mock_server = MockServer::start().await;
+    let rpc_response = json!({
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": MAP_CONTRACT_CLASS_HASH_SEPOLIA
+    });
+
+    let mock_rpc = MockServer::start().await;
+    let mock_rpc_uri = mock_rpc.uri().clone();
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({"method": "starknet_getClassHashAt"}),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(rpc_response))
+        .expect(1)
+        .mount(&mock_rpc)
+        .await;
+
+    let job_id = "sanitized-scarb-toml-job";
+    let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
+
+    Mock::given(method("POST"))
+        .and(path(format!("class-verify/{class_hash:#066x}")))
+        .and(move |req: &Request| {
+            if !matches_voyager_payload(req, expected) {
+                return false;
+            }
+
+            parse_request_body(req)
+                .and_then(|body| body.get("files").cloned())
+                .and_then(|files| files.get("Scarb.toml").cloned())
+                .and_then(|scarb_toml| scarb_toml.as_str().map(ToString::to_string))
+                .is_some_and(|scarb_toml| {
+                    !scarb_toml.contains("\n[dev-dependencies]")
+                        && !scarb_toml.contains("snforge_std")
+                        && scarb_toml
+                            .contains("# [dev-dependencies] section removed for remote compilation")
+                        && scarb_toml.contains("[scripts]")
+                })
+        })
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "verify",
+        "--contract-address",
+        MAP_CONTRACT_ADDRESS_SEPOLIA,
+        "--contract-name",
+        "Map",
+        "--verifier",
+        "voyager",
+        "--network",
+        "sepolia",
+        "--url",
+        &mock_rpc_uri,
+    ];
+
+    let snapbox = runner(&args)
+        .env("VERIFIER_API_URL", mock_server.uri())
+        .current_dir(contract_path.path())
+        .stdin("Y");
+
+    snapbox.assert().success();
+}
+
+#[tokio::test]
 async fn test_contract_name_not_found() {
     let contract_path = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/virtual_workspace");
 
@@ -433,19 +576,11 @@ async fn test_contract_name_not_found() {
     // For this test, the error happens before any RPC calls are made (contract name not found)
     // So no RPC mocks needed
 
-    let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
 
-    let expected_body = json!({
-        "project_dir_path": ".",
-        "name": "FibonacciContract",
-        "package_name": "cast_fibonacci",
-        "license": null
-    });
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
-        .and(body_partial_json(&expected_body))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": "unused" })))
         .expect(0)
         .mount(&mock_server)
         .await;
@@ -542,25 +677,27 @@ async fn test_test_files_flag_includes_test_files() {
 
     let job_id = "test-job-id-with-test-files";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
 
     // Mock the verification request and verify that test files are included
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
-        .and(body_partial_json(json!({
-            "name": "Map",
-            "package_name": "map"
-        })))
-        .and(|req: &Request| {
-            if let Ok(body_str) = std::str::from_utf8(&req.body)
-                && let Ok(body_json) = serde_json::from_str::<serde_json::Value>(body_str)
-                && let Some(files) = body_json.get("files")
-                && let Some(files_obj) = files.as_object()
-            {
-                // Verify that test files ARE present
-                return files_obj.contains_key("src/test_helpers.cairo")
-                    && files_obj.contains_key("src/tests.cairo");
+        .and(move |req: &Request| {
+            if !matches_voyager_payload(req, expected) {
+                return false;
             }
-            false
+
+            parse_request_body(req)
+                .and_then(|body| body.get("files").cloned())
+                .and_then(|files| files.as_object().cloned())
+                .is_some_and(|files| {
+                    files.contains_key("src/test_helpers.cairo")
+                        && files.contains_key("src/tests.cairo")
+                })
         })
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)
@@ -618,25 +755,27 @@ async fn test_without_test_files_flag_excludes_test_files() {
 
     let job_id = "test-job-id-without-test-files";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+    let expected = ExpectedVoyagerPayload {
+        name: "Map",
+        package_name: "map",
+        contract_file: "src/lib.cairo",
+    };
 
     // Mock the verification request - without --test-files flag, test files should be excluded
     Mock::given(method("POST"))
         .and(path(format!("class-verify/{class_hash:#066x}")))
-        .and(body_partial_json(json!({
-            "name": "Map",
-            "package_name": "map"
-        })))
-        .and(|req: &Request| {
-            if let Ok(body_str) = std::str::from_utf8(&req.body)
-                && let Ok(body_json) = serde_json::from_str::<serde_json::Value>(body_str)
-                && let Some(files) = body_json.get("files")
-                && let Some(files_obj) = files.as_object()
-            {
-                // Verify that test files are NOT present
-                return !files_obj.contains_key("src/test_helpers.cairo")
-                    && !files_obj.contains_key("src/tests.cairo");
+        .and(move |req: &Request| {
+            if !matches_voyager_payload(req, expected) {
+                return false;
             }
-            false
+
+            parse_request_body(req)
+                .and_then(|body| body.get("files").cloned())
+                .and_then(|files| files.as_object().cloned())
+                .is_some_and(|files| {
+                    !files.contains_key("src/test_helpers.cairo")
+                        && !files.contains_key("src/tests.cairo")
+                })
         })
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
         .expect(1)


### PR DESCRIPTION
## Summary
- align the Voyager verification payload with the backend expectations by sending `name`, `contract_file`, `contract-name`, `.` as the project dir, and a normalized license value
- sanitize uploaded `Scarb.toml` contents before remote compilation by stripping `[dev-dependencies]`
- resolve contract source files more reliably across standard and virtual workspaces, and extend Voyager request-body coverage for these cases

## Testing
- `cargo test -p sncast voyager -- --nocapture`
- `cargo test -p sncast voyager --test main -- --test-threads=1 --nocapture`
- run sncast verify locally and it worked https://sepolia-api.voyager.online/beta/class-verify/job/6aa719c8-6f4d-422e-b4f1-ac0b038832ec