### PR TITLE
Remove check for `SCARB_WITHOUT_CAIRO_TEST_TEMPLATE` and bump minimal scarb to 2.13.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,10 +312,10 @@ jobs:
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: '2.12.0'
+          scarb-version: "2.13.1"
 
-      - run: cargo test --profile ci --package forge --features scarb_2_12_0 --test main e2e::plugin_versions::new_with_minimal_scarb
-      - run: cargo test --profile ci --package forge --features scarb_2_12_0 --test main e2e::requirements::test_warning_on_scarb_version_below_recommended
+      - run: cargo test --profile ci --package forge --features scarb_2_13_1 --test main e2e::plugin_versions::new_with_minimal_scarb
+      - run: cargo test --profile ci --package forge --features scarb_2_13_1 --test main e2e::requirements::test_warning_on_scarb_version_below_recommended
 
   test-forge-scarb-plugin:
     name: Test Forge Scarb Plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `snforge_scarb_plugin` diagnostics for named-argument kind violations now include both possible values and invalid arguments found.
 - `snforge test --exact` now reports the exact number of filtered-out tests in summaries instead of `other`.
+- Minimal required `Scarb` version is now `2.13.1` (updated from `2.12.0`).
 
 #### Fixed
 

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 
 [features]
 # This should match `MINIMAL_SCARB_VERSION`
-scarb_2_12_0 = []
+scarb_2_13_1 = []
 no_scarb_installed = []
 non_exact_gas_assertions = []
 scheduled_latest_scarb_only = []

--- a/crates/forge/src/compatibility_check.rs
+++ b/crates/forge/src/compatibility_check.rs
@@ -38,16 +38,11 @@ impl Requirement<'_> {
                 },
             );
 
