### PR TITLE
Disable optimizations in ci profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,8 +480,10 @@ jobs:
           # TODO(#2781): Use `mdbook build`
           ./scripts/build_docs.sh
       - name: Install Forge
+        env:
+          CARGO_INCREMENTAL: 0
         run: |
-          cargo install --path crates/forge --locked
+          cargo install --path crates/forge --locked --debug
       - name: Verify Cairo listings
         run: |
           ./scripts/verify_cairo_listings.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lto = "thin"
 
 [profile.ci]
 inherits = "dev"
-opt-level = 3
+incremental = false
 
 [workspace.package]
 version = "0.59.0"


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Related #3305 

- Remove optimization config from `ci` profile. Currently the bottleneck is compilation, running tests is quite fast
- Additionally disable incremental compilation as there is no benefit of it on CI
- Use the same configuration when installing for docs tests

