### PR TITLE
Stop caching rust artifacts in all workflows

### DIFF
--- a/.github/workflows/_build-binaries-native.yml
+++ b/.github/workflows/_build-binaries-native.yml
@@ -71,8 +71,6 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
-
       - name: Setup LLVM on MacOS
         if: matrix.system == 'macos'
         run: |

--- a/.github/workflows/_build-binaries.yml
+++ b/.github/workflows/_build-binaries.yml
@@ -61,10 +61,6 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
-        with:
-          workspaces: starknet-foundry
-
       - name: Install cross
         if: matrix.cross
         uses: taiki-e/install-action@cross

--- a/.github/workflows/_build-plugin-binaries.yml
+++ b/.github/workflows/_build-plugin-binaries.yml
@@ -86,8 +86,6 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
-
       - name: Install cross
         if: matrix.cross
         uses: taiki-e/install-action@cross
@@ -106,9 +104,9 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          
+
           source scripts/handle_version.sh
-          
+
           PACKAGE_NAME=${{ inputs.plugin_name }}
           PACKAGE_NAME=${PACKAGE_NAME//-/_}  # Replace `-` with `_` in name
           PACKAGE_VERSION=$(get_version "${{ inputs.overridden_plugin_version }}" "crates/${{ inputs.plugin_name }}/Scarb.toml")

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@0b1efabc08b657293548b77fb76cc02d26091c7e
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - uses: actions/setup-node@v6
       - name: Install sitemap CLI
         run: |

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ matrix.version }}
@@ -82,7 +81,6 @@ jobs:
 
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ matrix.version }}
@@ -120,7 +118,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ matrix.version }}


### PR DESCRIPTION
- Due to the hard limit of 10GM cache on GitHub it's not efficient to store cache for all workflows. This PR removes cache logic from all jobs except main CI tests (`ci.yml` file)
