### PR TITLE
Optimize release builds for runtime performance 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,6 +3483,7 @@ dependencies = [
  "indoc",
  "insta",
  "itertools 0.14.0",
+ "mimalloc",
  "num-bigint",
  "openssl",
  "packages_validation",
@@ -4767,6 +4768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4979,6 +4990,15 @@ dependencies = [
  "log",
  "sprs",
  "web-time",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7351,6 +7371,7 @@ dependencies = [
  "fs_extra",
  "indoc",
  "itertools 0.14.0",
+ "mimalloc",
  "num-traits",
  "packages_validation",
  "primitive-types 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,13 @@ members = [
 
 exclude = ["crates/snforge-scarb-plugin"]
 
+[profile.release]
+codegen-units = 1
+lto = "thin"
+
 [profile.ci]
-inherits = "release"
-debug-assertions = true
+inherits = "dev"
+opt-level = 3
 
 [workspace.package]
 version = "0.58.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,3 +140,4 @@ comfy-table = "7"
 create-output-dir = "1.0.0"
 insta = { version = "1.46.0", features = ["filters"] }
 plotters = { version = "0.3", default-features = false, features = ["all_series", "all_elements", "svg_backend", "bitmap_backend", "bitmap_encoder", "full_palette", "colormaps", "ab_glyph"] }
+mimalloc = "0.1"

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -65,6 +65,7 @@ fs_extra.workspace = true
 comfy-table.workspace = true
 plotters.workspace = true
 create-output-dir.workspace = true
+mimalloc.workspace = true
 
 [[bin]]
 name = "snforge"

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -1,9 +1,13 @@
 use forge::{ExitStatus, main_execution};
 use foundry_ui::{UI, components::error::ErrorMessage};
+use mimalloc::MiMalloc;
 use std::io::IsTerminal;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::{env, io};
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn main() -> ExitCode {
     let _guard = init_logging();

--- a/crates/sncast/Cargo.toml
+++ b/crates/sncast/Cargo.toml
@@ -66,6 +66,7 @@ strum.workspace = true
 strum_macros.workspace = true
 primitive-types.workspace = true
 coins-ledger.workspace = true
+mimalloc.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -21,6 +21,7 @@ use configuration::load_config;
 use conversions::IntoConv;
 use data_transformer::transform;
 use foundry_ui::components::warning::WarningMessage;
+use mimalloc::MiMalloc;
 use shared::auto_completions::{Completions, generate_completions};
 use sncast::helpers::command::process_command_result;
 use sncast::helpers::config::{combine_cast_configs, get_global_config_path};
@@ -53,6 +54,9 @@ use starknet_types_core::felt::Felt;
 use tokio::runtime::Runtime;
 
 mod starknet_commands;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[derive(Parser)]
 #[command(


### PR DESCRIPTION
- Enable thin LTO
- Set codegen-units to 1
- Use mimalloc 

On OZ:
Before:
```
Benchmark 1: /Users/maciektr/Projects/forks/starknet-foundry/target/release/snforge test --profile=release --fuzzer-seed=11067975336895813681 -w
  Time (mean ± σ):     45.516 s ±  0.186 s    [User: 324.214 s, System: 24.364 s]
  Range (min … max):   45.297 s … 45.776 s    5 runs
```

Thin LTO:
```
Benchmark 1: /Users/maciektr/Projects/forks/starknet-foundry/target/release/snforge test --profile=release --fuzzer-seed=11067975336895813681 -w
  Time (mean ± σ):     43.745 s ±  0.270 s    [User: 306.863 s, System: 24.961 s]
  Range (min … max):   43.436 s … 44.037 s    5 runs
```

Fat LTO:
```
Benchmark 1: /Users/maciektr/Projects/forks/starknet-foundry/target/release/snforge test --profile=release --fuzzer-seed=11067975336895813681 -w
  Time (mean ± σ):     43.460 s ±  0.414 s    [User: 304.455 s, System: 24.738 s]
  Range (min … max):   43.084 s … 44.157 s    5 runs
```

Thin LTO + MiMalloc:
```
Benchmark 1: /Users/maciektr/Projects/forks/starknet-foundry/target/release/snforge test --profile=release --fuzzer-seed=11067975336895813681 -w
  Time (mean ± σ):     38.304 s ±  0.392 s    [User: 271.223 s, System: 7.359 s]
  Range (min … max):   37.938 s … 38.965 s    5 runs
```