### PR TITLE
Fix using cheats in library calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+- Bug with using cheats in library calls
+
 ## [0.58.0] - 2026-03-18
 
 ### Forge

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/execution_utils.rs
@@ -16,12 +16,10 @@ pub(crate) fn resolve_cheated_data_for_call(
     cheatnet_state: &mut CheatnetState,
 ) -> CheatedData {
     if let CallType::Delegate = entry_point.call_type {
-        // This is an edge case, when delegate call is made directly by test contract.
-        // In such case, `top_cheated_data()` will have a default value (i.e. all fields are None),
-        // so we need to get cheated data from the caller address, which is the test contract.
-        // See: https://github.com/foundry-rs/starknet-foundry/blob/62eb015ef06728ed9ddd89a0d0023e5f7f6cfe66/crates/cheatnet/src/trace_data.rs#L156
+        // When a delegate call is made directly by a test contract, `top_cheated_data()` will have a default value (all fields set to `None`).
+        // Therefore, we need to get cheated data for the current contract, which is the test contract.
         if cheatnet_state.trace_data.current_call_stack.size() == 1 {
-            cheatnet_state.get_cheated_data(entry_point.caller_address)
+            cheatnet_state.get_cheated_data(entry_point.storage_address)
         } else {
             cheatnet_state
                 .trace_data

--- a/crates/cheatnet/tests/cheatcodes/library_call.rs
+++ b/crates/cheatnet/tests/cheatcodes/library_call.rs
@@ -34,7 +34,7 @@ fn global_cheat_works_with_library_call_from_test() {
 
     assert_success(
         test_env.library_call_contract(&class_hash, "get_caller_address", &[]),
-        &[Felt::try_from_hex_str(TEST_ADDRESS).unwrap()],
+        &[ContractAddress::default().into()],
     );
 }
 
@@ -70,7 +70,7 @@ fn cheat_with_finite_span_works_with_library_call_from_test() {
 
     assert_success(
         test_env.library_call_contract(&class_hash, "get_caller_address", &[]),
-        &[Felt::try_from_hex_str(TEST_ADDRESS).unwrap()],
+        &[ContractAddress::default().into()],
     );
 }
 
@@ -104,7 +104,7 @@ fn cheat_with_indefinite_span_works_with_library_call_from_test() {
 
     assert_success(
         test_env.library_call_contract(&class_hash, "get_caller_address", &[]),
-        &[Felt::try_from_hex_str(TEST_ADDRESS).unwrap()],
+        &[ContractAddress::default().into()],
     );
 }
 

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -238,6 +238,9 @@ pub fn call_contract(
     .call_result
 }
 
+// This executes a library call as from a test contract.
+// `entry_point` below should match `library_call_syscall` entry point, except for `selector` and `calldata`:
+// https://github.com/foundry-rs/starknet-foundry/blob/421a339168a9e0b6502eac4fdc4fdeb0598c72b7/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs#L151
 pub fn library_call_contract(
     state: &mut dyn State,
     cheatnet_state: &mut CheatnetState,

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -253,7 +253,7 @@ pub fn library_call_contract(
         entry_point_selector,
         calldata,
         storage_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
-        caller_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
+        caller_address: ContractAddress::default(),
         call_type: CallType::Delegate,
         initial_gas: i64::MAX as u64,
     };

--- a/crates/forge/tests/data/contracts/cheat_caller_address_checker.cairo
+++ b/crates/forge/tests/data/contracts/cheat_caller_address_checker.cairo
@@ -1,7 +1,16 @@
+use starknet::ClassHash;
+
 #[starknet::interface]
 trait ICheatCallerAddressChecker<TContractState> {
     fn get_caller_address(ref self: TContractState) -> felt252;
     fn get_caller_address_and_emit_event(ref self: TContractState) -> felt252;
+}
+
+#[starknet::interface]
+trait ICheatCallerAddressLibraryCallChecker<TContractState> {
+    fn get_caller_address_via_library_call(
+        self: @TContractState, class_hash: ClassHash,
+    ) -> felt252;
 }
 
 #[starknet::contract]
@@ -38,6 +47,24 @@ mod CheatCallerAddressChecker {
             let caller_address = starknet::get_caller_address().into();
             self.emit(Event::CallerAddressEmitted(CallerAddressEmitted { caller_address }));
             caller_address
+        }
+    }
+}
+
+#[starknet::contract]
+mod CheatCallerAddressLibraryCallChecker {
+    use starknet::ClassHash;
+    use super::ICheatCallerAddressCheckerDispatcherTrait;
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl CheatCallerAddressLibraryCallCheckerImpl of super::ICheatCallerAddressLibraryCallChecker<ContractState> {
+        fn get_caller_address_via_library_call(
+            self: @ContractState, class_hash: ClassHash,
+        ) -> felt252 {
+            super::ICheatCallerAddressCheckerLibraryDispatcher { class_hash }.get_caller_address()
         }
     }
 }

--- a/crates/forge/tests/data/contracts/cheat_tx_info_checker.cairo
+++ b/crates/forge/tests/data/contracts/cheat_tx_info_checker.cairo
@@ -2,7 +2,7 @@ use starknet::info::TxInfo;
 use serde::Serde;
 use option::OptionTrait;
 use array::ArrayTrait;
-use starknet::ContractAddress;
+use starknet::{ClassHash, ContractAddress};
 use starknet::info::v2::ResourceBounds;
 
 #[starknet::interface]
@@ -21,6 +21,33 @@ trait ICheatTxInfoChecker<TContractState> {
     fn get_fee_data_availability_mode(self: @TContractState) -> u32;
     fn get_account_deployment_data(self: @TContractState) -> Span<felt252>;
     fn get_tx_info(self: @TContractState) -> starknet::info::v2::TxInfo;
+}
+
+#[starknet::interface]
+trait ICheatBlockNumberChecker<TContractState> {
+    fn get_block_number(ref self: TContractState) -> u64;
+}
+
+#[starknet::interface]
+trait ICheatBlockTimestampChecker<TContractState> {
+    fn get_block_timestamp(ref self: TContractState) -> u64;
+}
+
+#[starknet::interface]
+trait ICheatSequencerAddressChecker<TContractState> {
+    fn get_sequencer_address(ref self: TContractState) -> ContractAddress;
+}
+
+#[starknet::interface]
+trait ICheatExecutionInfoLibraryCallChecker<TContractState> {
+    fn get_block_number_via_library_call(ref self: TContractState, class_hash: ClassHash) -> u64;
+    fn get_block_timestamp_via_library_call(
+        ref self: TContractState, class_hash: ClassHash,
+    ) -> u64;
+    fn get_sequencer_address_via_library_call(
+        ref self: TContractState, class_hash: ClassHash,
+    ) -> ContractAddress;
+    fn get_tx_hash_via_library_call(self: @TContractState, class_hash: ClassHash) -> felt252;
 }
 
 #[starknet::contract]
@@ -102,5 +129,45 @@ mod CheatTxInfoChecker {
 
     fn get_tx_info_v2() -> Box<starknet::info::v2::TxInfo> {
         get_execution_info_v2().unbox().tx_info
+    }
+}
+
+#[starknet::contract]
+mod CheatExecutionInfoLibraryCallChecker {
+    use starknet::{ClassHash, ContractAddress};
+    use super::{
+        ICheatBlockNumberCheckerDispatcherTrait,
+        ICheatBlockTimestampCheckerDispatcherTrait,
+        ICheatSequencerAddressCheckerDispatcherTrait,
+        ICheatTxInfoCheckerDispatcherTrait,
+    };
+
+    #[storage]
+    struct Storage {}
+
+    #[abi(embed_v0)]
+    impl CheatExecutionInfoLibraryCallCheckerImpl of super::ICheatExecutionInfoLibraryCallChecker<ContractState> {
+        fn get_block_number_via_library_call(
+            ref self: ContractState, class_hash: ClassHash,
+        ) -> u64 {
+            super::ICheatBlockNumberCheckerLibraryDispatcher { class_hash }.get_block_number()
+        }
+
+        fn get_block_timestamp_via_library_call(
+            ref self: ContractState, class_hash: ClassHash,
+        ) -> u64 {
+            super::ICheatBlockTimestampCheckerLibraryDispatcher { class_hash }.get_block_timestamp()
+        }
+
+        fn get_sequencer_address_via_library_call(
+            ref self: ContractState, class_hash: ClassHash,
+        ) -> ContractAddress {
+            super::ICheatSequencerAddressCheckerLibraryDispatcher { class_hash }
+                .get_sequencer_address()
+        }
+
+        fn get_tx_hash_via_library_call(self: @ContractState, class_hash: ClassHash) -> felt252 {
+            super::ICheatTxInfoCheckerLibraryDispatcher { class_hash }.get_tx_hash()
+        }
     }
 }

--- a/crates/forge/tests/integration/cheat_caller_address.rs
+++ b/crates/forge/tests/integration/cheat_caller_address.rs
@@ -225,3 +225,266 @@ fn cheat_caller_address_with_span() {
 
     assert_passed(&result);
 }
+
+/// Verify that a cheat applied to `test_address()` is visible inside a library call made
+/// directly from test code.
+#[test]
+fn cheat_caller_address_direct_library_call_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait,
+                start_cheat_caller_address, stop_cheat_caller_address, test_address,
+            };
+
+            #[starknet::interface]
+            trait ICheatCallerAddressChecker<TContractState> {
+                fn get_caller_address(ref self: TContractState) -> felt252;
+            }
+
+            #[test]
+            fn test_cheat_applied_to_test_address_is_visible_in_library_call() {
+                let class_hash = *declare("CheatCallerAddressChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatCallerAddressCheckerLibraryDispatcher { class_hash };
+
+                let original_caller = lib_dispatcher.get_caller_address();
+                assert(original_caller == 0.try_into().unwrap(), 'Caller should be 0');
+
+                let target_caller: ContractAddress = 123.try_into().unwrap();
+                start_cheat_caller_address(test_address(), target_caller);
+
+                let caller = lib_dispatcher.get_caller_address();
+                assert(caller == 123, 'Wrong caller address');
+
+                stop_cheat_caller_address(test_address());
+
+                let caller = lib_dispatcher.get_caller_address();
+                assert(caller == original_caller, 'Caller did not reset');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatCallerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}
+
+/// Verify that a global cheat is visible inside a library call made directly from test code.
+#[test]
+fn cheat_caller_address_global_direct_library_call_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait,
+                start_cheat_caller_address_global, stop_cheat_caller_address_global,
+            };
+
+            #[starknet::interface]
+            trait ICheatCallerAddressChecker<TContractState> {
+                fn get_caller_address(ref self: TContractState) -> felt252;
+            }
+
+            #[test]
+            fn test_global_cheat_is_visible_in_library_call() {
+                let class_hash = *declare("CheatCallerAddressChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatCallerAddressCheckerLibraryDispatcher { class_hash };
+
+                let original_caller = lib_dispatcher.get_caller_address();
+                assert(original_caller == 0.try_into().unwrap(), 'Caller should be 0');
+
+                let target_caller: ContractAddress = 456.try_into().unwrap();
+                start_cheat_caller_address_global(target_caller);
+
+                let caller = lib_dispatcher.get_caller_address();
+                assert(caller == 456, 'Wrong caller address');
+
+                stop_cheat_caller_address_global();
+
+                let caller = lib_dispatcher.get_caller_address();
+                assert(caller == original_caller, 'Caller did not reset');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatCallerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}
+
+/// Verify that a cheat applied to `test_address()` is visible when the library call is made
+/// via the raw `library_call_syscall` directly from test code.
+#[test]
+fn cheat_caller_address_via_syscall_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use starknet::{library_call_syscall, SyscallResultTrait};
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait,
+                start_cheat_caller_address, stop_cheat_caller_address, test_address,
+            };
+
+            #[test]
+            fn test_cheat_via_syscall_is_visible_in_library_call() {
+                let class_hash = *declare("CheatCallerAddressChecker").unwrap().contract_class().class_hash;
+
+                let original_caller = *library_call_syscall(
+                    class_hash, selector!("get_caller_address"), array![].span(),
+                ).unwrap_syscall()[0];
+
+                let target_caller: ContractAddress = 123.try_into().unwrap();
+                start_cheat_caller_address(test_address(), target_caller);
+
+                let caller = *library_call_syscall(
+                    class_hash, selector!("get_caller_address"), array![].span(),
+                ).unwrap_syscall()[0];
+                assert(caller == 123, 'Wrong caller address');
+
+                stop_cheat_caller_address(test_address());
+
+                let caller = *library_call_syscall(
+                    class_hash, selector!("get_caller_address"), array![].span(),
+                ).unwrap_syscall()[0];
+                assert(caller == original_caller, 'Caller did not reset');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatCallerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}
+
+/// Verify that a cheat applied to `test_address()` is visible when the library call is made
+/// via the safe library dispatcher directly from test code.
+#[test]
+fn cheat_caller_address_via_safe_dispatcher_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait,
+                start_cheat_caller_address, stop_cheat_caller_address, test_address,
+            };
+
+            #[starknet::interface]
+            trait ICheatCallerAddressChecker<TContractState> {
+                fn get_caller_address(ref self: TContractState) -> felt252;
+            }
+
+            #[test]
+            #[feature("safe_dispatcher")]
+            fn test_cheat_via_safe_dispatcher_is_visible_in_library_call() {
+                let class_hash = *declare("CheatCallerAddressChecker").unwrap().contract_class().class_hash;
+                let safe_lib_dispatcher = ICheatCallerAddressCheckerSafeLibraryDispatcher { class_hash };
+
+                let original_caller = safe_lib_dispatcher.get_caller_address().unwrap();
+
+                let target_caller: ContractAddress = 123.try_into().unwrap();
+                start_cheat_caller_address(test_address(), target_caller);
+
+                let caller = safe_lib_dispatcher.get_caller_address().unwrap();
+                assert(caller == 123, 'Wrong caller address');
+
+                stop_cheat_caller_address(test_address());
+
+                let caller = safe_lib_dispatcher.get_caller_address().unwrap();
+                assert(caller == original_caller, 'Caller did not reset');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatCallerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}
+
+/// Verify that a cheat applied to a contract address is visible when that contract internally
+/// makes a library call.
+#[test]
+fn cheat_caller_address_library_call_from_contract() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait,
+                start_cheat_caller_address, stop_cheat_caller_address, test_address,
+            };
+
+            #[starknet::interface]
+            trait ICheatCallerAddressLibraryCallChecker<TContractState> {
+                fn get_caller_address_via_library_call(
+                    self: @TContractState, class_hash: starknet::ClassHash,
+                ) -> felt252;
+            }
+
+            #[test]
+            fn test_cheat_applied_to_contract_is_visible_in_its_library_call() {
+                let checker_class_hash = *declare("CheatCallerAddressChecker").unwrap().contract_class().class_hash;
+
+                let proxy = declare("CheatCallerAddressLibraryCallChecker").unwrap().contract_class();
+                let (proxy_address, _) = proxy.deploy(@array![]).unwrap();
+                let proxy_dispatcher = ICheatCallerAddressLibraryCallCheckerDispatcher {
+                    contract_address: proxy_address,
+                };
+
+                let target_caller: ContractAddress = 789.try_into().unwrap();
+                start_cheat_caller_address(proxy_address, target_caller);
+
+                let caller = proxy_dispatcher.get_caller_address_via_library_call(checker_class_hash);
+                assert(caller == 789, 'Wrong caller address');
+
+                stop_cheat_caller_address(proxy_address);
+
+                let caller = proxy_dispatcher.get_caller_address_via_library_call(checker_class_hash);
+                assert(caller == test_address().into(), 'Caller did not reset');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatCallerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatCallerAddressLibraryCallChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_caller_address_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}

