### PR TITLE
Fix sncast verify network selection without --network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimal recommended `Scarb` version is now `2.15.2` (updated from `2.14.0`)
 
+### Cast
+
+#### Fixed
+
+- `sncast verify` now uses the configured network or infers it from the RPC chain ID when `--network` is omitted.
+
 ## [0.59.0] - 2026-04-10
 
 ### Forge

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -167,7 +167,7 @@ pub async fn verify(
     };
     let provider = get_provider(&rpc_url)?;
     let inferred_network = if network.is_none() && config.network.is_none() {
-        Some(Network::try_from(get_chain_id(&provider).await?)?)
+        Network::try_from(get_chain_id(&provider).await?).ok()
     } else {
         None
     };
@@ -259,7 +259,7 @@ pub async fn verify(
 #[cfg(test)]
 mod tests {
     use super::resolve_verification_network;
-    use sncast::{MAINNET, Network, SEPOLIA};
+    use sncast::Network;
 
     #[test]
     fn uses_cli_network_when_provided() {
@@ -284,18 +284,14 @@ mod tests {
 
     #[test]
     fn infers_mainnet_from_chain_id_when_no_network_is_configured() {
-        let network =
-            resolve_verification_network(None, None, Some(Network::try_from(MAINNET).unwrap()))
-                .unwrap();
+        let network = resolve_verification_network(None, None, Some(Network::Mainnet)).unwrap();
 
         assert_eq!(network, Network::Mainnet);
     }
 
     #[test]
     fn infers_sepolia_from_chain_id_when_no_network_is_configured() {
-        let network =
-            resolve_verification_network(None, None, Some(Network::try_from(SEPOLIA).unwrap()))
-                .unwrap();
+        let network = resolve_verification_network(None, None, Some(Network::Sepolia)).unwrap();
 
         assert_eq!(network, Network::Sepolia);
     }

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -7,6 +7,7 @@ use sncast::helpers::rpc::FreeProvider;
 use sncast::response::ui::UI;
 use sncast::{Network, response::verify::VerifyResponse};
 use sncast::{get_chain_id, get_provider};
+use starknet_rust::providers::jsonrpc::{HttpTransport, JsonRpcClient};
 use starknet_types_core::felt::Felt;
 use std::{collections::HashMap, fmt};
 use url::Url;
@@ -82,17 +83,20 @@ impl fmt::Display for Verifier {
     }
 }
 
-fn resolve_verification_network(
+async fn resolve_verification_network(
     cli_network: Option<Network>,
     config_network: Option<Network>,
-    inferred_network: Option<Network>,
+    provider: &JsonRpcClient<HttpTransport>,
 ) -> Result<Network> {
-    cli_network
-        .or(config_network)
-        .or(inferred_network)
-        .ok_or_else(|| {
+    if let Some(network) = cli_network.or(config_network) {
+        return Ok(network);
+    }
+
+    let chain_id = get_chain_id(provider).await?;
+
+    Network::try_from(chain_id).map_err(|_| {
             anyhow!(
-                "Failed to infer verification network from the RPC chain ID; pass `--network mainnet` or `--network sepolia` explicitly"
+                "Failed to infer verification network from the RPC chain ID {chain_id:#x}; pass `--network mainnet` or `--network sepolia` explicitly"
             )
         })
 }
@@ -166,11 +170,6 @@ pub async fn verify(
         }
     };
     let provider = get_provider(&rpc_url)?;
-    let inferred_network = if network.is_none() && config.network.is_none() {
-        Network::try_from(get_chain_id(&provider).await?).ok()
-    } else {
-        None
-    };
 
     // Build JSON Payload for the verification request
     // get the parent dir of the manifest path
@@ -191,7 +190,7 @@ pub async fn verify(
         }
     };
 
-    let network = resolve_verification_network(network, config.network, inferred_network)?;
+    let network = resolve_verification_network(network, config.network, &provider).await?;
 
     // Handle test_files warning for Walnut
     if matches!(verifier, Verifier::Walnut) && test_files {
@@ -259,51 +258,99 @@ pub async fn verify(
 #[cfg(test)]
 mod tests {
     use super::resolve_verification_network;
+    use serde_json::json;
     use sncast::Network;
+    use sncast::get_provider;
+    use starknet_types_core::felt::Felt;
+    use url::Url;
+    use wiremock::matchers::{body_partial_json, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    #[test]
-    fn uses_cli_network_when_provided() {
-        let network = resolve_verification_network(
-            Some(Network::Mainnet),
-            Some(Network::Sepolia),
-            Some(Network::Sepolia),
-        )
-        .unwrap();
-
-        assert_eq!(network, Network::Mainnet);
+    fn unused_provider() -> starknet_rust::providers::jsonrpc::JsonRpcClient<
+        starknet_rust::providers::jsonrpc::HttpTransport,
+    > {
+        get_provider(&Url::parse("http://127.0.0.1:1").unwrap()).unwrap()
     }
 
-    #[test]
-    fn uses_config_network_when_cli_network_is_missing() {
+    async fn mock_provider_for_chain_id(
+        chain_id: Felt,
+    ) -> (
+        starknet_rust::providers::jsonrpc::JsonRpcClient<
+            starknet_rust::providers::jsonrpc::HttpTransport,
+        >,
+        MockServer,
+    ) {
+        let mock_rpc = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(body_partial_json(json!({"method": "starknet_chainId"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": format!("{chain_id:#x}")
+            })))
+            .expect(1)
+            .mount(&mock_rpc)
+            .await;
+
+        (
+            get_provider(&Url::parse(&mock_rpc.uri()).unwrap()).unwrap(),
+            mock_rpc,
+        )
+    }
+
+    #[tokio::test]
+    async fn uses_cli_network_when_provided() {
+        let provider = unused_provider();
         let network =
-            resolve_verification_network(None, Some(Network::Mainnet), Some(Network::Sepolia))
+            resolve_verification_network(Some(Network::Mainnet), Some(Network::Sepolia), &provider)
+                .await
                 .unwrap();
 
         assert_eq!(network, Network::Mainnet);
     }
 
-    #[test]
-    fn infers_mainnet_from_chain_id_when_no_network_is_configured() {
-        let network = resolve_verification_network(None, None, Some(Network::Mainnet)).unwrap();
+    #[tokio::test]
+    async fn uses_config_network_when_cli_network_is_missing() {
+        let provider = unused_provider();
+        let network = resolve_verification_network(None, Some(Network::Mainnet), &provider)
+            .await
+            .unwrap();
 
         assert_eq!(network, Network::Mainnet);
     }
 
-    #[test]
-    fn infers_sepolia_from_chain_id_when_no_network_is_configured() {
-        let network = resolve_verification_network(None, None, Some(Network::Sepolia)).unwrap();
+    #[tokio::test]
+    async fn infers_mainnet_from_chain_id_when_no_network_is_configured() {
+        let (provider, _mock_rpc) = mock_provider_for_chain_id(sncast::MAINNET).await;
+        let network = resolve_verification_network(None, None, &provider)
+            .await
+            .unwrap();
+
+        assert_eq!(network, Network::Mainnet);
+    }
+
+    #[tokio::test]
+    async fn infers_sepolia_from_chain_id_when_no_network_is_configured() {
+        let (provider, _mock_rpc) = mock_provider_for_chain_id(sncast::SEPOLIA).await;
+        let network = resolve_verification_network(None, None, &provider)
+            .await
+            .unwrap();
 
         assert_eq!(network, Network::Sepolia);
     }
 
-    #[test]
-    fn errors_when_network_cannot_be_resolved() {
-        let error = resolve_verification_network(None, None, None).unwrap_err();
+    #[tokio::test]
+    async fn errors_when_network_cannot_be_resolved() {
+        let (provider, _mock_rpc) =
+            mock_provider_for_chain_id(Felt::from_hex_unchecked("0x1234")).await;
+        let error = resolve_verification_network(None, None, &provider)
+            .await
+            .unwrap_err();
 
         assert!(
             error
                 .to_string()
-                .contains("Failed to infer verification network from the RPC chain ID")
+                .contains("Failed to infer verification network from the RPC chain ID 0x1234")
         );
     }
 }

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -2,11 +2,11 @@ use anyhow::{Result, anyhow, bail};
 use camino::Utf8PathBuf;
 use clap::{ArgGroup, Args, ValueEnum};
 use promptly::prompt;
-use sncast::get_provider;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::rpc::FreeProvider;
 use sncast::response::ui::UI;
 use sncast::{Network, response::verify::VerifyResponse};
+use sncast::{get_chain_id, get_provider};
 use starknet_types_core::felt::Felt;
 use std::{collections::HashMap, fmt};
 use url::Url;
@@ -82,6 +82,21 @@ impl fmt::Display for Verifier {
     }
 }
 
+fn resolve_verification_network(
+    cli_network: Option<Network>,
+    config_network: Option<Network>,
+    inferred_network: Option<Network>,
+) -> Result<Network> {
+    cli_network
+        .or(config_network)
+        .or(inferred_network)
+        .ok_or_else(|| {
+            anyhow!(
+                "Failed to infer verification network from the RPC chain ID; pass `--network mainnet` or `--network sepolia` explicitly"
+            )
+        })
+}
+
 fn display_files_and_confirm(
     verifier: &Verifier,
     files_to_display: Vec<String>,
@@ -136,7 +151,6 @@ pub async fn verify(
         test_files,
     } = args;
 
-    let url_provided = url.is_some();
     let rpc_url = match url {
         Some(url) => url,
         None => {
@@ -152,6 +166,11 @@ pub async fn verify(
         }
     };
     let provider = get_provider(&rpc_url)?;
+    let inferred_network = if network.is_none() && config.network.is_none() {
+        Some(Network::try_from(get_chain_id(&provider).await?)?)
+    } else {
+        None
+    };
 
     // Build JSON Payload for the verification request
     // get the parent dir of the manifest path
@@ -172,15 +191,7 @@ pub async fn verify(
         }
     };
 
-    // If --url is provided but --network is not, default to sepolia
-    // If neither is provided, the error is already handled above in rpc_url logic
-    let network = match (network, url_provided) {
-        (Some(network), _) => network,
-        (None, true) => Network::Sepolia, // --url provided but no --network
-        (None, false) => {
-            Network::Sepolia // fallback when config.url is set
-        }
-    };
+    let network = resolve_verification_network(network, config.network, inferred_network)?;
 
     // Handle test_files warning for Walnut
     if matches!(verifier, Verifier::Walnut) && test_files {
@@ -242,5 +253,61 @@ pub async fn verify(
                 .verify(contract_identifier, contract_name, package, test_files, ui)
                 .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_verification_network;
+    use sncast::{MAINNET, Network, SEPOLIA};
+
+    #[test]
+    fn uses_cli_network_when_provided() {
+        let network = resolve_verification_network(
+            Some(Network::Mainnet),
+            Some(Network::Sepolia),
+            Some(Network::Sepolia),
+        )
+        .unwrap();
+
+        assert_eq!(network, Network::Mainnet);
+    }
+
+    #[test]
+    fn uses_config_network_when_cli_network_is_missing() {
+        let network =
+            resolve_verification_network(None, Some(Network::Mainnet), Some(Network::Sepolia))
+                .unwrap();
+
+        assert_eq!(network, Network::Mainnet);
+    }
+
+    #[test]
+    fn infers_mainnet_from_chain_id_when_no_network_is_configured() {
+        let network =
+            resolve_verification_network(None, None, Some(Network::try_from(MAINNET).unwrap()))
+                .unwrap();
+
+        assert_eq!(network, Network::Mainnet);
+    }
+
+    #[test]
+    fn infers_sepolia_from_chain_id_when_no_network_is_configured() {
+        let network =
+            resolve_verification_network(None, None, Some(Network::try_from(SEPOLIA).unwrap()))
+                .unwrap();
+
+        assert_eq!(network, Network::Sepolia);
+    }
+
+    #[test]
+    fn errors_when_network_cannot_be_resolved() {
+        let error = resolve_verification_network(None, None, None).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to infer verification network from the RPC chain ID")
+        );
     }
 }

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -6,9 +6,24 @@ use crate::helpers::runner::runner;
 use indoc::formatdoc;
 use serde_json::json;
 use shared::test_utils::output_assert::assert_stderr_contains;
+use sncast::SEPOLIA;
 use starknet_types_core::felt::Felt;
+use std::fs;
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+async fn mock_sepolia_chain_id(mock_rpc: &MockServer) {
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({"method": "starknet_chainId"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 1,
+            "jsonrpc": "2.0",
+            "result": format!("{SEPOLIA:#x}")
+        })))
+        .expect(1)
+        .mount(mock_rpc)
+        .await;
+}
 
 #[tokio::test]
 async fn test_happy_case_contract_address() {
@@ -136,8 +151,76 @@ async fn test_happy_case_with_confirm_verification_flag() {
         .expect(1)
         .mount(&mock_rpc)
         .await;
+    mock_sepolia_chain_id(&mock_rpc).await;
 
     let job_id = "2b206064-ffee-4955-8a86-1ff3b854416a";
+    let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+
+    Mock::given(method("POST"))
+        .and(path(format!("class-verify/{class_hash:#066x}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "job_id": job_id })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "verify",
+        "--contract-address",
+        MAP_CONTRACT_ADDRESS_SEPOLIA,
+        "--contract-name",
+        "Map",
+        "--verifier",
+        "voyager",
+        "--confirm-verification",
+        "--url",
+        &mock_rpc_uri,
+    ];
+
+    let snapbox = runner(&args)
+        .env("VERIFIER_API_URL", mock_server.uri())
+        .current_dir(contract_path.path());
+
+    snapbox.assert().success();
+}
+
+#[tokio::test]
+async fn test_happy_case_uses_network_from_config() {
+    let contract_path = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/map");
+    fs::write(
+        contract_path.path().join("snfoundry.toml"),
+        "[sncast.default]\nnetwork = \"sepolia\"\n",
+    )
+    .unwrap();
+
+    let mock_server = MockServer::start().await;
+    let rpc_response = json!({
+        "id": 1,
+        "jsonrpc": "2.0",
+        "result": MAP_CONTRACT_CLASS_HASH_SEPOLIA
+    });
+
+    let mock_rpc = MockServer::start().await;
+    let mock_rpc_uri = mock_rpc.uri().clone();
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({"method": "starknet_getClassHashAt"}),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(rpc_response))
+        .expect(1)
+        .mount(&mock_rpc)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({"method": "starknet_chainId"})))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock_rpc)
+        .await;
+
+    let job_id = "config-network-job-id";
     let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
 
     Mock::given(method("POST"))

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -647,7 +647,7 @@ async fn test_error_when_chain_id_is_unrecognized_and_network_is_missing() {
         output,
         formatdoc! {"
         Command: verify
-        Error: Failed to infer verification network from the RPC chain ID; pass `--network mainnet` or `--network sepolia` explicitly
+        Error: Failed to infer verification network from the RPC chain ID 0x1234; pass `--network mainnet` or `--network sepolia` explicitly
         ",
         },
     );

--- a/crates/sncast/tests/e2e/verify/voyager.rs
+++ b/crates/sncast/tests/e2e/verify/voyager.rs
@@ -12,17 +12,21 @@ use std::fs;
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
-async fn mock_sepolia_chain_id(mock_rpc: &MockServer) {
+async fn mock_chain_id(mock_rpc: &MockServer, chain_id: Felt) {
     Mock::given(method("POST"))
         .and(body_partial_json(json!({"method": "starknet_chainId"})))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "id": 1,
             "jsonrpc": "2.0",
-            "result": format!("{SEPOLIA:#x}")
+            "result": format!("{chain_id:#x}")
         })))
         .expect(1)
         .mount(mock_rpc)
         .await;
+}
+
+async fn mock_sepolia_chain_id(mock_rpc: &MockServer) {
+    mock_chain_id(mock_rpc, SEPOLIA).await;
 }
 
 #[tokio::test]
@@ -594,6 +598,56 @@ async fn test_error_when_neither_network_nor_url_provided() {
         formatdoc! {"
         Command: verify
         Error: Either --network or --url must be provided
+        ",
+        },
+    );
+}
+
+#[tokio::test]
+async fn test_error_when_chain_id_is_unrecognized_and_network_is_missing() {
+    let contract_path = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/map");
+
+    let mock_server = MockServer::start().await;
+    let mock_rpc = MockServer::start().await;
+    let mock_rpc_uri = mock_rpc.uri().clone();
+
+    mock_chain_id(&mock_rpc, Felt::from_hex_unchecked("0x1234")).await;
+
+    let class_hash = Felt::from_hex(MAP_CONTRACT_CLASS_HASH_SEPOLIA).expect("Invalid class hash");
+
+    Mock::given(method("POST"))
+        .and(path(format!("class-verify/{class_hash:#066x}")))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(0)
+        .mount(&mock_server)
+        .await;
+
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "verify",
+        "--class-hash",
+        MAP_CONTRACT_CLASS_HASH_SEPOLIA,
+        "--contract-name",
+        "Map",
+        "--verifier",
+        "voyager",
+        "--confirm-verification",
+        "--url",
+        &mock_rpc_uri,
+    ];
+
+    let snapbox = runner(&args)
+        .env("VERIFIER_API_URL", mock_server.uri())
+        .current_dir(contract_path.path());
+
+    let output = snapbox.assert().success();
+
+    assert_stderr_contains(
+        output,
+        formatdoc! {"
+        Command: verify
+        Error: Failed to infer verification network from the RPC chain ID; pass `--network mainnet` or `--network sepolia` explicitly
         ",
         },
     );


### PR DESCRIPTION
## Summary
- remove the hardcoded Sepolia fallback in `sncast verify`
- resolve the verifier network in this order: CLI `--network`, `snfoundry.toml` `network`, then RPC `chain_id`
- update Voyager verify E2E coverage to reflect the new inference path and cover config-driven network selection

## Bugs fixed
- passing `--url <mainnet-rpc>` without `--network` no longer submits verification to Sepolia by default
- setting `network` in `snfoundry.toml` no longer gets ignored when CLI `--network` is omitted

## Implementation details
- `verify` now builds the provider first and only infers the network from `chain_id` when both CLI and config networks are absent
- if the RPC chain ID is not recognized as mainnet or sepolia, `verify` now returns an explicit error instead of silently assuming Sepolia
- added unit tests for network precedence and inference behavior
- updated the existing no-`--network` Voyager E2E case to mock `starknet_chainId`
- added an E2E test that verifies `config.network` is honored without performing `chainId` inference

## Testing
- `cargo fmt --all --check`
- `cargo test -p sncast --bin sncast starknet_commands::verify::tests:: -- --nocapture`
- `cargo test -p sncast --test main verify:: -- --nocapture --test-threads=1`
