### PR TITLE
Separate Scarb profile used from `sncast --profile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aliases `sncast get transaction` and `sncast get transaction-status` for `get tx` and `get tx-status`.
 - Support for serialization of corelib `Option` and `Result`, values passed via `--arguments`
 - `--dry-run` and `--detailed` flags for all transaction commands, allowing users to validate transaction logic and estimate fees without submitting to the network
+- Config setting for Scarb profile, as `scarb-profile` field in `snfoundry.toml`, and `--scarb-profile` cli flag
+
 
 #### Changed
 
 - In JSON output for `sncast utils` commands, the `"command"` field now includes the `utils` prefix (e.g. `"serialize"` -> `"utils serialize"`).
+- `--profile` now only determines `snfoundry.toml` profile. For Scarb profile, use `--scarb-profile` flag or `scarb-profile` from `snfoundry.toml` instead. Defaults to `release` if unspecified.
 
 #### Fixed
 

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -98,6 +98,7 @@ pub struct CastConfig {
     pub block_explorer: Option<block_explorer::Service>,
     pub show_explorer_links: bool,
     pub networks: NetworksConfig,
+    pub scarb_profile: String,
 }
 
 impl CastConfig {
@@ -120,6 +121,7 @@ impl Default for CastConfig {
             block_explorer: Some(block_explorer::Service::default()),
             show_explorer_links: show_explorer_links_default(),
             networks: NetworksConfig::default(),
+            scarb_profile: "release".to_string(),
         }
     }
 }
@@ -163,6 +165,12 @@ pub struct PartialCastConfig {
     #[serde(default)]
     /// Configurable urls of predefined networks - mainnet, sepolia, and devnet are supported
     pub networks: Option<NetworksConfig>,
+
+    #[serde(
+        default,
+        rename(serialize = "scarb-profile", deserialize = "scarb-profile")
+    )]
+    pub scarb_profile: Option<String>,
 
     /// Additional data not captured by deserializer.
     #[doc(hidden)]
@@ -221,6 +229,7 @@ impl Override for PartialCastConfig {
             block_explorer: other.block_explorer.or(self.block_explorer),
             show_explorer_links: other.show_explorer_links.or(self.show_explorer_links),
             networks: override_optional(self.networks.clone(), other.networks),
+            scarb_profile: other.scarb_profile.or_else(|| self.scarb_profile.clone()),
             unknown_fields: HashMap::default(),
         }
     }
@@ -310,6 +319,7 @@ impl TryFrom<PartialCastConfig> for CastConfig {
             block_explorer: p.block_explorer.or(d.block_explorer),
             show_explorer_links: p.show_explorer_links.unwrap_or(d.show_explorer_links),
             networks,
+            scarb_profile: p.scarb_profile.unwrap_or(d.scarb_profile),
         };
         config.validate()?;
         Ok(config)

--- a/crates/sncast/src/helpers/scarb_utils.rs
+++ b/crates/sncast/src/helpers/scarb_utils.rs
@@ -161,10 +161,11 @@ pub fn build_and_load_artifacts(
             &target_dir.join(&config.profile),
             package,
             ui,
-            CompilationOpts::default()
-        ).context("Failed to load artifacts. Make sure you have enabled sierra code generation in Scarb.toml")?
+            CompilationOpts::default(),
+        )
+        .context("Failed to load artifacts. Make sure you have enabled sierra code generation in Scarb.toml")?
         .into_iter()
-        .map(|(name, (artifacts, _))| (name, CastStarknetContractArtifacts { sierra: artifacts.sierra, casm: serde_json::to_string(&artifacts.casm).expect("valid serialization")  }))
+        .map(|(name, (artifacts, _))| (name, CastStarknetContractArtifacts { sierra: artifacts.sierra, casm: serde_json::to_string(&artifacts.casm).expect("valid serialization") }))
         .collect())
     } else {
         let profile = &config.profile;
@@ -176,7 +177,8 @@ pub fn build_and_load_artifacts(
             package,
             ui,
             CompilationOpts::default(),
-        ).context("Failed to load artifacts. Make sure you have enabled sierra code generation in Scarb.toml")?
+        )
+        .context("Failed to load artifacts. Make sure you have enabled sierra code generation in Scarb.toml")?
         .into_iter()
         .map(|(name, (artifacts, _))| (name, CastStarknetContractArtifacts { sierra: artifacts.sierra, casm: serde_json::to_string(&artifacts.casm).expect("valid serialization") }))
         .collect())

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -112,6 +112,10 @@ struct Cli {
     #[arg(short, long)]
     keystore: Option<Utf8PathBuf>,
 
+    /// Scarb profile for building contracts (e.g. release, dev)
+    #[arg(long)]
+    scarb_profile: Option<String>,
+
     /// If passed, output will be displayed in json format
     #[arg(short, long)]
     json: bool,
@@ -165,6 +169,7 @@ impl Cli {
                 timeout: self.wait_timeout,
                 retry_interval: self.wait_retry_interval,
             }),
+            scarb_profile: self.scarb_profile.clone(),
             ..Default::default()
         };
         config.validate()?;
@@ -344,7 +349,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 &BuildConfig {
                     scarb_toml_path: manifest_path,
                     json: cli.json,
-                    profile: cli.profile.unwrap_or("release".to_string()),
+                    profile: config.scarb_profile.clone(),
                 },
                 false,
                 // TODO(#3959) Remove `base_ui`
@@ -498,7 +503,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                     &BuildConfig {
                         scarb_toml_path: manifest_path,
                         json: cli.json,
-                        profile: cli.profile.unwrap_or("release".to_string()),
+                        profile: config.scarb_profile.clone(),
                     },
                     false,
                     // TODO(#3959) Remove `base_ui`
@@ -704,16 +709,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
         Commands::Get(get) => get::get(get, config, ui).await,
 
-        Commands::Utils(utils) => {
-            utils::utils(
-                utils,
-                config,
-                ui,
-                cli.json,
-                cli.profile.clone().unwrap_or("release".to_string()),
-            )
-            .await
-        }
+        Commands::Utils(utils) => utils::utils(utils, config, ui, cli.json).await,
 
         Commands::Multicall(multicall) => {
             multicall::multicall(multicall, config, ui, wait_config).await
@@ -755,7 +751,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 &BuildConfig {
                     scarb_toml_path: manifest_path.clone(),
                     json: cli.json,
-                    profile: cli.profile.unwrap_or("release".to_string()),
+                    profile: config.scarb_profile.clone(),
                 },
                 false,
                 // TODO(#3959) Remove `base_ui`
@@ -838,11 +834,10 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
         }
         // No local config file; profile must be in global config.
         (Some(profile), MaybeConfig::NoFile, MaybeConfig::NoProfile) => {
-            // Note: changed to error in the next PR
-            ui.print_warning(WarningMessage::new(format!(
+            bail!(
                 "Profile [{profile}] not found in global config at {}, and no local config found.",
-                global_path.clone().unwrap_or_default()
-            )));
+                global_path.unwrap_or_default()
+            );
         }
         // Note: this is potentially unreachable: `get_or_create_global_config_path` should always return dir with existing config file.
         // TODO: (#3436) remove this if missing global config becomes an error

--- a/crates/sncast/src/response/show_config.rs
+++ b/crates/sncast/src/response/show_config.rs
@@ -19,6 +19,7 @@ pub struct ShowConfigResponse {
     pub wait_retry_interval: Option<u64>,
     pub show_explorer_links: bool,
     pub block_explorer: Option<block_explorer::Service>,
+    pub scarb_profile: String,
 }
 
 impl SncastCommandMessage for ShowConfigResponse {
@@ -54,7 +55,8 @@ impl SncastCommandMessage for ShowConfigResponse {
             .field("Show Explorer Links", &self.show_explorer_links.to_string())
             .if_some(self.block_explorer.as_ref(), |b, explorer| {
                 b.field("Block Explorer", &format!("{explorer:?}"))
-            });
+            })
+            .field("Scarb Profile", &self.scarb_profile);
 
         builder.build()
     }

--- a/crates/sncast/src/starknet_commands/script/mod.rs
+++ b/crates/sncast/src/starknet_commands/script/mod.rs
@@ -51,7 +51,7 @@ pub fn run_script_command(
                 &BuildConfig {
                     scarb_toml_path: manifest_path.clone(),
                     json: cli.json,
-                    profile: cli.profile.clone().unwrap_or("dev".to_string()),
+                    profile: config.scarb_profile.clone(),
                 },
                 true,
                 // TODO(#3959) Remove `base_ui`

--- a/crates/sncast/src/starknet_commands/show_config.rs
+++ b/crates/sncast/src/starknet_commands/show_config.rs
@@ -55,5 +55,6 @@ pub async fn show_config(
         wait_retry_interval: wait_retry_interval.map(|v| u64::from(v.get())),
         show_explorer_links: cast_config.show_explorer_links,
         block_explorer,
+        scarb_profile: cast_config.scarb_profile,
     })
 }

--- a/crates/sncast/src/starknet_commands/utils/mod.rs
+++ b/crates/sncast/src/starknet_commands/utils/mod.rs
@@ -51,13 +51,7 @@ pub enum Commands {
     Selector(Selector),
 }
 
-pub async fn utils(
-    utils: Utils,
-    config: CastConfig,
-    ui: &UI,
-    json: bool,
-    profile: String,
-) -> anyhow::Result<ExitCode> {
+pub async fn utils(utils: Utils, config: CastConfig, ui: &UI, json: bool) -> anyhow::Result<ExitCode> {
     match utils.command {
         Commands::Serialize(serialize) => {
             let result = starknet_commands::utils::serialize::serialize(serialize, config, ui)
@@ -76,7 +70,7 @@ pub async fn utils(
                 &BuildConfig {
                     scarb_toml_path: manifest_path,
                     json,
-                    profile,
+                    profile: config.scarb_profile.clone(),
                 },
                 false,
                 // TODO(#3959) Remove `base_ui`

--- a/crates/sncast/src/starknet_commands/utils/mod.rs
+++ b/crates/sncast/src/starknet_commands/utils/mod.rs
@@ -101,7 +101,7 @@ pub async fn utils(utils: Utils, config: CastConfig, ui: &UI, json: bool) -> any
                         &BuildConfig {
                             scarb_toml_path: manifest_path,
                             json,
-                            profile,
+                            profile: config.scarb_profile.clone(),
                         },
                         false,
                         // TODO(#3959) Remove `base_ui`

--- a/crates/sncast/src/starknet_commands/utils/mod.rs
+++ b/crates/sncast/src/starknet_commands/utils/mod.rs
@@ -51,7 +51,12 @@ pub enum Commands {
     Selector(Selector),
 }
 
-pub async fn utils(utils: Utils, config: CastConfig, ui: &UI, json: bool) -> anyhow::Result<ExitCode> {
+pub async fn utils(
+    utils: Utils,
+    config: CastConfig,
+    ui: &UI,
+    json: bool,
+) -> anyhow::Result<ExitCode> {
     match utils.command {
         Commands::Serialize(serialize) => {
             let result = starknet_commands::utils::serialize::serialize(serialize, config, ui)

--- a/crates/sncast/tests/data/files/snfoundry_correct.toml
+++ b/crates/sncast/tests/data/files/snfoundry_correct.toml
@@ -38,6 +38,9 @@ network = "sepolia"
 account = "user1"
 accounts-file = "/path/to/account.json"
 
+[sncast.profile8]
+scarb-profile = "dev"
+
 [sncast.profile7.networks]
 sepolia = "http://127.0.0.1:5055/rpc"
 

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -707,7 +707,7 @@ async fn test_workspaces_package_no_contract() {
 }
 
 #[tokio::test]
-async fn test_no_scarb_profile() {
+async fn test_non_existent_profile() {
     let contract_path =
         duplicate_contract_directory_with_salt(CONTRACTS_DIR.to_string() + "/map", "put", "694215");
     fs::copy(
@@ -721,6 +721,8 @@ async fn test_no_scarb_profile() {
         accounts_json_path.as_str(),
         "--profile",
         "profile5",
+        "--scarb-profile",
+        "nonexistent_profile",
         "declare",
         "--url",
         URL,
@@ -737,7 +739,7 @@ async fn test_no_scarb_profile() {
         output,
         indoc! {"
             [..]
-            [WARNING] Profile profile5 does not exist in scarb, using 'release' profile.
+            [WARNING] Profile nonexistent_profile does not exist in scarb, using 'release' profile.
             Success: Declaration completed
 
             Class Hash:       [..]

--- a/crates/sncast/tests/e2e/script/general.rs
+++ b/crates/sncast/tests/e2e/script/general.rs
@@ -528,7 +528,7 @@ async fn test_state_file_rerun_failed_tx() {
 }
 
 #[tokio::test]
-async fn test_using_release_profile() {
+async fn test_using_release_scarb_profile() {
     let contract_dir = duplicate_contract_directory_with_salt(
         SCRIPTS_DIR.to_owned() + "/map_script/contracts/",
         "dummy",
@@ -547,7 +547,7 @@ async fn test_using_release_profile() {
         accounts_json_path.as_str(),
         "--account",
         "user5",
-        "--profile",
+        "--scarb-profile",
         "release",
         "script",
         "run",
@@ -559,7 +559,6 @@ async fn test_using_release_profile() {
     let snapbox = runner(&args).current_dir(script_dir.path());
 
     snapbox.assert().success().stdout_eq(indoc! {r"
-        [WARNING] Profile [release] not found in global config at [..]snfoundry.toml, and no local config found.
         ...
         Success: Script execution completed
         

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -24,6 +24,7 @@ async fn test_show_config_from_snfoundry_toml() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -54,6 +55,7 @@ async fn test_show_config_from_cli() {
         Wait Retry Interval: 1s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -74,6 +76,7 @@ async fn test_show_config_from_cli_and_snfoundry_toml() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      ViewBlock
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -94,6 +97,7 @@ async fn test_show_config_when_no_keystore() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -114,6 +118,7 @@ async fn test_show_config_when_keystore() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -134,6 +139,7 @@ async fn test_show_config_no_url() {
         Wait Retry Interval: 10s
         Show Explorer Links: false
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -154,6 +160,7 @@ async fn test_show_config_with_network() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     "});
 }
 
@@ -215,6 +222,16 @@ async fn test_stark_scan_as_block_explorer() {
 }
 
 #[tokio::test]
+async fn test_show_config_with_scarb_profile() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_correct.toml", None);
+    let args = vec!["--profile", "profile8", "show-config"];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+
+    assert_stdout_contains(snapbox.assert().success(), "Scarb Profile:       dev");
+}
+
+#[tokio::test]
 async fn test_show_config_malformed() {
     let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_malformed.toml", None);
     let args = vec!["show-config"];
@@ -261,6 +278,7 @@ async fn test_show_config_provider_error() {
             Wait Retry Interval: 5s
             Show Explorer Links: true
             Block Explorer:      Voyager
+            Scarb Profile:       release
         "},
     );
 }
@@ -286,6 +304,7 @@ async fn test_show_config_global_no_local() {
         Wait Retry Interval: 3s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -311,6 +330,7 @@ async fn test_show_config_global_only_profile() {
         Wait Retry Interval: 5s
         Show Explorer Links: false
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -356,6 +376,7 @@ async fn test_show_config_global_and_local_default() {
         Wait Retry Interval: 3s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -381,6 +402,7 @@ async fn test_show_config_global_and_local_profile() {
         Wait Retry Interval: 3s
         Show Explorer Links: true
         Block Explorer:      ViewBlock
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -413,10 +435,10 @@ async fn test_profile_missing_in_global_config() {
         .args(&args)
         .current_dir(t.path());
 
-    assert_stdout_contains(
-        snapbox.assert().success(),
+    assert_stderr_contains(
+        snapbox.assert().failure(),
         indoc! { r"
-            [WARNING] Profile [nonexistent] not found in global config at [..]snfoundry.toml, and no local config found.
+            Error: Profile [nonexistent] not found in global config at [..]snfoundry.toml, and no local config found.
         " },
     );
 }
@@ -639,5 +661,25 @@ async fn test_zero_wait_retry_interval_from_cli() {
     assert_stderr_contains(
         output,
         "error: invalid value '0' for '--wait-retry-interval <WAIT_RETRY_INTERVAL>': number would be zero for non-zero type",
+    );
+}
+
+#[tokio::test]
+async fn test_profile_missing_in_both_configs() {
+    let global_dir = copy_config_to_tempdir("tests/data/files/snfoundry_global_correct.toml", None);
+    let local_dir = copy_config_to_tempdir("tests/data/files/snfoundry_correct.toml", None);
+    let args = vec!["--profile", "nonexistent", "show-config"];
+
+    let snapbox = Cast::new()
+        .config_dir(global_dir.path())
+        .command()
+        .args(&args)
+        .current_dir(local_dir.path());
+
+    assert_stderr_contains(
+        snapbox.assert().failure(),
+        indoc! { r"
+            Error: Profile [nonexistent] not found in local config at [..]snfoundry.toml
+        " },
     );
 }

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -180,6 +180,7 @@ async fn test_show_config_cli_url_overrides_config_network() {
         Wait Retry Interval: 5s
         Show Explorer Links: true
         Block Explorer:      Voyager
+        Scarb Profile:       release
     ", URL});
 }
 
@@ -679,7 +680,7 @@ async fn test_profile_missing_in_both_configs() {
     assert_stderr_contains(
         snapbox.assert().failure(),
         indoc! { r"
-            Error: Profile [nonexistent] not found in local config at [..]snfoundry.toml
+            Error: Profile [nonexistent] not found in neither local config at [..]snfoundry.toml nor global config at [..]snfoundry.toml
         " },
     );
 }

--- a/docs/src/appendix/sncast/common.md
+++ b/docs/src/appendix/sncast/common.md
@@ -4,8 +4,18 @@ These flags must be specified directly after the `sncast` command and before the
 ## `--profile, -p <PROFILE_NAME>`
 Optional.
 
-Used for both `snfoundry.toml` and `Scarb.toml` if specified.
-Defaults to `default` (`snfoundry.toml`) and `release` (`Scarb.toml`) in most contexts.
+Used for `snfoundry.toml`.
+
+Selects the `[sncast.<PROFILE_NAME>]` section in `snfoundry.toml` (local and/or global).
+
+Defaults to `default`.
+
+## `--scarb-profile <PROFILE_NAME>`
+Optional.
+
+Used for `scarb` and `Scarb.toml` uses, mainly for building contracts.
+
+Defaults to `release`.
 
 ## `--account, -a <ACCOUNT_NAME>`
 Optional.

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -104,7 +104,7 @@ block-explorer = "Voyager"
 
 The `scarb-profile` field sets which [Scarb profile](https://docs.swmansion.com/scarb/docs/reference/manifest.html#profiles) `sncast` uses when it runs `scarb` commands (e.g. `scarb build` when declaring contracts or running scripts).
 
-If omitted, the effective default is `release`.
+Defaults to `release`.
 
 ```toml
 [sncast.myprofile]

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -102,7 +102,7 @@ block-explorer = "Voyager"
 
 #### `scarb-profile`
 
