### PR TITLE
CI: Retry flaky tests; Migrate `sncast` tests to `nextest` 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,27 +1,20 @@
 [profile.default]
 fail-fast = false
-
-[profile.snforge-ci]
-fail-fast = false
-retries = 0
-
-[profile.sncast-ci]
-fail-fast = false
 retries = 0
 
 [test-groups]
 devnet-sequential = { max-threads = 1 }
 ledger = { max-threads = 1 }
 
-[[profile.sncast-ci.overrides]]
-filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/) | test(/^helpers::devnet_provider::/) | test(/^helpers::devnet_detection::/)'
+[[profile.default.overrides]]
+filter = 'package(sncast) and (test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/) | test(/^helpers::devnet_provider::/) | test(/^helpers::devnet_detection::/))'
 test-group = "devnet-sequential"
 
-[[profile.sncast-ci.overrides]]
-filter = 'test(/^e2e::devnet_accounts::/) | test(/^e2e::script::init::/)'
+[[profile.default.overrides]]
+filter = 'package(sncast) and (test(/^e2e::devnet_accounts::/) | test(/^e2e::script::init::/))'
 retries = 1
 
-[[profile.sncast-ci.overrides]]
-filter = 'test(/^e2e::ledger::/) | test(/^docs_snippets::ledger::/)'
+[[profile.default.overrides]]
+filter = 'package(sncast) and (test(/^e2e::ledger::/) | test(/^docs_snippets::ledger::/))'
 test-group = "ledger"
 retries = 3

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,9 +5,15 @@ fail-fast = false
 fail-fast = false
 retries = 0
 
+[profile.snforge-ci]
+fail-fast = false
+retries = 0
+
 [test-groups]
 devnet-sequential = { max-threads = 1 }
 ledger-emulator = { max-threads = 1 }
+
+# sncast overrides
 
 [[profile.sncast-ci.overrides]]
 filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/)'
@@ -21,3 +27,6 @@ retries = 2
 filter = 'test(/^e2e::ledger::/)'
 test-group = "ledger-emulator"
 retries = 3
+
+# snforge overrides
+

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -22,6 +22,6 @@ filter = 'test(/^e2e::devnet_accounts::/) | test(/^e2e::script::init::/)'
 retries = 1
 
 [[profile.sncast-ci.overrides]]
-filter = 'test(/^e2e::ledger::/)'
+filter = 'test(/^e2e::ledger::/) | test(/^docs_snippets::ledger::/)'
 test-group = "ledger"
 retries = 3

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -16,7 +16,7 @@ ledger-emulator = { max-threads = 1 }
 # sncast overrides
 
 [[profile.sncast-ci.overrides]]
-filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/)'
+filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/) | test(/^helpers::devnet_provider::/) | test(/^helpers::devnet_detection::/)'
 test-group = "devnet-sequential"
 
 [[profile.sncast-ci.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,7 @@ retries = 1
 filter = 'package(sncast) and (test(/^e2e::ledger::/) | test(/^docs_snippets::ledger::/))'
 test-group = "ledger"
 retries = 3
+
+[[profile.default.overrides]]
+filter = 'package(sncast) and test(=e2e::devnet_accounts::use_devnet_account_with_network_flags)'
+retries = { backoff = "exponential", count = 3, delay = "5s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@ fail-fast = false
 
 [profile.sncast-ci]
 fail-fast = false
-retries = 0
+retries = 2
 
 [profile.snforge-ci]
 fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,19 +1,15 @@
 [profile.default]
 fail-fast = false
 
-[profile.sncast-ci]
-fail-fast = false
-retries = 2
+# sncast
 
-[profile.snforge-ci]
+[profile.sncast-ci]
 fail-fast = false
 retries = 0
 
 [test-groups]
 devnet-sequential = { max-threads = 1 }
-ledger-emulator = { max-threads = 1 }
-
-# sncast overrides
+ledger = { max-threads = 1 }
 
 [[profile.sncast-ci.overrides]]
 filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/) | test(/^helpers::devnet_provider::/) | test(/^helpers::devnet_detection::/)'
@@ -21,12 +17,16 @@ test-group = "devnet-sequential"
 
 [[profile.sncast-ci.overrides]]
 filter = 'test(/^e2e::devnet_accounts::/) | test(/^e2e::script::init::/)'
-retries = 2
+retries = 1
 
 [[profile.sncast-ci.overrides]]
 filter = 'test(/^e2e::ledger::/)'
-test-group = "ledger-emulator"
+test-group = "ledger"
 retries = 3
 
-# snforge overrides
+# snforge
+
+[profile.snforge-ci]
+fail-fast = false
+retries = 0
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,7 +1,9 @@
 [profile.default]
 fail-fast = false
 
-# sncast
+[profile.snforge-ci]
+fail-fast = false
+retries = 0
 
 [profile.sncast-ci]
 fail-fast = false
@@ -23,10 +25,3 @@ retries = 1
 filter = 'test(/^e2e::ledger::/)'
 test-group = "ledger"
 retries = 3
-
-# snforge
-
-[profile.snforge-ci]
-fail-fast = false
-retries = 0
-

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,23 @@
+[profile.default]
+fail-fast = false
+
+[profile.sncast-ci]
+fail-fast = false
+retries = 0
+
+[test-groups]
+devnet-sequential = { max-threads = 1 }
+ledger-emulator = { max-threads = 1 }
+
+[[profile.sncast-ci.overrides]]
+filter = 'test(/^e2e::/) | test(/^integration::/) | test(/^docs_snippets::/)'
+test-group = "devnet-sequential"
+
+[[profile.sncast-ci.overrides]]
+filter = 'test(/^e2e::devnet_accounts::/) | test(/^e2e::script::init::/)'
+retries = 2
+
+[[profile.sncast-ci.overrides]]
+filter = 'test(/^e2e::ledger::/)'
+test-group = "ledger-emulator"
+retries = 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' integration
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' integration
 
   test-forge-integration-native:
     name: Test Forge / Integration Tests (native)
@@ -150,7 +150,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}-native
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' integration
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' integration
 
   test-forge-e2e:
     name: Test Forge / E2E Tests
@@ -200,7 +200,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' e2e
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' e2e
 
   test-forge-e2e-native:
     name: Test Forge / E2E Tests (native)
@@ -250,7 +250,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}-native
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' e2e
+        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' e2e
 
   test-forge-e2e-snap:
     if: github.event_name == 'merge_group'
@@ -362,7 +362,7 @@ jobs:
         with:
           tool: nextest@0.9.98
       - name: Run tests (nextest)
-        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci
+        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast
       - name: Run doctests
         run: cargo test --profile ci -p sncast --doc
 
@@ -382,7 +382,7 @@ jobs:
         with:
           tool: nextest@0.9.98
       - name: Run tests (nextest)
-        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci --features ledger-emulator ledger --run-ignored all
+        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --features ledger-emulator ledger --run-ignored all
 
   fmt-lint-typos:
     name: Lint and Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' integration
+        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' integration
 
   test-forge-integration-native:
     name: Test Forge / Integration Tests (native)
@@ -150,7 +150,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}-native
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' integration
+        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' integration
 
   test-forge-e2e:
     name: Test Forge / E2E Tests
@@ -200,7 +200,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' e2e
+        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}.tar.zst' e2e
 
   test-forge-e2e-native:
     name: Test Forge / E2E Tests (native)
@@ -250,7 +250,7 @@ jobs:
         with:
           name: nextest-archive-${{ runner.os }}-native
       - name: nextest partition ${{ matrix.partition }}/3
-        run: cargo nextest run --no-fail-fast --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' e2e
+        run: cargo nextest run --no-fail-fast --profile snforge-ci --partition 'count:${{ matrix.partition }}/3' --archive-file 'nextest-archive-${{ runner.os }}-native.tar.zst' e2e
 
   test-forge-e2e-snap:
     if: github.event_name == 'merge_group'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,8 +358,13 @@ jobs:
         with:
           cache-key: 'cast'
           save-cache: 'true'
