### PR TITLE
Fix `sncast` exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Aliases `sncast get transaction` and `sncast get transaction-status` for `get tx` and `get tx-status`.
 
+#### Changed
+
+- In JSON output for `sncast utils` commands, the `"command"` field now includes the `utils` prefix (e.g. `"serialize"` -> `"utils serialize"`).
+
 #### Fixed
 
 - `sncast verify` now uses the configured network or infers it from the RPC chain ID when `--network` is omitted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Cast
 
+#### Added
+
+- Aliases `sncast get transaction` and `sncast get transaction-status` for `get tx` and `get tx-status`.
+
 #### Fixed
 
 - `sncast verify` now uses the configured network or infers it from the RPC chain ID when `--network` is omitted.
+- `sncast` now returns non-zero exit code when a command fails.
 
 ## [0.59.0] - 2026-04-10
 

--- a/crates/sncast/src/helpers/command.rs
+++ b/crates/sncast/src/helpers/command.rs
@@ -8,6 +8,7 @@ use foundry_ui::Message;
 use serde::Serialize;
 use std::process::ExitCode;
 
+#[must_use]
 pub fn process_command_result<T>(
     command: &str,
     result: Result<T>,

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -529,13 +529,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                     Err(err) => {
                         // TODO(#3960) This will return json output saying that `deploy` command was run
                         //  even though the invoked command was declare.
-                        let exit_code = process_command_result::<DeclareTransactionResponse>(
+                        return Ok(process_command_result::<DeclareTransactionResponse>(
                             "deploy",
                             Err(err),
                             ui,
                             None,
-                        );
-                        return Ok(exit_code);
+                        ));
                     }
                 }
             } else {

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -351,8 +351,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
             let result = match result {
                 Ok(DeclareResponse::DryRun(response)) => {
-                    process_command_result("declare", Ok(response), ui, None);
-                    return Ok(());
+                    return Ok(process_command_result("declare", Ok(response), ui, None));
                 }
                 Ok(DeclareResponse::Success(declare_transaction_response)) => {
                     Ok(declare_transaction_response)
@@ -430,8 +429,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
             let result = match result {
                 Ok(DeclareResponse::DryRun(response)) => {
-                    process_command_result("declare", Ok(response), ui, None);
-                    return Ok(());
+                    return Ok(process_command_result("declare", Ok(response), ui, None));
                 }
                 Ok(DeclareResponse::Success(declare_transaction_response)) => {
                     Ok(declare_transaction_response)

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -51,6 +51,7 @@ use starknet_rust::core::types::contract::{AbiEntry, SierraClass};
 use starknet_rust::core::utils::get_selector_from_name;
 use starknet_rust::providers::Provider;
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 use tokio::runtime::Runtime;
 
 mod starknet_commands;
@@ -284,7 +285,7 @@ fn init_logging() {
         .expect("could not set up global logger");
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<ExitCode> {
     init_logging();
 
     let cli = Cli::parse();
@@ -304,7 +305,7 @@ fn main() -> Result<()> {
 }
 
 #[expect(clippy::too_many_lines)]
-async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> {
+async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<ExitCode> {
     let wait_config = WaitForTx {
         wait: cli.wait,
         wait_params: config.wait_params,
@@ -385,13 +386,13 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                 None
             };
 
-            process_command_result("declare", result, ui, block_explorer_link);
+            let exit_code = process_command_result("declare", result, ui, block_explorer_link);
 
             if let Some(deploy_command_message) = deploy_command_message {
                 ui.print_notification(deploy_command_message?);
             }
 
-            Ok(())
+            Ok(exit_code)
         }
 
         Commands::DeclareFrom(declare_from) => {
@@ -443,9 +444,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            process_command_result("declare-from", result, ui, block_explorer_link);
-
-            Ok(())
+            Ok(process_command_result("declare-from", result, ui, block_explorer_link))
         }
 
         Commands::Deploy(deploy) => {
@@ -525,13 +524,13 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
                     Err(err) => {
                         // TODO(#3960) This will return json output saying that `deploy` command was run
                         //  even though the invoked command was declare.
-                        process_command_result::<DeclareTransactionResponse>(
+                        let exit_code = process_command_result::<DeclareTransactionResponse>(
                             "deploy",
                             Err(err),
                             ui,
                             None,
                         );
-                        return Ok(());
+                        return Ok(exit_code);
                     }
                 }
             } else {
@@ -576,9 +575,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            process_command_result("deploy", result, ui, block_explorer_link);
-
-            Ok(())
+            Ok(process_command_result("deploy", result, ui, block_explorer_link))
         }
 
         Commands::Call(Call {
@@ -609,15 +606,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             .await
             .map_err(handle_starknet_command_error);
 
-            if let Some(transformed_result) =
-                transform_response(&result, &contract_class, &selector)
+            if let Some(transformed_result) = transform_response(&result, &contract_class, &selector)
             {
-                process_command_result("call", Ok(transformed_result), ui, None);
+                Ok(process_command_result("call", Ok(transformed_result), ui, None))
             } else {
-                process_command_result("call", result, ui, None);
+                Ok(process_command_result("call", result, ui, None))
             }
-
-            Ok(())
         }
 
         Commands::Invoke(invoke) => {
@@ -669,9 +663,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
 
-            process_command_result("invoke", result, ui, block_explorer_link);
-
-            Ok(())
+            Ok(process_command_result("invoke", result, ui, block_explorer_link))
         }
 
         Commands::Get(get) => get::get(get, config, ui).await,
@@ -704,9 +696,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             )
             .await;
 
-            process_command_result("show-config", result, ui, None);
-
-            Ok(())
+            Ok(process_command_result("show-config", result, ui, None))
         }
 
         // TODO(#4214): Remove moved sncast commands
@@ -739,13 +729,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
             )
             .await;
 
-            process_command_result("verify", result, ui, None);
-            Ok(())
+            Ok(process_command_result("verify", result, ui, None))
         }
 
         Commands::Completions(completions) => {
             generate_completions(completions.shell, &mut Cli::command())?;
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
 
         // TODO(#4214): Remove moved sncast commands
@@ -756,10 +745,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<()> 
 
         Commands::Ledger(ledger) => {
             let result = ledger::ledger(&ledger, ui).await;
-
-            process_command_result("ledger", result, ui, None);
-
-            Ok(())
+            Ok(process_command_result("ledger", result, ui, None))
         }
 
         Commands::Script(_) => unreachable!(),

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -444,7 +444,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            Ok(process_command_result("declare-from", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "declare-from",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
 
         Commands::Deploy(deploy) => {
@@ -575,7 +580,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            Ok(process_command_result("deploy", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "deploy",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
 
         Commands::Call(Call {
@@ -606,9 +616,15 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
             .await
             .map_err(handle_starknet_command_error);
 
-            if let Some(transformed_result) = transform_response(&result, &contract_class, &selector)
+            if let Some(transformed_result) =
+                transform_response(&result, &contract_class, &selector)
             {
-                Ok(process_command_result("call", Ok(transformed_result), ui, None))
+                Ok(process_command_result(
+                    "call",
+                    Ok(transformed_result),
+                    ui,
+                    None,
+                ))
             } else {
                 Ok(process_command_result("call", result, ui, None))
             }
@@ -663,7 +679,12 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
 
-            Ok(process_command_result("invoke", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "invoke",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
 
         Commands::Get(get) => get::get(get, config, ui).await,

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -22,6 +22,7 @@ use sncast::{SignerSource, SignerType, WaitForTx, get_chain_id};
 use starknet_rust::providers::Provider;
 use starknet_types_core::felt::Felt;
 use std::io::{self, IsTerminal};
+use std::process::ExitCode;
 use std::{fs::OpenOptions, io::Write};
 use toml::Value;
 
@@ -223,7 +224,7 @@ pub async fn account(
     config: CastConfig,
     ui: &UI,
     wait_config: WaitForTx,
-) -> anyhow::Result<()> {
+) -> Result<ExitCode> {
     match account.command {
         Commands::Import(import) => {
             let provider = import.rpc.get_provider(&config, ui).await?;
@@ -251,8 +252,7 @@ pub async fn account(
                 );
             }
 
-            process_command_result("account import", result, ui, None);
-            Ok(())
+            Ok(process_command_result("account import", result, ui, None))
         }
         Commands::Create(create) => {
             let provider = create.rpc.get_provider(&config, ui).await?;
@@ -289,8 +289,7 @@ pub async fn account(
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
 
-            process_command_result("account create", result, ui, block_explorer_link);
-            Ok(())
+            Ok(process_command_result("account create", result, ui, block_explorer_link))
         }
 
         Commands::Deploy(deploy) => {
@@ -332,8 +331,7 @@ pub async fn account(
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            process_command_result("account deploy", result, ui, block_explorer_link);
-            Ok(())
+            Ok(process_command_result("account deploy", result, ui, block_explorer_link))
         }
 
         Commands::Delete(delete) => {
@@ -347,8 +345,7 @@ pub async fn account(
                 delete.yes,
             );
 
-            process_command_result("account delete", result, ui, None);
-            Ok(())
+            Ok(process_command_result("account delete", result, ui, None))
         }
 
         Commands::List(options) => {
@@ -356,7 +353,7 @@ pub async fn account(
                 "account delete",
                 AccountsListMessage::new(config.accounts_file, options.display_private_keys)?,
             );
-            Ok(())
+            Ok(ExitCode::SUCCESS)
         }
     }
 }

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -289,7 +289,12 @@ pub async fn account(
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
 
-            Ok(process_command_result("account create", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "account create",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
 
         Commands::Deploy(deploy) => {
@@ -331,7 +336,12 @@ pub async fn account(
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            Ok(process_command_result("account deploy", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "account deploy",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
 
         Commands::Delete(delete) => {

--- a/crates/sncast/src/starknet_commands/get/balance.rs
+++ b/crates/sncast/src/starknet_commands/get/balance.rs
@@ -9,6 +9,7 @@ use sncast::response::balance::BalanceResponse;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::ui::UI;
 use sncast::{get_account, get_block_id};
+use std::process::ExitCode;
 use starknet_rust::{
     core::{types::FunctionCall, utils::get_selector_from_name},
     providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport},
@@ -70,7 +71,7 @@ pub struct Balance {
     pub rpc: RpcArgs,
 }
 
-pub async fn balance(balance: Balance, config: CastConfig, ui: &UI) -> anyhow::Result<()> {
+pub async fn balance(balance: Balance, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
     let provider = balance.rpc.get_provider(&config, ui).await?;
     let account = get_account(&config, &provider, &balance.rpc, ui).await?;
 
@@ -78,9 +79,7 @@ pub async fn balance(balance: Balance, config: CastConfig, ui: &UI) -> anyhow::R
         .await
         .map_err(handle_starknet_command_error);
 
-    process_command_result("get balance", result, ui, None);
-
-    Ok(())
+    Ok(process_command_result("get balance", result, ui, None))
 }
 
 pub async fn get_balance(

--- a/crates/sncast/src/starknet_commands/get/balance.rs
+++ b/crates/sncast/src/starknet_commands/get/balance.rs
@@ -9,12 +9,12 @@ use sncast::response::balance::BalanceResponse;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::ui::UI;
 use sncast::{get_account, get_block_id};
-use std::process::ExitCode;
 use starknet_rust::{
     core::{types::FunctionCall, utils::get_selector_from_name},
     providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport},
 };
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 
 #[derive(Args, Debug, Clone)]
 #[group(multiple = false)]

--- a/crates/sncast/src/starknet_commands/get/class_hash_at.rs
+++ b/crates/sncast/src/starknet_commands/get/class_hash_at.rs
@@ -8,10 +8,10 @@ use sncast::response::class_hash_at::ClassHashAtResponse;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::ui::UI;
-use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 
 #[derive(Debug, Args)]
 #[command(about = "Get the class hash of a contract deployed at a given address")]
@@ -29,11 +29,7 @@ pub struct ClassHashAt {
     pub rpc: RpcArgs,
 }
 
-pub async fn class_hash_at(
-    args: ClassHashAt,
-    config: CastConfig,
-    ui: &UI,
-) -> anyhow::Result<ExitCode> {
+pub async fn class_hash_at(args: ClassHashAt, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
     let provider = args.rpc.get_provider(&config, ui).await?;
 
     let result = get_class_hash_at(&provider, args.contract_address, &args.block_id)
@@ -43,7 +39,12 @@ pub async fn class_hash_at(
     let chain_id = provider.chain_id().await?;
     let block_explorer_link = block_explorer_link_if_allowed(&result, chain_id, &config).await;
 
-    Ok(process_command_result("get class-hash-at", result, ui, block_explorer_link))
+    Ok(process_command_result(
+        "get class-hash-at",
+        result,
+        ui,
+        block_explorer_link,
+    ))
 }
 
 async fn get_class_hash_at(

--- a/crates/sncast/src/starknet_commands/get/class_hash_at.rs
+++ b/crates/sncast/src/starknet_commands/get/class_hash_at.rs
@@ -8,6 +8,7 @@ use sncast::response::class_hash_at::ClassHashAtResponse;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::ui::UI;
+use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
@@ -28,7 +29,11 @@ pub struct ClassHashAt {
     pub rpc: RpcArgs,
 }
 
-pub async fn class_hash_at(args: ClassHashAt, config: CastConfig, ui: &UI) -> anyhow::Result<()> {
+pub async fn class_hash_at(
+    args: ClassHashAt,
+    config: CastConfig,
+    ui: &UI,
+) -> anyhow::Result<ExitCode> {
     let provider = args.rpc.get_provider(&config, ui).await?;
 
     let result = get_class_hash_at(&provider, args.contract_address, &args.block_id)
@@ -38,8 +43,7 @@ pub async fn class_hash_at(args: ClassHashAt, config: CastConfig, ui: &UI) -> an
     let chain_id = provider.chain_id().await?;
     let block_explorer_link = block_explorer_link_if_allowed(&result, chain_id, &config).await;
 
-    process_command_result("get class-hash-at", result, ui, block_explorer_link);
-    Ok(())
+    Ok(process_command_result("get class-hash-at", result, ui, block_explorer_link))
 }
 
 async fn get_class_hash_at(

--- a/crates/sncast/src/starknet_commands/get/class_hash_at.rs
+++ b/crates/sncast/src/starknet_commands/get/class_hash_at.rs
@@ -29,7 +29,11 @@ pub struct ClassHashAt {
     pub rpc: RpcArgs,
 }
 
-pub async fn class_hash_at(args: ClassHashAt, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
+pub async fn class_hash_at(
+    args: ClassHashAt,
+    config: CastConfig,
+    ui: &UI,
+) -> anyhow::Result<ExitCode> {
     let provider = args.rpc.get_provider(&config, ui).await?;
 
     let result = get_class_hash_at(&provider, args.contract_address, &args.block_id)

--- a/crates/sncast/src/starknet_commands/get/mod.rs
+++ b/crates/sncast/src/starknet_commands/get/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use sncast::helpers::configuration::CastConfig;
 use sncast::response::ui::UI;
+use std::process::ExitCode;
 
 pub mod balance;
 pub mod class_hash_at;
@@ -35,18 +36,16 @@ pub enum GetCommands {
     ClassHashAt(class_hash_at::ClassHashAt),
 }
 
-pub async fn get(get: Get, config: CastConfig, ui: &UI) -> anyhow::Result<()> {
+pub async fn get(get: Get, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
     match get.command {
-        GetCommands::TxStatus(status) => tx_status::tx_status(status, config, ui).await?,
+        GetCommands::TxStatus(status) => tx_status::tx_status(status, config, ui).await,
 
-        GetCommands::Tx(tx) => transaction::transaction(tx, config, ui).await?,
+        GetCommands::Tx(tx) => transaction::transaction(tx, config, ui).await,
 
-        GetCommands::Balance(balance) => balance::balance(balance, config, ui).await?,
+        GetCommands::Balance(balance) => balance::balance(balance, config, ui).await,
 
-        GetCommands::Nonce(nonce) => nonce::nonce(nonce, config, ui).await?,
+        GetCommands::Nonce(nonce) => nonce::nonce(nonce, config, ui).await,
 
-        GetCommands::ClassHashAt(args) => class_hash_at::class_hash_at(args, config, ui).await?,
+        GetCommands::ClassHashAt(args) => class_hash_at::class_hash_at(args, config, ui).await,
     }
-
-    Ok(())
 }

--- a/crates/sncast/src/starknet_commands/get/nonce.rs
+++ b/crates/sncast/src/starknet_commands/get/nonce.rs
@@ -7,10 +7,10 @@ use sncast::helpers::rpc::RpcArgs;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::nonce::NonceResponse;
 use sncast::response::ui::UI;
-use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 
 #[derive(Debug, Args)]
 #[command(about = "Get the nonce of a contract")]

--- a/crates/sncast/src/starknet_commands/get/nonce.rs
+++ b/crates/sncast/src/starknet_commands/get/nonce.rs
@@ -7,6 +7,7 @@ use sncast::helpers::rpc::RpcArgs;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::nonce::NonceResponse;
 use sncast::response::ui::UI;
+use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
@@ -27,15 +28,14 @@ pub struct Nonce {
     pub rpc: RpcArgs,
 }
 
-pub async fn nonce(nonce: Nonce, config: CastConfig, ui: &UI) -> Result<()> {
+pub async fn nonce(nonce: Nonce, config: CastConfig, ui: &UI) -> Result<ExitCode> {
     let provider = nonce.rpc.get_provider(&config, ui).await?;
 
     let result = get_nonce(&provider, nonce.contract_address, &nonce.block_id)
         .await
         .map_err(handle_starknet_command_error);
 
-    process_command_result("get nonce", result, ui, None);
-    Ok(())
+    Ok(process_command_result("get nonce", result, ui, None))
 }
 
 pub async fn get_nonce(

--- a/crates/sncast/src/starknet_commands/get/transaction.rs
+++ b/crates/sncast/src/starknet_commands/get/transaction.rs
@@ -8,10 +8,10 @@ use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::transaction::TransactionResponse;
 use sncast::response::ui::UI;
 use starknet_rust::core::types::TransactionResponseFlag;
-use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 
 #[derive(Debug, Args)]
 #[command(about = "Get the details of a transaction")]
@@ -38,7 +38,12 @@ pub async fn transaction(tx: Transaction, config: CastConfig, ui: &UI) -> Result
     let chain_id = provider.chain_id().await?;
     let block_explorer_link = block_explorer_link_if_allowed(&result, chain_id, &config).await;
 
-    Ok(process_command_result("get tx", result, ui, block_explorer_link))
+    Ok(process_command_result(
+        "get tx",
+        result,
+        ui,
+        block_explorer_link,
+    ))
 }
 
 async fn get_transaction(

--- a/crates/sncast/src/starknet_commands/get/transaction.rs
+++ b/crates/sncast/src/starknet_commands/get/transaction.rs
@@ -8,6 +8,7 @@ use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::transaction::TransactionResponse;
 use sncast::response::ui::UI;
 use starknet_rust::core::types::TransactionResponseFlag;
+use std::process::ExitCode;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
@@ -27,7 +28,7 @@ pub struct Transaction {
     pub rpc: RpcArgs,
 }
 
-pub async fn transaction(tx: Transaction, config: CastConfig, ui: &UI) -> Result<()> {
+pub async fn transaction(tx: Transaction, config: CastConfig, ui: &UI) -> Result<ExitCode> {
     let provider = tx.rpc.get_provider(&config, ui).await?;
 
     let result = get_transaction(&provider, tx.transaction_hash, tx.with_proof_facts)
@@ -37,8 +38,7 @@ pub async fn transaction(tx: Transaction, config: CastConfig, ui: &UI) -> Result
     let chain_id = provider.chain_id().await?;
     let block_explorer_link = block_explorer_link_if_allowed(&result, chain_id, &config).await;
 
-    process_command_result("get tx", result, ui, block_explorer_link);
-    Ok(())
+    Ok(process_command_result("get tx", result, ui, block_explorer_link))
 }
 
 async fn get_transaction(

--- a/crates/sncast/src/starknet_commands/get/tx_status.rs
+++ b/crates/sncast/src/starknet_commands/get/tx_status.rs
@@ -6,11 +6,11 @@ use sncast::helpers::rpc::RpcArgs;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::tx_status::{ExecutionStatus, FinalityStatus, TransactionStatusResponse};
 use sncast::response::ui::UI;
-use std::process::ExitCode;
 use starknet_rust::core::types::{TransactionExecutionStatus, TransactionStatus};
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_types_core::felt::Felt;
+use std::process::ExitCode;
 
 #[derive(Debug, Args)]
 #[command(about = "Get the status of a transaction")]

--- a/crates/sncast/src/starknet_commands/get/tx_status.rs
+++ b/crates/sncast/src/starknet_commands/get/tx_status.rs
@@ -6,6 +6,7 @@ use sncast::helpers::rpc::RpcArgs;
 use sncast::response::errors::{StarknetCommandError, handle_starknet_command_error};
 use sncast::response::tx_status::{ExecutionStatus, FinalityStatus, TransactionStatusResponse};
 use sncast::response::ui::UI;
+use std::process::ExitCode;
 use starknet_rust::core::types::{TransactionExecutionStatus, TransactionStatus};
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
@@ -21,15 +22,14 @@ pub struct TxStatus {
     pub rpc: RpcArgs,
 }
 
-pub async fn tx_status(tx_status: TxStatus, config: CastConfig, ui: &UI) -> anyhow::Result<()> {
+pub async fn tx_status(tx_status: TxStatus, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
     let provider = tx_status.rpc.get_provider(&config, ui).await?;
 
     let result = get_tx_status(&provider, tx_status.transaction_hash)
         .await
         .map_err(handle_starknet_command_error);
 
-    process_command_result("get tx-status", result, ui, None);
-    Ok(())
+    Ok(process_command_result("get tx-status", result, ui, None))
 }
 
 pub async fn get_tx_status(

--- a/crates/sncast/src/starknet_commands/get/tx_status.rs
+++ b/crates/sncast/src/starknet_commands/get/tx_status.rs
@@ -22,7 +22,11 @@ pub struct TxStatus {
     pub rpc: RpcArgs,
 }
 
-pub async fn tx_status(tx_status: TxStatus, config: CastConfig, ui: &UI) -> anyhow::Result<ExitCode> {
+pub async fn tx_status(
+    tx_status: TxStatus,
+    config: CastConfig,
+    ui: &UI,
+) -> anyhow::Result<ExitCode> {
     let provider = tx_status.rpc.get_provider(&config, ui).await?;
 
     let result = get_tx_status(&provider, tx_status.transaction_hash)

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -120,8 +120,12 @@ pub async fn multicall(
             });
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            process_command_result("multicall execute", result, ui, block_explorer_link);
-            Ok(())
+            Ok(process_command_result(
+                "multicall execute",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
     }
 }

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -97,7 +97,12 @@ pub async fn multicall(
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            Ok(process_command_result("multicall run", result, ui, block_explorer_link))
+            Ok(process_command_result(
+                "multicall run",
+                result,
+                ui,
+                block_explorer_link,
+            ))
         }
         starknet_commands::multicall::Commands::Execute(execute) => {
             let provider = execute.rpc.get_provider(&config, ui).await?;

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::{Value, json};
+use std::process::ExitCode;
 
 pub mod contract_registry;
 pub mod deploy;
@@ -45,7 +46,7 @@ pub async fn multicall(
     config: CastConfig,
     ui: &UI,
     wait_config: WaitForTx,
-) -> Result<()> {
+) -> Result<ExitCode> {
     #[derive(Serialize)]
     struct MulticallMessage {
         file_contents: String,
@@ -68,8 +69,7 @@ pub async fn multicall(
                     output_path,
                     new.overwrite,
                 );
-
-                process_command_result("multicall new", result, ui, None);
+                Ok(process_command_result("multicall new", result, ui, None))
             } else {
                 ui.print_message(
                     "multicall_new",
@@ -77,8 +77,8 @@ pub async fn multicall(
                         file_contents: DEFAULT_MULTICALL_CONTENTS.to_string(),
                     },
                 );
+                Ok(ExitCode::SUCCESS)
             }
-            Ok(())
         }
         starknet_commands::multicall::Commands::Run(run) => {
             let provider = run.rpc.get_provider(&config, ui).await?;
@@ -97,8 +97,7 @@ pub async fn multicall(
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
-            process_command_result("multicall run", result, ui, block_explorer_link);
-            Ok(())
+            Ok(process_command_result("multicall run", result, ui, block_explorer_link))
         }
         starknet_commands::multicall::Commands::Execute(execute) => {
             let provider = execute.rpc.get_provider(&config, ui).await?;

--- a/crates/sncast/src/starknet_commands/script/mod.rs
+++ b/crates/sncast/src/starknet_commands/script/mod.rs
@@ -9,6 +9,7 @@ use sncast::helpers::scarb_utils::{
 };
 use sncast::response::ui::UI;
 use sncast::{chain_id_to_network_name, get_chain_id, get_default_state_file_name};
+use std::process::ExitCode;
 use tokio::runtime::Runtime;
 
 pub mod init;
@@ -31,11 +32,11 @@ pub fn run_script_command(
     runtime: Runtime,
     script: &Script,
     ui: &UI,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ExitCode> {
     match &script.command {
         starknet_commands::script::Commands::Init(init) => {
             let result = starknet_commands::script::init::init(init, ui);
-            process_command_result("script init", result, ui, None);
+            Ok(process_command_result("script init", result, ui, None))
         }
         starknet_commands::script::Commands::Run(run) => {
             let manifest_path = assert_manifest_path_exists()?;
@@ -95,9 +96,7 @@ pub fn run_script_command(
                 ui,
             );
 
-            process_command_result("script run", result, ui, None);
+            Ok(process_command_result("script run", result, ui, None))
         }
     }
-
-    Ok(())
 }

--- a/crates/sncast/src/starknet_commands/utils/mod.rs
+++ b/crates/sncast/src/starknet_commands/utils/mod.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Subcommand};
 use sncast::response::ui::UI;
+use std::process::ExitCode;
 use sncast::{
     helpers::{
         configuration::CastConfig,
@@ -48,14 +49,14 @@ pub async fn utils(
     ui: &UI,
     json: bool,
     profile: String,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<ExitCode> {
     match utils.command {
         Commands::Serialize(serialize) => {
             let result = starknet_commands::utils::serialize::serialize(serialize, config, ui)
                 .await
                 .map_err(handle_starknet_command_error);
 
-            process_command_result("serialize", result, ui, None);
+            Ok(process_command_result("utils serialize", result, ui, None))
         }
 
         Commands::ClassHash(class_hash) => {
@@ -78,14 +79,12 @@ pub async fn utils(
             let result = class_hash::get_class_hash(&class_hash, &artifacts)
                 .map_err(handle_starknet_command_error);
 
-            process_command_result("class-hash", result, ui, None);
+            Ok(process_command_result("utils class-hash", result, ui, None))
         }
 
         Commands::Selector(sel) => {
             let result = selector::get_selector(&sel).map_err(handle_starknet_command_error);
-            process_command_result("selector", result, ui, None);
+            Ok(process_command_result("utils selector", result, ui, None))
         }
     }
-
-    Ok(())
 }

--- a/crates/sncast/src/starknet_commands/utils/mod.rs
+++ b/crates/sncast/src/starknet_commands/utils/mod.rs
@@ -1,6 +1,5 @@
 use clap::{Args, Subcommand};
 use sncast::response::ui::UI;
-use std::process::ExitCode;
 use sncast::{
     helpers::{
         configuration::CastConfig,
@@ -11,6 +10,7 @@ use sncast::{
     },
     response::errors::handle_starknet_command_error,
 };
+use std::process::ExitCode;
 
 use crate::{
     process_command_result,

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -179,7 +179,7 @@ pub async fn test_invalid_class_hash() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -378,7 +378,7 @@ pub async fn test_account_already_exists() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -561,7 +561,7 @@ pub async fn test_keystore_without_account() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -597,7 +597,7 @@ pub async fn test_keystore_file_already_exists() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -634,7 +634,7 @@ pub async fn test_keystore_account_file_already_exists() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -1026,6 +1026,7 @@ pub async fn test_no_explorer_links_on_localhost() {
     );
 }
 
+// TODO(#4027): Fix either test or underlying bug
 #[tokio::test]
 pub async fn test_use_url_from_config() {
     let accounts_file = "accounts.json";

--- a/crates/sncast/tests/e2e/account/delete.rs
+++ b/crates/sncast/tests/e2e/account/delete.rs
@@ -18,7 +18,7 @@ pub fn test_no_accounts_in_network() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -43,7 +43,7 @@ pub fn test_account_does_not_exist() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -75,7 +75,7 @@ pub fn test_delete_abort() {
     // Run test with a negative user input
     let snapbox = runner(&args).current_dir(temp_dir.path()).stdin("n");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
     assert_stderr_contains(
         output,
         indoc! {r"

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -351,7 +351,7 @@ pub async fn test_keystore_already_deployed() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -392,7 +392,7 @@ pub async fn test_keystore_key_mismatch() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -428,7 +428,7 @@ pub async fn test_deploy_keystore_inexistent_keystore_file() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -464,7 +464,7 @@ pub async fn test_deploy_keystore_inexistent_account_file() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -504,7 +504,7 @@ pub async fn test_deploy_keystore_no_status() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/account/import.rs
+++ b/crates/sncast/tests/e2e/account/import.rs
@@ -524,7 +524,7 @@ pub async fn test_invalid_private_key_file_path() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     let expected_file_error = "No such file or directory [..]";
 
@@ -566,7 +566,7 @@ pub async fn test_invalid_private_key_in_file() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -871,7 +871,7 @@ pub async fn test_use_url_from_config() {
         "account",
         "import",
         "--address",
-        "0x123",
+        DEVNET_PREDEPLOYED_ACCOUNT_ADDRESS,
         "--private-key",
         "0x456",
         "--type",

--- a/crates/sncast/tests/e2e/balance.rs
+++ b/crates/sncast/tests/e2e/balance.rs
@@ -234,7 +234,7 @@ pub async fn nonexistent_token_address() {
 
     let snapbox = runner(&args).current_dir(tempdir.path());
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -171,7 +171,7 @@ fn test_wrong_calldata() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     // TODO(#3107)
     // 0x496e70757420746f6f206c6f6e6720666f7220617267756d656e7473 is "Input too long for arguments"
@@ -233,7 +233,7 @@ fn test_wrong_block_id() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/class_hash_at.rs
+++ b/crates/sncast/tests/e2e/class_hash_at.rs
@@ -73,7 +73,7 @@ async fn test_json_output() {
 async fn test_nonexistent_contract_address() {
     let args = vec!["get", "class-hash-at", "0x0", "--url", URL];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -96,7 +96,7 @@ async fn test_invalid_block_id() {
         URL,
     ];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -338,7 +338,7 @@ async fn test_contract_already_declared() {
     runner(&args).current_dir(tempdir.path()).assert().success();
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -377,7 +377,7 @@ async fn test_contract_already_declared_estimate_fee() {
     runner(&args).current_dir(tempdir.path()).assert().success();
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -408,7 +408,7 @@ async fn test_invalid_nonce() {
     ];
 
     let snapbox = runner(&args).current_dir(contract_path.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -441,7 +441,7 @@ async fn test_wrong_contract_name_passed() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
     assert_stderr_contains(
         output,
         indoc! {r"
@@ -554,7 +554,7 @@ fn test_too_low_gas() {
     ];
 
     let snapbox = runner(&args).current_dir(contract_path.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -695,7 +695,7 @@ async fn test_workspaces_package_no_contract() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/declare_from.rs
+++ b/crates/sncast/tests/e2e/declare_from.rs
@@ -119,7 +119,7 @@ async fn test_contract_already_declared() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -150,7 +150,7 @@ async fn test_class_hash_does_not_exist_on_source_network() {
     ];
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -298,7 +298,7 @@ async fn test_declare_from_sierra_does_not_exist() {
         URL,
     ];
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -329,7 +329,7 @@ async fn test_declare_from_sierra_invalid_json() {
         URL,
     ];
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -389,7 +389,7 @@ async fn test_declare_from_sierra_already_declared() {
         URL,
     ];
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -259,7 +259,7 @@ fn test_wrong_calldata() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -337,7 +337,7 @@ fn test_contract_already_deployed() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -373,7 +373,7 @@ fn test_too_low_gas() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
     // TODO Check extra blank line
     println!("====\n{}\n====", output.as_stderr());
 
@@ -652,7 +652,7 @@ async fn test_deploy_with_declare_invalid_nonce() {
     let snapbox = runner(&args)
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
         .current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -252,7 +252,7 @@ fn test_wrong_calldata() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -296,7 +296,7 @@ fn test_too_low_gas() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/multicall/execute.rs
+++ b/crates/sncast/tests/e2e/multicall/execute.rs
@@ -33,7 +33,7 @@ async fn test_one_invoke() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().failure();
+    let output = snapbox.assert().success();
 
     assert_stdout_contains(
         output,
@@ -83,7 +83,7 @@ async fn test_two_invokes() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().failure();
+    let output = snapbox.assert().success();
 
     assert_stdout_contains(
         output,
@@ -129,7 +129,7 @@ async fn test_deploy_and_invoke() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().failure();
+    let output = snapbox.assert().success();
 
     assert_stdout_contains(
         output,
@@ -177,7 +177,7 @@ async fn test_use_id() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().failure();
+    let output = snapbox.assert().success();
 
     assert_stdout_contains(
         output,

--- a/crates/sncast/tests/e2e/multicall/execute.rs
+++ b/crates/sncast/tests/e2e/multicall/execute.rs
@@ -33,7 +33,7 @@ async fn test_one_invoke() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stdout_contains(
         output,
@@ -83,7 +83,7 @@ async fn test_two_invokes() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stdout_contains(
         output,
@@ -129,7 +129,7 @@ async fn test_deploy_and_invoke() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stdout_contains(
         output,
@@ -177,7 +177,7 @@ async fn test_use_id() {
     let snapbox = runner(&args)
         .current_dir(tempdir.path())
         .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stdout_contains(
         output,
@@ -223,7 +223,7 @@ async fn test_non_existent_id() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -262,7 +262,7 @@ async fn test_duplicated_id() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -291,7 +291,7 @@ async fn test_unrecognized_command() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -320,7 +320,7 @@ async fn test_empty_calls() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/multicall/new.rs
+++ b/crates/sncast/tests/e2e/multicall/new.rs
@@ -73,7 +73,7 @@ async fn test_directory_non_existent() {
     ];
 
     let snapbox = runner(&args).current_dir(tmp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert!(output.as_stdout().is_empty());
 
@@ -105,7 +105,7 @@ async fn test_file_invalid_path() {
     ];
 
     let snapbox = runner(&args).current_dir(tmp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert!(output.as_stdout().is_empty());
     assert_stderr_contains(

--- a/crates/sncast/tests/e2e/multicall/run.rs
+++ b/crates/sncast/tests/e2e/multicall/run.rs
@@ -113,7 +113,7 @@ async fn test_invalid_path() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert!(output.as_stdout().is_empty());
 
@@ -152,7 +152,7 @@ async fn test_deploy_fail() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -187,7 +187,7 @@ async fn test_invoke_fail() {
     ];
 
     let snapbox = runner(&args).current_dir(tempdir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -223,7 +223,7 @@ async fn test_deploy_success_invoke_fails() {
 
     let snapbox = runner(&args).current_dir(tempdir.path());
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
     assert_stderr_contains(
         output,
         indoc! {r"

--- a/crates/sncast/tests/e2e/nonce.rs
+++ b/crates/sncast/tests/e2e/nonce.rs
@@ -62,7 +62,7 @@ async fn test_happy_case_json() {
 async fn test_nonexistent_contract_address() {
     let args = vec!["get", "nonce", "0x0", "--url", URL];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -85,7 +85,7 @@ async fn test_invalid_block_id() {
         URL,
     ];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -274,7 +274,7 @@ async fn test_nonexistent_account_address() {
     ];
 
     let snapbox = runner(&args).current_dir(SCRIPTS_DIR.to_owned() + "/map_script/scripts");
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/script/init.rs
+++ b/crates/sncast/tests/e2e/script/init.rs
@@ -118,7 +118,7 @@ fn test_init_fails_when_scripts_dir_exists_in_cwd() {
         .expect("Failed to create scripts directory in the current temp directory");
 
     let snapbox = runner(&["script", "init", script_name]).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -143,7 +143,7 @@ fn test_init_twice_fails() {
     assert!(temp_dir.path().join(INIT_SCRIPTS_DIR).exists());
 
     let snapbox = runner(&args).current_dir(temp_dir.path());
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/selector.rs
+++ b/crates/sncast/tests/e2e/selector.rs
@@ -24,7 +24,7 @@ fn test_selector_json_output() {
     let stdout = output.get_output().stdout.clone();
 
     let json: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
-    assert_eq!(json["command"], "selector");
+    assert_eq!(json["command"], "utils selector");
     assert_eq!(json["type"], "response");
     assert_eq!(
         json["selector"],

--- a/crates/sncast/tests/e2e/selector.rs
+++ b/crates/sncast/tests/e2e/selector.rs
@@ -36,7 +36,7 @@ fn test_selector_json_output() {
 fn test_selector_with_parentheses() {
     let args = vec!["utils", "selector", "transfer(u256)"];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/serialize.rs
+++ b/crates/sncast/tests/e2e/serialize.rs
@@ -224,7 +224,7 @@ async fn test_wrong_function_name() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/serialize.rs
+++ b/crates/sncast/tests/e2e/serialize.rs
@@ -112,7 +112,7 @@ async fn test_abi_file_missing_function() {
         "nested_struct_fn",
     ];
 
-    let output = runner(&args).current_dir(tempdir.path()).assert().success();
+    let output = runner(&args).current_dir(tempdir.path()).assert().failure();
 
     assert_stderr_contains(
         output,
@@ -144,13 +144,13 @@ async fn test_abi_file_missing_type() {
         "nested_struct_fn",
     ];
 
-    let output = runner(&args).current_dir(tempdir.path()).assert().success();
+    let output = runner(&args).current_dir(tempdir.path()).assert().failure();
 
     assert_stderr_contains(
         output,
         indoc! {r#"
-    Command: serialize
-    Error: Error while processing Cairo-like calldata: Struct "NestedStructWithField" not found in ABI
+        Command: utils serialize
+        Error: Error while processing Cairo-like calldata: Struct "NestedStructWithField" not found in ABI
     "#},
     );
 }
@@ -178,7 +178,7 @@ async fn test_happy_case_json() {
     let snapbox = runner(&args).current_dir(tempdir.path());
 
     snapbox.assert().success().stdout_eq(indoc! {r#"
-        {"calldata":["0x24","0x60"],"command":"serialize","type":"response"}
+        {"calldata":["0x24","0x60"],"command":"utils serialize","type":"response"}
     "#});
 }
 
@@ -198,7 +198,7 @@ async fn test_contract_does_not_exist() {
     ];
 
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -251,8 +251,8 @@ async fn test_rpc_args_not_passed_when_using_class_hash() {
 
     let snapbox = runner(&args).current_dir(tempdir.path());
 
-    snapbox.assert().success().stderr_eq(indoc! {r"
-    Command: serialize
+    snapbox.assert().failure().stderr_eq(indoc! {r"
+    Command: utils serialize
     Error: Either `--network` or `--url` must be provided when using `--class-hash`
     "});
 }
@@ -276,8 +276,8 @@ async fn test_rpc_args_not_passed_when_using_contract_address() {
 
     let snapbox = runner(&args).current_dir(tempdir.path());
 
-    snapbox.assert().success().stderr_eq(indoc! {r"
-    Command: serialize
+    snapbox.assert().failure().stderr_eq(indoc! {r"
+    Command: utils serialize
     Error: Either `--network` or `--url` must be provided when using `--contract-address`
     "});
 }

--- a/crates/sncast/tests/e2e/transaction.rs
+++ b/crates/sncast/tests/e2e/transaction.rs
@@ -156,7 +156,7 @@ async fn test_declare_transaction() {
 async fn test_nonexistent_transaction() {
     let args = vec!["get", "tx", "0x1", "--url", URL];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/tx_status.rs
+++ b/crates/sncast/tests/e2e/tx_status.rs
@@ -11,7 +11,7 @@ const REVERTED_TX_HASH: &str = "0x00ae35dacba17cde62b8ceb12e3b18f4ab6e103fa2d5e3
 async fn test_incorrect_transaction_hash() {
     let args = vec!["get", "tx-status", "0x1", "--url", URL];
     let snapbox = runner(&args);
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -641,7 +641,7 @@ async fn test_error_when_chain_id_is_unrecognized_and_network_is_missing() {
         .env("VERIFIER_API_URL", mock_server.uri())
         .current_dir(contract_path.path());
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -311,7 +311,7 @@ async fn test_failed_verification_contract_address() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -366,7 +366,7 @@ async fn test_failed_verification_class_hash() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -437,7 +437,7 @@ async fn test_failed_class_hash_lookup() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -560,7 +560,7 @@ async fn test_contract_name_not_found() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -591,7 +591,7 @@ async fn test_error_when_neither_network_nor_url_provided() {
 
     let snapbox = runner(&args).current_dir(contract_path.path());
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/verify/walnut.rs
+++ b/crates/sncast/tests/e2e/verify/walnut.rs
@@ -149,7 +149,7 @@ async fn test_failed_verification_contract_address() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -200,7 +200,7 @@ async fn test_failed_verification_class_hash() {
         .current_dir(contract_path.path())
         .stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -234,7 +234,7 @@ async fn test_verification_abort() {
 
     let snapbox = runner(&args).current_dir(contract_path.path()).stdin("n");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -319,7 +319,7 @@ async fn test_wrong_contract_name_passed() {
 
     let snapbox = runner(&args).current_dir(contract_path.path()).stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,
@@ -514,7 +514,7 @@ async fn test_worskpaces_package_no_contract() {
 
     let snapbox = runner(&args).current_dir(tempdir.path()).stdin("Y");
 
-    let output = snapbox.assert().success();
+    let output = snapbox.assert().failure();
 
     assert_stderr_contains(
         output,

--- a/docs/src/appendix/sncast/get/get.md
+++ b/docs/src/appendix/sncast/get/get.md
@@ -5,5 +5,5 @@ It has the following subcommands:
 * [`balance`](./balance.md)
 * [`class-hash-at`](./class_hash_at.md)
 * [`nonce`](./nonce.md)
-* [`tx`](./tx.md)
-* [`tx-status`](./tx-status.md)
+* [`tx`](./tx.md) (alias: `transaction`)
+* [`tx-status`](./tx-status.md) (alias: `transaction-status`)

--- a/docs/src/appendix/sncast/get/tx-status.md
+++ b/docs/src/appendix/sncast/get/tx-status.md
@@ -1,6 +1,8 @@
 # `get tx-status`
 
-Get the status of a transaction
+Get the status of a transaction. 
+
+This command is also available as `get transaction-status`.
 
 ## `<TRANSACTION_HASH>`
 

--- a/docs/src/appendix/sncast/get/tx.md
+++ b/docs/src/appendix/sncast/get/tx.md
@@ -1,6 +1,8 @@
 # `get tx`
 
-Get the details of a transaction
+Get the details of a transaction. 
+
+This command is also available as `get transaction`.
 
 ## `<TRANSACTION_HASH>`
 

--- a/docs/src/starknet/account-import.md
+++ b/docs/src/starknet/account-import.md
@@ -76,6 +76,8 @@ This section shows how to export your private key from specific wallets.
 
 To import an account into the file holding the accounts info (`~/.starknet_accounts/starknet_open_zeppelin_accounts.json` by default), use the `account import` command.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast \
     account import \
@@ -115,6 +117,8 @@ Type in your private key and press enter:
 
 To import Ready account, set the `--type` flag to `ready`.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast \
     account import \
@@ -129,6 +133,8 @@ $ sncast \
 
 To import Braavos account, set the `--type` flag to `braavos`.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast \
     account import \
@@ -143,6 +149,8 @@ $ sncast \
 
 To import OpenZeppelin account, set the `--type` flag to `oz` or  `open_zeppelin`.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast \
     account import \

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -104,6 +104,8 @@ sections.
 
 To import an account to the `default accounts file`, use the `account import` command.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast \
     account import \
@@ -158,6 +160,8 @@ There is also possibility to show private keys with the `--display-private-keys`
 Delete an account from `accounts-file` and its associated Scarb profile. If you pass this command, you will be asked to
 confirm the deletion.
 
+<!-- TODO(#4225) -->
+<!-- { "ignored": true } -->
 ```shell
 $ sncast account delete \
     --name new_account \

--- a/docs/src/starknet/invoke.md
+++ b/docs/src/starknet/invoke.md
@@ -17,7 +17,8 @@ For detailed CLI description, see [invoke command reference](../appendix/sncast/
 ### General Example
 
 <!-- TODO(#2736) -->
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast \
   --account my_account \

--- a/docs/src/starknet/ledger.md
+++ b/docs/src/starknet/ledger.md
@@ -87,7 +87,7 @@ $ sncast \
     --name my_ledger_account
 ```
 
-<!-- { "requires_ledger": true } -->
+<!-- { "ignored": true, "requires_ledger": true } -->
 ```shell
 $ sncast \
     account create \
@@ -112,7 +112,7 @@ A signing confirmation will be shown on the Ledger device. Once approved, the de
 
 If you already have a deployed account managed by your Ledger, you can import it:
 
-<!-- { "requires_ledger": true } -->
+<!-- { "ignored": true, "requires_ledger": true } -->
 ```shell
 $ sncast \
     account import \
@@ -123,7 +123,7 @@ $ sncast \
     --type oz
 ```
 
-<!-- { "requires_ledger": true } -->
+<!-- { "ignored": true, "requires_ledger": true } -->
 ```shell
 $ sncast \
     account import \

--- a/docs/src/starknet/multicall.md
+++ b/docs/src/starknet/multicall.md
@@ -83,7 +83,8 @@ After running `sncast multicall run --path file.toml`, a declared contract will 
 > For numbers larger than 2^63 - 1 (that can't fit into `i64`), use string format (e.g., `"9223372036854775808"`) due to TOML parser limitations.
 
 <!-- TODO: Adjust snippet and check remove ignoring output -->
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast multicall run --path multicall_example.toml
 ```

--- a/docs/src/starknet/script.md
+++ b/docs/src/starknet/script.md
@@ -257,7 +257,8 @@ sncast_std = "0.33.0"
 To run the script, do:
 
 <!-- TODO(#2736) -->
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast \
   script run my_script
@@ -335,7 +336,8 @@ Please note that `map` contract was specified as the dependency. In our example,
 
 To run the script, do:
 
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast \
   --account example_user \
@@ -363,7 +365,8 @@ status: success
 As [an idempotency](#state-file) feature is turned on by default, executing the same script once again ends with a success
 and only `call` functions are being executed (as they do not change the network state):
 
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast \
   --account example_user \
@@ -388,7 +391,8 @@ status: success
 
 whereas, when we run the same script once again with `--no-state-file` flag set, it fails (as the `Map` contract is already deployed):
 
-<!-- { "ignored_output": true } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true } -->
 ```shell
 $ sncast \
   --account example_user \

--- a/docs/src/starknet/verify.md
+++ b/docs/src/starknet/verify.md
@@ -27,7 +27,8 @@ First, ensure that you have created a `Scarb.toml` file for your contract (it sh
 
 ### Using Walnut
 
-<!-- { "ignored_output": true, "replace_network": false } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true, "replace_network": false } -->
 ```shell
 $ sncast \
     verify \
@@ -57,7 +58,8 @@ Contract successfully verified
 
 ### Using Voyager
 
-<!-- { "ignored_output": true, "replace_network": false } -->
+<!-- TODO(#4225) -->
+<!-- { "ignored": true, "ignored_output": true, "replace_network": false } -->
 ```shell
 $ sncast \
     verify \


### PR DESCRIPTION
Closes #4184

## Stack
- #4215 
- #4210
- #4218 
- #4217 
- #4219
- #4220
- #4223
- #4224

## Introduced changes

<!-- A brief description of the changes -->

- Ensure `ExitCode` produced by `process_command_result` is not ignored, and determines `sncast` exit code
- Misc
  - Fix `sncast utils` subcommands messaging (`"serialize"` -> `"utils serialize"` etc.)

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
