### PR TITLE
Debugger Scarb.toml validation

### DIFF
--- a/crates/forge/src/profile_validation/coverage.rs
+++ b/crates/forge/src/profile_validation/coverage.rs
@@ -5,11 +5,6 @@ use scarb_metadata::Metadata;
 
 /// Checks if coverage can be based on scarb version and profile settings extracted from the provided [`Metadata`].
 pub fn check_coverage_compatibility(scarb_metadata: &Metadata) -> anyhow::Result<()> {
-    check_profile(scarb_metadata)
-}
-
-/// Checks if the runtime profile settings in the provided from [`Metadata`] contain the required entries for coverage generation.
-fn check_profile(scarb_metadata: &Metadata) -> anyhow::Result<()> {
     const CAIRO_COVERAGE_REQUIRED_ENTRIES: &[(&str, &str)] = &[
         ("unstable-add-statements-functions-debug-info", "true"),
         ("unstable-add-statements-code-locations-debug-info", "true"),

--- a/crates/forge/src/profile_validation/debugger.rs
+++ b/crates/forge/src/profile_validation/debugger.rs
@@ -1,0 +1,37 @@
+use crate::profile_validation::{check_cairo_profile_entries, get_manifest};
+use anyhow::ensure;
+use indoc::formatdoc;
+use scarb_metadata::Metadata;
+
+/// Checks if debugger can be launched based on profile settings extracted from the provided [`Metadata`].
+pub fn check_debugger_compatibility(scarb_metadata: &Metadata) -> anyhow::Result<()> {
+    const DEBUGGER_REQUIRED_ENTRIES: &[(&str, &str)] = &[
+        ("unstable-add-statements-code-locations-debug-info", "true"),
+        ("unstable-add-statements-functions-debug-info", "true"),
+        ("add-functions-debug-info", "true"),
+        ("skip-optimizations", "true"),
+    ];
+
+    let manifest = get_manifest(scarb_metadata)?;
+
+    let has_needed_entries =
+        check_cairo_profile_entries(&manifest, scarb_metadata, DEBUGGER_REQUIRED_ENTRIES);
+
+    ensure!(
+        has_needed_entries,
+        formatdoc! {
+            "Scarb.toml must have the following Cairo compiler configuration to launch the debugger:
+
+            [profile.{profile}.cairo]
+            unstable-add-statements-code-locations-debug-info = true
+            unstable-add-statements-functions-debug-info = true
+            add-functions-debug-info = true
+            skip-optimizations = true
+            ... other entries ...
+            ",
+            profile = scarb_metadata.current_profile
+        },
+    );
+
+    Ok(())
+}

--- a/crates/forge/src/profile_validation/mod.rs
+++ b/crates/forge/src/profile_validation/mod.rs
@@ -1,9 +1,11 @@
 mod backtrace;
 mod coverage;
+mod debugger;
 
 use crate::TestArgs;
 use crate::profile_validation::backtrace::check_backtrace_compatibility;
 use crate::profile_validation::coverage::check_coverage_compatibility;
+use crate::profile_validation::debugger::check_debugger_compatibility;
 use forge_runner::backtrace::is_backtrace_enabled;
 use scarb_metadata::Metadata;
 use std::fs;
@@ -17,9 +19,15 @@ pub fn check_profile_compatibility(
     if test_args.coverage {
         check_coverage_compatibility(scarb_metadata)?;
     }
+
+    if test_args.launch_debugger {
+        check_debugger_compatibility(scarb_metadata)?;
+    }
+
     if is_backtrace_enabled() {
         check_backtrace_compatibility(test_args, scarb_metadata)?;
     }
+
     Ok(())
 }
 

--- a/crates/forge/tests/e2e/debugger.rs
+++ b/crates/forge/tests/e2e/debugger.rs
@@ -1,10 +1,38 @@
-use super::common::runner::{setup_package, snforge_test_bin_path, test_runner};
+use crate::e2e::common::runner::{setup_package, snforge_test_bin_path, test_runner};
 use assert_fs::fixture::{FileWriteStr, PathChild};
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 use shared::test_utils::output_assert::assert_stdout_contains;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
+
+#[test]
+fn test_fail_wrong_scarb_toml_configuration_for_launch_debugger() {
+    let temp = setup_package("debugging");
+
+    let output = test_runner(&temp)
+        .arg("test_debugging_trace_success")
+        .arg("--exact")
+        .arg("--launch-debugger")
+        .assert()
+        .failure();
+
+    assert_stdout_contains(
+        output,
+        indoc! {
+            "[ERROR] Scarb.toml must have the following Cairo compiler configuration to launch the debugger:
+
+            [profile.dev.cairo]
+            unstable-add-statements-code-locations-debug-info = true
+            unstable-add-statements-functions-debug-info = true
+            add-functions-debug-info = true
+            skip-optimizations = true
+            ... other entries ...
+
+            "
+        },
+    );
+}
 
 #[test]
 fn test_launch_debugger_waits_for_connection() {
@@ -61,6 +89,19 @@ fn test_launch_debugger_waits_for_connection() {
 #[test]
 fn test_launch_debugger_fails_for_fuzzer_test() {
     let temp = setup_package("debugging");
+
+    let manifest_path = temp.child("Scarb.toml");
+    let existing = fs::read_to_string(&manifest_path).unwrap();
+    manifest_path
+        .write_str(&formatdoc!(
+            "{existing}
+            [profile.dev.cairo]
+            unstable-add-statements-code-locations-debug-info = true
+            unstable-add-statements-functions-debug-info = true
+            add-functions-debug-info = true
+            skip-optimizations = true",
+        ))
+        .unwrap();
 
     let output = test_runner(&temp)
         .args([


### PR DESCRIPTION
Closes https://github.com/software-mansion/cairo-debugger/issues/109

## Introduced changes

- added validation of Scarb.toml fields when forge is used with `--launch-debugger`, similar to coverage checks

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation - not needed, updated in #4160
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md` - imo not needed, is obvious part of #4160 
