### PR TITLE
Bump `starknet-rust` to stable version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,6 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "regex",
- "reqwest 0.13.2",
  "scarb-api",
  "scarb-metadata",
  "scarb-ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,13 +2529,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.6.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96272c2ff28b807e09250b180ad1fb7889a3258f7455759b5c3c58b719467130"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
+ "cpubits",
+ "ctutils",
  "hybrid-array",
  "num-traits",
- "subtle",
  "zeroize",
 ]
 
@@ -2560,6 +2573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -4095,9 +4117,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.3"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -7639,9 +7661,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b6146f9696cc1bab30018143d4b653b6f4ecd729791431efc92c3e90514024"
+checksum = "d341a85d902801c29edfba1e1b5c8db66c619074265d6aac8cbee4be1736fb58"
 dependencies = [
  "starknet-rust-accounts",
  "starknet-rust-contract",
@@ -7653,14 +7675,14 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-accounts"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b44a478beea593433568033ddf98652c82c40964f184d5538227fa62b73bb44"
+checksum = "23552b3f35b8535bade1e7d151071ec00216f1eb7ef7d2dec4d5fa732728edd8"
 dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-rust-core",
- "starknet-rust-crypto 0.19.0-rc.2",
+ "starknet-rust-crypto 0.19.0",
  "starknet-rust-providers",
  "starknet-rust-signers",
  "thiserror 2.0.18",
@@ -7668,9 +7690,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-contract"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9823c26cb78c4e6df65f9f6ee59cd299f85a93694dc8322fe1fe3b868af065e"
+checksum = "93364bcf91df50f95c4a31230a629a68b0f51960bae0247eb10493c7efe36c76"
 dependencies = [
  "serde_json",
  "starknet-rust-accounts",
@@ -7680,12 +7702,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-core"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "569226367a40cddf07f7f14383f5be9f4c1fa52cef7be2d905fa2a897f981809"
+checksum = "c3df45149a385127210bbd9bd06cbf5cee09b0e7c17ba65829eec64c6eff37b2"
 dependencies = [
  "base64 0.22.1",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "flate2",
  "foldhash 0.2.0",
  "hex",
@@ -7698,15 +7720,15 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-rust-core-derive",
- "starknet-rust-crypto 0.19.0-rc.2",
+ "starknet-rust-crypto 0.19.0",
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-rust-core-derive"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d911d1ca1ed6ecebe90d124d12b61f16739e25fa6687485815beaa7f81ea3e"
+checksum = "8500b18bdc6e7db3c012ee2a04bd134c23290e04a6d08b4d2c8e976be793d639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7736,12 +7758,12 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-crypto"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf77ef1ab88a77d148667c04fe4861cd781c69d3ce1d46c1feeef9fb9cacba5"
+checksum = "d2d8000df55d98f3910ef66e8e0cfeac398dd5f335613a497b0e2c905cb728fa"
 dependencies = [
  "blake2",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "digest",
  "hex",
  "hmac",
@@ -7750,7 +7772,7 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-rust-curve 0.19.0-rc.2",
+ "starknet-rust-curve 0.19.0",
  "starknet-types-core",
  "zeroize",
 ]
@@ -7766,18 +7788,18 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-curve"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d622cdfeafddcd71fe264b091182b5b4b346b2facd77633cd84d6583ea3903c"
+checksum = "3ee2272de9f1fd3c41c32238500fab9c377571e706db87e1d96d60379536cd7d"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-rust-macros"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545290f65fd6dba0750efad65af70c7a7168872875a96bd97cf22ad914d76c08"
+checksum = "5806f18cf68277105bcd20600190f43f5350de4ee0bc321e4cd8f29a3a60bf4e"
 dependencies = [
  "starknet-rust-core",
  "syn 2.0.117",
@@ -7785,9 +7807,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-providers"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4b352ab86502a900bbe0c532979a48c09b8416732a8e947335bea409e3af81"
+checksum = "c176e31616e2768129fa0b13adf8325b28f2ae2afb4f1a34e5abd21477caa276"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7806,22 +7828,22 @@ dependencies = [
 
 [[package]]
 name = "starknet-rust-signers"
-version = "0.19.0-rc.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a2d55bc378e906cf8855e328071ed8ace79dba340a4224ffa0d834f1b99bda"
+checksum = "20c3115dbe415b97eefa39f1176831bfcc4717360ceb25ac5cfdb1349bf16aff"
 dependencies = [
  "async-trait",
  "auto_impl",
  "coins-bip32",
  "coins-ledger",
- "crypto-bigint 0.6.1",
+ "crypto-bigint 0.7.3",
  "eth-keystore",
  "getrandom 0.2.17",
  "rand 0.8.5",
  "semver",
  "starknet-rust-core",
- "starknet-rust-crypto 0.19.0-rc.2",
- "starknet-rust-curve 0.19.0-rc.2",
+ "starknet-rust-crypto 0.19.0",
+ "starknet-rust-curve 0.19.0",
  "thiserror 2.0.18",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ toml = "1.0.6"
 rpassword = "7.3.1"
 promptly = "0.3.1"
 ptree = "0.5.2"
-reqwest = { version = "0.13.1", features = ["json", "rustls"] }
+reqwest = { version = "0.13.1", features = ["json"] }
 fs_extra = "1.3.0"
 openssl = { version = "0.10", features = ["vendored"] }
 toml_edit = "0.25.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ rayon = "1.10"
 regex = "1.11.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
-starknet-rust = "0.19.0-rc.2"
+starknet-rust = "0.19.0"
 starknet-rust-crypto = "0.9.0"
 tempfile = "3.24.0"
 thiserror = "2.0.17"

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -37,7 +37,6 @@ regex.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 starknet-rust.workspace = true
-reqwest.workspace = true
 num-bigint.workspace = true
 clap.workspace = true
 clap_complete.workspace = true


### PR DESCRIPTION
- Bump `starknet-rust` to `0.19.0`
- Revert changes from https://github.com/foundry-rs/starknet-foundry/pull/4264