### PR TITLE
Fix compiler config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimal recommended `Scarb` version is now `2.15.2` (updated from `2.14.0`)
 
+#### Fixed
+
+- Validation of Scarb's compiler config now properly takes into account `[cairo]` section and keys without `unstable-` prefix
+
 ### Cast
 
 #### Added

--- a/crates/forge/src/profile_validation/backtrace.rs
+++ b/crates/forge/src/profile_validation/backtrace.rs
@@ -1,20 +1,20 @@
 use crate::TestArgs;
-use crate::profile_validation::{check_cairo_profile_entries, get_manifest};
+use crate::profile_validation::{bool_field, bool_field_or_unstable};
 use anyhow::ensure;
+use camino::Utf8PathBuf;
 use indoc::formatdoc;
-use scarb_metadata::Metadata;
+use serde_json::Value;
 
-/// Checks if backtrace can be generated based on scarb version, profile settings extracted from
-/// the provided [`Metadata`] and if native execution is disabled in the provided [`TestArgs`].
 #[allow(unused_variables)]
 pub fn check_backtrace_compatibility(
     test_args: &TestArgs,
-    scarb_metadata: &Metadata,
+    compiler_config: &Value,
+    profile: &str,
+    workspace_manifest_path: &Utf8PathBuf,
 ) -> anyhow::Result<()> {
     #[cfg(feature = "cairo-native")]
     check_if_native_disabled(test_args)?;
-    check_profile(scarb_metadata)?;
-    Ok(())
+    check_profile(compiler_config, profile, workspace_manifest_path)
 }
 
 /// Checks if native execution is disabled in the provided [`TestArgs`].
