### PR TITLE
Support for `Option` and `Result` in `--arguments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Aliases `sncast get transaction` and `sncast get transaction-status` for `get tx` and `get tx-status`.
-- Support serializing corelib `Option` and `Result` values passed via `--arguments`
+- Support for serialization of corelib `Option` and `Result`, values passed via `--arguments`
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast get class-hash-at` command to get the class hash of a contract at a given address.
 - `--with-proof-facts` flag for `sncast get tx` to include proof facts in tx response. Read more [here](https://community.starknet.io/t/snip-36-in-protocol-proof-verification/116123l).
 - `--proof-file` and `--proof-facts-file` flags for `sncast invoke` to attach proof data from files.
+- Support serializing corelib `Option` and `Result` values passed via `--arguments`
 
 ## [0.58.1] - 2026-03-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Aliases `sncast get transaction` and `sncast get transaction-status` for `get tx` and `get tx-status`.
+- Support serializing corelib `Option` and `Result` values passed via `--arguments`
 
 #### Changed
 
@@ -53,7 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast get class-hash-at` command to get the class hash of a contract at a given address.
 - `--with-proof-facts` flag for `sncast get tx` to include proof facts in tx response. Read more [here](https://community.starknet.io/t/snip-36-in-protocol-proof-verification/116123l).
 - `--proof-file` and `--proof-facts-file` flags for `sncast invoke` to attach proof data from files.
-- Support serializing corelib `Option` and `Result` values passed via `--arguments`
 
 ## [0.58.1] - 2026-03-31
 

--- a/crates/data-transformer/src/shared/path.rs
+++ b/crates/data-transformer/src/shared/path.rs
@@ -86,5 +86,5 @@ fn extract_generic_args(
         return Err(PathSplitError::MoreThanOneGenericArg);
     };
 
-    Ok((*generic_arg).to_string())
+    Ok(generic_arg.to_string())
 }

--- a/crates/data-transformer/src/shared/path.rs
+++ b/crates/data-transformer/src/shared/path.rs
@@ -86,5 +86,5 @@ fn extract_generic_args(
         return Err(PathSplitError::MoreThanOneGenericArg);
     };
 
-    Ok(generic_arg.to_string())
+    Ok((*generic_arg).to_string())
 }

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -6,7 +6,7 @@ use super::{SupportedCalldataKind, build_representation};
 use crate::shared;
 use crate::shared::parsing::parse_expression;
 use crate::shared::path::SplitResult;
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use cairo_lang_parser::utils::SimpleParserDatabase;
 use cairo_lang_syntax::node::ast::{
     Expr, ExprFunctionCall, ExprListParenthesized, ExprPath, ExprStructCtorCall,
@@ -50,6 +50,8 @@ impl EnumOrStruct for AbiEnum {
 }
 
 const UNIT_TYPE: &str = "()";
+const OPTION_TYPE: &str = "core::option::Option";
+const RESULT_TYPE: &str = "core::result::Result";
 
 fn strip_generic_suffix(type_str: &str) -> &str {
     if let Some(idx) = type_str.find("::<") {
@@ -66,92 +68,66 @@ fn base_type_name(type_str: &str) -> &str {
         .unwrap_or(type_str)
 }
 
-fn validate_path_argument(
-    param_type: &str,
-    path_argument: &[String],
-    path_argument_joined: &str,
-) -> Result<()> {
-        .last()
-        .expect("path_argument must be non-empty: caller ensures split_last() succeeded");
-    if *last != base_type_name(param_type) && path_argument_joined != param_type {
-    let last = path_argument
+fn validate_path_argument(param_type: &str, path_argument_joined: &str) -> Result<()> {
+    let canonical = strip_generic_suffix(param_type);
+
+    if canonical != path_argument_joined
+        && !canonical.ends_with(&format!("::{path_argument_joined}"))
+    {
         bail!(r#"Invalid argument type, expected "{param_type}", got "{path_argument_joined}""#)
     }
     Ok(())
 }
 
-fn is_valid_corelib_enum_path(type_name: &str, enum_path: &[String]) -> bool {
-    let module = type_name.to_lowercase();
-    matches!(enum_path, [only] if only == type_name)
-        || matches!(enum_path, [core, m, last] if core == "core" && m == &module && last == type_name)
-}
-
-/// Validates the user-supplied enum path against the expected corelib type, then
-/// looks up `variant_name` in `variants` (a slice of `(name, position, inner_type)`).
-fn resolve_corelib_enum_variant_with<'a>(
-    expected_type: &'a str,
-    type_name: &str,
-    enum_path: &[String],
-    variant_name: &str,
-    variants: &[(&str, usize, Option<&'a str>)],
-) -> Result<ResolvedEnumVariant<'a>> {
-    if !is_valid_corelib_enum_path(type_name, enum_path) {
-        return Err(anyhow::anyhow!(
-            r#"Invalid argument type, expected "{expected_type}", got "{}""#,
-            enum_path.join("::")
-        ));
-    }
-    variants
-        .iter()
-        .find(|(name, _, _)| *name == variant_name)
-        .map(|&(_, position, inner_type)| ResolvedEnumVariant {
-            position,
-            inner_type,
-        })
-        .ok_or_else(|| {
-            anyhow::anyhow!(r#"Invalid variant "{variant_name}" for type "{expected_type}""#)
-        })
+/// Extracts the generic argument string from `type_str` if it starts with `type_prefix`.
+/// e.g. `"core::option::Option::<u32>"` with prefix `"core::option::Option"` → `"u32"`.
+fn extract_generic_args<'a>(type_str: &'a str, type_prefix: &str) -> Option<&'a str> {
+    type_str
+        .strip_prefix(type_prefix)
+        .and_then(|s| s.strip_prefix("::<"))
+        .and_then(|s| s.strip_suffix('>'))
 }
 
 fn resolve_corelib_enum_variant<'a>(
     expected_type: &'a str,
     variant_name: &str,
-    enum_path: &[String],
-) -> Option<Result<ResolvedEnumVariant<'a>>> {
-    // core::option::Option::<T>  ->  Some(T) at 0, None at 1
-    if let Some(inner) = expected_type
-        .strip_prefix("core::option::Option::<")
-        .and_then(|s| s.strip_suffix('>'))
-    {
-        return Some(resolve_corelib_enum_variant_with(
-            expected_type,
-            "Option",
-            enum_path,
-            variant_name,
-            &[("Some", 0, Some(inner)), ("None", 1, None)],
-        ));
+) -> Result<Option<ResolvedEnumVariant<'a>>> {
+    let invalid_variant =
+        || anyhow!(r#"Invalid variant "{variant_name}" for type "{expected_type}""#);
+
+    if let Some(inner) = extract_generic_args(expected_type, OPTION_TYPE) {
+        let (position, inner_type) = match variant_name {
+            "Some" => (0, Some(inner)),
+            "None" => (1, None),
+            _ => return Err(invalid_variant()),
+        };
+
+        return Ok(Some(ResolvedEnumVariant {
+            position,
+            inner_type,
+        }));
     }
 
-    // core::result::Result::<T, E>  ->  Ok(T) at 0, Err(E) at 1
-    if let Some(inner) = expected_type
-        .strip_prefix("core::result::Result::<")
-        .and_then(|s| s.strip_suffix('>'))
-    {
-        // A well-formed Result type always contains a top-level comma separating T and E.
-        // If absent the ABI entry is malformed; fall through to ABI lookup.
-        let split_pos = top_level_comma_pos(inner)?;
-        let ok_type = inner[..split_pos].trim();
-        let err_type = inner[split_pos + 1..].trim();
-        return Some(resolve_corelib_enum_variant_with(
-            expected_type,
-            "Result",
-            enum_path,
-            variant_name,
-            &[("Ok", 0, Some(ok_type)), ("Err", 1, Some(err_type))],
-        ));
+    if let Some(inner) = extract_generic_args(expected_type, RESULT_TYPE) {
+        let Some(split_pos) = top_level_comma_pos(inner) else {
+            bail!(
+                r#"Malformed ABI type "{expected_type}": missing comma between Ok and Err types"#
+            );
+        };
+
+        let (position, inner_type) = match variant_name {
+            "Ok" => (0, Some(inner[..split_pos].trim())),
+            "Err" => (1, Some(inner[split_pos + 1..].trim())),
+            _ => return Err(invalid_variant()),
+        };
+
+        return Ok(Some(ResolvedEnumVariant {
+            position,
+            inner_type,
+        }));
     }
 
-    None
+    Ok(None)
 }
 
 fn top_level_comma_pos(s: &str) -> Option<usize> {
@@ -173,7 +149,7 @@ fn top_level_comma_pos(s: &str) -> Option<usize> {
 fn split_variant_from_path(path: &[String]) -> Result<(&str, &[String])> {
     let (variant, rest) = path
         .split_last()
-        .ok_or_else(|| anyhow::anyhow!("Expected an enum variant path, got an empty path"))?;
+        .ok_or_else(|| anyhow!("Expected an enum variant path, got an empty path"))?;
     Ok((variant, rest))
 }
 
@@ -243,7 +219,7 @@ fn find_item_with_path<'item, T: EnumOrStruct>(
         });
 
         return full_path_item.ok_or_else(|| {
-            anyhow::anyhow!(
+            anyhow!(
                 r#"{} "{}" not found in ABI"#,
                 T::VARIANT_CAPITALIZED,
                 path.join("::")
@@ -321,7 +297,7 @@ impl SupportedCalldataKind for ExprStructCtorCall<'_> {
         let struct_path: Vec<String> = split(&self.path(db), db)?;
         let struct_path_joined = struct_path.clone().join("::");
 
-        validate_path_argument(expected_type, &struct_path, &struct_path_joined)?;
+        validate_path_argument(expected_type, &struct_path_joined)?;
 
         let structs_from_abi = find_all_structs(abi);
         let struct_abi_definition = find_item_with_path(structs_from_abi, &struct_path)?;
@@ -389,10 +365,10 @@ fn resolve_enum_variant<'a>(
     abi: &'a [AbiEntry],
 ) -> Result<ResolvedEnumVariant<'a>> {
     let enum_path_joined = enum_path.join("::");
-    validate_path_argument(expected_type, enum_path, &enum_path_joined)?;
+    validate_path_argument(expected_type, &enum_path_joined)?;
 
-    if let Some(result) = resolve_corelib_enum_variant(expected_type, variant_name, enum_path) {
-        result
+    if let Some(resolved) = resolve_corelib_enum_variant(expected_type, variant_name)? {
+        Ok(resolved)
     } else {
         let (position, variant) = find_enum_variant_position(variant_name, enum_path, abi)?;
         Ok(ResolvedEnumVariant {
@@ -419,10 +395,6 @@ impl SupportedCalldataKind for ExprPath<'_> {
             resolved.inner_type.is_none(),
             r#"Variant "{enum_variant_name}" of "{expected_type}" requires a value, use "{enum_variant_name}(<value>)""#
         );
-
-        if enum_variant.r#type != "()" {
-            bail!(r#"Couldn't find variant "{enum_variant_name}" in enum "{enum_path_joined}""#)
-        }
 
         Ok(AllowedCalldataArgument::Enum(CalldataEnum::new(
             resolved.position,

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -61,6 +61,8 @@ fn strip_generic_suffix(type_str: &str) -> &str {
     }
 }
 
+/// Returns just the last path segment of a type, ignoring generic arguments.
+/// E.g. `"core::option::Option::<u32>"` → `"Option"`.
 fn base_type_name(type_str: &str) -> &str {
     strip_generic_suffix(type_str)
         .split("::")
@@ -71,6 +73,10 @@ fn base_type_name(type_str: &str) -> &str {
 fn validate_path_argument(param_type: &str, path_argument_joined: &str) -> Result<()> {
     let canonical = strip_generic_suffix(param_type);
 
+    // Validate that the argument matches the expected type, allowing partially-qualified
+    // paths (e.g. `option::Option` for `core::option::Option`). The `::` prefix ensures
+    // the match starts at a real segment boundary, rejecting mid-segment substrings
+    // (e.g. `ion::Option` would falsely match `core::option::Option` without it).
     if canonical != path_argument_joined
         && !canonical.ends_with(&format!("::{path_argument_joined}"))
     {
@@ -88,6 +94,9 @@ fn extract_generic_args<'a>(type_str: &'a str, type_prefix: &str) -> Option<&'a 
         .and_then(|s| s.strip_suffix('>'))
 }
 
+/// Resolves a variant for the built-in `Option` and `Result` types, which are not
+/// listed in the ABI and must be handled specially. Returns `None` if `expected_type`
+/// is neither, signalling the caller to fall through to a regular ABI lookup.
 fn resolve_corelib_enum_variant<'a>(
     expected_type: &'a str,
     variant_name: &str,
@@ -130,6 +139,9 @@ fn resolve_corelib_enum_variant<'a>(
     Ok(None)
 }
 
+/// Finds the position of the first comma that is not nested inside `<>` or `()`.
+/// Used to split the two generic arguments of `Result::<OkType, ErrType>` without
+/// being confused by commas inside nested generic types.
 fn top_level_comma_pos(s: &str) -> Option<usize> {
     let mut angle_depth = 0;
     let mut paren_depth = 0;
@@ -171,6 +183,8 @@ fn find_all_structs(abi: &[AbiEntry]) -> Vec<&AbiStruct> {
         .collect()
 }
 
+/// Looks up `variant` in the ABI enum identified by `path` and returns its
+/// index in the enum definition together with the full `AbiNamedMember`.
 fn find_enum_variant_position<'a>(
     variant: &str,
     path: &[String],
@@ -367,6 +381,7 @@ fn resolve_enum_variant<'a>(
     let enum_path_joined = enum_path.join("::");
     validate_path_argument(expected_type, &enum_path_joined)?;
 
+    // First, check if the variant belongs to a corelib type (Option or Result) that is not listed in the contract's ABI.
     if let Some(resolved) = resolve_corelib_enum_variant(expected_type, variant_name)? {
         Ok(resolved)
     } else {

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -41,17 +41,140 @@ impl EnumOrStruct for AbiEnum {
     }
 }
 
+const UNIT_TYPE: &str = "()";
+
+fn strip_generic_suffix(type_str: &str) -> &str {
+    if let Some(idx) = type_str.find("::<") {
+        &type_str[..idx]
+    } else {
+        type_str
+    }
+}
+
+fn base_type_name(type_str: &str) -> &str {
+    strip_generic_suffix(type_str)
+        .split("::")
+        .last()
+        .unwrap_or(type_str)
+}
+
 fn validate_path_argument(
     param_type: &str,
     path_argument: &[String],
-    path_argument_joined: &String,
+    path_argument_joined: &str,
 ) -> Result<()> {
-    if *path_argument.last().unwrap() != param_type.split("::").last().unwrap()
-        && path_argument_joined != param_type
-    {
+        .last()
+        .expect("path_argument must be non-empty: caller ensures split_last() succeeded");
+    if *last != base_type_name(param_type) && path_argument_joined != param_type {
+    let last = path_argument
         bail!(r#"Invalid argument type, expected "{param_type}", got "{path_argument_joined}""#)
     }
     Ok(())
+}
+
+/// A resolved enum variant with its serialization position and optional inner type.
+struct ResolvedEnumVariant<'a> {
+    /// 0-based position used for serialization
+    position: usize,
+    /// Inner type, or `None` for unit variants
+    inner_type: Option<&'a str>,
+}
+
+fn is_valid_corelib_enum_path(type_name: &str, enum_path: &[String]) -> bool {
+    let module = type_name.to_lowercase();
+    matches!(enum_path, [only] if only == type_name)
+        || matches!(enum_path, [core, m, last] if core == "core" && m == &module && last == type_name)
+}
+
+/// Validates the user-supplied enum path against the expected corelib type, then
+/// looks up `variant_name` in `variants` (a slice of `(name, position, inner_type)`).
+fn resolve_corelib_enum_variant_with<'a>(
+    expected_type: &'a str,
+    type_name: &str,
+    enum_path: &[String],
+    variant_name: &str,
+    variants: &[(&str, usize, Option<&'a str>)],
+) -> Result<ResolvedEnumVariant<'a>> {
+    if !is_valid_corelib_enum_path(type_name, enum_path) {
+        return Err(anyhow::anyhow!(
+            r#"Invalid argument type, expected "{expected_type}", got "{}""#,
+            enum_path.join("::")
+        ));
+    }
+    variants
+        .iter()
+        .find(|(name, _, _)| *name == variant_name)
+        .map(|&(_, position, inner_type)| ResolvedEnumVariant {
+            position,
+            inner_type,
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(r#"Invalid variant "{variant_name}" for type "{expected_type}""#)
+        })
+}
+
+fn resolve_corelib_enum_variant<'a>(
+    expected_type: &'a str,
+    variant_name: &str,
+    enum_path: &[String],
+) -> Option<Result<ResolvedEnumVariant<'a>>> {
+    // core::option::Option::<T>  ->  Some(T) at 0, None at 1
+    if let Some(inner) = expected_type
+        .strip_prefix("core::option::Option::<")
+        .and_then(|s| s.strip_suffix('>'))
+    {
+        return Some(resolve_corelib_enum_variant_with(
+            expected_type,
+            "Option",
+            enum_path,
+            variant_name,
+            &[("Some", 0, Some(inner)), ("None", 1, None)],
+        ));
+    }
+
+    // core::result::Result::<T, E>  ->  Ok(T) at 0, Err(E) at 1
+    if let Some(inner) = expected_type
+        .strip_prefix("core::result::Result::<")
+        .and_then(|s| s.strip_suffix('>'))
+    {
+        // A well-formed Result type always contains a top-level comma separating T and E.
+        // If absent the ABI entry is malformed; fall through to ABI lookup.
+        let split_pos = top_level_comma_pos(inner)?;
+        let ok_type = inner[..split_pos].trim();
+        let err_type = inner[split_pos + 1..].trim();
+        return Some(resolve_corelib_enum_variant_with(
+            expected_type,
+            "Result",
+            enum_path,
+            variant_name,
+            &[("Ok", 0, Some(ok_type)), ("Err", 1, Some(err_type))],
+        ));
+    }
+
+    None
+}
+
+fn top_level_comma_pos(s: &str) -> Option<usize> {
+    let mut depth = 0;
+    s.char_indices().find_map(|(i, c)| match c {
+        '<' => {
+            depth += 1;
+            None
+        }
+        '>' if depth > 0 => {
+            depth -= 1;
+            None
+        }
+        ',' if depth == 0 => Some(i),
+        _ => None,
+    })
+}
+
+fn split_variant_from_path(path: &[String]) -> Result<(String, Vec<String>)> {
+    let (variant, rest) = path
+        .split_last()
+        .ok_or_else(|| anyhow::anyhow!("Expected an enum variant path, got an empty path"))?;
+    Ok((variant.clone(), rest.to_vec()))
 }
 
 fn split(path: &ExprPath, db: &SimpleParserDatabase) -> Result<Vec<String>> {
@@ -73,7 +196,7 @@ fn find_all_structs(abi: &[AbiEntry]) -> Vec<&AbiStruct> {
 }
 
 fn find_enum_variant_position<'a>(
-    variant: &String,
+    variant: &str,
     path: &[String],
     abi: &'a [AbiEntry],
 ) -> Result<(usize, &'a AbiNamedMember)> {
@@ -112,24 +235,26 @@ fn find_item_with_path<'item, T: EnumOrStruct>(
 ) -> Result<&'item T> {
     // Argument is a module path to an item (module_name::StructName {})
     if path.len() > 1 {
-        let full_path_item = items_from_abi
-            .into_iter()
-            .find(|x| x.name() == path.join("::"));
+        let path_joined = path.join("::");
+        let full_path_item = items_from_abi.into_iter().find(|x| {
+            let name = x.name();
+            // Also match monomorphized generics, e.g. ABI name `foo::Bar::<u32>` against path `foo::Bar`
+            name == path_joined || strip_generic_suffix(&name) == path_joined
+        });
 
-        ensure!(
-            full_path_item.is_some(),
-            r#"{} "{}" not found in ABI"#,
-            T::VARIANT_CAPITALIZED,
-            path.join("::")
-        );
-
-        return Ok(full_path_item.unwrap());
+        return full_path_item.ok_or_else(|| {
+            anyhow::anyhow!(
+                r#"{} "{}" not found in ABI"#,
+                T::VARIANT_CAPITALIZED,
+                path.join("::")
+            )
+        });
     }
 
     // Argument is just the name of the item (Struct {})
     let mut matching_items_from_abi: Vec<&T> = items_from_abi
         .into_iter()
-        .filter(|x| x.name().split("::").last() == path.last().map(String::as_str))
+        .filter(|x| base_type_name(&x.name()) == path.last().map_or("", String::as_str))
         .collect();
 
     ensure!(
@@ -257,6 +382,26 @@ impl SupportedCalldataKind for ExprStructCtorCall<'_> {
     }
 }
 
+fn resolve_enum_variant<'a>(
+    variant_name: &str,
+    enum_path: &[String],
+    expected_type: &'a str,
+    abi: &'a [AbiEntry],
+) -> Result<ResolvedEnumVariant<'a>> {
+    let enum_path_joined = enum_path.join("::");
+    validate_path_argument(expected_type, enum_path, &enum_path_joined)?;
+
+    if let Some(result) = resolve_corelib_enum_variant(expected_type, variant_name, enum_path) {
+        result
+    } else {
+        let (position, variant) = find_enum_variant_position(variant_name, enum_path, abi)?;
+        Ok(ResolvedEnumVariant {
+            position,
+            inner_type: Some(variant.r#type.as_str()).filter(|t| *t != UNIT_TYPE),
+        })
+    }
+}
+
 // Unit enum variants
 impl SupportedCalldataKind for ExprPath<'_> {
     fn transform(
@@ -265,22 +410,21 @@ impl SupportedCalldataKind for ExprPath<'_> {
         abi: &[AbiEntry],
         db: &SimpleParserDatabase,
     ) -> Result<AllowedCalldataArgument> {
-        // Enums with no value - Enum::Variant
-        let enum_path_with_variant = split(self, db)?;
-        let (enum_variant_name, enum_path) = enum_path_with_variant.split_last().unwrap();
-        let enum_path_joined = enum_path.join("::");
+        let (enum_variant_name, enum_path) = split_variant_from_path(&split(self, db)?)?;
 
-        validate_path_argument(expected_type, enum_path, &enum_path_joined)?;
+        let resolved = resolve_enum_variant(&enum_variant_name, &enum_path, expected_type, abi)?;
 
-        let (enum_position, enum_variant) =
-            find_enum_variant_position(enum_variant_name, enum_path, abi)?;
+        ensure!(
+            resolved.inner_type.is_none(),
+            r#"Variant "{enum_variant_name}" of "{expected_type}" takes no value"#
+        );
 
         if enum_variant.r#type != "()" {
             bail!(r#"Couldn't find variant "{enum_variant_name}" in enum "{enum_path_joined}""#)
         }
 
         Ok(AllowedCalldataArgument::Enum(CalldataEnum::new(
-            enum_position,
+            resolved.position,
             None,
         )))
     }
@@ -294,25 +438,28 @@ impl SupportedCalldataKind for ExprFunctionCall<'_> {
         abi: &[AbiEntry],
         db: &SimpleParserDatabase,
     ) -> Result<AllowedCalldataArgument> {
-        // Enums with value - Enum::Variant(10)
-        let enum_path_with_variant = split(&self.path(db), db)?;
-        let (enum_variant_name, enum_path) = enum_path_with_variant.split_last().unwrap();
-        let enum_path_joined = enum_path.join("::");
+        let (enum_variant_name, enum_path) = split_variant_from_path(&split(&self.path(db), db)?)?;
 
-        validate_path_argument(expected_type, enum_path, &enum_path_joined)?;
+        let resolved = resolve_enum_variant(&enum_variant_name, &enum_path, expected_type, abi)?;
 
-        let (enum_position, enum_variant) =
-            find_enum_variant_position(enum_variant_name, enum_path, abi)?;
+        let inner_type = resolved.inner_type.with_context(|| {
+            format!(r#"Variant "{enum_variant_name}" of "{expected_type}" takes no value"#)
+        })?;
 
         let arguments = self.arguments(db).arguments(db);
-        // Enum variant constructor invocation has one argument - an ArgList.
-        // We parse it to a vector of expressions and pop + unwrap safely.
-        let expr = parse_argument_list(&arguments, db)?.pop().unwrap();
 
-        let parsed_expr = build_representation(expr, &enum_variant.r#type, abi, db)?;
+        let mut args_list = parse_argument_list(&arguments, db)?;
+        ensure!(
+            args_list.len() == 1,
+            r#"Variant "{enum_variant_name}" of "{expected_type}" expects exactly 1 argument, got {}"#,
+            args_list.len()
+        );
+        let expr = args_list.pop().unwrap();
+
+        let parsed_expr = build_representation(expr, inner_type, abi, db)?;
 
         Ok(AllowedCalldataArgument::Enum(CalldataEnum::new(
-            enum_position,
+            resolved.position,
             Some(Box::new(parsed_expr)),
         )))
     }

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -23,6 +23,14 @@ pub trait EnumOrStruct {
     fn name(&self) -> String;
 }
 
+/// A resolved enum variant with its serialization position and optional inner type.
+struct ResolvedEnumVariant<'a> {
+    /// 0-based position used for serialization
+    position: usize,
+    /// Inner type, or `None` for unit variants
+    inner_type: Option<&'a str>,
+}
+
 impl EnumOrStruct for AbiStruct {
     const VARIANT: &'static str = "struct";
     const VARIANT_CAPITALIZED: &'static str = "Struct";
@@ -70,14 +78,6 @@ fn validate_path_argument(
         bail!(r#"Invalid argument type, expected "{param_type}", got "{path_argument_joined}""#)
     }
     Ok(())
-}
-
-/// A resolved enum variant with its serialization position and optional inner type.
-struct ResolvedEnumVariant<'a> {
-    /// 0-based position used for serialization
-    position: usize,
-    /// Inner type, or `None` for unit variants
-    inner_type: Option<&'a str>,
 }
 
 fn is_valid_corelib_enum_path(type_name: &str, enum_path: &[String]) -> bool {
@@ -155,26 +155,26 @@ fn resolve_corelib_enum_variant<'a>(
 }
 
 fn top_level_comma_pos(s: &str) -> Option<usize> {
-    let mut depth = 0;
-    s.char_indices().find_map(|(i, c)| match c {
-        '<' => {
-            depth += 1;
-            None
+    let mut angle_depth = 0;
+    let mut paren_depth = 0;
+    s.char_indices().find_map(|(i, c)| {
+        match c {
+            '<' => angle_depth += 1,
+            '>' => angle_depth -= 1,
+            '(' => paren_depth += 1,
+            ')' => paren_depth -= 1,
+            ',' if angle_depth == 0 && paren_depth == 0 => return Some(i),
+            _ => {}
         }
-        '>' if depth > 0 => {
-            depth -= 1;
-            None
-        }
-        ',' if depth == 0 => Some(i),
-        _ => None,
+        None
     })
 }
 
-fn split_variant_from_path(path: &[String]) -> Result<(String, Vec<String>)> {
+fn split_variant_from_path(path: &[String]) -> Result<(&str, &[String])> {
     let (variant, rest) = path
         .split_last()
         .ok_or_else(|| anyhow::anyhow!("Expected an enum variant path, got an empty path"))?;
-    Ok((variant.clone(), rest.to_vec()))
+    Ok((variant, rest))
 }
 
 fn split(path: &ExprPath, db: &SimpleParserDatabase) -> Result<Vec<String>> {
@@ -410,13 +410,14 @@ impl SupportedCalldataKind for ExprPath<'_> {
         abi: &[AbiEntry],
         db: &SimpleParserDatabase,
     ) -> Result<AllowedCalldataArgument> {
-        let (enum_variant_name, enum_path) = split_variant_from_path(&split(self, db)?)?;
+        let path = split(self, db)?;
+        let (enum_variant_name, enum_path) = split_variant_from_path(&path)?;
 
-        let resolved = resolve_enum_variant(&enum_variant_name, &enum_path, expected_type, abi)?;
+        let resolved = resolve_enum_variant(enum_variant_name, enum_path, expected_type, abi)?;
 
         ensure!(
             resolved.inner_type.is_none(),
-            r#"Variant "{enum_variant_name}" of "{expected_type}" takes no value"#
+            r#"Variant "{enum_variant_name}" of "{expected_type}" requires a value, use "{enum_variant_name}(<value>)""#
         );
 
         if enum_variant.r#type != "()" {
@@ -438,9 +439,10 @@ impl SupportedCalldataKind for ExprFunctionCall<'_> {
         abi: &[AbiEntry],
         db: &SimpleParserDatabase,
     ) -> Result<AllowedCalldataArgument> {
-        let (enum_variant_name, enum_path) = split_variant_from_path(&split(&self.path(db), db)?)?;
+        let path = split(&self.path(db), db)?;
+        let (enum_variant_name, enum_path) = split_variant_from_path(&path)?;
 
-        let resolved = resolve_enum_variant(&enum_variant_name, &enum_path, expected_type, abi)?;
+        let resolved = resolve_enum_variant(enum_variant_name, enum_path, expected_type, abi)?;
 
         let inner_type = resolved.inner_type.with_context(|| {
             format!(r#"Variant "{enum_variant_name}" of "{expected_type}" takes no value"#)

--- a/crates/data-transformer/tests/data/data_transformer/Scarb.toml
+++ b/crates/data-transformer/tests/data/data_transformer/Scarb.toml
@@ -7,7 +7,7 @@ edition = "2024_07"
 
 [dependencies]
 starknet = "2.9.4"
-alexandria_data_structures = "0.4.0"
+alexandria_data_structures = "0.5.0"
 
 [dev-dependencies]
 snforge_std = "0.39.0"

--- a/crates/data-transformer/tests/data/data_transformer/src/lib.cairo
+++ b/crates/data-transformer/tests/data/data_transformer/src/lib.cairo
@@ -34,6 +34,29 @@ pub struct BitArray {
     bit: felt252,
 }
 
+#[derive(Serde, Drop)]
+pub struct StructWithOption {
+    a: felt252,
+    b: Option<u32>,
+}
+
+#[derive(Serde, Drop)]
+pub enum EnumWithOption {
+    None: (),
+    Some: Option<felt252>,
+}
+
+#[derive(Serde, Drop)]
+pub struct Wrapper<T> {
+    value: T,
+}
+
+#[derive(Serde, Drop)]
+pub enum MaybeValue<T> {
+    Nothing: (),
+    Just: T,
+}
+
 #[starknet::interface]
 pub trait IDataTransformer<TContractState> {
     fn simple_fn(ref self: TContractState, a: felt252) -> felt252;
@@ -63,6 +86,15 @@ pub trait IDataTransformer<TContractState> {
     fn span_fn(ref self: TContractState, a: Span<felt252>) -> Span<felt252>;
     fn multiple_signed_fn(ref self: TContractState, a: i32, b: i8);
     fn no_args_fn(ref self: TContractState);
+    fn option_fn(ref self: TContractState, a: Option<u32>) -> Option<u32>;
+    fn struct_with_option_fn(ref self: TContractState, a: StructWithOption) -> StructWithOption;
+    fn enum_with_option_fn(ref self: TContractState, a: EnumWithOption) -> EnumWithOption;
+    fn option_of_enum_fn(
+        ref self: TContractState, a: Option<EnumWithOption>,
+    ) -> Option<EnumWithOption>;
+    fn result_fn(ref self: TContractState, a: Result<u32, felt252>) -> Result<u32, felt252>;
+    fn wrapper_fn(ref self: TContractState, a: Wrapper<u32>) -> Wrapper<u32>;
+    fn maybe_value_fn(ref self: TContractState, a: MaybeValue<felt252>) -> MaybeValue<felt252>;
 }
 
 #[starknet::contract]
@@ -131,6 +163,29 @@ mod DataTransformer {
         }
         fn multiple_signed_fn(ref self: ContractState, a: i32, b: i8) {}
         fn no_args_fn(ref self: ContractState) {}
+        fn option_fn(ref self: ContractState, a: Option<u32>) -> Option<u32> {
+            a
+        }
+        fn struct_with_option_fn(ref self: ContractState, a: StructWithOption) -> StructWithOption {
+            a
+        }
+        fn enum_with_option_fn(ref self: ContractState, a: EnumWithOption) -> EnumWithOption {
+            a
+        }
+        fn option_of_enum_fn(
+            ref self: ContractState, a: Option<EnumWithOption>,
+        ) -> Option<EnumWithOption> {
+            a
+        }
+        fn result_fn(ref self: ContractState, a: Result<u32, felt252>) -> Result<u32, felt252> {
+            a
+        }
+        fn wrapper_fn(ref self: ContractState, a: Wrapper<u32>) -> Wrapper<u32> {
+            a
+        }
+        fn maybe_value_fn(ref self: ContractState, a: MaybeValue<felt252>) -> MaybeValue<felt252> {
+            a
+        }
     }
 }
 

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -712,6 +712,61 @@ fn test_happy_case_result_err() {
     assert_eq!(result, vec![Felt::ONE, Felt::from(999u32)]);
 }
 
+fn result_tuple_with_array_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "function",
+                "name": "result_tuple_array_fn",
+                "inputs": [{"name": "a", "type": "core::result::Result::<(core::array::Array::<core::integer::u32>, core::integer::u64), core::option::Option::<(core::integer::u32, core::integer::u64)>>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_result_ok_with_tuple_containing_array() {
+    let abi = result_tuple_with_array_abi();
+    let result = transform(
+        "Result::Ok((array![1_u32, 2_u32], 3_u64))",
+        &abi,
+        &get_selector_from_name("result_tuple_array_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Ok=0, array length=2, elements 1 and 2, then u64=3
+    assert_eq!(
+        result,
+        vec![
+            Felt::ZERO,
+            Felt::TWO,
+            Felt::ONE,
+            Felt::TWO,
+            Felt::from(3u32)
+        ]
+    );
+}
+
+#[test]
+fn test_result_err_with_option_of_tuple_e() {
+    let abi = result_tuple_with_array_abi();
+    let result = transform(
+        "Result::Err(Option::Some((3_u32, 4_u64)))",
+        &abi,
+        &get_selector_from_name("result_tuple_array_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Err=1, Option::Some=0, tuple fields 1 and 2
+    assert_eq!(
+        result,
+        vec![Felt::ONE, Felt::ZERO, Felt::from(3u32), Felt::from(4u64)]
+    );
+}
+
 fn custom_generic_abi() -> Vec<AbiEntry> {
     serde_json::from_str(
         r#"[
@@ -859,7 +914,7 @@ fn test_option_value_variant_missing_value() {
     );
 
     result.unwrap_err().assert_contains(
-        r#"Variant "Some" of "core::option::Option::<core::integer::u32>" takes no value"#,
+        r#"Variant "Some" of "core::option::Option::<core::integer::u32>" requires a value, use "Some(<value>)""#,
     );
 }
 

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -528,7 +528,51 @@ async fn test_external_struct_function_invalid_path_to_external_struct() {
 
     result
         .unwrap_err()
-        .assert_contains(r#"Struct "something::BitArray" not found in ABI"#);
+        .assert_contains(r#"Invalid argument type, expected "data_transformer_contract::BitArray", got "something::BitArray""#);
+}
+
+#[tokio::test]
+async fn test_external_struct_function_partial_path_not_found_in_abi() {
+    // "bit_array::BitArray" passes the path suffix check against
+    // "alexandria_data_structures::bit_array::BitArray", but find_item_with_path
+    // requires an exact full-path match for multi-segment inputs → not found.
+    let input = indoc!(
+        "
+        data_transformer_contract::BitArray { bit: 23 }, \
+        bit_array::BitArray { data: array![0], current: 1, read_pos: 2, write_pos: 3 }
+        "
+    );
+
+    let result = run_transformer(input, "external_struct_fn").await;
+
+    result
+        .unwrap_err()
+        .assert_contains(r#"Struct "bit_array::BitArray" not found in ABI"#);
+}
+
+#[tokio::test]
+async fn test_external_struct_function_disambiguates_same_name_with_full_path() {
+    // Both "data_transformer_contract::BitArray" and
+    // "alexandria_data_structures::bit_array::BitArray" share the name "BitArray".
+    // Providing the full path for each resolves the correct struct unambiguously.
+    let input = indoc!(
+        "
+        data_transformer_contract::BitArray { bit: 23 }, \
+        alexandria_data_structures::bit_array::BitArray { data: array![0], current: 1, read_pos: 2, write_pos: 3 }
+        "
+    );
+
+    let result = run_transformer(input, "external_struct_fn").await.unwrap();
+
+    let expected_output = [
+        Felt::from_hex_unchecked("0x17"),
+        Felt::from_hex_unchecked("0x1"),
+        Felt::from_hex_unchecked("0x0"),
+        Felt::from_hex_unchecked("0x1"),
+        Felt::from_hex_unchecked("0x2"),
+        Felt::from_hex_unchecked("0x3"),
+    ];
+    assert_eq!(result, expected_output);
 }
 
 #[tokio::test]
@@ -878,7 +922,7 @@ fn test_happy_case_option_none() {
 fn test_happy_case_option_some() {
     let abi = option_u32_abi();
     let result = transform(
-        "Option::Some(42)",
+        "option::Option::Some(42)",
         &abi,
         &get_selector_from_name("option_fn").unwrap(),
     )
@@ -1006,7 +1050,7 @@ fn test_happy_case_result_ok_with_option_none() {
 }
 
 #[test]
-fn test_happy_case_option_some_full_path() {
+fn test_happy_case_option_some_module_path() {
     let abi = option_u32_abi();
     let result = transform(
         "core::option::Option::Some(5)",
@@ -1030,6 +1074,20 @@ fn test_happy_case_option_none_full_path() {
     .unwrap();
 
     assert_eq!(result, vec![Felt::ONE]);
+}
+
+#[test]
+fn test_result_invalid_module_path() {
+    let abi = result_nested_abi();
+    let result = transform(
+        "option::Result::Ok(7)",
+        &abi,
+        &get_selector_from_name("result_nested_fn").unwrap(),
+    );
+
+    result.unwrap_err().assert_contains(
+        r#"Invalid argument type, expected "core::result::Result::<core::option::Option::<core::integer::u32>, core::felt252>", got "option::Result""#,
+    );
 }
 
 #[test]

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -565,6 +565,432 @@ async fn test_happy_case_implicit_contract_constructor() {
     assert_eq!(result, expected_output);
 }
 
+fn option_complex_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "enum",
+                "name": "data_transformer_contract::EnumWithOption",
+                "variants": [
+                    {"name": "None", "type": "()"},
+                    {"name": "Some", "type": "core::option::Option::<core::felt252>"}
+                ]
+            },
+            {
+                "type": "struct",
+                "name": "data_transformer_contract::StructWithOption",
+                "members": [
+                    {"name": "a", "type": "core::felt252"},
+                    {"name": "b", "type": "core::option::Option::<core::integer::u32>"}
+                ]
+            },
+            {
+                "type": "function",
+                "name": "struct_with_option_fn",
+                "inputs": [{"name": "a", "type": "data_transformer_contract::StructWithOption"}],
+                "outputs": [],
+                "state_mutability": "view"
+            },
+            {
+                "type": "function",
+                "name": "enum_with_option_fn",
+                "inputs": [{"name": "a", "type": "data_transformer_contract::EnumWithOption"}],
+                "outputs": [],
+                "state_mutability": "view"
+            },
+            {
+                "type": "function",
+                "name": "option_of_enum_fn",
+                "inputs": [{"name": "a", "type": "core::option::Option::<data_transformer_contract::EnumWithOption>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_happy_case_struct_with_option_some() {
+    let abi = option_complex_abi();
+    let result = transform(
+        "StructWithOption { a: 1, b: Option::Some(99) }",
+        &abi,
+        &get_selector_from_name("struct_with_option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // a=1, b=Some(99) -> [0, 99]
+    assert_eq!(result, vec![Felt::ONE, Felt::ZERO, Felt::from(99u32)]);
+}
+
+#[test]
+fn test_happy_case_struct_with_option_none() {
+    let abi = option_complex_abi();
+    let result = transform(
+        "StructWithOption { a: 7, b: Option::None }",
+        &abi,
+        &get_selector_from_name("struct_with_option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // a=7, b=None -> [1]
+    assert_eq!(result, vec![Felt::from(7u32), Felt::ONE]);
+}
+
+#[test]
+fn test_happy_case_enum_with_option_variant_some() {
+    let abi = option_complex_abi();
+    let result = transform(
+        "EnumWithOption::Some(Option::Some(42))",
+        &abi,
+        &get_selector_from_name("enum_with_option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // EnumWithOption::Some is variant 1, inner Option::Some(42) -> [0, 42]
+    assert_eq!(result, vec![Felt::ONE, Felt::ZERO, Felt::from(42u32)]);
+}
+
+#[test]
+fn test_happy_case_enum_with_option_variant_some_none() {
+    let abi = option_complex_abi();
+    let result = transform(
+        "EnumWithOption::Some(Option::None)",
+        &abi,
+        &get_selector_from_name("enum_with_option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // EnumWithOption::Some is variant 1, inner Option::None -> [1]
+    assert_eq!(result, vec![Felt::ONE, Felt::ONE]);
+}
+
+#[test]
+fn test_happy_case_option_of_enum_some() {
+    let abi = option_complex_abi();
+    let result = transform(
+        "Option::Some(EnumWithOption::Some(Option::Some(10)))",
+        &abi,
+        &get_selector_from_name("option_of_enum_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Option::Some -> [0], EnumWithOption::Some -> [1], Option::Some(10) -> [0, 10]
+    assert_eq!(
+        result,
+        vec![Felt::ZERO, Felt::ONE, Felt::ZERO, Felt::from(10u32)]
+    );
+}
+
+fn result_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "function",
+                "name": "result_fn",
+                "inputs": [{"name": "a", "type": "core::result::Result::<core::integer::u32, core::felt252>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_happy_case_result_err() {
+    let abi = result_abi();
+    let result = transform(
+        "Result::Err(999)",
+        &abi,
+        &get_selector_from_name("result_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Err is variant 1, value is felt252
+    assert_eq!(result, vec![Felt::ONE, Felt::from(999u32)]);
+}
+
+fn custom_generic_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "struct",
+                "name": "data_transformer_contract::Wrapper::<core::integer::u32>",
+                "members": [
+                    {"name": "value", "type": "core::integer::u32"}
+                ]
+            },
+            {
+                "type": "enum",
+                "name": "data_transformer_contract::MaybeValue::<core::felt252>",
+                "variants": [
+                    {"name": "Nothing", "type": "()"},
+                    {"name": "Just", "type": "core::felt252"}
+                ]
+            },
+            {
+                "type": "function",
+                "name": "wrapper_fn",
+                "inputs": [{"name": "a", "type": "data_transformer_contract::Wrapper::<core::integer::u32>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            },
+            {
+                "type": "function",
+                "name": "maybe_value_fn",
+                "inputs": [{"name": "a", "type": "data_transformer_contract::MaybeValue::<core::felt252>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_happy_case_custom_generic_struct_full_path() {
+    let abi = custom_generic_abi();
+    let result = transform(
+        "data_transformer_contract::Wrapper { value: 7 }",
+        &abi,
+        &get_selector_from_name("wrapper_fn").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(result, vec![Felt::from(7u32)]);
+}
+
+#[test]
+fn test_happy_case_custom_generic_enum_unit_variant() {
+    let abi = custom_generic_abi();
+    let result = transform(
+        "MaybeValue::Nothing",
+        &abi,
+        &get_selector_from_name("maybe_value_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Nothing is variant 0
+    assert_eq!(result, vec![Felt::ZERO]);
+}
+
+#[test]
+fn test_happy_case_custom_generic_enum_value_variant() {
+    let abi = custom_generic_abi();
+    let result = transform(
+        "MaybeValue::Just(123)",
+        &abi,
+        &get_selector_from_name("maybe_value_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Just is variant 1
+    assert_eq!(result, vec![Felt::ONE, Felt::from(123u32)]);
+}
+
+fn option_u32_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "function",
+                "name": "option_fn",
+                "inputs": [{"name": "a", "type": "core::option::Option::<core::integer::u32>"}],
+                "outputs": [{"type": "core::option::Option::<core::integer::u32>"}],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_happy_case_option_none() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::None",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // In Cairo corelib Option: Some=0, None=1
+    assert_eq!(result, vec![Felt::ONE]);
+}
+
+#[test]
+fn test_happy_case_option_some() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::Some(42)",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // In Cairo corelib Option: Some=0, None=1; Some(42) serializes as [0, 42]
+    assert_eq!(result, vec![Felt::ZERO, Felt::from(42u32)]);
+}
+
+// Option::None(x) — unit variant called with a value
+#[test]
+fn test_option_unit_variant_called_with_value() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::None(99)",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    );
+
+    result.unwrap_err().assert_contains(
+        r#"Variant "None" of "core::option::Option::<core::integer::u32>" takes no value"#,
+    );
+}
+
+// Option::Some without parens — value-carrying variant used as unit
+#[test]
+fn test_option_value_variant_missing_value() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::Some",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    );
+
+    result.unwrap_err().assert_contains(
+        r#"Variant "Some" of "core::option::Option::<core::integer::u32>" takes no value"#,
+    );
+}
+
+// MaybeValue::Nothing(x) — non-corelib unit variant called with a value
+#[test]
+fn test_custom_generic_enum_unit_variant_called_with_value() {
+    let abi = custom_generic_abi();
+    let result = transform(
+        "MaybeValue::Nothing(1)",
+        &abi,
+        &get_selector_from_name("maybe_value_fn").unwrap(),
+    );
+
+    result
+        .unwrap_err()
+        .assert_contains(r#"Variant "Nothing" of "data_transformer_contract::MaybeValue::<core::felt252>" takes no value"#);
+}
+
+#[test]
+fn test_option_wrong_variant() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::Other",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    );
+
+    result
+        .unwrap_err()
+        .assert_contains(r#"Invalid variant "Other" for type"#);
+}
+
+// Option::Some(1, 2) — value-carrying variant called with wrong number of arguments
+#[test]
+fn test_option_some_too_many_args() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "Option::Some(1, 2)",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    );
+
+    result
+        .unwrap_err()
+        .assert_contains(r#"Variant "Some" of "core::option::Option::<core::integer::u32>" expects exactly 1 argument, got 2"#);
+}
+
+fn result_nested_abi() -> Vec<AbiEntry> {
+    serde_json::from_str(
+        r#"[
+            {
+                "type": "function",
+                "name": "result_nested_fn",
+                "inputs": [{"name": "a", "type": "core::result::Result::<core::option::Option::<core::integer::u32>, core::felt252>"}],
+                "outputs": [],
+                "state_mutability": "view"
+            }
+        ]"#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn test_happy_case_result_ok_with_option_some() {
+    let abi = result_nested_abi();
+    let result = transform(
+        "Result::Ok(Option::Some(7))",
+        &abi,
+        &get_selector_from_name("result_nested_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Ok=0, Some=0, value=7
+    assert_eq!(result, vec![Felt::ZERO, Felt::ZERO, Felt::from(7u32)]);
+}
+
+#[test]
+fn test_happy_case_result_ok_with_option_none() {
+    let abi = result_nested_abi();
+    let result = transform(
+        "Result::Ok(Option::None)",
+        &abi,
+        &get_selector_from_name("result_nested_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Ok=0, None=1
+    assert_eq!(result, vec![Felt::ZERO, Felt::ONE]);
+}
+
+#[test]
+fn test_happy_case_option_some_full_path() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "core::option::Option::Some(5)",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    )
+    .unwrap();
+
+    // Some=0, value=5
+    assert_eq!(result, vec![Felt::ZERO, Felt::from(5u32)]);
+}
+
+#[test]
+fn test_happy_case_option_none_full_path() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "core::option::Option::None",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(result, vec![Felt::ONE]);
+}
+
+#[test]
+fn test_option_invalid_non_corelib_path() {
+    let abi = option_u32_abi();
+    let result = transform(
+        "foo::Option::Some(5)",
+        &abi,
+        &get_selector_from_name("option_fn").unwrap(),
+    );
+
+    result
+        .unwrap_err()
+        .assert_contains(r#"Invalid argument type, expected "core::option::Option::<core::integer::u32>", got "foo::Option""#);
+}
+
 #[tokio::test]
 async fn test_external_enum_function_ambiguous_enum_name_cairo_expression_input() {
     // https://sepolia.voyager.online/class/0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d#code

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -343,10 +343,10 @@ async fn deploy_data_transformer_contract() -> (tempfile::TempDir, String) {
 }
 
 #[tokio::test]
-async fn test_happy_case_call_with_option() {
+async fn test_happy_case_call_with_option_and_result() {
     let (tempdir, contract_address) = deploy_data_transformer_contract().await;
 
-    let args = vec![
+    runner(&[
         "--accounts-file",
         "accounts.json",
         "call",
@@ -358,24 +358,17 @@ async fn test_happy_case_call_with_option() {
         "option_fn",
         "--arguments",
         "Option::Some(42_u32)",
-    ];
+    ])
+    .current_dir(tempdir.path())
+    .assert()
+    .success()
+    .stdout_eq(indoc! {r"
+        Success: Call completed
 
-    runner(&args)
-        .current_dir(tempdir.path())
-        .assert()
-        .success()
-        .stdout_eq(indoc! {r"
-            Success: Call completed
+        Response: [0x0, 0x2a]
+    "});
 
-            Response: [0x0, 0x2a]
-        "});
-}
-
-#[tokio::test]
-async fn test_happy_case_call_with_result() {
-    let (tempdir, contract_address) = deploy_data_transformer_contract().await;
-
-    let args = vec![
+    runner(&[
         "--accounts-file",
         "accounts.json",
         "call",
@@ -387,15 +380,13 @@ async fn test_happy_case_call_with_result() {
         "result_fn",
         "--arguments",
         "Result::Ok(99_u32)",
-    ];
+    ])
+    .current_dir(tempdir.path())
+    .assert()
+    .success()
+    .stdout_eq(indoc! {r"
+        Success: Call completed
 
-    runner(&args)
-        .current_dir(tempdir.path())
-        .assert()
-        .success()
-        .stdout_eq(indoc! {r"
-            Success: Call completed
-
-            Response: [0x0, 0x63]
-        "});
+        Response: [0x0, 0x63]
+    "});
 }

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -1,7 +1,10 @@
 use crate::helpers::constants::{
-    ACCOUNT_FILE_PATH, DATA_TRANSFORMER_CONTRACT_ADDRESS_SEPOLIA, MAP_CONTRACT_ADDRESS_SEPOLIA, URL,
+    ACCOUNT_FILE_PATH, DATA_TRANSFORMER_CONTRACT_ADDRESS_SEPOLIA, DATA_TRANSFORMER_CONTRACT_DIR,
+    MAP_CONTRACT_ADDRESS_SEPOLIA, URL,
 };
-use crate::helpers::fixtures::invoke_contract;
+use crate::helpers::fixtures::{
+    copy_directory_to_tempdir, create_and_deploy_oz_account, invoke_contract, join_tempdirs,
+};
 use crate::helpers::runner::runner;
 use crate::helpers::shell::os_specific_shell;
 use camino::Utf8PathBuf;
@@ -292,4 +295,107 @@ fn test_json_output_format() {
     snapbox.assert().success().stdout_eq(indoc! {r#"
         {"command":"call","response":"0x0","response_raw":["0x0"],"type":"response"}
     "#});
+}
+
+async fn deploy_data_transformer_contract() -> (tempfile::TempDir, String) {
+    let contract_dir = copy_directory_to_tempdir(DATA_TRANSFORMER_CONTRACT_DIR);
+    let tempdir = create_and_deploy_oz_account().await;
+    join_tempdirs(&contract_dir, &tempdir);
+
+    let contents = std::fs::read_to_string(tempdir.path().join("accounts.json")).unwrap();
+    let items: serde_json::Value = serde_json::from_str(&contents).unwrap();
+    let account_address = items["alpha-sepolia"]["my_account"]["address"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let deploy_args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "--json",
+        "deploy",
+        "--url",
+        URL,
+        "--contract-name",
+        "DataTransformer",
+        "--arguments",
+        &account_address,
+    ];
+    let deploy_output = runner(&deploy_args)
+        .current_dir(tempdir.path())
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let contract_address = deploy_output
+        .split(|&b| b == b'\n')
+        .find_map(|line| {
+            let json: serde_json::Value = serde_json::from_slice(line).ok()?;
+            json["contract_address"].as_str().map(str::to_string)
+        })
+        .unwrap();
+
+    (tempdir, contract_address)
+}
+
+#[tokio::test]
+async fn test_happy_case_call_with_option() {
+    let (tempdir, contract_address) = deploy_data_transformer_contract().await;
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "call",
+        "--url",
+        URL,
+        "--contract-address",
+        &contract_address,
+        "--function",
+        "option_fn",
+        "--arguments",
+        "Option::Some(42_u32)",
+    ];
+
+    runner(&args)
+        .current_dir(tempdir.path())
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r"
+            Success: Call completed
+
+            Response: [0x0, 0x2a]
+        "});
+}
+
+#[tokio::test]
+async fn test_happy_case_call_with_result() {
+    let (tempdir, contract_address) = deploy_data_transformer_contract().await;
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "call",
+        "--url",
+        URL,
+        "--contract-address",
+        &contract_address,
+        "--function",
+        "result_fn",
+        "--arguments",
+        "Result::Ok(99_u32)",
+    ];
+
+    runner(&args)
+        .current_dir(tempdir.path())
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r"
+            Success: Call completed
+
+            Response: [0x0, 0x63]
+        "});
 }

--- a/crates/sncast/tests/helpers/constants.rs
+++ b/crates/sncast/tests/helpers/constants.rs
@@ -44,3 +44,5 @@ pub const DATA_TRANSFORMER_CONTRACT_CLASS_HASH_SEPOLIA: &str =
     "0x0786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0";
 pub const DATA_TRANSFORMER_CONTRACT_ABI_PATH: &str =
     "tests/data/files/data_transformer_contract_abi.json";
+pub const DATA_TRANSFORMER_CONTRACT_DIR: &str =
+    "../../crates/data-transformer/tests/data/data_transformer";

--- a/docs/src/starknet/calldata-transformation.md
+++ b/docs/src/starknet/calldata-transformation.md
@@ -113,6 +113,8 @@ Calldata: [0x24, 0x60]
 * `bytes31`
 * `Array` - using `array![]` macro
 * `Span` - using `array![].span()` macro and function call
+* `Option` - using `Option::Some(value)` or `Option::None`
+* `Result` - using `Result::Ok(value)` or `Result::Err(value)`
 
 Numeric types (primitives and `felt252`) can be paseed with type suffix specified for example `--arguments 420_u64`.
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3976

## Introduced changes

<!-- A brief description of the changes -->

- Add support for `Option` and `Result` in data transformer, to allow them to be used with `--arguments` in `sncast`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