-      - name: Run tests
-        run: cargo test --profile ci -p sncast
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
+      - name: Run tests (nextest)
+        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci
+      - name: Run doctests
+        run: cargo test --profile ci -p sncast --doc
 
   test-ledger:
     name: Test Ledger
@@ -373,8 +378,11 @@ jobs:
         with:
           cache-key: 'cast-ledger'
           save-cache: 'true'
-      - name: Run tests
-        run: cargo test --profile ci -p sncast --features ledger-emulator ledger -- --ignored
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
+      - name: Run tests (nextest)
+        run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci --features ledger-emulator ledger --run-ignored all
 
   fmt-lint-typos:
     name: Lint and Format

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           tool: nextest@0.9.98
 
-      - run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci
+      - run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast
 
   get-version:
     name: Get current foundry version

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -136,7 +136,11 @@ jobs:
           tool_versions: |
             starknet-devnet ${{ steps.get-devnet-version.outputs.version }}
 
-      - run: cargo test --profile ci -p sncast
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
+
+      - run: cargo nextest run --no-fail-fast --cargo-profile ci -p sncast --profile sncast-ci
 
   get-version:
     name: Get current foundry version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ If you are a more experienced Starknet Foundry contributor you can pick any issu
 Please make sure the feature you are implementing is thoroughly tested with automatic tests.
 You can check existing tests in the repository to see the recommended approach to testing.
 