@@ -27,23 +27,20 @@ fn check_if_native_disabled(test_args: &TestArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Checks if the runtime profile settings in the provided from [`Metadata`] contain the required entries for backtrace generation.
-fn check_profile(scarb_metadata: &Metadata) -> anyhow::Result<()> {
-    const BACKTRACE_REQUIRED_ENTRIES: &[(&str, &str)] = &[
-        ("unstable-add-statements-functions-debug-info", "true"),
-        ("unstable-add-statements-code-locations-debug-info", "true"),
-        ("panic-backtrace", "true"),
-    ];
-
-    let manifest = get_manifest(scarb_metadata)?;
-
+fn check_profile(
+    compiler_config: &Value,
+    profile: &str,
+    workspace_manifest_path: &Utf8PathBuf,
+) -> anyhow::Result<()> {
     let has_needed_entries =
-        check_cairo_profile_entries(&manifest, scarb_metadata, BACKTRACE_REQUIRED_ENTRIES);
+        bool_field_or_unstable(compiler_config, "add_statements_code_locations_debug_info")
+            && bool_field_or_unstable(compiler_config, "add_statements_functions_debug_info")
+            && bool_field(compiler_config, "panic_backtrace");
 
     ensure!(
         has_needed_entries,
         formatdoc! {
-            "Scarb.toml must have the following Cairo compiler configuration to run backtrace:
+            "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to run backtrace:
 
             [profile.{profile}.cairo]
             unstable-add-statements-functions-debug-info = true
@@ -51,7 +48,6 @@ fn check_profile(scarb_metadata: &Metadata) -> anyhow::Result<()> {
             panic-backtrace = true
             ... other entries ...
             ",
-            profile = scarb_metadata.current_profile
         },
     );
 

--- a/crates/forge/src/profile_validation/coverage.rs
+++ b/crates/forge/src/profile_validation/coverage.rs
@@ -1,25 +1,32 @@
-use crate::profile_validation::{check_cairo_profile_entries, get_manifest};
+use crate::profile_validation::{bool_field_or_unstable, str_field};
 use anyhow::ensure;
+use camino::Utf8PathBuf;
 use indoc::formatdoc;
-use scarb_metadata::Metadata;
+use serde_json::Value;
 
-/// Checks if coverage can be based on scarb version and profile settings extracted from the provided [`Metadata`].
-pub fn check_coverage_compatibility(scarb_metadata: &Metadata) -> anyhow::Result<()> {
-    const CAIRO_COVERAGE_REQUIRED_ENTRIES: &[(&str, &str)] = &[
-        ("unstable-add-statements-functions-debug-info", "true"),
-        ("unstable-add-statements-code-locations-debug-info", "true"),
-        ("inlining-strategy", "avoid"),
-    ];
-
-    let manifest = get_manifest(scarb_metadata)?;
-
+pub fn check_coverage_compatibility(
+    compiler_config: &Value,
+    profile: &str,
+    workspace_manifest_path: &Utf8PathBuf,
+) -> anyhow::Result<()> {
     let has_needed_entries =
-        check_cairo_profile_entries(&manifest, scarb_metadata, CAIRO_COVERAGE_REQUIRED_ENTRIES);
+        bool_field_or_unstable(compiler_config, "add_statements_code_locations_debug_info")
+            && bool_field_or_unstable(compiler_config, "add_statements_functions_debug_info")
+            && (compiler_config
+                .get("compiler_optimizations")
+                .and_then(|v| v.get("Enabled"))
+                .and_then(|v| v.get("inlining_strategy"))
+                .and_then(|v| v.as_str())
+                == Some("avoid")
+                // When optimizations are disabled, the inlining strategy is set to `avoid`.
+                || str_field(compiler_config, "compiler_optimizations") == "Disabled"
+                // For compatibility with older Scarb versions.
+                || str_field(compiler_config, "inlining_strategy") == "avoid");
 
     ensure!(
         has_needed_entries,
         formatdoc! {
-            "Scarb.toml must have the following Cairo compiler configuration to run coverage:
+            "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to run coverage:
 
             [profile.{profile}.cairo]
             unstable-add-statements-functions-debug-info = true
@@ -27,7 +34,6 @@ pub fn check_coverage_compatibility(scarb_metadata: &Metadata) -> anyhow::Result
             inlining-strategy = \"avoid\"
             ... other entries ...
             ",
-            profile = scarb_metadata.current_profile
         },
     );
 

--- a/crates/forge/src/profile_validation/debugger.rs
+++ b/crates/forge/src/profile_validation/debugger.rs
@@ -1,26 +1,23 @@
-use crate::profile_validation::{check_cairo_profile_entries, get_manifest};
+use crate::profile_validation::{bool_field, bool_field_or_unstable, str_field};
 use anyhow::ensure;
+use camino::Utf8PathBuf;
 use indoc::formatdoc;
-use scarb_metadata::Metadata;
+use serde_json::Value;
 
-/// Checks if debugger can be launched based on profile settings extracted from the provided [`Metadata`].
-pub fn check_debugger_compatibility(scarb_metadata: &Metadata) -> anyhow::Result<()> {
-    const DEBUGGER_REQUIRED_ENTRIES: &[(&str, &str)] = &[
-        ("unstable-add-statements-code-locations-debug-info", "true"),
-        ("unstable-add-statements-functions-debug-info", "true"),
-        ("add-functions-debug-info", "true"),
-        ("skip-optimizations", "true"),
-    ];
-
-    let manifest = get_manifest(scarb_metadata)?;
-
-    let has_needed_entries =
-        check_cairo_profile_entries(&manifest, scarb_metadata, DEBUGGER_REQUIRED_ENTRIES);
+pub fn check_debugger_compatibility(
+    compiler_config: &Value,
+    profile: &str,
+    workspace_manifest_path: &Utf8PathBuf,
+) -> anyhow::Result<()> {
+    let has_needed_entries = bool_field(compiler_config, "add_functions_debug_info")
+        && bool_field_or_unstable(compiler_config, "add_statements_code_locations_debug_info")
+        && bool_field_or_unstable(compiler_config, "add_statements_functions_debug_info")
+        && str_field(compiler_config, "compiler_optimizations") == "Disabled";
 
     ensure!(
         has_needed_entries,
         formatdoc! {
-            "Scarb.toml must have the following Cairo compiler configuration to launch the debugger:
+            "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to launch the debugger:
 
             [profile.{profile}.cairo]
             unstable-add-statements-code-locations-debug-info = true
@@ -29,7 +26,6 @@ pub fn check_debugger_compatibility(scarb_metadata: &Metadata) -> anyhow::Result
             skip-optimizations = true
             ... other entries ...
             ",
-            profile = scarb_metadata.current_profile
         },
     );
 

--- a/crates/forge/src/profile_validation/mod.rs
+++ b/crates/forge/src/profile_validation/mod.rs
@@ -1,69 +1,100 @@
+use crate::TestArgs;
+use backtrace::check_backtrace_compatibility;
+use coverage::check_coverage_compatibility;
+use debugger::check_debugger_compatibility;
+use forge_runner::backtrace::is_backtrace_enabled;
+use scarb_api::test_targets_by_name;
+use scarb_metadata::{Metadata, PackageMetadata, TargetMetadata};
+use serde_json::Value;
+
 mod backtrace;
 mod coverage;
 mod debugger;
 
-use crate::TestArgs;
-use crate::profile_validation::backtrace::check_backtrace_compatibility;
-use crate::profile_validation::coverage::check_coverage_compatibility;
-use crate::profile_validation::debugger::check_debugger_compatibility;
-use forge_runner::backtrace::is_backtrace_enabled;
-use scarb_metadata::Metadata;
-use std::fs;
-use toml_edit::{DocumentMut, Table};
-
-/// Checks if current profile provided in [`Metadata`] can be used to run coverage and backtrace if applicable.
-pub fn check_profile_compatibility(
+/// Checks if the compiler settings provided in [`Metadata`] can be used to run
+/// coverage, backtrace and debugger if applicable.
+pub fn check_compiler_config_compatibility(
     test_args: &TestArgs,
     scarb_metadata: &Metadata,
+    packages_to_build: &[PackageMetadata],
 ) -> anyhow::Result<()> {
-    if test_args.coverage {
-        check_coverage_compatibility(scarb_metadata)?;
-    }
+    for package in packages_to_build {
+        if test_args.no_optimization
+            && let Some(starknet_target) = package
+                .targets
+                .iter()
+                .find(|target| target.kind == "starknet-contract")
+        {
+            check_compiler_config_for_target(starknet_target, test_args, scarb_metadata)?;
+        }
 
-    if test_args.launch_debugger {
-        check_debugger_compatibility(scarb_metadata)?;
-    }
-
-    if is_backtrace_enabled() {
-        check_backtrace_compatibility(test_args, scarb_metadata)?;
+        for test_target in test_targets_by_name(package).values() {
+            check_compiler_config_for_target(test_target, test_args, scarb_metadata)?;
+        }
     }
 
     Ok(())
 }
 
-/// Gets the runtime manifest from the [`Metadata`] and parses it into a [`DocumentMut`].
-fn get_manifest(scarb_metadata: &Metadata) -> anyhow::Result<DocumentMut> {
-    Ok(fs::read_to_string(&scarb_metadata.runtime_manifest)?.parse::<DocumentMut>()?)
-}
-
-/// Check if the Cairo profile entries in the manifest contain the required entries.
-fn check_cairo_profile_entries(
-    manifest: &DocumentMut,
+fn check_compiler_config_for_target(
+    target: &TargetMetadata,
+    test_args: &TestArgs,
     scarb_metadata: &Metadata,
-    required_entries: &[(&str, &str)],
-) -> bool {
-    manifest
-        .get("profile")
-        .and_then(|profile| profile.get(&scarb_metadata.current_profile))
-        .and_then(|profile| profile.get("cairo"))
-        .and_then(|cairo| cairo.as_table())
-        .is_some_and(|profile_cairo| {
-            required_entries
-                .iter()
-                .all(|(key, value)| contains_entry_with_value(profile_cairo, key, value))
-        })
+) -> anyhow::Result<()> {
+    let Some(compiler_config) = scarb_metadata
+        .compilation_units
+        .iter()
+        .find(|cu| &cu.target == target)
+        .map(|cu| &cu.compiler_config)
+    else {
+        // We should never enter this branch, it's just a failsafe.
+        // Reason: If there exists a target for a package, it has to have a compilation unit
+        // corresponding to it.
+        return Ok(());
+    };
+
+    let profile = &scarb_metadata.current_profile;
+    let workspace_manifest_path = &scarb_metadata.workspace.manifest_path;
+
+    if test_args.coverage {
+        check_coverage_compatibility(compiler_config, profile, workspace_manifest_path)?;
+    }
+    if test_args.launch_debugger {
+        check_debugger_compatibility(compiler_config, profile, workspace_manifest_path)?;
+    }
+    if is_backtrace_enabled() {
+        check_backtrace_compatibility(
+            test_args,
+            compiler_config,
+            profile,
+            workspace_manifest_path,
+        )?;
+    }
+
+    Ok(())
 }
 
-/// Check if the table contains an entry with the given key and value.
-/// Accepts only bool and string values.
-fn contains_entry_with_value(table: &Table, key: &str, value: &str) -> bool {
-    table.get(key).is_some_and(|entry| {
-        if let Some(entry) = entry.as_bool() {
-            entry.to_string() == value
-        } else if let Some(entry) = entry.as_str() {
-            entry == value
-        } else {
-            false
-        }
-    })
+/// This function exists for backwards compatibility purposes.
+/// `add_statements_code_locations_debug_info` and `add_statements_functions_debug_info`
+/// keys in compiler config had `unstable` prefix in Scarb versions before 2.15.0-rc.0.
+fn bool_field_or_unstable(compiler_config: &Value, key: &str) -> bool {
+    compiler_config
+        .get(key)
+        .or_else(|| compiler_config.get(format!("unstable_{key}")))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn bool_field(compiler_config: &Value, key: &str) -> bool {
+    compiler_config
+        .get(key)
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn str_field<'a>(compiler_config: &'a Value, key: &str) -> &'a str {
+    compiler_config
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
 }

--- a/crates/forge/src/run_tests/workspace.rs
+++ b/crates/forge/src/run_tests/workspace.rs
@@ -1,5 +1,5 @@
 use super::package::RunForPackageArgs;
-use crate::profile_validation::check_profile_compatibility;
+use crate::profile_validation::check_compiler_config_compatibility;
 use crate::run_tests::messages::latest_blocks_numbers::LatestBlocksNumbersMessage;
 use crate::run_tests::messages::overall_summary::OverallSummaryMessage;
 use crate::run_tests::messages::partition::{PartitionFinishedMessage, PartitionStartedMessage};
@@ -76,13 +76,13 @@ pub async fn execute_workspace(
         ColorOption::Auto => (),
     }
 
-    check_profile_compatibility(args, scarb_metadata)?;
+    let packages: Vec<PackageMetadata> =
+        packages_from_filter(scarb_metadata, &args.scarb_args.packages_filter)?;
+
+    check_compiler_config_compatibility(args, scarb_metadata, &packages)?;
 
     error_if_snforge_std_not_compatible(scarb_metadata)?;
     warn_if_snforge_std_does_not_match_package_version(scarb_metadata, &ui)?;
-
-    let packages: Vec<PackageMetadata> =
-        packages_from_filter(scarb_metadata, &args.scarb_args.packages_filter)?;
 
     let artifacts_dir_path =
         target_dir_for_workspace(scarb_metadata).join(&scarb_metadata.current_profile);

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -91,7 +91,7 @@ fn test_wrong_scarb_toml_configuration() {
     assert_stdout_contains(
         output,
         indoc! {
-           "[ERROR] Scarb.toml must have the following Cairo compiler configuration to run backtrace:
+           "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to run backtrace:
 
             [profile.dev.cairo]
             unstable-add-statements-functions-debug-info = true
@@ -99,6 +99,75 @@ fn test_wrong_scarb_toml_configuration() {
             panic-backtrace = true
             ... other entries ..."
         },
+    );
+}
+
+// `add-statements-code-locations-debug-info` is available from Scarb 2.15.0
+#[test]
+fn test_complex_scarb_toml_configuration_without_unstable() {
+    let temp = setup_package("backtrace_vm_error");
+
+    let manifest_path = temp.child("Scarb.toml");
+
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+
+    scarb_toml["profile"]["dev"]["cairo"]
+        .as_table_like_mut()
+        .unwrap()
+        .remove("unstable-add-statements-code-locations-debug-info")
+        .unwrap();
+    scarb_toml["cairo"]["add-statements-code-locations-debug-info"] = value(true);
+
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .assert()
+        .failure();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+            error occurred in contract 'OuterContract'
+            stack backtrace:
+        "#},
+    );
+}
+
+#[test]
+fn test_complex_scarb_toml_configuration() {
+    let temp = setup_package("backtrace_vm_error");
+
+    let manifest_path = temp.child("Scarb.toml");
+
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+
+    scarb_toml["profile"]["dev"]["cairo"]
+        .as_table_like_mut()
+        .unwrap()
+        .remove("unstable-add-statements-code-locations-debug-info")
+        .unwrap();
+    scarb_toml["cairo"]["unstable-add-statements-code-locations-debug-info"] = value(true);
+
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .assert()
+        .failure();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r#"
+            error occurred in contract 'OuterContract'
+            stack backtrace:
+        "#},
     );
 }
 

--- a/crates/forge/tests/e2e/coverage.rs
+++ b/crates/forge/tests/e2e/coverage.rs
@@ -34,6 +34,69 @@ fn test_coverage_project_and_pass_args() {
 }
 
 #[test]
+fn test_complex_correct_set_up() {
+    let temp = setup_package("coverage_project");
+
+    let manifest_path = temp.child("Scarb.toml");
+
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+
+    scarb_toml["profile"]["dev"]["cairo"]
+        .as_table_like_mut()
+        .unwrap()
+        .remove("inlining-strategy")
+        .unwrap();
+    scarb_toml["cairo"]["inlining-strategy"] = value("avoid");
+
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    test_runner(&temp)
+        .arg("--coverage")
+        .arg("--")
+        .arg("--output-path")
+        .arg("./my_file.lcov")
+        .assert()
+        .success();
+
+    assert!(temp.join("my_file.lcov").is_file())
+}
+
+// `skip-optimizations` also sets `inlining-strategy` to `avoid` - available from Scarb 2.14.0
+#[test]
+fn test_complex_correct_set_up_with_skip_optimizations() {
+    let temp = setup_package("coverage_project");
+
+    let manifest_path = temp.child("Scarb.toml");
+
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+
+    scarb_toml["profile"]["dev"]["cairo"]
+        .as_table_like_mut()
+        .unwrap()
+        .remove("inlining-strategy")
+        .unwrap();
+    scarb_toml["cairo"]["skip-optimizations"] = value(true);
+
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    test_runner(&temp)
+        .arg("--coverage")
+        .arg("--")
+        .arg("--output-path")
+        .arg("./my_file.lcov")
+        .assert()
+        .success();
+
+    assert!(temp.join("my_file.lcov").is_file())
+}
+
+#[test]
 fn test_fail_wrong_set_up() {
     let temp = setup_package("coverage_project");
 
@@ -54,7 +117,7 @@ fn test_fail_wrong_set_up() {
     assert_stdout_contains(
         output,
         indoc! {
-            "[ERROR] Scarb.toml must have the following Cairo compiler configuration to run coverage:
+            "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to run coverage:
 
             [profile.dev.cairo]
             unstable-add-statements-functions-debug-info = true

--- a/crates/forge/tests/e2e/debugger.rs
+++ b/crates/forge/tests/e2e/debugger.rs
@@ -1,4 +1,5 @@
 use crate::e2e::common::runner::{setup_package, snforge_test_bin_path, test_runner};
+use assert_fs::TempDir;
 use assert_fs::fixture::{FileWriteStr, PathChild};
 use indoc::{formatdoc, indoc};
 use shared::test_utils::output_assert::assert_stdout_contains;
@@ -20,7 +21,7 @@ fn test_fail_wrong_scarb_toml_configuration_for_launch_debugger() {
     assert_stdout_contains(
         output,
         indoc! {
-            "[ERROR] Scarb.toml must have the following Cairo compiler configuration to launch the debugger:
+            "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to launch the debugger:
 
             [profile.dev.cairo]
             unstable-add-statements-code-locations-debug-info = true
@@ -52,6 +53,34 @@ fn test_launch_debugger_waits_for_connection() {
         ))
         .unwrap();
 
+    launch_and_wait_for_connection(temp)
+}
+
+#[test]
+fn test_launch_debugger_waits_for_connection_with_complex_config() {
+    let temp = setup_package("debugging");
+
+    let manifest_path = temp.child("Scarb.toml");
+
+    let existing = fs::read_to_string(&manifest_path).unwrap();
+    manifest_path
+        .write_str(&formatdoc!(
+            "{existing}
+            [profile.dev.cairo]
+            add-statements-functions-debug-info = true
+            add-functions-debug-info = true
+
+            [cairo]
+            skip-optimizations = true
+            unstable-add-statements-code-locations-debug-info = true
+            ",
+        ))
+        .unwrap();
+
+    launch_and_wait_for_connection(temp)
+}
+
+fn launch_and_wait_for_connection(temp: TempDir) {
     let mut child = Command::new(snforge_test_bin_path())
         .args([
             "test",


### PR DESCRIPTION
Closes #4254
Closes #4292 
Closes https://github.com/software-mansion/cairo-debugger/issues/109

## Introduced changes

- previously the config validation relied on checking the content of the Scarb.toml, which led to poor UX (e.g. `[cairo]` section was ignored completely). Now we read the config from scarb metadata which is more reliable. Also, previously a wrong Scarb.toml was used - the `runtime_manifest` instead of `workspace.manifest_path`

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