-            let min_version_to_display = self
-                .minimal_recommended_version
-                .as_ref()
-                .unwrap_or(&self.minimal_version);
-
             if !is_valid {
                 is_valid = false;
                 format!(
                     "❌ {} Version {} doesn't satisfy minimal {}\n{}",
-                    self.name, version, min_version_to_display, self.helper_text
+                    self.name, version, self.minimal_version, self.helper_text
                 )
             } else if !is_min_recommended {
                 format!(

--- a/crates/forge/src/compatibility_check.rs
+++ b/crates/forge/src/compatibility_check.rs
@@ -292,7 +292,7 @@ mod tests {
 
         assert!(!is_valid);
         assert!(validation_output.contains("❌ Scarb Version"));
-        assert!(validation_output.contains("doesn't satisfy minimal 999.0.0"));
+        assert!(validation_output.contains("doesn't satisfy minimal 111.0.0"));
     }
 
     #[cfg(feature = "no_scarb_installed")]

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -40,7 +40,7 @@ mod warn;
 
 pub const CAIRO_EDITION: &str = "2024_07";
 
-const MINIMAL_SCARB_VERSION: Version = Version::new(2, 12, 0);
+const MINIMAL_SCARB_VERSION: Version = Version::new(2, 13, 1);
 const MINIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 16, 1);
 const MAXIMAL_RECOMMENDED_SCARB_VERSION: Version = Version::new(2, 18, 0);
 const MINIMAL_USC_VERSION: Version = Version::new(2, 0, 0);

--- a/crates/forge/src/new.rs
+++ b/crates/forge/src/new.rs
@@ -20,8 +20,6 @@ const OZ_UTILS_VERSION: Version = Version::new(2, 1, 0);
 
 static TEMPLATES_DIR: Dir = include_dir!("snforge_templates");
 
-const SCARB_WITHOUT_CAIRO_TEST_TEMPLATE: Version = Version::new(2, 13, 0);
-
 struct Dependency {
     name: String,
     version: String,
@@ -360,30 +358,10 @@ pub fn new(
             cmd.arg("--no-vcs");
         }
 
-        // TODO(#3910)
-        let test_runner = if scarb_version < SCARB_WITHOUT_CAIRO_TEST_TEMPLATE {
-            "cairo-test"
-        } else {
-            "none"
-        };
-
-        cmd.env("SCARB_INIT_TEST_RUNNER", test_runner)
+        cmd.env("SCARB_INIT_TEST_RUNNER", "none")
             .env("SCARB_INIT_EMPTY", "true")
             .run()
             .context("Failed to initialize a new project")?;
-
-        // TODO(#3910)
-        if scarb_version < SCARB_WITHOUT_CAIRO_TEST_TEMPLATE {
-            ScarbCommand::new_with_stdio()
-                .current_dir(&project_path)
-                .manifest_path(scarb_manifest_path.clone())
-                .offline()
-                .arg("remove")
-                .arg("--dev")
-                .arg("cairo_test")
-                .run()
-                .context("Failed to remove cairo_test dependency")?;
-        }
     }
 
     add_template_to_scarb_manifest(&scarb_manifest_path)?;

--- a/crates/forge/src/new.rs
+++ b/crates/forge/src/new.rs
@@ -74,13 +74,14 @@ impl TemplateManifestConfig {
             .parse::<DocumentMut>()
             .context("invalid document")?;
 
+        set_cairo_edition(&mut document, CAIRO_EDITION);
+        add_assert_macros(&mut document)?;
+
         if self.contract_target {
             add_target_to_toml(&mut document);
         }
 
-        set_cairo_edition(&mut document, CAIRO_EDITION);
         add_test_script(&mut document);
-        add_assert_macros(&mut document)?;
         add_allow_prebuilt_macros(&mut document)?;
 
         if self.fork_config {

--- a/crates/forge/tests/e2e/new.rs
+++ b/crates/forge/tests/e2e/new.rs
@@ -6,7 +6,6 @@ use forge::CAIRO_EDITION;
 use forge::Template;
 use forge::scarb::config::SCARB_MANIFEST_TEMPLATE_CONTENT;
 use indoc::{formatdoc, indoc};
-use itertools::Itertools;
 use regex::Regex;
 use scarb_api::ScarbCommand;
 use shared::consts::FREE_RPC_PROVIDER_URL;
@@ -118,7 +117,7 @@ fn validate_init(project_path: &PathBuf, validate_snforge_std: bool, template: &
     let scarb_toml = fs::read_to_string(manifest_path.clone()).unwrap();
 
     let expected = get_expected_manifest_content(template, validate_snforge_std);
-    assert_manifest_matches(&expected, &scarb_toml);
+    assert_data_eq!(&scarb_toml, expected);
 
     let mut scarb_toml = DocumentMut::from_str(&scarb_toml).unwrap();
 
@@ -304,21 +303,4 @@ fn create_new_project_and_check_gitignore() {
     };
 
     assert_eq!(gitignore_content, expected_gitignore_content);
-}
-
-/// Asserts that two manifest contents match, ignoring the order of lines.
-///
-/// # Why Line Order Can Vary
-///
-/// Starting from Scarb version 2.13, `scarb init` no longer inserts the `[dev-dependencies]` section.
-/// When tools like `forge new` generate a new project, they insert this section later
-/// in the manifest. As a result, the relative placement of `[dev-dependencies]` and other sections
-/// might differ depending on the version of Scarb used.
-fn assert_manifest_matches(expected: &str, actual: &str) {
-    // TODO(#3910)
-    fn sort_lines(s: &str) -> String {
-        s.lines().sorted().join("\n")
-    }
-
-    assert_data_eq!(sort_lines(actual), sort_lines(expected));
 }

--- a/crates/forge/tests/e2e/plugin_versions.rs
+++ b/crates/forge/tests/e2e/plugin_versions.rs
@@ -35,7 +35,7 @@ fn new_with_minimal_scarb() {
     let temp = tempdir_with_tool_versions().unwrap();
     Command::new("asdf")
         .current_dir(&temp)
-        .args(["set", "scarb", "2.12.0"])
+        .args(["set", "scarb", "2.13.1"])
         .assert()
         .success();
     runner(&temp)

--- a/crates/forge/tests/e2e/plugin_versions.rs
+++ b/crates/forge/tests/e2e/plugin_versions.rs
@@ -29,7 +29,7 @@ fn new_with_new_scarb() {
     assert_eq!(snforge_std, env!("CARGO_PKG_VERSION"));
 }
 
-#[cfg(feature = "scarb_2_12_0")]
+#[cfg(feature = "scarb_2_13_1")]
 #[test]
 fn new_with_minimal_scarb() {
     let temp = tempdir_with_tool_versions().unwrap();

--- a/crates/forge/tests/e2e/requirements.rs
+++ b/crates/forge/tests/e2e/requirements.rs
@@ -30,7 +30,7 @@ fn test_warning_on_scarb_version_below_recommended() {
         indoc! {r"
     Checking requirements
 
-    ⚠️  Scarb Version 2.12.0 doesn't satisfy minimal recommended [..]
+    ⚠️  Scarb Version 2.13.1 doesn't satisfy minimal recommended [..]
     ✅ Universal Sierra Compiler [..]
     "},
     );

--- a/crates/forge/tests/e2e/requirements.rs
+++ b/crates/forge/tests/e2e/requirements.rs
@@ -19,7 +19,7 @@ fn happy_path() {
     );
 }
 
-#[cfg(feature = "scarb_2_12_0")]
+#[cfg(feature = "scarb_2_13_1")]
 #[test]
 fn test_warning_on_scarb_version_below_recommended() {
     let temp = setup_package("simple_package");

--- a/crates/sncast/src/starknet_commands/script/init.rs
+++ b/crates/sncast/src/starknet_commands/script/init.rs
@@ -7,12 +7,9 @@ use clap::Args;
 use foundry_ui::components::warning::WarningMessage;
 use indoc::{formatdoc, indoc};
 use scarb_api::ScarbCommand;
-use scarb_api::version::scarb_version;
-use semver::Version;
 use sncast::helpers::constants::INIT_SCRIPTS_DIR;
 use sncast::helpers::scarb_utils::get_cairo_version;
 use sncast::response::script::init::ScriptInitResponse;
-use toml_edit::DocumentMut;
 
 #[derive(Args, Debug)]
 pub struct Init {
@@ -61,17 +58,6 @@ fn get_script_root_dir_path(script_name: &str) -> Result<Utf8PathBuf> {
 }
 
 fn init_scarb_project(script_name: &str, script_root_dir: &Utf8PathBuf) -> Result<()> {
-    const SCARB_WITHOUT_CAIRO_TEST_TEMPLATE: Version = Version::new(2, 13, 0);
-
-    let version = scarb_version()?;
-
-    // TODO(#3910)
-    let test_runner = if version.scarb < SCARB_WITHOUT_CAIRO_TEST_TEMPLATE {
-        "cairo-test"
-    } else {
-        "none"
-    };
-
     ScarbCommand::new()
         .args([
             "new",
@@ -81,14 +67,9 @@ fn init_scarb_project(script_name: &str, script_root_dir: &Utf8PathBuf) -> Resul
             "--quiet",
             script_root_dir.as_str(),
         ])
-        .env("SCARB_INIT_TEST_RUNNER", test_runner)
+        .env("SCARB_INIT_TEST_RUNNER", "none")
         .run()
         .context("Failed to init Scarb project")?;
-
-    // TODO(#3910)
-    if version.scarb < SCARB_WITHOUT_CAIRO_TEST_TEMPLATE {
-        remove_cairo_test_dependency(script_root_dir)?;
-    }
 
     Ok(())
 }
@@ -182,12 +163,4 @@ fn clean_created_dir_and_files(script_root_dir: &Utf8PathBuf, ui: &UI) {
             format!("Failed to clean created files by init command at {script_root_dir}"),
         );
     }
-}
-
-fn remove_cairo_test_dependency(script_root_dir: &Utf8PathBuf) -> Result<()> {
-    let manifest_path = script_root_dir.join("Scarb.toml");
-    let mut document: DocumentMut = fs::read_to_string(&manifest_path)?.parse()?;
-    document.remove("dev-dependencies");
-    fs::write(manifest_path, document.to_string())?;
-    Ok(())
 }

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -14,7 +14,7 @@ In this section, we will walk through the process of installing Starknet Foundry
       * [Requirements](#requirements)
       * [Linux and macOS](#linux-and-macos)
           * [Install asdf](#install-asdf)
-          * [Install Scarb version >= 2.12.0](#install-scarb-version--2120)
+          * [Install Scarb version >= 2.13.1](#install-scarb-version--2131)
           * [(Optional) Rust Installation](#optional-rust-installation)
           * [Install Starknet Foundry](#install-starknet-foundry)
       * [Windows](#windows)
@@ -63,7 +63,7 @@ snforge --version
 
 To use Starknet Foundry, you need:
 
-- [Scarb](https://docs.swmansion.com/scarb/download.html) version >= 2.12.0
+- [Scarb](https://docs.swmansion.com/scarb/download.html) version >= 2.13.1
 - [Universal-Sierra-Compiler](https://github.com/software-mansion/universal-sierra-compiler)
 - _(Optional for Scarb >= 2.10.0)_[^note] [Rust](https://www.rust-lang.org/tools/install) version >= 1.80.1
 
@@ -97,7 +97,7 @@ To verify that asdf was installed, run
 asdf --version
 ```
 
-#### Install Scarb version >= 2.12.0
+#### Install Scarb version >= 2.13.1
 
 First, add Scarb plugin to asdf
 
@@ -123,7 +123,7 @@ To verify that Scarb was installed, run
 scarb --version
 ```
 
-and verify that version is >= 2.12.0
+and verify that version is >= 2.13.1
 
 #### (Optional) Rust Installation
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3910 #4091 

## Introduced changes

<!-- A brief description of the changes -->

- Remove check for `SCARB_WITHOUT_CAIRO_TEST_TEMPLATE`. 
- Because of the above, bump `minmal required` scarb to 2.13.1
- Fix bug in `requirement-check`. In check `minimal recommended` was displayed, when it should be `minimal required` 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