+#### Flaky tests
+
+Some tests fail intermittently due to dependence on an external service, network issues, etc.
+
+If no clear fix is possible or trivial, to avoid blocking CI, configure targeted retries for known flaky tests in [`.config/nextest.toml`](./.config/nextest.toml).
+Choose retry count, backoff and other options based on context: 
+- observed fail rate
+- external dependency reliability
+- expected recovery time
+
 #### Snapshot tests
 Some tests use [`insta`](https://crates.io/crates/insta) snapshots files (`.snap`) to store expected test output, specifically for testing some of Starknet Foundry features with older Scarb versions.
 When adding such test case, please add a `snap_` prefix to its name to ensure it's tested on CI for all supported Scarb versions.

--- a/crates/forge/tests/e2e/common/runner.rs
+++ b/crates/forge/tests/e2e/common/runner.rs
@@ -7,6 +7,7 @@ use assert_fs::fixture::{FileWriteStr, PathChild, PathCopy};
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
 use shared::command::CommandExt;
+use shared::test_utils::nextest::is_nextest;
 use shared::test_utils::node_url::node_rpc_url;
 use snapbox::cargo_bin;
 use snapbox::cmd::Command as SnapboxCommand;
@@ -23,7 +24,7 @@ pub(crate) fn runner<T: AsRef<Path>>(temp_dir: T) -> SnapboxCommand {
 
 // If ran on CI, we want to get the nextest's built binary
 pub fn snforge_test_bin_path() -> PathBuf {
-    if env::var("NEXTEST").unwrap_or("0".to_string()) == "1" {
+    if is_nextest() {
         let snforge_nextest_env =
             env::var("NEXTEST_BIN_EXE_snforge").expect("No snforge binary for nextest found");
         return PathBuf::from(snforge_nextest_env);

--- a/crates/shared/src/test_utils/mod.rs
+++ b/crates/shared/src/test_utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod nextest;
 pub mod node_url;
 pub mod output_assert;

--- a/crates/shared/src/test_utils/nextest.rs
+++ b/crates/shared/src/test_utils/nextest.rs
@@ -1,0 +1,4 @@
+#[must_use]
+pub fn is_nextest() -> bool {
+    std::env::var("NEXTEST").as_deref() == Ok("1")
+}

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -5,12 +5,11 @@ use crate::helpers::constants::{
 use crate::helpers::fixtures::{
     copy_directory_to_tempdir, create_and_deploy_oz_account, invoke_contract, join_tempdirs,
 };
-use crate::helpers::runner::runner;
+use crate::helpers::runner::{runner, sncast_test_bin_path};
 use crate::helpers::shell::os_specific_shell;
 use camino::Utf8PathBuf;
 use indoc::indoc;
 use shared::test_utils::output_assert::assert_stderr_contains;
-use snapbox::cargo_bin;
 use sncast::helpers::fee::FeeSettings;
 
 #[test]
@@ -249,7 +248,7 @@ fn test_wrong_block_id() {
 
 #[test]
 fn test_happy_case_shell() {
-    let binary_path = cargo_bin!("sncast");
+    let binary_path = sncast_test_bin_path();
     let command = os_specific_shell(&Utf8PathBuf::from("tests/shell/call"));
 
     let snapbox = command
@@ -261,7 +260,7 @@ fn test_happy_case_shell() {
 
 #[test]
 fn test_leading_negative_values() {
-    let binary_path = cargo_bin!("sncast");
+    let binary_path = sncast_test_bin_path();
     let command = os_specific_shell(&Utf8PathBuf::from("tests/shell/call_unsigned"));
 
     let snapbox = command

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -7,12 +7,11 @@ use crate::helpers::fixtures::{
     duplicate_contract_directory_with_salt, get_transaction_by_hash, get_transaction_hash,
     get_transaction_receipt, join_tempdirs,
 };
-use crate::helpers::runner::runner;
+use crate::helpers::runner::{runner, sncast_test_bin_path};
 use crate::helpers::shell::os_specific_shell;
 use camino::Utf8PathBuf;
 use indoc::indoc;
 use shared::test_utils::output_assert::{AsOutput, assert_stderr_contains, assert_stdout_contains};
-use snapbox::cargo_bin;
 use sncast::AccountType;
 use sncast::helpers::constants::OZ_CLASS_HASH;
 use sncast::helpers::fee::FeeArgs;
@@ -389,7 +388,7 @@ fn test_too_low_gas() {
 #[tokio::test]
 async fn test_happy_case_shell() {
     let tempdir = create_and_deploy_oz_account().await;
-    let binary_path = cargo_bin!("sncast");
+    let binary_path = sncast_test_bin_path();
     let command = os_specific_shell(&Utf8PathBuf::from("tests/shell/deploy"));
 
     let snapbox = command

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -6,12 +6,11 @@ use crate::helpers::fixtures::{
     create_and_deploy_account, create_and_deploy_oz_account, get_transaction_by_hash,
     get_transaction_hash, get_transaction_receipt,
 };
-use crate::helpers::runner::runner;
+use crate::helpers::runner::{runner, sncast_test_bin_path};
 use crate::helpers::shell::os_specific_shell;
 use camino::Utf8PathBuf;
 use indoc::indoc;
 use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains};
-use snapbox::cargo_bin;
 use sncast::AccountType;
 use sncast::helpers::constants::{BRAAVOS_CLASS_HASH, OZ_CLASS_HASH, READY_CLASS_HASH};
 use sncast::helpers::fee::FeeArgs;
@@ -343,7 +342,7 @@ async fn test_happy_case_cairo_expression_calldata() {
 #[tokio::test]
 async fn test_happy_case_shell() {
     let tempdir = create_and_deploy_oz_account().await;
-    let binary_path = cargo_bin!("sncast");
+    let binary_path = sncast_test_bin_path();
     let command = os_specific_shell(&Utf8PathBuf::from("tests/shell/invoke"));
 
     let snapbox = command

--- a/crates/sncast/tests/e2e/utils/serialize.rs
+++ b/crates/sncast/tests/e2e/utils/serialize.rs
@@ -2,12 +2,11 @@ use crate::helpers::constants::{
     DATA_TRANSFORMER_CONTRACT_ABI_PATH, DATA_TRANSFORMER_CONTRACT_ADDRESS_SEPOLIA,
     DATA_TRANSFORMER_CONTRACT_CLASS_HASH_SEPOLIA, MAP_CONTRACT_ADDRESS_SEPOLIA, URL,
 };
-use crate::helpers::runner::runner;
+use crate::helpers::runner::{runner, sncast_test_bin_path};
 use crate::helpers::shell::os_specific_shell;
 use camino::Utf8PathBuf;
 use indoc::indoc;
 use shared::test_utils::output_assert::assert_stderr_contains;
-use snapbox::cargo_bin;
 use tempfile::tempdir;
 
 #[tokio::test]
@@ -284,7 +283,7 @@ async fn test_rpc_args_not_passed_when_using_contract_address() {
 
 #[tokio::test]
 async fn test_happy_case_shell() {
-    let binary_path = cargo_bin!("sncast");
+    let binary_path = sncast_test_bin_path();
     let command = os_specific_shell(&Utf8PathBuf::from("tests/shell/serialize"));
 
     let snapbox = command

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -13,12 +13,24 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
 
+fn is_nextest() -> bool {
+    std::env::var("NEXTEST").as_deref() == Ok("1")
+}
+
+fn is_listing() -> bool {
+    std::env::args().any(|a| a == "--list")
+}
+
+fn verify_devnet_availability(address: &str) -> bool {
+    TcpStream::connect(address).is_ok()
+}
+
 #[expect(clippy::zombie_processes)]
 #[cfg(test)]
 #[ctor]
 fn start_devnet() {
-    fn verify_devnet_availability(address: &str) -> bool {
-        TcpStream::connect(address).is_ok()
+    if is_listing() {
+        return;
     }
 
     let port = Url::parse(URL).unwrap().port().unwrap_or(80).to_string();
@@ -27,12 +39,19 @@ fn start_devnet() {
         .host()
         .expect("Can't parse devnet URL!")
         .to_string();
+    let addr = format!("{host}:{port}");
 
-    loop {
-        if verify_devnet_availability(&format!("{host}:{port}")) {
-            stop_devnet();
-        } else {
-            break;
+    if is_nextest() {
+        if verify_devnet_availability(&addr) {
+            return;
+        }
+    } else {
+        loop {
+            if verify_devnet_availability(&addr) {
+                stop_devnet();
+            } else {
+                break;
+            }
         }
     }
 
@@ -61,7 +80,7 @@ fn start_devnet() {
     let timeout = Duration::from_secs(30);
 
     loop {
-        if verify_devnet_availability(&format!("{host}:{port}")) {
+        if verify_devnet_availability(&addr) {
             break;
         } else if now.elapsed() >= timeout {
             eprintln!("Timed out while waiting for devnet!");
@@ -81,6 +100,10 @@ fn start_devnet() {
 #[cfg(test)]
 #[dtor]
 fn stop_devnet() {
+    if is_nextest() || is_listing() {
+        return;
+    }
+
     let port = Url::parse(URL).unwrap().port().unwrap_or(80).to_string();
     let pattern = format!("starknet-devnet.*{port}.*{DEVNET_SEED}");
 

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -6,16 +6,13 @@ use crate::helpers::fixtures::{
     deploy_latest_oz_account, deploy_ready_account,
 };
 use ctor::{ctor, dtor};
+use shared::test_utils::nextest::is_nextest;
 use std::net::TcpStream;
 use std::process::{Command, Stdio};
 use std::string::ToString;
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
-
-fn is_nextest() -> bool {
-    std::env::var("NEXTEST").as_deref() == Ok("1")
-}
 
 fn is_listing() -> bool {
     std::env::args().any(|a| a == "--list")

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
 
+/// Detects nextest test discovery mode (`--list`) to skip devnet lifecycle side effects.
 fn is_listing() -> bool {
     std::env::args().any(|a| a == "--list")
 }

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -14,7 +14,8 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
 
-/// Detects `nextest` list phase to skip devnet lifecycle side effects.
+/// Detects `nextest` list phase: https://github.com/foundry-rs/starknet-foundry/pull/4297#discussion_r3147207375
+/// This allows us to avoid devnet lifecycle side effects.
 fn is_nextest_list_mode() -> bool {
     is_nextest()
         && (std::env::var("NEXTEST_TEST_PHASE").as_deref() == Ok("list")

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -14,9 +14,12 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
 
-/// Detects nextest test discovery mode (`--list`) to skip devnet lifecycle side effects.
-fn is_listing() -> bool {
-    std::env::args().any(|a| a == "--list")
+/// Detects `nextest` list phase to skip devnet lifecycle side effects.
+fn is_nextest_list_mode() -> bool {
+    is_nextest()
+        && (std::env::var("NEXTEST_TEST_PHASE").as_deref() == Ok("list")
+            // Fallback for older versions of `nextest` that don't set `NEXTEST_TEST_PHASE`.
+            || std::env::args().any(|a| a == "--list"))
 }
 
 fn verify_devnet_availability(address: &str) -> bool {
@@ -27,7 +30,7 @@ fn verify_devnet_availability(address: &str) -> bool {
 #[cfg(test)]
 #[ctor]
 fn start_devnet() {
-    if is_listing() {
+    if is_nextest_list_mode() {
         return;
     }
 
@@ -98,7 +101,7 @@ fn start_devnet() {
 #[cfg(test)]
 #[dtor]
 fn stop_devnet() {
-    if is_nextest() || is_listing() {
+    if is_nextest() {
         return;
     }
 

--- a/crates/sncast/tests/helpers/devnet.rs
+++ b/crates/sncast/tests/helpers/devnet.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 use url::Url;
 
-/// Detects `nextest` list phase: https://github.com/foundry-rs/starknet-foundry/pull/4297#discussion_r3147207375
+/// Detects `nextest` list phase: `<https://github.com/foundry-rs/starknet-foundry/pull/4297#discussion_r3147207375>`.
 /// This allows us to avoid devnet lifecycle side effects.
 fn is_nextest_list_mode() -> bool {
     is_nextest()

--- a/crates/sncast/tests/helpers/runner.rs
+++ b/crates/sncast/tests/helpers/runner.rs
@@ -132,7 +132,8 @@ impl EnvPath {
     }
 }
 
-fn sncast_test_bin_path() -> PathBuf {
+#[must_use]
+pub fn sncast_test_bin_path() -> PathBuf {
     if is_nextest() {
         let sncast_nextest_env =
             std::env::var("NEXTEST_BIN_EXE_sncast").expect("No sncast binary for nextest found");

--- a/crates/sncast/tests/helpers/runner.rs
+++ b/crates/sncast/tests/helpers/runner.rs
@@ -4,6 +4,8 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
+use shared::test_utils::nextest::is_nextest;
+
 #[must_use]
 pub fn runner(args: &[&str]) -> CastCommand {
     Cast::new().command().args(args)
@@ -25,7 +27,7 @@ impl Cast {
             state: CastState {
                 config_dir: EnvPath::temp_dir(),
             },
-            sncast_bin: cargo_bin!("sncast").to_path_buf(),
+            sncast_bin: sncast_test_bin_path(),
         }
     }
 
@@ -128,4 +130,14 @@ impl EnvPath {
             EnvPath::Unmanaged(p) => p,
         }
     }
+}
+
+fn sncast_test_bin_path() -> PathBuf {
+    if is_nextest() {
+        let sncast_nextest_env =
+            std::env::var("NEXTEST_BIN_EXE_sncast").expect("No sncast binary for nextest found");
+        return PathBuf::from(sncast_nextest_env);
+    }
+
+    cargo_bin!("sncast").to_path_buf()
 }

--- a/docs/src/development/environment-setup.md
+++ b/docs/src/development/environment-setup.md
@@ -55,6 +55,18 @@ Tests can be run with:
 $ cargo test
 ```
 
+`cargo test` is the primary way to run tests locally.
+
+> ❗️ **Warning**
+>
+> `cargo nextest run` may leave an orphan `starknet-devnet` process in some scenarios.
+> For local runs, prefer `cargo test`.
+> If you want to use `nextest`, find and `kill` orphan devnet process:
+>
+> ```shell
+> $ ps aux | grep starknet-devnet | grep -v grep
+> ```
+
 ## Cairo Native
 
 To develop Starknet Foundry with Cairo Native support, you need to enable the `cairo-native` feature in Cargo and


### PR DESCRIPTION
## Stack

- #4297
- #4298 

<!-- Reference any GitHub issues resolved by this PR -->

Closes #4285 

## Introduced changes

<!-- A brief description of the changes -->

- Migrate `sncast` tests from `cargo test` to `nextest`
- Add retries for known flaky test groups + ledger
- Keep retries at zero for now otherwise 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