-The `scarb-profile` field sets which [Scarb profile](https://docs.swmansion.com/scarb/docs/reference/manifest.html#profiles) `sncast` uses when it runs `scarb` commands (e.g. `scarb build` when declaring contracts or running scripts).
+The `scarb-profile` field sets which [Scarb profile](https://docs.swmansion.com/scarb/docs/reference/profiles.html) `sncast` uses when it runs `scarb` commands (e.g. `scarb build` when declaring contracts or running scripts).
 
 Defaults to `release`.
 

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -100,6 +100,17 @@ The `block-explorer` field specifies the block explorer service used to display 
 block-explorer = "Voyager"
 ```
 
+#### `scarb-profile`
+
+The `scarb-profile` field sets which [Scarb profile](https://docs.swmansion.com/scarb/docs/reference/manifest.html#profiles) `sncast` uses when it runs `scarb` commands (e.g. `scarb build` when declaring contracts or running scripts).
+
+If omitted, the effective default is `release`.
+
+```toml
+[sncast.myprofile]
+scarb-profile = "release"
+```
+
 #### `[sncast.<profile-name>.networks]`
 
 The URLs of the predefined networks can be configured.
@@ -124,6 +135,7 @@ keystore = "~/keystore"
 wait-params = { timeout = 500, retry-interval = 10 }
 block-explorer = "Voyager"
 show-explorer-links = true
+scarb-profile = "release"
 
 [sncast.myprofile1.networks]
 mainnet = "https://mainnet.your-node.com"

--- a/docs/src/projects/configuration.md
+++ b/docs/src/projects/configuration.md
@@ -42,8 +42,12 @@ defined in the profile.
 > `snfoundry.toml` file has to be present in current or any of the parent directories.
 
 > 📝 **Note**
-> If there is a profile with the same name in Scarb.toml, scarb will use this profile. If not, scarb will default to using the dev profile.
-> (This applies only to subcommands using scarb - namely `declare` and `script`).
+> `--profile` only selects the `snfoundry.toml` profile. 
+> 
+> The Scarb profile is set with `--scarb-profile` or the `scarb-profile` field under `[sncast.<profile>]` (defaults to value `release`). 
+> See [common flags](../appendix/sncast/common.md)). 
+> If that Scarb profile does not exist in `Scarb.toml`, `sncast` falls back with a warning.
+> (Applies to subcommands using Scarb - namely `declare`, `verify`, `script`, and `utils class-hash`.)
 
 > 💡 **Info**
 > Not all parameters have to be present in the configuration - you can choose to include only some of them and supply


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

## Stack
- #4175
- #4205 
- #4249
- #4234 

## Introduced changes

<!-- A brief description of the changes -->

Allow configuring scarb profile separately from sncast config:
- `--scarb-profile` in cli
- `scarb-profile` in `snfoundry.toml` 

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
