### PR TITLE
Skip config pass for tests filtered out by name

### DIFF
--- a/crates/forge-runner/src/running/with_config.rs
+++ b/crates/forge-runner/src/running/with_config.rs
@@ -4,6 +4,7 @@ use crate::{
         TestDetails,
         raw::TestTargetRaw,
         with_config::{TestCaseWithConfig, TestTargetWithConfig},
+        with_config_resolved::sanitize_test_case_name,
     },
     running::config_run::run_config_pass,
 };
@@ -21,6 +22,7 @@ use universal_sierra_compiler_api::compile_raw_sierra_at_path;
 pub fn test_target_with_config(
     test_target_raw: TestTargetRaw,
     tracked_resource: &ForgeTrackedResource,
+    name_pre_filter: impl Fn(&str) -> bool + Sync,
 ) -> Result<TestTargetWithConfig> {
     macro_rules! by_id {
         ($field:ident) => {{
@@ -50,8 +52,16 @@ pub fn test_target_with_config(
         .and_then(|info| info.executables.get("snforge_internal_test_executable"))
         .unwrap_or(&default_executables);
 
+    let total_executables = executables.len();
+
     let test_cases = executables
         .par_iter()
+        .filter(|case| {
+            case.debug_name
+                .as_deref()
+                .map(|name| name_pre_filter(&sanitize_test_case_name(name)))
+                .unwrap_or(true)
+        })
         .map(|case| -> Result<TestCaseWithConfig> {
             let func = funcs[&case.id];
 
@@ -65,7 +75,14 @@ pub fn test_target_with_config(
                 test_details,
             })
         })
-        .collect::<Result<_>>()?;
+        .collect::<Result<Vec<TestCaseWithConfig>>>()?;
+
+    tracing::debug!(
+        total_executables,
+        config_pass_ran = test_cases.len(),
+        config_pass_skipped = total_executables - test_cases.len(),
+        "config pass pre-filtering complete"
+    );
 
     Ok(TestTargetWithConfig {
         tests_location: test_target_raw.tests_location,

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -155,6 +155,7 @@ async fn test_package_with_config_resolved(
         let test_target = test_target_with_config(
             test_target,
             &forge_config.test_runner_config.tracked_resource,
+            |name| tests_filter.passes_name_pre_filter(name),
         )?;
 
         let test_target =

--- a/crates/forge/src/test_filter.rs
+++ b/crates/forge/src/test_filter.rs
@@ -85,6 +85,28 @@ impl TestsFilter {
         }
     }
 
+    pub fn passes_name_pre_filter(&self, name: &str) -> bool {
+        match &self.name_filter {
+            NameFilter::All => {}
+            NameFilter::Match(filter) => {
+                if !name.contains(filter.as_str()) {
+                    return false;
+                }
+            }
+            NameFilter::ExactMatch(exact) => {
+                if name != exact.as_str() {
+                    return false;
+                }
+            }
+        }
+        if !self.skip_filter.is_empty()
+            && self.skip_filter.iter().any(|s| name.contains(s.as_str()))
+        {
+            return false;
+        }
+        true
+    }
+
     pub(crate) fn filter_tests(
         &self,
         test_cases: &mut Vec<TestCaseWithResolvedConfig>,


### PR DESCRIPTION
Closes #3899

<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Pre-filter test cases by name and skip patterns before running the expensive `run_config_pass` VM execution, avoiding unnecessary work when a name filter or `--skip` flag is provided.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
