### PR TITLE
Proper sncast error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `#[derive(Fuzzable)]` macro that automatically generates `Fuzzable` trait implementations for structs and enums
 
+### Cast
+
+#### Fixed
+
+- Errors no longer bypass foundry UI; `--json` now works for top-level errors where plain text was printed before.
+- Build failures now return command errors instead of panicking.
+- In command errors, `command` tag now universally displays full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
+
 ## [0.60.0] - 2026-04-27
 
 ### Forge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- Non-panic errors no longer bypass foundry UI; `--json` now works for user-facing errors where plain text was printed before (excluding clap arg-parsing errors).
+- Non-panic errors no longer bypass foundry UI. `--json` now works for user-facing errors where plain text was printed before (excluding clap arg-parsing errors).
 - Build failures now return command errors instead of panicking.
 - In command errors, `command` field now universally displays a full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Non-panic errors no longer bypass foundry UI; `--json` now works for user-facing errors where plain text was printed before (excluding clap arg-parsing errors).
 - Build failures now return command errors instead of panicking.
-- In command errors, `command` tag now universally displays a full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
+- In command errors, `command` field now universally displays a full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
 
 ## [0.60.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-- Errors no longer bypass foundry UI; `--json` now works for top-level errors where plain text was printed before.
+- Non-panic errors no longer bypass foundry UI; `--json` now works for user-facing errors where plain text was printed before (excluding clap arg-parsing errors).
 - Build failures now return command errors instead of panicking.
-- In command errors, `command` tag now universally displays full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
+- In command errors, `command` tag now universally displays a full command path (`get tx-status`, `account import`) (previously in some cases, only top-level command name was shown, e.g. `get`, `account`).
 
 ## [0.60.0] - 2026-04-27
 

--- a/crates/sncast/src/helpers/command.rs
+++ b/crates/sncast/src/helpers/command.rs
@@ -30,7 +30,7 @@ where
             ExitCode::SUCCESS
         }
         Err(err) => {
-            let err = ResponseError::new(command.to_string(), format!("{err:#}"));
+            let err = ResponseError::from_anyhow(command.to_string(), &err);
             ui.print_error(command, err);
             ExitCode::FAILURE
         }

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -289,7 +289,6 @@ impl PartialCastConfig {
 }
 
 pub struct CliConfigOpts {
-    pub command_name: String,
     pub profile: Option<String>,
 }
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -859,8 +859,7 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
             Sources:
             - CLI flags
             - Local config: {local}
-            - Global config: {global}
-        ",
+            - Global config: {global}",
             local = local_path.as_ref().map_or("missing", |p| p.as_str()),
             global = global_path.as_ref().map_or("missing", |p| p.as_str()),
         }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -290,8 +290,9 @@ fn main() -> ExitCode {
     init_logging();
 
     let matches = Cli::command().get_matches();
+    // Avoids duplicate arguments parsing
     let cli = Cli::from_arg_matches(&matches)
-        .expect("Cli reconstruct from its own matches always succeeds");
+        .expect("should always be possible to reconstruct cli from its own matches");
 
     let ui = UI::new(output_format_from_json_flag(cli.json));
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -357,7 +357,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 // TODO(#3959) Remove `base_ui`
                 ui.base_ui(),
             )
