### PR TITLE
Catch and retry errors for curls used for tool installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,14 @@ jobs:
 
       - name: Install cairo-profiler
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          cairo-profiler --version
       - name: Install cairo-coverage
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          cairo-coverage --version
 
       - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
@@ -235,10 +239,14 @@ jobs:
 
       - name: Install cairo-profiler
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          cairo-profiler --version
       - name: Install cairo-coverage
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          cairo-coverage --version
 
       - uses: actions/checkout@v6
       - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
@@ -287,10 +295,14 @@ jobs:
 
       - name: Install cairo-profiler
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          cairo-profiler --version
       - name: Install cairo-coverage
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          cairo-coverage --version
 
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-tools

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -89,10 +89,14 @@ jobs:
       - uses: software-mansion/setup-universal-sierra-compiler@v1
       - name: Install cairo-profiler
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-profiler/main/scripts/install.sh | sh
+          cairo-profiler --version
       - name: Install cairo-coverage
         run: |
-          curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          set -euo pipefail
+          curl -sSL --fail --retry 5 --retry-all-errors --connect-timeout 10 -H "Authorization: Bearer ${{ github.token }}" https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
+          cairo-coverage --version
 
       - name: Determine test features
         id: test_features


### PR DESCRIPTION
Harden tests against tool installation errors, e.g. https://github.com/foundry-rs/starknet-foundry/actions/runs/25003437094/job/73220809486

- Display errors rather than failing silently 
- add retries, gh token to avoid rate limit, timeouts, etc.