--- a/crates/forge/tests/integration/cheat_execution_info.rs
+++ b/crates/forge/tests/integration/cheat_execution_info.rs
@@ -711,3 +711,286 @@ fn cheat_transaction_hash_with_span() {
 
     assert_passed(&result);
 }
+
+/// Verify that `block_number`, `block_timestamp`, `sequencer_address` and `transaction_hash` cheats
+/// applied to `test_address()` are visible inside library calls made directly from test code.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn cheat_execution_info_direct_library_call_from_test() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait, test_address,
+                start_cheat_block_number, stop_cheat_block_number,
+                start_cheat_block_timestamp, stop_cheat_block_timestamp,
+                start_cheat_sequencer_address, stop_cheat_sequencer_address,
+                start_cheat_transaction_hash, stop_cheat_transaction_hash,
+            };
+
+            #[starknet::interface]
+            trait ICheatBlockNumberChecker<TContractState> {
+                fn get_block_number(ref self: TContractState) -> u64;
+            }
+
+            #[starknet::interface]
+            trait ICheatBlockTimestampChecker<TContractState> {
+                fn get_block_timestamp(ref self: TContractState) -> u64;
+            }
+
+            #[starknet::interface]
+            trait ICheatSequencerAddressChecker<TContractState> {
+                fn get_sequencer_address(ref self: TContractState) -> ContractAddress;
+            }
+
+            #[starknet::interface]
+            trait ICheatTxInfoChecker<TContractState> {
+                fn get_tx_hash(self: @TContractState) -> felt252;
+            }
+
+            #[test]
+            fn test_cheat_block_number_direct_library_call_from_test() {
+                let class_hash = *declare("CheatBlockNumberChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatBlockNumberCheckerLibraryDispatcher { class_hash };
+
+                let original = lib_dispatcher.get_block_number();
+
+                start_cheat_block_number(test_address(), 1234_u64);
+
+                let cheated = lib_dispatcher.get_block_number();
+                assert(cheated == 1234, 'Wrong block number');
+
+                stop_cheat_block_number(test_address());
+
+                let restored = lib_dispatcher.get_block_number();
+                assert(restored == original, 'Block number not restored');
+            }
+
+            #[test]
+            fn test_cheat_block_timestamp_direct_library_call_from_test() {
+                let class_hash = *declare("CheatBlockTimestampChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatBlockTimestampCheckerLibraryDispatcher { class_hash };
+
+                let original = lib_dispatcher.get_block_timestamp();
+
+                start_cheat_block_timestamp(test_address(), 9999_u64);
+
+                let cheated = lib_dispatcher.get_block_timestamp();
+                assert(cheated == 9999, 'Wrong block timestamp');
+
+                stop_cheat_block_timestamp(test_address());
+
+                let restored = lib_dispatcher.get_block_timestamp();
+                assert(restored == original, 'Block timestamp not restored');
+            }
+
+            #[test]
+            fn test_cheat_sequencer_address_direct_library_call_from_test() {
+                let class_hash = *declare("CheatSequencerAddressChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatSequencerAddressCheckerLibraryDispatcher { class_hash };
+
+                let original = lib_dispatcher.get_sequencer_address();
+
+                let target_sequencer: ContractAddress = 42.try_into().unwrap();
+                start_cheat_sequencer_address(test_address(), target_sequencer);
+
+                let cheated = lib_dispatcher.get_sequencer_address();
+                assert(cheated == target_sequencer, 'Wrong sequencer address');
+
+                stop_cheat_sequencer_address(test_address());
+
+                let restored = lib_dispatcher.get_sequencer_address();
+                assert(restored == original, 'Sequencer address not restored');
+            }
+
+            #[test]
+            fn test_cheat_transaction_hash_direct_library_call_from_test() {
+                let class_hash = *declare("CheatTxInfoChecker").unwrap().contract_class().class_hash;
+                let lib_dispatcher = ICheatTxInfoCheckerLibraryDispatcher { class_hash };
+
+                let original = lib_dispatcher.get_tx_hash();
+
+                start_cheat_transaction_hash(test_address(), 0xdeadbeef);
+
+                let cheated = lib_dispatcher.get_tx_hash();
+                assert(cheated == 0xdeadbeef, 'Wrong tx hash');
+
+                stop_cheat_transaction_hash(test_address());
+
+                let restored = lib_dispatcher.get_tx_hash();
+                assert(restored == original, 'Tx hash not restored');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatBlockNumberChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_block_number_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatBlockTimestampChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_block_timestamp_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatSequencerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_sequencer_address_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatTxInfoChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_tx_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}
+
+/// Verify that cheats applied to a contract address are visible when that contract internally
+/// makes library calls. Tests `block_number`, `block_timestamp`, `sequencer_address` and `tx_hash`.
+#[test]
+#[allow(clippy::too_many_lines)]
+fn cheat_execution_info_library_call_from_contract() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait, test_address,
+                start_cheat_block_number, stop_cheat_block_number,
+                start_cheat_block_timestamp, stop_cheat_block_timestamp,
+                start_cheat_sequencer_address, stop_cheat_sequencer_address,
+                start_cheat_transaction_hash, stop_cheat_transaction_hash,
+            };
+
+            #[starknet::interface]
+            trait ICheatExecutionInfoLibraryCallChecker<TContractState> {
+                fn get_block_number_via_library_call(
+                    ref self: TContractState, class_hash: starknet::ClassHash,
+                ) -> u64;
+                fn get_block_timestamp_via_library_call(
+                    ref self: TContractState, class_hash: starknet::ClassHash,
+                ) -> u64;
+                fn get_sequencer_address_via_library_call(
+                    ref self: TContractState, class_hash: starknet::ClassHash,
+                ) -> ContractAddress;
+                fn get_tx_hash_via_library_call(
+                    self: @TContractState, class_hash: starknet::ClassHash,
+                ) -> felt252;
+            }
+
+            fn deploy_proxy() -> (ICheatExecutionInfoLibraryCallCheckerDispatcher, ContractAddress) {
+                let proxy = declare("CheatExecutionInfoLibraryCallChecker").unwrap().contract_class();
+                let (proxy_address, _) = proxy.deploy(@array![]).unwrap();
+                (ICheatExecutionInfoLibraryCallCheckerDispatcher { contract_address: proxy_address }, proxy_address)
+            }
+
+            #[test]
+            fn test_cheat_block_number_library_call_from_contract() {
+                let block_number_class_hash = *declare("CheatBlockNumberChecker").unwrap().contract_class().class_hash;
+                let (proxy, proxy_address) = deploy_proxy();
+
+                let original = proxy.get_block_number_via_library_call(block_number_class_hash);
+
+                start_cheat_block_number(proxy_address, 5678_u64);
+
+                let cheated = proxy.get_block_number_via_library_call(block_number_class_hash);
+                assert(cheated == 5678, 'Wrong block number');
+
+                stop_cheat_block_number(proxy_address);
+
+                let restored = proxy.get_block_number_via_library_call(block_number_class_hash);
+                assert(restored == original, 'Block number not restored');
+            }
+
+            #[test]
+            fn test_cheat_block_timestamp_library_call_from_contract() {
+                let class_hash = *declare("CheatBlockTimestampChecker").unwrap().contract_class().class_hash;
+                let (proxy, proxy_address) = deploy_proxy();
+
+                let original = proxy.get_block_timestamp_via_library_call(class_hash);
+
+                start_cheat_block_timestamp(proxy_address, 7777_u64);
+
+                let cheated = proxy.get_block_timestamp_via_library_call(class_hash);
+                assert(cheated == 7777, 'Wrong block timestamp');
+
+                stop_cheat_block_timestamp(proxy_address);
+
+                let restored = proxy.get_block_timestamp_via_library_call(class_hash);
+                assert(restored == original, 'Block timestamp not restored');
+            }
+
+            #[test]
+            fn test_cheat_sequencer_address_library_call_from_contract() {
+                let class_hash = *declare("CheatSequencerAddressChecker").unwrap().contract_class().class_hash;
+                let (proxy, proxy_address) = deploy_proxy();
+
+                let original = proxy.get_sequencer_address_via_library_call(class_hash);
+
+                let target_sequencer: ContractAddress = 99.try_into().unwrap();
+                start_cheat_sequencer_address(proxy_address, target_sequencer);
+
+                let cheated = proxy.get_sequencer_address_via_library_call(class_hash);
+                assert(cheated == target_sequencer, 'Wrong sequencer address');
+
+                stop_cheat_sequencer_address(proxy_address);
+
+                let restored = proxy.get_sequencer_address_via_library_call(class_hash);
+                assert(restored == original, 'Sequencer address not restored');
+            }
+
+            #[test]
+            fn test_cheat_transaction_hash_library_call_from_contract() {
+                let class_hash = *declare("CheatTxInfoChecker").unwrap().contract_class().class_hash;
+                let (proxy, proxy_address) = deploy_proxy();
+
+                let original = proxy.get_tx_hash_via_library_call(class_hash);
+
+                start_cheat_transaction_hash(proxy_address, 0xcafebabe);
+
+                let cheated = proxy.get_tx_hash_via_library_call(class_hash);
+                assert(cheated == 0xcafebabe, 'Wrong tx hash');
+
+                stop_cheat_transaction_hash(proxy_address);
+
+                let restored = proxy.get_tx_hash_via_library_call(class_hash);
+                assert(restored == original, 'Tx hash not restored');
+            }
+            "#
+        ),
+        Contract::from_code_path(
+            "CheatBlockNumberChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_block_number_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatBlockTimestampChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_block_timestamp_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatSequencerAddressChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_sequencer_address_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatTxInfoChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_tx_info_checker.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "CheatExecutionInfoLibraryCallChecker".to_string(),
+            Path::new("tests/data/contracts/cheat_tx_info_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::SierraGas);
+
+    assert_passed(&result);
+}


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3880

## Introduced changes

<!-- A brief description of the changes -->

- Use `storage_address` instead of `caller_address` when getting cheated data for library call in tests
- Fix helper test function `library_call_contract` to use default caller address
