### PR TITLE
Prevent premature automation trigger in ledger tests

### DIFF
--- a/crates/sncast/src/helpers/ledger/emulator_transport.rs
+++ b/crates/sncast/src/helpers/ledger/emulator_transport.rs
@@ -27,7 +27,10 @@ fn io_err(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> LedgerError
 
 impl SpeculosHttpTransport {
     pub fn new(url: String) -> Result<Self, LedgerError> {
-        let client = Client::builder().build().map_err(io_err)?;
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(io_err)?;
         Ok(Self {
             client,
             base_url: url,

--- a/crates/sncast/tests/docs_snippets/ledger.rs
+++ b/crates/sncast/tests/docs_snippets/ledger.rs
@@ -55,7 +55,7 @@ async fn test_ledger_docs_snippets() {
 
     // sign-hash snippets need a fresh Speculos instance each time: ENABLE_BLIND_SIGN fires
     // All other snippets share one instance to keep the total startup count low.
-    let (shared_client, shared_url) = setup_speculos(DOCS_SNIPPETS_PORT_BASE);
+    let (shared_client, shared_url) = setup_speculos(DOCS_SNIPPETS_PORT_BASE).await;
     let mut sign_hash_port_offset = 1;
 
     for snippet in &snippets {
@@ -88,7 +88,7 @@ async fn test_ledger_docs_snippets() {
         let (snippet_client, snippet_url) = if args.contains(&"sign-hash") {
             let port = DOCS_SNIPPETS_PORT_BASE + sign_hash_port_offset;
             sign_hash_port_offset += 1;
-            setup_speculos(port)
+            setup_speculos(port).await
         } else {
             (shared_client.clone(), shared_url.clone())
         };

--- a/crates/sncast/tests/e2e/ledger/account.rs
+++ b/crates/sncast/tests/e2e/ledger/account.rs
@@ -20,15 +20,13 @@ use speculos_client::AutomationRule;
 use tempfile::tempdir;
 use test_case::test_case;
 
-#[test_case("oz", "open_zeppelin", OZ_CLASS_HASH.into_hex_string(), 6001, &[automation::APPROVE_PUBLIC_KEY]; "oz_account_type")]
-#[test_case("ready", "ready", READY_CLASS_HASH.into_hex_string(), 6002, &[automation::APPROVE_PUBLIC_KEY]; "ready_account_type")]
+#[test_case("oz", "open_zeppelin", OZ_CLASS_HASH.into_hex_string(), 6001, &[]; "oz_account_type")]
+#[test_case("ready", "ready", READY_CLASS_HASH.into_hex_string(), 6002, &[]; "ready_account_type")]
 // Braavos calls sign_hash twice during fee estimation (tx_hash + aux_hash) because
 // is_signer_interactive() always returns false — see BraavosAccountFactory::is_signer_interactive.
-// That means we need two APPROVE_BLIND_SIGN_HASH after the public key approval.
 #[test_case(
     "braavos", "braavos", BRAAVOS_CLASS_HASH.into_hex_string(), 6003,
     &[
-        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH, // tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // aux_hash
     ];
@@ -114,13 +112,8 @@ async fn test_create_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_create_ledger_account_add_profile() {
-    let (client, url) = setup_speculos(6004).await;
+    let (_client, url) = setup_speculos(6004).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
-
-    client
-        .automation(&[automation::APPROVE_PUBLIC_KEY])
-        .await
-        .unwrap();
 
     let output = runner(&[
         "--accounts-file",
@@ -158,30 +151,25 @@ async fn test_create_ledger_account_add_profile() {
 
 #[test_case(
     "oz", OZ_LEDGER_PATH, 6005,
-    // create: public key only (OZ skips signing during fee estimation)
     // deploy: 1 sign_hash
     &[
-        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "oz_account_type"
 )]
 #[test_case(
     "ready", READY_LEDGER_PATH, 6006,
-    // create: public key only (Ready skips signing during fee estimation)
     // deploy: 1 sign_hash
     &[
-        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "ready_account_type"
 )]
 #[test_case(
     "braavos", BRAAVOS_LEDGER_PATH, 6007,
-    // create: public key + 2x sign_hash (tx_hash + aux_hash)
+    // create: 2x sign_hash (tx_hash + aux_hash)
     // deploy: 2x sign_hash (tx_hash + aux_hash)
     &[
-        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH, // create: tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // create: aux_hash
         automation::APPROVE_BLIND_SIGN_HASH, // deploy: tx_hash
@@ -364,13 +352,8 @@ async fn test_import_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_import_ledger_account_add_profile() {
-    let (client, url) = setup_speculos(6012).await;
+    let (_client, url) = setup_speculos(6012).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
-
-    client
-        .automation(&[automation::APPROVE_PUBLIC_KEY])
-        .await
-        .unwrap();
 
     let oz_class_hash = OZ_CLASS_HASH.into_hex_string();
 

--- a/crates/sncast/tests/e2e/ledger/account.rs
+++ b/crates/sncast/tests/e2e/ledger/account.rs
@@ -20,13 +20,15 @@ use speculos_client::AutomationRule;
 use tempfile::tempdir;
 use test_case::test_case;
 
-#[test_case("oz", "open_zeppelin", OZ_CLASS_HASH.into_hex_string(), 6001, &[]; "oz_account_type")]
-#[test_case("ready", "ready", READY_CLASS_HASH.into_hex_string(), 6002, &[]; "ready_account_type")]
+#[test_case("oz", "open_zeppelin", OZ_CLASS_HASH.into_hex_string(), 6001, &[automation::APPROVE_PUBLIC_KEY]; "oz_account_type")]
+#[test_case("ready", "ready", READY_CLASS_HASH.into_hex_string(), 6002, &[automation::APPROVE_PUBLIC_KEY]; "ready_account_type")]
 // Braavos calls sign_hash twice during fee estimation (tx_hash + aux_hash) because
 // is_signer_interactive() always returns false — see BraavosAccountFactory::is_signer_interactive.
+// That means we need two APPROVE_BLIND_SIGN_HASH after the public key approval.
 #[test_case(
     "braavos", "braavos", BRAAVOS_CLASS_HASH.into_hex_string(), 6003,
     &[
+        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH, // tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // aux_hash
     ];
@@ -112,8 +114,13 @@ async fn test_create_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_create_ledger_account_add_profile() {
-    let (_client, url) = setup_speculos(6004).await;
+    let (client, url) = setup_speculos(6004).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
+
+    client
+        .automation(&[automation::APPROVE_PUBLIC_KEY])
+        .await
+        .unwrap();
 
     let output = runner(&[
         "--accounts-file",
@@ -151,25 +158,30 @@ async fn test_create_ledger_account_add_profile() {
 
 #[test_case(
     "oz", OZ_LEDGER_PATH, 6005,
+    // create: public key only (OZ skips signing during fee estimation)
     // deploy: 1 sign_hash
     &[
+        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "oz_account_type"
 )]
 #[test_case(
     "ready", READY_LEDGER_PATH, 6006,
+    // create: public key only (Ready skips signing during fee estimation)
     // deploy: 1 sign_hash
     &[
+        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "ready_account_type"
 )]
 #[test_case(
     "braavos", BRAAVOS_LEDGER_PATH, 6007,
-    // create: 2x sign_hash (tx_hash + aux_hash)
+    // create: public key + 2x sign_hash (tx_hash + aux_hash)
     // deploy: 2x sign_hash (tx_hash + aux_hash)
     &[
+        automation::APPROVE_PUBLIC_KEY,
         automation::APPROVE_BLIND_SIGN_HASH, // create: tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // create: aux_hash
         automation::APPROVE_BLIND_SIGN_HASH, // deploy: tx_hash
@@ -352,8 +364,13 @@ async fn test_import_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_import_ledger_account_add_profile() {
-    let (_client, url) = setup_speculos(6012).await;
+    let (client, url) = setup_speculos(6012).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
+
+    client
+        .automation(&[automation::APPROVE_PUBLIC_KEY])
+        .await
+        .unwrap();
 
     let oz_class_hash = OZ_CLASS_HASH.into_hex_string();
 

--- a/crates/sncast/tests/e2e/ledger/account.rs
+++ b/crates/sncast/tests/e2e/ledger/account.rs
@@ -24,12 +24,11 @@ use test_case::test_case;
 #[test_case("ready", "ready", READY_CLASS_HASH.into_hex_string(), 6002, &[automation::APPROVE_PUBLIC_KEY]; "ready_account_type")]
 // Braavos calls sign_hash twice during fee estimation (tx_hash + aux_hash) because
 // is_signer_interactive() always returns false — see BraavosAccountFactory::is_signer_interactive.
-// That means we need ENABLE_BLIND_SIGN + two APPROVE_BLIND_SIGN_HASH after the public key approval.
+// That means we need two APPROVE_BLIND_SIGN_HASH after the public key approval.
 #[test_case(
     "braavos", "braavos", BRAAVOS_CLASS_HASH.into_hex_string(), 6003,
     &[
         automation::APPROVE_PUBLIC_KEY,
-        automation::ENABLE_BLIND_SIGN,
         automation::APPROVE_BLIND_SIGN_HASH, // tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // aux_hash
     ];
@@ -44,7 +43,7 @@ async fn test_create_ledger_account(
     port: u16,
     automations: &[speculos_client::AutomationRule<'static>],
 ) {
-    let (client, url) = setup_speculos(port);
+    let (client, url) = setup_speculos(port).await;
     let tempdir = tempdir().unwrap();
 
     client.automation(automations).await.unwrap();
@@ -115,7 +114,7 @@ async fn test_create_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_create_ledger_account_add_profile() {
-    let (client, url) = setup_speculos(6004);
+    let (client, url) = setup_speculos(6004).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
 
     client
@@ -160,10 +159,9 @@ async fn test_create_ledger_account_add_profile() {
 #[test_case(
     "oz", OZ_LEDGER_PATH, 6005,
     // create: public key only (OZ skips signing during fee estimation)
-    // deploy: enable blind sign + 1 sign_hash
+    // deploy: 1 sign_hash
     &[
         automation::APPROVE_PUBLIC_KEY,
-        automation::ENABLE_BLIND_SIGN,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "oz_account_type"
@@ -171,21 +169,19 @@ async fn test_create_ledger_account_add_profile() {
 #[test_case(
     "ready", READY_LEDGER_PATH, 6006,
     // create: public key only (Ready skips signing during fee estimation)
-    // deploy: enable blind sign + 1 sign_hash
+    // deploy: 1 sign_hash
     &[
         automation::APPROVE_PUBLIC_KEY,
-        automation::ENABLE_BLIND_SIGN,
         automation::APPROVE_BLIND_SIGN_HASH,
     ];
     "ready_account_type"
 )]
 #[test_case(
     "braavos", BRAAVOS_LEDGER_PATH, 6007,
-    // create: public key + enable blind sign + 2x sign_hash (tx_hash + aux_hash)
-    // deploy: 2x sign_hash again (tx_hash + aux_hash), blind sign already enabled
+    // create: public key + 2x sign_hash (tx_hash + aux_hash)
+    // deploy: 2x sign_hash (tx_hash + aux_hash)
     &[
         automation::APPROVE_PUBLIC_KEY,
-        automation::ENABLE_BLIND_SIGN,
         automation::APPROVE_BLIND_SIGN_HASH, // create: tx_hash
         automation::APPROVE_BLIND_SIGN_HASH, // create: aux_hash
         automation::APPROVE_BLIND_SIGN_HASH, // deploy: tx_hash
@@ -201,7 +197,7 @@ async fn test_deploy_ledger_account(
     port: u16,
     automations: &[AutomationRule<'static>],
 ) {
-    let (client, url) = setup_speculos(port);
+    let (client, url) = setup_speculos(port).await;
 
     client.automation(automations).await.unwrap();
 
@@ -275,7 +271,7 @@ async fn test_deploy_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_invalid_derivation_path() {
-    let (_client, url) = setup_speculos(6008);
+    let (_client, url) = setup_speculos(6008).await;
 
     let output = runner(&[
         "ledger",
@@ -305,7 +301,7 @@ async fn test_import_ledger_account(
     class_hash: String,
     port: u16,
 ) {
-    let (client, url) = setup_speculos(port);
+    let (client, url) = setup_speculos(port).await;
     let tempdir = tempdir().unwrap();
 
     client
@@ -368,7 +364,7 @@ async fn test_import_ledger_account(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_import_ledger_account_add_profile() {
-    let (client, url) = setup_speculos(6012);
+    let (client, url) = setup_speculos(6012).await;
     let tempdir = copy_config_to_tempdir("tests/data/files/correct_snfoundry.toml", None);
 
     client

--- a/crates/sncast/tests/e2e/ledger/basic.rs
+++ b/crates/sncast/tests/e2e/ledger/basic.rs
@@ -5,7 +5,7 @@ use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_co
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_app_version() {
-    let (_client, url) = setup_speculos(4001);
+    let (_client, url) = setup_speculos(4001).await;
 
     let output = runner(&["ledger", "app-version"])
         .env("LEDGER_EMULATOR_URL", &url)
@@ -18,7 +18,7 @@ async fn test_get_app_version() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_public_key_headless() {
-    let (_client, url) = setup_speculos(4002);
+    let (_client, url) = setup_speculos(4002).await;
 
     let output = runner(&[
         "ledger",
@@ -40,7 +40,7 @@ async fn test_get_public_key_headless() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_get_public_key_with_confirmation() {
-    let (client, url) = setup_speculos(4003);
+    let (client, url) = setup_speculos(4003).await;
 
     client
         .automation(&[automation::APPROVE_PUBLIC_KEY])
@@ -61,13 +61,10 @@ async fn test_get_public_key_with_confirmation() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_sign_hash() {
-    let (client, url) = setup_speculos(4004);
+    let (client, url) = setup_speculos(4004).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -88,7 +85,7 @@ async fn test_sign_hash() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_sign_hash_invalid_format() {
-    let (_client, url) = setup_speculos(4005);
+    let (_client, url) = setup_speculos(4005).await;
 
     let output = runner(&[
         "ledger",

--- a/crates/sncast/tests/e2e/ledger/mod.rs
+++ b/crates/sncast/tests/e2e/ledger/mod.rs
@@ -49,6 +49,13 @@ pub(crate) const LEDGER_ACCOUNT_NAME: &str = "my_ledger";
 pub(crate) fn setup_speculos(port: u16) -> (Arc<SpeculosClient>, String) {
     let client = Arc::new(SpeculosClient::new(DeviceModel::Nanox, port, APP_PATH).unwrap());
     let url = format!("http://127.0.0.1:{port}");
+
+    // Arbitrary wait time to prevent premature automation trigger:
+    // SpeculosClient::new() returns once the Speculos launcher starts
+    // but the Starknet app may not be loaded yet. If rules are registered before the app
+    // finishes initializing, it fires at the wrong time and leaves emulator in a broken state.
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
     (client, url)
 }
 

--- a/crates/sncast/tests/e2e/ledger/mod.rs
+++ b/crates/sncast/tests/e2e/ledger/mod.rs
@@ -46,15 +46,14 @@ pub(crate) const LEDGER_PUBLIC_KEY: &str =
 
 pub(crate) const LEDGER_ACCOUNT_NAME: &str = "my_ledger";
 
-pub(crate) fn setup_speculos(port: u16) -> (Arc<SpeculosClient>, String) {
+pub(crate) async fn setup_speculos(port: u16) -> (Arc<SpeculosClient>, String) {
     let client = Arc::new(SpeculosClient::new(DeviceModel::Nanox, port, APP_PATH).unwrap());
     let url = format!("http://127.0.0.1:{port}");
 
-    // Arbitrary wait time to prevent premature automation trigger:
-    // SpeculosClient::new() returns once the Speculos launcher starts
-    // but the Starknet app may not be loaded yet. If rules are registered before the app
-    // finishes initializing, it fires at the wrong time and leaves emulator in a broken state.
-    std::thread::sleep(std::time::Duration::from_secs(2));
+    client
+        .automation(&[automation::ENABLE_BLIND_SIGN])
+        .await
+        .unwrap();
 
     (client, url)
 }
@@ -308,7 +307,6 @@ pub(crate) mod automation {
         ],
     };
 
-    /// Must be used with [`ENABLE_BLIND_SIGN`].
     pub(crate) const APPROVE_BLIND_SIGN_HASH: AutomationRule<'static> = AutomationRule {
         text: None,
         regexp: Some(Cow::Borrowed("^Cancel$")),

--- a/crates/sncast/tests/e2e/ledger/network.rs
+++ b/crates/sncast/tests/e2e/ledger/network.rs
@@ -259,10 +259,7 @@ async fn test_ledger_import_and_invoke(
     let (client, url) = setup_speculos(port).await;
 
     client
-        .automation(&[
-            automation::APPROVE_BLIND_SIGN_HASH,
-            automation::APPROVE_PUBLIC_KEY,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 

--- a/crates/sncast/tests/e2e/ledger/network.rs
+++ b/crates/sncast/tests/e2e/ledger/network.rs
@@ -259,7 +259,10 @@ async fn test_ledger_import_and_invoke(
     let (client, url) = setup_speculos(port).await;
 
     client
-        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
+        .automation(&[
+            automation::APPROVE_BLIND_SIGN_HASH,
+            automation::APPROVE_PUBLIC_KEY,
+        ])
         .await
         .unwrap();
 

--- a/crates/sncast/tests/e2e/ledger/network.rs
+++ b/crates/sncast/tests/e2e/ledger/network.rs
@@ -22,13 +22,10 @@ use test_case::test_case;
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_invoke_happy_case() {
-    let (client, url) = setup_speculos(5001);
+    let (client, url) = setup_speculos(5001).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -69,13 +66,10 @@ async fn test_ledger_invoke_happy_case() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_invoke_with_wait() {
-    let (client, url) = setup_speculos(5002);
+    let (client, url) = setup_speculos(5002).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -118,13 +112,10 @@ async fn test_ledger_invoke_with_wait() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_deploy_happy_case() {
-    let (client, url) = setup_speculos(5004);
+    let (client, url) = setup_speculos(5004).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -164,13 +155,10 @@ async fn test_ledger_deploy_happy_case() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_deploy_with_constructor() {
-    let (client, url) = setup_speculos(5005);
+    let (client, url) = setup_speculos(5005).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -212,13 +200,10 @@ async fn test_ledger_deploy_with_constructor() {
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_declare() {
-    let (client, url) = setup_speculos(5006);
+    let (client, url) = setup_speculos(5006).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 
@@ -271,11 +256,10 @@ async fn test_ledger_import_and_invoke(
     ledger_account_id: Option<u32>,
     port: u16,
 ) {
-    let (client, url) = setup_speculos(port);
+    let (client, url) = setup_speculos(port).await;
 
     client
         .automation(&[
-            automation::ENABLE_BLIND_SIGN,
             automation::APPROVE_BLIND_SIGN_HASH,
             automation::APPROVE_PUBLIC_KEY,
         ])
@@ -359,13 +343,10 @@ async fn test_ledger_import_and_invoke(
 #[tokio::test]
 #[ignore = "requires Speculos installation"]
 async fn test_ledger_multicall() {
-    let (client, url) = setup_speculos(5007);
+    let (client, url) = setup_speculos(5007).await;
 
     client
-        .automation(&[
-            automation::ENABLE_BLIND_SIGN,
-            automation::APPROVE_BLIND_SIGN_HASH,
-        ])
+        .automation(&[automation::APPROVE_BLIND_SIGN_HASH])
         .await
         .unwrap();
 


### PR DESCRIPTION
sncast ledger tests often fails on CI e.g. https://github.com/foundry-rs/starknet-foundry/actions/runs/24411719684/job/71310044869

~~Potentially, it may be caused by automation rules (used to set up the "device" state for testing) trigger sooner than emulator client is ready to receive them, resulting in a broken state and failed tests. This PR adds a simple 2s sleep in speculos setup and also additional 30s timeout for the apdu client.~~