-            .expect("Failed to build contract");
+            .context("Failed to build contract")?;
 
             let result = with_account!(&account, |account| {
                 starknet_commands::declare::declare(
@@ -394,7 +394,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 // TODO(#3785)
                 let contract_artifacts = artifacts
                     .get(&declare.contract_name)
-                    .expect("Failed to get contract artifacts");
+                    .context("Failed to get contract artifacts")?;
                 let contract_definition: SierraClass =
                     serde_json::from_str(&contract_artifacts.sierra)
                         .context("Failed to parse sierra artifact")?;
@@ -511,7 +511,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                     // TODO(#3959) Remove `base_ui`
                     ui.base_ui(),
                 )
-                .expect("Failed to build contract");
+                .context("Failed to build contract")?;
 
                 let declare_result = with_account!(&account, |account| {
                     declare(

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -290,7 +290,6 @@ fn main() -> ExitCode {
     init_logging();
 
     let matches = Cli::command().get_matches();
-    // Avoids duplicate arguments parsing
     let cli = Cli::from_arg_matches(&matches)
         .expect("should always be possible to reconstruct cli from its own matches");
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -302,7 +302,7 @@ fn main() -> ExitCode {
         Err(err) => {
             ui.print_error(
                 &command_name,
-                ResponseError::new(command_name.clone(), format!("{err:#}")),
+                ResponseError::from_anyhow(command_name.clone(), &err),
             );
             ExitCode::FAILURE
         }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -17,7 +17,7 @@ use crate::starknet_commands::{
 use crate::starknet_commands::{get, multicall};
 use anyhow::{Context, Result, bail};
 use camino::Utf8PathBuf;
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand};
 use configuration::{Override, find_config_file};
 use conversions::IntoConv;
 use data_transformer::transform;
@@ -38,7 +38,7 @@ use sncast::response::declare::{
     AlreadyDeclaredResponse, DeclareResponse, DeclareTransactionResponse, DeployCommandMessage,
 };
 use sncast::response::deploy::{DeployResponse, DeployResponseWithDeclare};
-use sncast::response::errors::handle_starknet_command_error;
+use sncast::response::errors::{ResponseError, handle_starknet_command_error};
 use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::transformed_call::transform_response;
 use sncast::response::ui::UI;
@@ -137,28 +137,6 @@ struct Cli {
 }
 
 impl Cli {
-    fn command_name(&self) -> String {
-        match self.command {
-            Commands::Get(_) => "get",
-            Commands::Declare(_) => "declare",
-            Commands::DeclareFrom(_) => "declare-from",
-            Commands::Deploy(_) => "deploy",
-            Commands::Call(_) => "call",
-            Commands::Invoke(_) => "invoke",
-            Commands::Multicall(_) => "multicall",
-            Commands::Account(_) => "account",
-            Commands::ShowConfig(_) => "show-config",
-            Commands::Script(_) => "script",
-            Commands::TxStatus(_) => "tx-status",
-            Commands::Verify(_) => "verify",
-            Commands::Completions(_) => "completions",
-            Commands::Utils(_) => "utils",
-            Commands::Balance(_) => "balance",
-            Commands::Ledger(_) => "ledger",
-        }
-        .to_string()
-    }
-
     /// Prepares and validates [`PartialCastConfig`] from CLI args.
     pub fn to_partial_config(&self) -> Result<PartialCastConfig> {
         let config = PartialCastConfig {
@@ -308,24 +286,54 @@ fn init_logging() {
         .expect("could not set up global logger");
 }
 
-fn main() -> Result<ExitCode> {
+fn main() -> ExitCode {
     init_logging();
 
-    let cli = Cli::parse();
+    let matches = Cli::command().get_matches();
+    let cli = Cli::from_arg_matches(&matches)
+        .expect("Cli reconstruct from its own matches always succeeds");
 
-    let output_format = output_format_from_json_flag(cli.json);
+    let ui = UI::new(output_format_from_json_flag(cli.json));
 
-    let ui = UI::new(output_format);
+    let command_name = command_path(&matches);
 
+    match run(cli, &ui) {
+        Ok(code) => code,
+        Err(err) => {
+            ui.print_error(
+                &command_name,
+                ResponseError::new(command_name.clone(), format!("{err:#}")),
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Return canonical subcommand path (e.g. `account import`, `get tx`) or `sncast` if none.
+fn command_path(matches: &ArgMatches) -> String {
+    let mut parts = Vec::new();
+    let mut cur = matches;
+    while let Some((name, sub)) = cur.subcommand() {
+        parts.push(name.to_string());
+        cur = sub;
+    }
+    if parts.is_empty() {
+        "sncast".to_string()
+    } else {
+        parts.join(" ")
+    }
+}
+
+fn run(cli: Cli, ui: &UI) -> Result<ExitCode> {
     let runtime = Runtime::new().expect("Failed to instantiate Runtime");
 
     if let Commands::Completions(completions) = &cli.command {
         generate_completions(completions.shell, &mut Cli::command())
     } else if let Commands::Script(script) = &cli.command {
-        run_script_command(&cli, runtime, script, &ui)
+        run_script_command(&cli, runtime, script, ui)
     } else {
-        let config = get_cast_config(&cli, &ui)?;
-        runtime.block_on(run_async_command(cli, config, &ui))
+        let config = get_cast_config(&cli, ui)?;
+        runtime.block_on(run_async_command(cli, config, ui))
     }
 }
 
@@ -774,7 +782,6 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
 
 fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
     let opts = CliConfigOpts {
-        command_name: cli.command_name(),
         profile: cli.profile.clone(),
     };
 

--- a/crates/sncast/src/response/errors.rs
+++ b/crates/sncast/src/response/errors.rs
@@ -16,12 +16,26 @@ use thiserror::Error;
 pub struct ResponseError {
     command: String,
     error: String,
+    flat_error: String,
 }
 
 impl ResponseError {
     #[must_use]
     pub fn new(command: String, error: String) -> Self {
-        Self { command, error }
+        Self {
+            command,
+            error: error.clone(),
+            flat_error: error,
+        }
+    }
+
+    #[must_use]
+    pub fn from_anyhow(command: String, error: &anyhow::Error) -> Self {
+        Self {
+            command,
+            error: format!("{error:?}"),
+            flat_error: format!("{error:#}"),
+        }
     }
 }
 
@@ -38,7 +52,7 @@ impl Message for ResponseError {
 
     fn json(&self) -> Value {
         json!({
-            "error": self.error,
+            "error": self.flat_error,
         })
     }
 }

--- a/crates/sncast/src/starknet_commands/script/mod.rs
+++ b/crates/sncast/src/starknet_commands/script/mod.rs
@@ -57,7 +57,7 @@ pub fn run_script_command(
                 // TODO(#3959) Remove `base_ui`
                 ui.base_ui(),
             )
-            .expect("Failed to build artifacts");
+            .context("Failed to build artifacts")?;
             // TODO(#2042): remove duplicated compilation
             build(
                 &package_metadata,
@@ -68,7 +68,7 @@ pub fn run_script_command(
                 },
                 "dev",
             )
-            .expect("Failed to build script");
+            .context("Failed to build script")?;
             let metadata_with_deps = get_scarb_metadata_with_deps(&manifest_path)?;
 
             let chain_id = runtime.block_on(get_chain_id(&provider))?;

--- a/crates/sncast/tests/e2e/account/import.rs
+++ b/crates/sncast/tests/e2e/account/import.rs
@@ -468,14 +468,15 @@ pub async fn test_invalid_private_key_file_path() {
     let snapbox = runner(&args);
     let output = snapbox.assert().failure();
 
-    let expected_file_error = "No such file or directory [..]";
-
     assert_stderr_contains(
         output,
         formatdoc! {r"
         Command: account import
-        Error: Failed to obtain private key from the file my_private_key: {}
-        ", expected_file_error},
+        Error: Failed to obtain private key from the file my_private_key
+
+        Caused by:
+            No such file or directory [..]
+        "},
     );
 }
 
@@ -514,7 +515,10 @@ pub async fn test_invalid_private_key_in_file() {
         output,
         indoc! {r"
         Command: account import
-        Error: Failed to obtain private key from the file my_private_key: failed to create Felt from string: invalid dec string
+        Error: Failed to obtain private key from the file my_private_key
+
+        Caused by:
+            failed to create Felt from string: invalid dec string
         "},
     );
 }

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -208,11 +208,9 @@ async fn test_invalid_selector() {
     assert_stderr_contains(
         output,
         indoc! {r"
-        Error: Failed to convert entry point selector to FieldElement
-
-        Caused by:
-            the provided name contains non-ASCII characters
-  "},
+        Command: call
+        Error: Failed to convert entry point selector to FieldElement: the provided name contains non-ASCII characters
+        "},
     );
 }
 

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -209,7 +209,10 @@ async fn test_invalid_selector() {
         output,
         indoc! {r"
         Command: call
-        Error: Failed to convert entry point selector to FieldElement: the provided name contains non-ASCII characters
+        Error: Failed to convert entry point selector to FieldElement
+
+        Caused by:
+            the provided name contains non-ASCII characters
         "},
     );
 }

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -674,7 +674,7 @@ async fn test_many_packages_default() {
 
     assert_stderr_contains(
         output,
-        "Error: More than one package found in scarb metadata - specify package using --package flag",
+        r#"{"command":"declare","error":"More than one package found in scarb metadata - specify package using --package flag","type":"error"}"#,
     );
 }
 

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -472,7 +472,39 @@ fn test_scarb_build_fails_when_wrong_cairo_path() {
     let output = snapbox.assert().failure();
     assert_stderr_contains(
         output,
-        "Failed to build contract: Failed to build using scarb; `scarb` exited with error",
+        indoc! {r"
+            Command: declare
+            Error: Failed to build contract
+
+            Caused by:
+                Failed to build using scarb; `scarb` exited with error
+        "},
+    );
+}
+
+#[test]
+fn test_scarb_build_fails_when_wrong_cairo_path_json() {
+    let tempdir = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/build_fails");
+    let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
+
+    let args = vec![
+        "--json",
+        "--accounts-file",
+        accounts_json_path.as_str(),
+        "--account",
+        "user1",
+        "declare",
+        "--url",
+        URL,
+        "--contract-name",
+        "BuildFails",
+    ];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+    assert_stderr_contains(
+        output,
+        r#"{"command":"declare","error":"Failed to build contract: Failed to build using scarb; `scarb` exited with error","type":"error"}"#,
     );
 }
 

--- a/crates/sncast/tests/e2e/declare.rs
+++ b/crates/sncast/tests/e2e/declare.rs
@@ -653,7 +653,7 @@ fn test_scarb_no_casm_artifact() {
 }
 
 #[tokio::test]
-async fn test_many_packages_default() {
+async fn test_many_packages_default_json() {
     let tempdir = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/multiple_packages");
     let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
     let args = vec![
@@ -679,7 +679,7 @@ async fn test_many_packages_default() {
 }
 
 #[tokio::test]
-async fn test_workspaces_package_specified_virtual_fibonacci() {
+async fn test_workspaces_package_specified_virtual_fibonacci_json() {
     let tempdir = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/virtual_workspace");
     let accounts_json_path = get_accounts_path("tests/data/accounts/accounts.json");
     let args = vec![

--- a/crates/sncast/tests/e2e/declare_from.rs
+++ b/crates/sncast/tests/e2e/declare_from.rs
@@ -386,7 +386,10 @@ async fn test_declare_from_sierra_does_not_exist() {
         output,
         indoc! {r"
         Command: declare-from
-        Error: Failed to read sierra file at [..]contract_class.json: No such file or directory [..]
+        Error: Failed to read sierra file at [..]contract_class.json
+
+        Caused by:
+            No such file or directory [..]
         "},
     );
 }
@@ -417,7 +420,10 @@ async fn test_declare_from_sierra_invalid_json() {
         output,
         indoc! {r"
         Command: declare-from
-        Error: Failed to parse sierra file: missing field `sierra_program` at line 1 column 25
+        Error: Failed to parse sierra file
+
+        Caused by:
+            missing field `sierra_program` at line 1 column 25
         "},
     );
 }

--- a/crates/sncast/tests/e2e/main_tests.rs
+++ b/crates/sncast/tests/e2e/main_tests.rs
@@ -223,6 +223,28 @@ async fn test_missing_account_flag() {
 }
 
 #[tokio::test]
+async fn test_missing_account_flag_json() {
+    let args = vec![
+        "--json",
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "declare",
+        "--url",
+        URL,
+        "--contract-name",
+        "whatever",
+    ];
+
+    let snapbox = runner(&args);
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        r#"{"command":"declare","error":"Account name not passed nor found in snfoundry.toml","type":"error"}"#,
+    );
+}
+
+#[tokio::test]
 async fn test_inexistent_keystore() {
     let accounts_file = "empty_accounts.json";
     let temp_dir = tempfile::tempdir().expect("Unable to create a temporary directory");

--- a/crates/sncast/tests/e2e/mod.rs
+++ b/crates/sncast/tests/e2e/mod.rs
@@ -7,7 +7,6 @@ mod declare;
 mod declare_from;
 mod deploy;
 mod devnet_accounts;
-mod error_routing_baseline;
 mod fee;
 mod invoke;
 pub(crate) mod ledger;

--- a/crates/sncast/tests/e2e/mod.rs
+++ b/crates/sncast/tests/e2e/mod.rs
@@ -7,6 +7,7 @@ mod declare;
 mod declare_from;
 mod deploy;
 mod devnet_accounts;
+mod error_routing_baseline;
 mod fee;
 mod invoke;
 pub(crate) mod ledger;

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -196,7 +196,10 @@ async fn test_only_one_from_url_and_network_allowed() {
         output,
         indoc! { r"
             Command: show-config
-            Error: Failed to load local config at [..]snfoundry.toml: Only one of `url` or `network` may be specified
+            Error: Failed to load local config at [..]snfoundry.toml
+
+            Caused by:
+                Only one of `url` or `network` may be specified
         " },
     );
 }
@@ -213,7 +216,10 @@ async fn test_stark_scan_as_block_explorer() {
         output,
         indoc! { r"
             Command: show-config
-            Error: Failed to load local config at [..]snfoundry.toml: starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
+            Error: Failed to load local config at [..]snfoundry.toml
+
+            Caused by:
+                starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
         " },
     );
 }
@@ -240,11 +246,11 @@ async fn test_show_config_malformed() {
         output,
         indoc! { r"
             Command: show-config
-            Error: Failed to load local config at [..]snfoundry.toml: Failed to parse snfoundry.toml config file: TOML parse error at line 2, column 10
-              |
-            2 | invalid =
-              |          ^
-            string values must be quoted, expected literal string
+            Error: Failed to load local config at [..]snfoundry.toml
+
+            Caused by:
+                0: Failed to parse snfoundry.toml config file
+                1: TOML parse error at line 2, column 10
         " },
     );
 }
@@ -460,7 +466,10 @@ async fn test_default_global_profile_with_invalid_values() {
         output,
         indoc! { r"
             Command: show-config
-            Error: Failed to load global config at [..]snfoundry.toml: starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
+            Error: Failed to load global config at [..]snfoundry.toml
+
+            Caused by:
+                starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
         " },
     );
 }
@@ -486,7 +495,10 @@ async fn test_default_global_profile_with_unsupported_field() {
         output,
         indoc! { r#"
             Command: show-config
-            Error: Failed to load global config at [..]snfoundry.toml: unknown field(s) ["bar", "baz", "foo"]
+            Error: Failed to load global config at [..]snfoundry.toml
+
+            Caused by:
+                unknown field(s) ["bar", "baz", "foo"]
         "# },
     );
 }
@@ -532,7 +544,10 @@ async fn test_invalid_effective_config() {
             - CLI flags
             - Local config: [..]snfoundry.toml
             - Global config: [..]snfoundry.toml
-            : retry_interval cannot be greater than timeout
+
+
+            Caused by:
+                retry_interval cannot be greater than timeout
         " },
     );
 }
@@ -571,7 +586,10 @@ async fn test_invalid_effective_config_from_cli() {
             - CLI flags
             - Local config: missing
             - Global config: [..]snfoundry.toml
-            : retry_interval cannot be greater than timeout
+
+
+            Caused by:
+                retry_interval cannot be greater than timeout
         " },
     );
 }
@@ -623,7 +641,10 @@ async fn test_zero_wait_params_in_config() {
         output,
         indoc! { r"
             Command: show-config
-            Error: Failed to load local config at [..]snfoundry.toml: Failed to parse field `wait-params.retry-interval`: invalid value: integer `0`, expected a nonzero u8
+            Error: Failed to load local config at [..]snfoundry.toml
+
+            Caused by:
+                Failed to parse field `wait-params.retry-interval`: invalid value: integer `0`, expected a nonzero u8
         "},
     );
 }

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -256,6 +256,20 @@ async fn test_show_config_malformed() {
 }
 
 #[tokio::test]
+async fn test_show_config_malformed_json() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_malformed.toml", None);
+    let args = vec!["--json", "show-config"];
+
+    let snapbox = runner(&args).current_dir(tempdir.path());
+    let output = snapbox.assert().failure();
+
+    assert_stderr_contains(
+        output,
+        r#"{"command":"show-config","error":"Failed to load local config at [..]snfoundry.toml: Failed to parse snfoundry.toml config file: TOML parse error at line 2, column 10\n  |\n2 | invalid =\n  |          ^\nstring values must be quoted, expected literal string\n","type":"error"}"#,
+    );
+}
+
+#[tokio::test]
 async fn test_show_config_provider_error() {
     let t = tempdir().unwrap();
     fs::write(

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -559,7 +559,6 @@ async fn test_invalid_effective_config() {
             - Local config: [..]snfoundry.toml
             - Global config: [..]snfoundry.toml
 
-
             Caused by:
                 retry_interval cannot be greater than timeout
         " },
@@ -600,7 +599,6 @@ async fn test_invalid_effective_config_from_cli() {
             - CLI flags
             - Local config: missing
             - Global config: [..]snfoundry.toml
-
 
             Caused by:
                 retry_interval cannot be greater than timeout

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -195,10 +195,8 @@ async fn test_only_one_from_url_and_network_allowed() {
     assert_stderr_contains(
         output,
         indoc! { r"
-            Error: Failed to load local config at [..]snfoundry.toml
-
-            Caused by:
-                Only one of `url` or `network` may be specified
+            Command: show-config
+            Error: Failed to load local config at [..]snfoundry.toml: Only one of `url` or `network` may be specified
         " },
     );
 }
@@ -214,10 +212,8 @@ async fn test_stark_scan_as_block_explorer() {
     assert_stderr_contains(
         output,
         indoc! { r"
-            Error: Failed to load local config at [..]snfoundry.toml
-
-            Caused by:
-                starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
+            Command: show-config
+            Error: Failed to load local config at [..]snfoundry.toml: starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
         " },
     );
 }
@@ -243,11 +239,12 @@ async fn test_show_config_malformed() {
     assert_stderr_contains(
         output,
         indoc! { r"
-            Error: Failed to load local config at [..]snfoundry.toml
-
-            Caused by:
-                0: Failed to parse snfoundry.toml config file
-                1: TOML parse error at line 2, column 10
+            Command: show-config
+            Error: Failed to load local config at [..]snfoundry.toml: Failed to parse snfoundry.toml config file: TOML parse error at line 2, column 10
+              |
+            2 | invalid =
+              |          ^
+            string values must be quoted, expected literal string
         " },
     );
 }
@@ -462,10 +459,8 @@ async fn test_default_global_profile_with_invalid_values() {
     assert_stderr_contains(
         output,
         indoc! { r"
-            Error: Failed to load global config at [..]snfoundry.toml
-
-            Caused by:
-                starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
+            Command: show-config
+            Error: Failed to load global config at [..]snfoundry.toml: starkscan.co was terminated and `'StarkScan'` is no longer available. Please set `block-explorer` to `'Voyager'` or other explorer of your choice.
         " },
     );
 }
@@ -490,10 +485,8 @@ async fn test_default_global_profile_with_unsupported_field() {
     assert_stderr_contains(
         output,
         indoc! { r#"
-            Error: Failed to load global config at [..]snfoundry.toml
-
-            Caused by:
-                unknown field(s) ["bar", "baz", "foo"]
+            Command: show-config
+            Error: Failed to load global config at [..]snfoundry.toml: unknown field(s) ["bar", "baz", "foo"]
         "# },
     );
 }
@@ -533,14 +526,13 @@ async fn test_invalid_effective_config() {
     assert_stderr_contains(
         output,
         indoc! { r"
+            Command: show-config
             Error: Unable to combine configs. Fix conflicts between config sources and try again.
             Sources:
             - CLI flags
             - Local config: [..]snfoundry.toml
             - Global config: [..]snfoundry.toml
-
-            Caused by:
-                retry_interval cannot be greater than timeout
+            : retry_interval cannot be greater than timeout
         " },
     );
 }
@@ -573,14 +565,13 @@ async fn test_invalid_effective_config_from_cli() {
     assert_stderr_contains(
         output,
         indoc! { r"
+            Command: show-config
             Error: Unable to combine configs. Fix conflicts between config sources and try again.
             Sources:
             - CLI flags
             - Local config: missing
             - Global config: [..]snfoundry.toml
-
-            Caused by:
-                retry_interval cannot be greater than timeout
+            : retry_interval cannot be greater than timeout
         " },
     );
 }
@@ -631,10 +622,8 @@ async fn test_zero_wait_params_in_config() {
     assert_stderr_contains(
         output,
         indoc! { r"
-            Error: Failed to load local config at [..]snfoundry.toml
-
-            Caused by:
-                Failed to parse field `wait-params.retry-interval`: invalid value: integer `0`, expected a nonzero u8
+            Command: show-config
+            Error: Failed to load local config at [..]snfoundry.toml: Failed to parse field `wait-params.retry-interval`: invalid value: integer `0`, expected a nonzero u8
         "},
     );
 }

--- a/crates/sncast/tests/e2e/utils/serialize.rs
+++ b/crates/sncast/tests/e2e/utils/serialize.rs
@@ -149,7 +149,10 @@ async fn test_abi_file_missing_type() {
         output,
         indoc! {r#"
         Command: utils serialize
-        Error: Error while processing Cairo-like calldata: Struct "NestedStructWithField" not found in ABI
+        Error: Error while processing Cairo-like calldata
+
+        Caused by:
+            Struct "NestedStructWithField" not found in ABI
     "#},
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3957 

## Introduced changes

<!-- A brief description of the changes -->

- Non-panic errors no longer bypass foundry UI, meaning they will be correctly displayed in line with human-readable / json format.
  So instead of: 
  ```
  Error: Failed to load global config at /Users/runner/.config/starknet-foundry/snfoundry.toml

  Caused by:
      Failed to parse field `block-explorer`: unknown variant `Starkscan`, expected one of `Voyager`, `StarkScan`, `ViewBlock`, `OkLink`
  ```
  we have:
  - in human readable format:
  ```
  Command: show-config
  Error: Failed to load global config at /Users/runner/.config/starknet-foundry/snfoundry.toml
  
  Caused by:
      Failed to parse field `block-explorer`: unknown variant `Starkscan`, expected one of `Voyager`, `StarkScan`, `ViewBlock`, `OkLink`
  ```
  - in json format:
  ```
  {"command":"show-config","error":"Failed to load global config at /Users/runner/.config/starknet-foundry/snfoundry.toml: Failed to parse field `block-explorer`: unknown variant `Starkscan`, expected one of `Voyager`, `StarkScan`, `ViewBlock`, `OkLink`","type":"error"}
  ```
- Build failures now return command errors instead of panicking.
- In command errors, `command` tag now universally displays a full command path (`get tx-status`, `account import`) 
  - previously in some cases, only top-level command name was shown, e.g. `get`, `account`

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
