### PR TITLE
Bump supported `scarb` to `2.17.0` and minimal recommended to `2.15.2`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.16.1
+scarb 2.17.0
 starknet-devnet 0.8.0-rc.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.16.1
-starknet-devnet 0.7.2
+starknet-devnet 0.8.0-rc.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Changed
+
+- Minimal recommended `Scarb` version is now `2.15.2` (updated from `2.14.0`)
+
 ## [0.59.0] - 2026-04-10
 
 ### Forge

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -42,8 +42,8 @@ mod warn;
 pub const CAIRO_EDITION: &str = "2024_07";
 
 const MINIMAL_SCARB_VERSION: Version = Version::new(2, 12, 0);
-const MINIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 14, 0);
-const MAXIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 16, 0);
+const MINIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 15, 2);
+const MAXIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 17, 0);
 const MINIMAL_USC_VERSION: Version = Version::new(2, 0, 0);
 const MINIMAL_SNFORGE_STD_VERSION: Version = Version::new(0, 50, 0);
 

--- a/crates/forge/tests/integration/cheat_execution_info.rs
+++ b/crates/forge/tests/integration/cheat_execution_info.rs
@@ -591,6 +591,8 @@ fn cheat_transaction_hash_with_span() {
             use array::SpanTrait;
             use snforge_std::{ test_address, declare, ContractClassTrait, DeclareResultTrait, cheat_transaction_hash, stop_cheat_transaction_hash, CheatSpan };
             use starknet::info::v2::ResourceBounds;
+            use starknet::syscalls::get_execution_info_v2_syscall;
+            use starknet::SyscallResultTrait;
 
             #[starknet::interface]
             trait ICheatTxInfoChecker<TContractState> {
@@ -659,19 +661,19 @@ fn cheat_transaction_hash_with_span() {
 
             #[test]
             fn test_cheat_transaction_hash_test_address() {
-                let tx_info_before = starknet::get_tx_info().unbox();
+                let tx_info_before = get_execution_info_v2_syscall().unwrap_syscall().unbox().tx_info.unbox();
 
                 cheat_transaction_hash(test_address(), 421,CheatSpan::TargetCalls(1) );
 
                 let mut expected_tx_info = tx_info_before;
                 expected_tx_info.transaction_hash = 421;
 
-                let tx_info = starknet::get_tx_info().unbox();
+                let tx_info = get_execution_info_v2_syscall().unwrap_syscall().unbox().tx_info.unbox();
                 assert_tx_info(tx_info, expected_tx_info);
 
                 stop_cheat_transaction_hash(test_address());
 
-                let tx_info = starknet::get_tx_info().unbox();
+                let tx_info = get_execution_info_v2_syscall().unwrap_syscall().unbox().tx_info.unbox();
                 assert_tx_info(tx_info, tx_info_before);
             }
         "#

--- a/crates/sncast/tests/e2e/transaction.rs
+++ b/crates/sncast/tests/e2e/transaction.rs
@@ -106,7 +106,7 @@ async fn test_deploy_account_transaction() {
             Constructor Calldata:        [0x[..]]
             Resource Bounds L1 Gas:      max_amount=0, max_price_per_unit=1500000000
             Resource Bounds L1 Data Gas: max_amount=672, max_price_per_unit=1500000000
-            Resource Bounds L2 Gas:      max_amount=1313760, max_price_per_unit=1500000000
+            Resource Bounds L2 Gas:      max_amount=3302760, max_price_per_unit=1500000000
             Tip:                         0
             Paymaster Data:              []
             Nonce DA Mode:               L1

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -154,7 +154,7 @@ async fn deploy_account_to_devnet<T: AccountFactory + Sync>(factory: T, address:
         .deploy_v3(salt.parse().expect("Failed to parse salt"))
         .l1_gas(100_000)
         .l1_gas_price(10_000_000_000_000)
-        .l2_gas(1_000_000)
+        .l2_gas(1_000_000_000)
         .l2_gas_price(10_000_000_000_000)
         .l1_data_gas(100_000)
         .l1_data_gas_price(10_000_000_000_000)


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related #4091 

## Introduced changes

<!-- A brief description of the changes -->

- Bump `scarb` to `2.17.0`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
