### PR TITLE
Parallelize config passes with test execution across workspace packages

### DIFF
--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -51,7 +51,7 @@ mod execution;
 mod hints;
 mod setup;
 mod syscall_handler;
-pub mod with_config;
+pub mod target;
 
 use crate::debugging::build_debugging_trace;
 pub use hints::hints_to_params;

--- a/crates/forge-runner/src/running/target.rs
+++ b/crates/forge-runner/src/running/target.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, sync::Arc};
 use universal_sierra_compiler_api::compile_raw_sierra_at_path;
 
 #[tracing::instrument(skip_all, level = "debug")]
-pub fn test_target_with_config(
+pub fn prepare_test_target(
     test_target_raw: TestTargetRaw,
     tracked_resource: &ForgeTrackedResource,
 ) -> Result<TestTargetWithConfig> {

--- a/crates/forge/src/block_number_map.rs
+++ b/crates/forge/src/block_number_map.rs
@@ -7,51 +7,51 @@ use starknet_rust::{
 };
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
+use std::sync::Mutex;
 use tokio::runtime::Handle;
 use url::Url;
 
+/// Caches block numbers fetched from RPC nodes, shared across concurrent config passes.
 #[derive(Default)]
 pub struct BlockNumberMap {
-    url_to_latest_block_number: HashMap<Url, BlockNumber>,
-    url_and_hash_to_block_number: HashMap<(Url, Felt), BlockNumber>,
+    url_to_latest_block_number: Mutex<HashMap<Url, BlockNumber>>,
+    url_and_hash_to_block_number: Mutex<HashMap<(Url, Felt), BlockNumber>>,
 }
 
 impl BlockNumberMap {
-    pub async fn get_latest_block_number(&mut self, url: Url) -> Result<BlockNumber> {
-        let block_number = if let Some(block_number) = self.url_to_latest_block_number.get(&url) {
-            *block_number
-        } else {
-            let latest_block_number = fetch_latest_block_number(url.clone()).await?;
+    pub async fn get_latest_block_number(&self, url: Url) -> Result<BlockNumber> {
+        // Release lock before awaiting.
+        {
+            let map = self.url_to_latest_block_number.lock().unwrap();
+            if let Some(&block_number) = map.get(&url) {
+                return Ok(block_number);
+            }
+        }
 
-            self.url_to_latest_block_number
-                .insert(url, latest_block_number);
+        let fetched = fetch_latest_block_number(url.clone()).await?;
 
-            latest_block_number
-        };
-
-        Ok(block_number)
+        // or_insert avoids overwriting if a concurrent task raced us.
+        let mut map = self.url_to_latest_block_number.lock().unwrap();
+        Ok(*map.entry(url).or_insert(fetched))
     }
 
-    pub async fn get_block_number_for_hash(&mut self, url: Url, hash: Felt) -> Result<BlockNumber> {
-        let block_number = if let Some(block_number) =
-            self.url_and_hash_to_block_number.get(&(url.clone(), hash))
+    pub async fn get_block_number_for_hash(&self, url: Url, hash: Felt) -> Result<BlockNumber> {
         {
-            *block_number
-        } else {
-            let block_number = fetch_block_number_for_hash(url.clone(), hash).await?;
+            let map = self.url_and_hash_to_block_number.lock().unwrap();
+            if let Some(&block_number) = map.get(&(url.clone(), hash)) {
+                return Ok(block_number);
+            }
+        }
 
-            self.url_and_hash_to_block_number
-                .insert((url, hash), block_number);
+        let fetched = fetch_block_number_for_hash(url.clone(), hash).await?;
 
-            block_number
-        };
-
-        Ok(block_number)
+        let mut map = self.url_and_hash_to_block_number.lock().unwrap();
+        Ok(*map.entry((url, hash)).or_insert(fetched))
     }
 
     #[must_use]
-    pub fn get_url_to_latest_block_number(&self) -> &HashMap<Url, BlockNumber> {
-        &self.url_to_latest_block_number
+    pub fn get_url_to_latest_block_number(&self) -> HashMap<Url, BlockNumber> {
+        self.url_to_latest_block_number.lock().unwrap().clone()
     }
 }
 

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -67,7 +67,7 @@ impl PackageTestResult {
 }
 
 pub struct RunForPackageArgs {
-    config_handles: Vec<JoinHandle<Result<TestTargetWithConfig>>>,
+    pub config_handles: Vec<JoinHandle<Result<TestTargetWithConfig>>>,
     pub tests_filter: TestsFilter,
     pub forge_config: Arc<ForgeConfig>,
     pub fork_targets: Vec<ForkTarget>,

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -30,7 +30,7 @@ use forge_runner::{
         with_config_resolved::{TestCaseWithResolvedConfig, sanitize_test_case_name},
     },
     partition::PartitionConfig,
-    running::with_config::test_target_with_config,
+    running::target::prepare_test_target,
     scarb::load_test_artifacts,
     test_case_summary::AnyTestCaseSummary,
     test_target_summary::TestTargetSummary,
@@ -67,7 +67,7 @@ impl PackageTestResult {
 }
 
 pub struct RunForPackageArgs {
-    pub config_handles: Vec<JoinHandle<Result<TestTargetWithConfig>>>,
+    pub target_handles: Vec<JoinHandle<Result<TestTargetWithConfig>>>,
     pub tests_filter: TestsFilter,
     pub forge_config: Arc<ForgeConfig>,
     pub fork_targets: Vec<ForkTarget>,
@@ -138,13 +138,13 @@ impl RunForPackageArgs {
 
         let tracked_resource = forge_config.test_runner_config.tracked_resource;
 
-        let config_handles = raw_test_targets
+        let target_handles = raw_test_targets
             .into_iter()
-            .map(|t| spawn_config_pass(t, tracked_resource))
+            .map(|t| spawn_prepare_test_target(t, tracked_resource))
             .collect();
 
         Ok(RunForPackageArgs {
-            config_handles,
+            target_handles,
             forge_config,
             tests_filter,
             fork_targets: forge_config_from_scarb.fork,
@@ -154,11 +154,11 @@ impl RunForPackageArgs {
     }
 }
 
-fn spawn_config_pass(
+fn spawn_prepare_test_target(
     target: TestTargetRaw,
     tracked_resource: ForgeTrackedResource,
 ) -> JoinHandle<Result<TestTargetWithConfig>> {
-    tokio::task::spawn_blocking(move || test_target_with_config(target, &tracked_resource))
+    tokio::task::spawn_blocking(move || prepare_test_target(target, &tracked_resource))
 }
 
 fn sum_test_cases_from_test_target(
@@ -185,7 +185,7 @@ fn sum_test_cases_from_test_target(
 #[tracing::instrument(skip_all, level = "debug")]
 pub async fn run_for_package(
     RunForPackageArgs {
-        config_handles,
+        target_handles,
         forge_config,
         tests_filter,
         fork_targets,
@@ -201,11 +201,16 @@ pub async fn run_for_package(
     let mut all_tests = 0;
     let mut not_filtered_total = 0;
 
-    for handle in config_handles {
-        let with_config = handle.await??;
+    for handle in target_handles {
+        let target_with_config = handle.await??;
 
-        let mut resolved =
-            resolve_config(with_config, &fork_targets, block_number_map, &tests_filter).await?;
+        let mut resolved = resolve_config(
+            target_with_config,
+            &fork_targets,
+            block_number_map,
+            &tests_filter,
+        )
+        .await?;
 
         let all = sum_test_cases_from_test_target(
             &resolved.test_cases,

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -23,12 +23,11 @@ use camino::{Utf8Path, Utf8PathBuf};
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use console::Style;
 use forge_runner::{
-    forge_config::ForgeConfig,
+    forge_config::{ForgeConfig, ForgeTrackedResource},
     package_tests::{
         raw::TestTargetRaw,
-        with_config_resolved::{
-            TestCaseWithResolvedConfig, TestTargetWithResolvedConfig, sanitize_test_case_name,
-        },
+        with_config::TestTargetWithConfig,
+        with_config_resolved::{TestCaseWithResolvedConfig, sanitize_test_case_name},
     },
     partition::PartitionConfig,
     running::with_config::test_target_with_config,
@@ -40,6 +39,7 @@ use foundry_ui::{UI, components::labeled::LabeledMessage};
 use scarb_api::{CompilationOpts, get_contracts_artifacts_and_source_sierra_paths};
 use scarb_metadata::{Metadata, PackageMetadata};
 use std::sync::Arc;
+use tokio::task::JoinHandle;
 
 pub struct PackageTestResult {
     summaries: Vec<TestTargetSummary>,
@@ -67,11 +67,12 @@ impl PackageTestResult {
 }
 
 pub struct RunForPackageArgs {
-    pub test_targets: Vec<TestTargetRaw>,
+    config_handles: Vec<JoinHandle<Result<TestTargetWithConfig>>>,
     pub tests_filter: TestsFilter,
     pub forge_config: Arc<ForgeConfig>,
     pub fork_targets: Vec<ForkTarget>,
     pub package_name: String,
+    pub package_root: Utf8PathBuf,
 }
 
 impl RunForPackageArgs {
@@ -85,7 +86,7 @@ impl RunForPackageArgs {
         partitioning_config: PartitionConfig,
         ui: &UI,
     ) -> Result<RunForPackageArgs> {
-        let raw_test_targets = load_test_artifacts(artifacts_dir, &package)?;
+        let mut raw_test_targets = load_test_artifacts(artifacts_dir, &package)?;
 
         let contracts = get_contracts_artifacts_and_source_sierra_paths(
             artifacts_dir,
@@ -120,7 +121,7 @@ impl RunForPackageArgs {
             args.trace_args.clone(),
         ));
 
-        let test_filter = TestsFilter::from_flags(
+        let tests_filter = TestsFilter::from_flags(
             args.test_filter.clone(),
             args.exact,
             args.skip.clone(),
@@ -131,49 +132,33 @@ impl RunForPackageArgs {
             partitioning_config,
         );
 
+        if args.deterministic_output {
+            raw_test_targets.sort_by_key(|t| t.tests_location);
+        }
+
+        let tracked_resource = forge_config.test_runner_config.tracked_resource;
+
+        let config_handles = raw_test_targets
+            .into_iter()
+            .map(|t| spawn_config_pass(t, tracked_resource))
+            .collect();
+
         Ok(RunForPackageArgs {
-            test_targets: raw_test_targets,
+            config_handles,
             forge_config,
-            tests_filter: test_filter,
+            tests_filter,
             fork_targets: forge_config_from_scarb.fork,
-            package_name: package.name,
+            package_name: package.name.clone(),
+            package_root: package.root,
         })
     }
 }
 
-#[tracing::instrument(skip_all, level = "debug")]
-async fn test_package_with_config_resolved(
-    test_targets: Vec<TestTargetRaw>,
-    fork_targets: &[ForkTarget],
-    block_number_map: &mut BlockNumberMap,
-    forge_config: &ForgeConfig,
-    tests_filter: &TestsFilter,
-) -> Result<Vec<TestTargetWithResolvedConfig>> {
-    let mut test_targets_with_resolved_config = Vec::with_capacity(test_targets.len());
-
-    for test_target in test_targets {
-        let test_target = test_target_with_config(
-            test_target,
-            &forge_config.test_runner_config.tracked_resource,
-        )?;
-
-        let test_target =
-            resolve_config(test_target, fork_targets, block_number_map, tests_filter).await?;
-
-        test_targets_with_resolved_config.push(test_target);
-    }
-
-    Ok(test_targets_with_resolved_config)
-}
-
-fn sum_test_cases_from_package(
-    test_targets: &[TestTargetWithResolvedConfig],
-    partitioning_config: &PartitionConfig,
-) -> usize {
-    test_targets
-        .iter()
-        .map(|tt| sum_test_cases_from_test_target(&tt.test_cases, partitioning_config))
-        .sum()
+fn spawn_config_pass(
+    target: TestTargetRaw,
+    tracked_resource: ForgeTrackedResource,
+) -> JoinHandle<Result<TestTargetWithConfig>> {
+    tokio::task::spawn_blocking(move || test_target_with_config(target, &tracked_resource))
 }
 
 fn sum_test_cases_from_test_target(
@@ -200,61 +185,66 @@ fn sum_test_cases_from_test_target(
 #[tracing::instrument(skip_all, level = "debug")]
 pub async fn run_for_package(
     RunForPackageArgs {
-        test_targets,
+        config_handles,
         forge_config,
         tests_filter,
         fork_targets,
         package_name,
+        package_root: _,
     }: RunForPackageArgs,
-    block_number_map: &mut BlockNumberMap,
+    block_number_map: &BlockNumberMap,
     ui: Arc<UI>,
     exit_first_channel: &mut ExitFirstChannel,
-    deterministic_output: bool,
 ) -> Result<PackageTestResult> {
-    let mut test_targets = test_package_with_config_resolved(
-        test_targets,
-        &fork_targets,
-        block_number_map,
-        &forge_config,
-        &tests_filter,
-    )
-    .await?;
-    let all_tests = sum_test_cases_from_package(&test_targets, &tests_filter.partitioning_config);
+    // Resolve all targets first so the collected count includes #[ignore] filtering.
+    let mut resolved_targets = vec![];
+    let mut all_tests = 0;
+    let mut not_filtered_total = 0;
 
-    for test_target in &mut test_targets {
-        tests_filter.filter_tests(&mut test_target.test_cases)?;
+    for handle in config_handles {
+        let with_config = handle.await??;
+
+        let mut resolved =
+            resolve_config(with_config, &fork_targets, block_number_map, &tests_filter).await?;
+
+        let all = sum_test_cases_from_test_target(
+            &resolved.test_cases,
+            &tests_filter.partitioning_config,
+        );
+        tests_filter.filter_tests(&mut resolved.test_cases)?;
+        let not_filtered = sum_test_cases_from_test_target(
+            &resolved.test_cases,
+            &tests_filter.partitioning_config,
+        );
+        all_tests += all;
+        not_filtered_total += not_filtered;
+
+        resolved_targets.push(resolved);
     }
 
-    warn_if_incompatible_rpc_version(&test_targets, ui.clone()).await?;
-
-    let not_filtered =
-        sum_test_cases_from_package(&test_targets, &tests_filter.partitioning_config);
     ui.println(&CollectedTestsCountMessage {
-        tests_num: not_filtered,
+        tests_num: not_filtered_total,
         package_name: package_name.clone(),
     });
 
+    warn_if_incompatible_rpc_version(&resolved_targets, ui.clone()).await?;
+
     let mut summaries = vec![];
 
-    if deterministic_output {
-        test_targets.sort_by_key(|t| t.tests_location);
-    }
-
-    for test_target in test_targets {
-        let ui = ui.clone();
+    for resolved in resolved_targets {
         ui.println(&TestsRunMessage::new(
-            test_target.tests_location,
+            resolved.tests_location,
             sum_test_cases_from_test_target(
-                &test_target.test_cases,
+                &resolved.test_cases,
                 &tests_filter.partitioning_config,
             ),
         ));
 
         let summary = run_for_test_target(
-            test_target,
+            resolved,
             forge_config.clone(),
             &tests_filter,
-            ui,
+            ui.clone(),
             exit_first_channel,
         )
         .await?;
@@ -267,7 +257,7 @@ pub async fn run_for_package(
     let filtered_count = if let NameFilter::ExactMatch(_) = tests_filter.name_filter {
         None
     } else {
-        Some(all_tests - not_filtered)
+        Some(all_tests - not_filtered_total)
     };
 
     ui.println(&TestsSummaryMessage::new(&summaries, filtered_count));

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -227,12 +227,12 @@ pub async fn run_for_package(
         resolved_targets.push(resolved);
     }
 
+    warn_if_incompatible_rpc_version(&resolved_targets, ui.clone()).await?;
+
     ui.println(&CollectedTestsCountMessage {
         tests_num: not_filtered_total,
         package_name: package_name.clone(),
     });
-
-    warn_if_incompatible_rpc_version(&resolved_targets, ui.clone()).await?;
 
     let mut summaries = vec![];
 

--- a/crates/forge/src/run_tests/resolve_config.rs
+++ b/crates/forge/src/run_tests/resolve_config.rs
@@ -232,7 +232,7 @@ mod tests {
                     "https://not_taken.com",
                     BlockId::BlockNumber(120)
                 )],
-                &mut BlockNumberMap::default(),
+                &BlockNumberMap::default(),
                 &tests_filter,
             )
             .await
@@ -265,7 +265,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &[],
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -306,7 +306,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -351,7 +351,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -408,7 +408,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -477,7 +477,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -535,7 +535,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -585,7 +585,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &[],
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -634,7 +634,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await
@@ -679,7 +679,7 @@ mod tests {
         let resolved = resolve_config(
             test_target,
             &fork_targets,
-            &mut BlockNumberMap::default(),
+            &BlockNumberMap::default(),
             &tests_filter,
         )
         .await

--- a/crates/forge/src/run_tests/resolve_config.rs
+++ b/crates/forge/src/run_tests/resolve_config.rs
@@ -23,7 +23,7 @@ use starknet_api::block::BlockNumber;
 pub async fn resolve_config(
     test_target: TestTargetWithConfig,
     fork_targets: &[ForkTarget],
-    block_number_map: &mut BlockNumberMap,
+    block_number_map: &BlockNumberMap,
     tests_filter: &TestsFilter,
 ) -> Result<TestTargetWithResolvedConfig> {
     let mut test_cases = Vec::with_capacity(test_target.test_cases.len());
@@ -64,7 +64,7 @@ pub async fn resolve_config(
 
 async fn resolve_fork_config(
     fork_config: Option<RawForkConfig>,
-    block_number_map: &mut BlockNumberMap,
+    block_number_map: &BlockNumberMap,
     fork_targets: &[ForkTarget],
 ) -> Result<Option<ResolvedForkConfig>> {
     let Some(fc) = fork_config else {

--- a/crates/forge/src/run_tests/resolve_config.rs
+++ b/crates/forge/src/run_tests/resolve_config.rs
@@ -262,14 +262,9 @@ mod tests {
             PartitionConfig::default(),
         );
 
-        let resolved = resolve_config(
-            test_target,
-            &[],
-            &BlockNumberMap::default(),
-            &tests_filter,
-        )
-        .await
-        .unwrap();
+        let resolved = resolve_config(test_target, &[], &BlockNumberMap::default(), &tests_filter)
+            .await
+            .unwrap();
 
         assert_eq!(resolved.test_cases.len(), 1);
         assert!(resolved.test_cases[0].config.ignored);
@@ -582,14 +577,9 @@ mod tests {
             PartitionConfig::default(),
         );
 
-        let resolved = resolve_config(
-            test_target,
-            &[],
-            &BlockNumberMap::default(),
-            &tests_filter,
-        )
-        .await
-        .unwrap();
+        let resolved = resolve_config(test_target, &[], &BlockNumberMap::default(), &tests_filter)
+            .await
+            .unwrap();
 
         assert_eq!(resolved.test_cases.len(), 1);
 

--- a/crates/forge/src/run_tests/workspace.rs
+++ b/crates/forge/src/run_tests/workspace.rs
@@ -96,7 +96,7 @@ pub async fn execute_workspace(
         }
     }
 
-    let mut block_number_map = BlockNumberMap::default();
+    let block_number_map = BlockNumberMap::default();
     let mut all_tests = vec![];
     let mut total_filtered_count = Some(0);
     let mut exit_first_channel = ExitFirstChannel::new();
@@ -107,12 +107,14 @@ pub async fn execute_workspace(
 
     let partitioning_config = get_partitioning_config(args, &ui, &packages, &artifacts_dir_path)?;
 
-    for package in packages {
+    // Spawn config passes for all packages before running any tests so that
+    // compilation overlaps with test execution across packages.
+    let mut all_package_args = Vec::with_capacity(packages.len());
+    for pkg in packages {
         let cwd = env::current_dir()?;
-        env::set_current_dir(&package.root)?;
-
-        let args = RunForPackageArgs::build(
-            package,
+        env::set_current_dir(&pkg.root)?;
+        let pkg_args = RunForPackageArgs::build(
+            pkg,
             scarb_metadata,
             args,
             &cache_dir,
@@ -120,21 +122,25 @@ pub async fn execute_workspace(
             partitioning_config.clone(),
             &ui,
         )?;
+        env::set_current_dir(&cwd)?;
+        all_package_args.push(pkg_args);
+    }
+
+    for pkg_args in all_package_args {
+        let cwd = env::current_dir()?;
+        env::set_current_dir(&pkg_args.package_root)?;
 
         let result = run_for_package(
-            args,
-            &mut block_number_map,
+            pkg_args,
+            &block_number_map,
             ui.clone(),
             &mut exit_first_channel,
-            deterministic_output,
         )
         .await?;
 
         let filtered = result.filtered();
         all_tests.extend(result.summaries());
-
         total_filtered_count = calculate_total_filtered_count(total_filtered_count, filtered);
-        // Restore the original working directory.
         env::set_current_dir(&cwd)?;
     }
 
@@ -146,10 +152,9 @@ pub async fn execute_workspace(
 
     FailedTestsCache::new(&cache_dir).save_failed_tests(&all_failed_tests)?;
 
-    if !block_number_map.get_url_to_latest_block_number().is_empty() {
-        ui.println(&LatestBlocksNumbersMessage::new(
-            block_number_map.get_url_to_latest_block_number().clone(),
-        ));
+    let url_to_block_number = block_number_map.get_url_to_latest_block_number();
+    if !url_to_block_number.is_empty() {
+        ui.println(&LatestBlocksNumbersMessage::new(url_to_block_number));
     }
 
     ui.println(&TestsFailureSummaryMessage::new(&all_failed_tests));

--- a/crates/forge/src/test_filter.rs
+++ b/crates/forge/src/test_filter.rs
@@ -85,6 +85,21 @@ impl TestsFilter {
         }
     }
 
+    fn is_in_partition(&self, sanitized_name: &str) -> bool {
+        match &self.partitioning_config {
+            PartitionConfig::Disabled => true,
+            PartitionConfig::Enabled {
+                partition,
+                partition_map,
+            } => {
+                let idx = partition_map
+                    .get_assigned_index(sanitized_name)
+                    .expect("Partition map must contain all test cases");
+                idx == partition.index()
+            }
+        }
+    }
+
     pub(crate) fn filter_tests(
         &self,
         test_cases: &mut Vec<TestCaseWithResolvedConfig>,
@@ -132,22 +147,9 @@ impl TestCaseFilter for TestsFilter {
     {
         // Order of filter checks matters, because we do not want to display a test as ignored if
         // it was excluded due to partitioning.
-        match &self.partitioning_config {
-            PartitionConfig::Enabled {
-                partition,
-                partition_map,
-            } => {
-                let sanitized_test_case_name = sanitize_test_case_name(&test_case.name);
-                let test_assigned_index = partition_map
-                    .get_assigned_index(&sanitized_test_case_name)
-                    .expect("Partition map must contain all test cases");
-                let partition_index = partition.index();
-
-                if test_assigned_index != partition_index {
-                    return FilterResult::Excluded(ExcludeReason::ExcludedFromPartition);
-                }
-            }
-            PartitionConfig::Disabled => {}
+        let sanitized_test_case_name = sanitize_test_case_name(&test_case.name);
+        if !self.is_in_partition(&sanitized_test_case_name) {
+            return FilterResult::Excluded(ExcludeReason::ExcludedFromPartition);
         }
 
         let case_ignored = test_case.config.is_ignored();

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -75,6 +75,7 @@ fn fork_simple_decorator() {
     assert_passed(&result);
 }
 
+#[allow(clippy::too_many_lines)]
 #[test]
 fn fork_aliased_decorator() {
     let test = test_case!(indoc!(

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -27,6 +27,7 @@ use forge_runner::forge_config::ForgeTrackedResource;
 use forge_runner::forge_config::{
     ExecutionDataToSave, ForgeConfig, OutputConfig, TestRunnerConfig,
 };
+use forge_runner::running::with_config::test_target_with_config;
 use forge_runner::scarb::load_test_artifacts;
 use scarb_api::ScarbCommand;
 use scarb_api::metadata::metadata_for_dir;
@@ -132,54 +133,65 @@ fn fork_aliased_decorator() {
 
     let ui = Arc::new(UI::default());
     let result = rt
-        .block_on(run_for_package(
-            RunForPackageArgs {
-                test_targets: raw_test_targets,
-                package_name: "test_package".to_string(),
-                tests_filter: TestsFilter::from_flags(
-                    None,
-                    false,
-                    Vec::new(),
-                    false,
-                    false,
-                    false,
-                    FailedTestsCache::default(),
-                    PartitionConfig::default(),
-                ),
-                forge_config: Arc::new(ForgeConfig {
-                    test_runner_config: Arc::new(TestRunnerConfig {
-                        exit_first: false,
-                        deterministic_output: false,
-                        fuzzer_runs: NonZeroU32::new(256).unwrap(),
-                        fuzzer_seed: 12345,
-                        max_n_steps: None,
-                        is_vm_trace_needed: false,
-                        cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                            .unwrap()
-                            .join(CACHE_DIR),
-                        contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap())
-                            .unwrap(),
-                        tracked_resource: ForgeTrackedResource::CairoSteps,
-                        environment_variables: test.env().clone(),
+        .block_on(async {
+            let config_handles = raw_test_targets
+                .into_iter()
+                .map(|t| {
+                    tokio::task::spawn_blocking(move || {
+                        test_target_with_config(t, &ForgeTrackedResource::CairoSteps)
+                    })
+                })
+                .collect();
+            run_for_package(
+                RunForPackageArgs {
+                    config_handles,
+                    package_name: "test_package".to_string(),
+                    package_root: Utf8PathBuf::default(),
+                    tests_filter: TestsFilter::from_flags(
+                        None,
+                        false,
+                        Vec::new(),
+                        false,
+                        false,
+                        false,
+                        FailedTestsCache::default(),
+                        PartitionConfig::default(),
+                    ),
+                    forge_config: Arc::new(ForgeConfig {
+                        test_runner_config: Arc::new(TestRunnerConfig {
+                            exit_first: false,
+                            deterministic_output: false,
+                            fuzzer_runs: NonZeroU32::new(256).unwrap(),
+                            fuzzer_seed: 12345,
+                            max_n_steps: None,
+                            is_vm_trace_needed: false,
+                            cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+                                .unwrap()
+                                .join(CACHE_DIR),
+                            contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap())
+                                .unwrap(),
+                            tracked_resource: ForgeTrackedResource::CairoSteps,
+                            environment_variables: test.env().clone(),
+                        }),
+                        output_config: Arc::new(OutputConfig {
+                            detailed_resources: false,
+                            execution_data_to_save: ExecutionDataToSave::default(),
+                            trace_args: TraceArgs::default(),
+                            gas_report: false,
+                        }),
                     }),
-                    output_config: Arc::new(OutputConfig {
-                        detailed_resources: false,
-                        execution_data_to_save: ExecutionDataToSave::default(),
-                        trace_args: TraceArgs::default(),
-                        gas_report: false,
-                    }),
-                }),
-                fork_targets: vec![ForkTarget {
-                    name: "FORK_NAME_FROM_SCARB_TOML".to_string(),
-                    url: node_rpc_url().as_str().parse().unwrap(),
-                    block_id: BlockId::BlockTag,
-                }],
-            },
-            &mut BlockNumberMap::default(),
-            ui,
-            &mut ExitFirstChannel::default(),
-            false,
-        ))
+                    fork_targets: vec![ForkTarget {
+                        name: "FORK_NAME_FROM_SCARB_TOML".to_string(),
+                        url: node_rpc_url().as_str().parse().unwrap(),
+                        block_id: BlockId::BlockTag,
+                    }],
+                },
+                &BlockNumberMap::default(),
+                ui,
+                &mut ExitFirstChannel::default(),
+            )
+            .await
+        })
         .expect("Runner fail")
         .summaries();
 
@@ -226,54 +238,65 @@ fn fork_aliased_decorator_overrding() {
 
     let ui = Arc::new(UI::default());
     let result = rt
-        .block_on(run_for_package(
-            RunForPackageArgs {
-                test_targets: raw_test_targets,
-                package_name: "test_package".to_string(),
-                tests_filter: TestsFilter::from_flags(
-                    None,
-                    false,
-                    Vec::new(),
-                    false,
-                    false,
-                    false,
-                    FailedTestsCache::default(),
-                    PartitionConfig::default(),
-                ),
-                forge_config: Arc::new(ForgeConfig {
-                    test_runner_config: Arc::new(TestRunnerConfig {
-                        exit_first: false,
-                        deterministic_output: false,
-                        fuzzer_runs: NonZeroU32::new(256).unwrap(),
-                        fuzzer_seed: 12345,
-                        max_n_steps: None,
-                        is_vm_trace_needed: false,
-                        cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                            .unwrap()
-                            .join(CACHE_DIR),
-                        contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap())
-                            .unwrap(),
-                        tracked_resource: ForgeTrackedResource::CairoSteps,
-                        environment_variables: test.env().clone(),
+        .block_on(async {
+            let config_handles = raw_test_targets
+                .into_iter()
+                .map(|t| {
+                    tokio::task::spawn_blocking(move || {
+                        test_target_with_config(t, &ForgeTrackedResource::CairoSteps)
+                    })
+                })
+                .collect();
+            run_for_package(
+                RunForPackageArgs {
+                    config_handles,
+                    package_name: "test_package".to_string(),
+                    package_root: Utf8PathBuf::default(),
+                    tests_filter: TestsFilter::from_flags(
+                        None,
+                        false,
+                        Vec::new(),
+                        false,
+                        false,
+                        false,
+                        FailedTestsCache::default(),
+                        PartitionConfig::default(),
+                    ),
+                    forge_config: Arc::new(ForgeConfig {
+                        test_runner_config: Arc::new(TestRunnerConfig {
+                            exit_first: false,
+                            deterministic_output: false,
+                            fuzzer_runs: NonZeroU32::new(256).unwrap(),
+                            fuzzer_seed: 12345,
+                            max_n_steps: None,
+                            is_vm_trace_needed: false,
+                            cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+                                .unwrap()
+                                .join(CACHE_DIR),
+                            contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap())
+                                .unwrap(),
+                            tracked_resource: ForgeTrackedResource::CairoSteps,
+                            environment_variables: test.env().clone(),
+                        }),
+                        output_config: Arc::new(OutputConfig {
+                            detailed_resources: false,
+                            execution_data_to_save: ExecutionDataToSave::default(),
+                            trace_args: TraceArgs::default(),
+                            gas_report: false,
+                        }),
                     }),
-                    output_config: Arc::new(OutputConfig {
-                        detailed_resources: false,
-                        execution_data_to_save: ExecutionDataToSave::default(),
-                        trace_args: TraceArgs::default(),
-                        gas_report: false,
-                    }),
-                }),
-                fork_targets: vec![ForkTarget {
-                    name: "FORK_NAME_FROM_SCARB_TOML".to_string(),
-                    url: node_rpc_url().as_str().parse().unwrap(),
-                    block_id: BlockId::BlockNumber(12_341_234),
-                }],
-            },
-            &mut BlockNumberMap::default(),
-            ui,
-            &mut ExitFirstChannel::default(),
-            false,
-        ))
+                    fork_targets: vec![ForkTarget {
+                        name: "FORK_NAME_FROM_SCARB_TOML".to_string(),
+                        url: node_rpc_url().as_str().parse().unwrap(),
+                        block_id: BlockId::BlockNumber(12_341_234),
+                    }],
+                },
+                &BlockNumberMap::default(),
+                ui,
+                &mut ExitFirstChannel::default(),
+            )
+            .await
+        })
         .expect("Runner fail")
         .summaries();
 

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -27,7 +27,7 @@ use forge_runner::forge_config::ForgeTrackedResource;
 use forge_runner::forge_config::{
     ExecutionDataToSave, ForgeConfig, OutputConfig, TestRunnerConfig,
 };
-use forge_runner::running::with_config::test_target_with_config;
+use forge_runner::running::target::prepare_test_target;
 use forge_runner::scarb::load_test_artifacts;
 use scarb_api::ScarbCommand;
 use scarb_api::metadata::metadata_for_dir;
@@ -75,7 +75,7 @@ fn fork_simple_decorator() {
     assert_passed(&result);
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 #[test]
 fn fork_aliased_decorator() {
     let test = test_case!(indoc!(
@@ -135,17 +135,17 @@ fn fork_aliased_decorator() {
     let ui = Arc::new(UI::default());
     let result = rt
         .block_on(async {
-            let config_handles = raw_test_targets
+            let target_handles = raw_test_targets
                 .into_iter()
                 .map(|t| {
                     tokio::task::spawn_blocking(move || {
-                        test_target_with_config(t, &ForgeTrackedResource::CairoSteps)
+                        prepare_test_target(t, &ForgeTrackedResource::CairoSteps)
                     })
                 })
                 .collect();
             run_for_package(
                 RunForPackageArgs {
-                    config_handles,
+                    target_handles,
                     package_name: "test_package".to_string(),
                     package_root: Utf8PathBuf::default(),
                     tests_filter: TestsFilter::from_flags(
@@ -240,17 +240,17 @@ fn fork_aliased_decorator_overrding() {
     let ui = Arc::new(UI::default());
     let result = rt
         .block_on(async {
-            let config_handles = raw_test_targets
+            let target_handles = raw_test_targets
                 .into_iter()
                 .map(|t| {
                     tokio::task::spawn_blocking(move || {
-                        test_target_with_config(t, &ForgeTrackedResource::CairoSteps)
+                        prepare_test_target(t, &ForgeTrackedResource::CairoSteps)
                     })
                 })
                 .collect();
             run_for_package(
                 RunForPackageArgs {
-                    config_handles,
+                    target_handles,
                     package_name: "test_package".to_string(),
                     package_root: Utf8PathBuf::default(),
                     tests_filter: TestsFilter::from_flags(

--- a/crates/forge/tests/utils/running_tests.rs
+++ b/crates/forge/tests/utils/running_tests.rs
@@ -14,7 +14,7 @@ use forge_runner::forge_config::{
     ExecutionDataToSave, ForgeConfig, ForgeTrackedResource, OutputConfig, TestRunnerConfig,
 };
 use forge_runner::partition::PartitionConfig;
-use forge_runner::running::with_config::test_target_with_config;
+use forge_runner::running::target::prepare_test_target;
 use forge_runner::scarb::load_test_artifacts;
 use forge_runner::test_target_summary::TestTargetSummary;
 use foundry_ui::UI;
@@ -51,15 +51,13 @@ pub fn run_test_case(
 
     let ui = Arc::new(UI::default());
     rt.block_on(async {
-        let config_handles = raw_test_targets
+        let target_handles = raw_test_targets
             .into_iter()
-            .map(|t| {
-                tokio::task::spawn_blocking(move || test_target_with_config(t, &tracked_resource))
-            })
+            .map(|t| tokio::task::spawn_blocking(move || prepare_test_target(t, &tracked_resource)))
             .collect();
         run_for_package(
             RunForPackageArgs {
-                config_handles,
+                target_handles,
                 package_name: "test_package".to_string(),
                 package_root: Utf8PathBuf::default(),
                 tests_filter: TestsFilter::from_flags(

--- a/crates/forge/tests/utils/running_tests.rs
+++ b/crates/forge/tests/utils/running_tests.rs
@@ -14,6 +14,7 @@ use forge_runner::forge_config::{
     ExecutionDataToSave, ForgeConfig, ForgeTrackedResource, OutputConfig, TestRunnerConfig,
 };
 use forge_runner::partition::PartitionConfig;
+use forge_runner::running::with_config::test_target_with_config;
 use forge_runner::scarb::load_test_artifacts;
 use forge_runner::test_target_summary::TestTargetSummary;
 use foundry_ui::UI;
@@ -49,49 +50,59 @@ pub fn run_test_case(
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
 
     let ui = Arc::new(UI::default());
-    rt.block_on(run_for_package(
-        RunForPackageArgs {
-            test_targets: raw_test_targets,
-            package_name: "test_package".to_string(),
-            tests_filter: TestsFilter::from_flags(
-                None,
-                false,
-                Vec::new(),
-                false,
-                false,
-                false,
-                FailedTestsCache::default(),
-                PartitionConfig::default(),
-            ),
-            forge_config: Arc::new(ForgeConfig {
-                test_runner_config: Arc::new(TestRunnerConfig {
-                    exit_first: false,
-                    deterministic_output: false,
-                    fuzzer_runs: NonZeroU32::new(256).unwrap(),
-                    fuzzer_seed: 12345,
-                    max_n_steps: None,
-                    is_vm_trace_needed: false,
-                    cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                        .unwrap()
-                        .join(CACHE_DIR),
-                    contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap()).unwrap(),
-                    tracked_resource,
-                    environment_variables: test.env().clone(),
+    rt.block_on(async {
+        let config_handles = raw_test_targets
+            .into_iter()
+            .map(|t| {
+                tokio::task::spawn_blocking(move || test_target_with_config(t, &tracked_resource))
+            })
+            .collect();
+        run_for_package(
+            RunForPackageArgs {
+                config_handles,
+                package_name: "test_package".to_string(),
+                package_root: Utf8PathBuf::default(),
+                tests_filter: TestsFilter::from_flags(
+                    None,
+                    false,
+                    Vec::new(),
+                    false,
+                    false,
+                    false,
+                    FailedTestsCache::default(),
+                    PartitionConfig::default(),
+                ),
+                forge_config: Arc::new(ForgeConfig {
+                    test_runner_config: Arc::new(TestRunnerConfig {
+                        exit_first: false,
+                        deterministic_output: false,
+                        fuzzer_runs: NonZeroU32::new(256).unwrap(),
+                        fuzzer_seed: 12345,
+                        max_n_steps: None,
+                        is_vm_trace_needed: false,
+                        cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+                            .unwrap()
+                            .join(CACHE_DIR),
+                        contracts_data: ContractsData::try_from(test.contracts(&ui).unwrap())
+                            .unwrap(),
+                        tracked_resource,
+                        environment_variables: test.env().clone(),
+                    }),
+                    output_config: Arc::new(OutputConfig {
+                        detailed_resources: false,
+                        execution_data_to_save: ExecutionDataToSave::default(),
+                        trace_args: TraceArgs::default(),
+                        gas_report: false,
+                    }),
                 }),
-                output_config: Arc::new(OutputConfig {
-                    detailed_resources: false,
-                    execution_data_to_save: ExecutionDataToSave::default(),
-                    trace_args: TraceArgs::default(),
-                    gas_report: false,
-                }),
-            }),
-            fork_targets: vec![],
-        },
-        &mut BlockNumberMap::default(),
-        ui,
-        &mut ExitFirstChannel::default(),
-        false,
-    ))
+                fork_targets: vec![],
+            },
+            &BlockNumberMap::default(),
+            ui,
+            &mut ExitFirstChannel::default(),
+        )
+        .await
+    })
     .expect("Runner fail")
     .summaries()
 }


### PR DESCRIPTION

[snforge-profile-2026-04-01T14:55:23.716033+02:00.json](https://github.com/user-attachments/files/26410764/snforge-profile-2026-04-01T14.55.23.716033%2B02.00.json)

<img width="1628" height="747" alt="image" src="https://github.com/user-attachments/assets/38d11f77-7556-4458-9ef4-539812aaa468" />

<img width="1317" height="747" alt="image" src="https://github.com/user-attachments/assets/70ceb55a-349d-44dc-b6d3-8a879ebf3b9a" />


Benchmark (with scarb incremental - on OZ)
<img width="915" height="188" alt="image" src="https://github.com/user-attachments/assets/e025fdd9-e79e-4ab6-85f9-0e2437ea2b1b" />

Spawn config handles for all packages upfront so CASM compilations overlap with test execution rather than blocking it.

<!-- Reference any GitHub issues resolved by this PR -->

Closes #2675 

## Introduced changes

<!-- A brief description of the changes -->

-

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
