### PR TITLE
bump `asdf/actions` version used to `4.0.1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,11 @@ jobs:
       versions: ${{ steps.get_versions.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
-        with:
-          tool_versions: |
-            scarb latest
+      - uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
+      - run: |
+          asdf plugin add scarb
+          asdf install scarb latest
+          asdf set --home scarb latest
 
       - name: Get versions
         id: get_versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       versions: ${{ steps.get_versions.outputs.versions }}
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
         with:
           tool_versions: |
             scarb latest
@@ -174,7 +174,7 @@ jobs:
           curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
 
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
         with:
@@ -222,7 +222,7 @@ jobs:
           curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
 
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
       - uses: ./.github/actions/setup-tools
       - uses: taiki-e/install-action@v2
         with:
@@ -287,7 +287,7 @@ jobs:
         # No setup scarb action is used because we want to install multiple versions of scarb through asdf
         with:
           setup-scarb: 'false'
-      - uses: asdf-vm/actions/install@1902764435ca0dd2f3388eea723a4f92a4eb8302
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
       - run: cargo test --profile ci --package forge --features test_for_multiple_scarb_versions e2e::plugin_diagnostic
 
   test-requirements-check-special-conditions:
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
       - uses: ./.github/actions/setup-tools
       - name: Run tests
         run: cargo test --profile ci -p sncast
@@ -370,7 +370,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
       - uses: ./.github/actions/setup-tools
       - name: Run tests
         run: cargo test --profile ci -p sncast --features ledger-emulator ledger -- --ignored

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
         with:
           tool_versions: |
             scarb latest
@@ -130,7 +130,7 @@ jobs:
           devnet_version=$(grep starknet-devnet .tool-versions | cut -d " " -f 2)
           echo "Devnet version: $devnet_version"
           echo "version=$devnet_version" >> "$GITHUB_OUTPUT"
-      - uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
         with:
           tool_versions: |
             starknet-devnet ${{ steps.get-devnet-version.outputs.version }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,10 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
-        with:
-          tool_versions: |
-            scarb latest
+      - uses: asdf-vm/actions/setup@b7bcd026f18772e44fe1026d729e1611cc435d47
+      - run: |
+          asdf plugin add scarb
+          asdf install scarb latest
+          asdf set --home scarb latest
 
       - name: Get versions
         id: get_versions


### PR DESCRIPTION
Following [update](https://github.com/asdf-vm/asdf/pull/1822) to asdf repo that removes bunch of files, old asdf action versions fails on CI:

https://github.com/foundry-rs/starknet-foundry/actions/runs/24383742897/job/71212711982?pr=4276

This bumps action across the board 

