### PR TITLE
Display number of filtered out tests with `--exact` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `snforge_scarb_plugin` diagnostics for named-argument kind violations now include both possible values and invalid arguments found.
+- `snforge test --exact` now reports the exact number of filtered-out tests in summaries instead of `other`.
 
 #### Fixed
 

--- a/crates/forge-runner/src/tests_summary.rs
+++ b/crates/forge-runner/src/tests_summary.rs
@@ -1,25 +1,18 @@
 use crate::test_target_summary::TestTargetSummary;
 use serde::Serialize;
 
-// TODO(#2574): Bring back "filtered out" number in tests summary when running with `--exact` flag
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub enum FilteredTestsCount {
-    Exact(usize),
-    Other,
-}
-
 #[derive(Serialize)]
 pub struct TestsSummary {
     passed: usize,
     failed: usize,
     interrupted: usize,
     ignored: usize,
-    filtered: FilteredTestsCount,
+    filtered: usize,
 }
 
 impl TestsSummary {
     #[must_use]
-    pub fn new(summaries: &[TestTargetSummary], filtered: FilteredTestsCount) -> Self {
+    pub fn new(summaries: &[TestTargetSummary], filtered: usize) -> Self {
         let passed = summaries.iter().map(TestTargetSummary::count_passed).sum();
         let failed = summaries.iter().map(TestTargetSummary::count_failed).sum();
         let interrupted = summaries
@@ -39,12 +32,6 @@ impl TestsSummary {
 
     #[must_use]
     pub fn format_summary_message(&self) -> String {
-        let filtered = match self.filtered {
-            FilteredTestsCount::Exact(value) => value.to_string(),
-            // TODO(#2574): Bring back "filtered out" number in tests summary when running with `--exact` flag
-            FilteredTestsCount::Other => "other".to_string(),
-        };
-
         let interrupted = if self.interrupted > 0 {
             format!("\nInterrupted execution of {} test(s).", self.interrupted)
         } else {
@@ -52,8 +39,8 @@ impl TestsSummary {
         };
 
         format!(
-            "{} passed, {} failed, {} ignored, {filtered} filtered out{interrupted}",
-            self.passed, self.failed, self.ignored,
+            "{} passed, {} failed, {} ignored, {} filtered out{interrupted}",
+            self.passed, self.failed, self.ignored, self.filtered
         )
     }
 }

--- a/crates/forge/src/run_tests/messages/overall_summary.rs
+++ b/crates/forge/src/run_tests/messages/overall_summary.rs
@@ -1,6 +1,6 @@
 use console::style;
 use forge_runner::test_target_summary::TestTargetSummary;
-use forge_runner::tests_summary::{FilteredTestsCount, TestsSummary};
+use forge_runner::tests_summary::TestsSummary;
 use foundry_ui::{Message, components::labeled::LabeledMessage};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -14,7 +14,7 @@ impl OverallSummaryMessage {
     pub const LABEL: &str = "Tests summary";
 
     #[must_use]
-    pub fn new(summaries: &[TestTargetSummary], filtered: FilteredTestsCount) -> Self {
+    pub fn new(summaries: &[TestTargetSummary], filtered: usize) -> Self {
         Self {
             summary: TestsSummary::new(summaries, filtered),
         }

--- a/crates/forge/src/run_tests/messages/tests_summary.rs
+++ b/crates/forge/src/run_tests/messages/tests_summary.rs
@@ -1,8 +1,5 @@
 use console::style;
-use forge_runner::{
-    test_target_summary::TestTargetSummary,
-    tests_summary::{FilteredTestsCount, TestsSummary},
-};
+use forge_runner::{test_target_summary::TestTargetSummary, tests_summary::TestsSummary};
 use foundry_ui::{Message, components::labeled::LabeledMessage};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -16,7 +13,7 @@ impl TestsSummaryMessage {
     pub const LABEL: &str = "Tests";
 
     #[must_use]
-    pub fn new(summaries: &[TestTargetSummary], filtered: FilteredTestsCount) -> Self {
+    pub fn new(summaries: &[TestTargetSummary], filtered: usize) -> Self {
         Self {
             summary: TestsSummary::new(summaries, filtered),
         }

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -37,7 +37,6 @@ use forge_runner::{
     scarb::load_test_artifacts,
     test_case_summary::AnyTestCaseSummary,
     test_target_summary::TestTargetSummary,
-    tests_summary::FilteredTestsCount,
 };
 use foundry_ui::{UI, components::labeled::LabeledMessage};
 use scarb_api::{CompilationOpts, get_contracts_artifacts_and_source_sierra_paths};
@@ -49,12 +48,12 @@ type PrepareTargetHandle = JoinHandle<Result<PrepareTestTargetResult>>;
 
 pub struct PackageTestResult {
     summaries: Vec<TestTargetSummary>,
-    filtered: FilteredTestsCount,
+    filtered: usize,
 }
 
 impl PackageTestResult {
     #[must_use]
-    pub fn new(summaries: Vec<TestTargetSummary>, filtered: FilteredTestsCount) -> Self {
+    pub fn new(summaries: Vec<TestTargetSummary>, filtered: usize) -> Self {
         Self {
             summaries,
             filtered,
@@ -62,7 +61,7 @@ impl PackageTestResult {
     }
 
     #[must_use]
-    pub fn filtered(&self) -> FilteredTestsCount {
+    pub fn filtered(&self) -> usize {
         self.filtered
     }
 
@@ -284,12 +283,7 @@ pub async fn run_for_package(
         summaries.push(s);
     }
 
-    // TODO(#2574): Bring back "filtered out" number in tests summary when running with `--exact` flag
-    let filtered_count = if let NameFilter::ExactMatch(_) = tests_filter.name_filter {
-        FilteredTestsCount::Other
-    } else {
-        FilteredTestsCount::Exact(prefiltered_out_total + all_tests - not_filtered_total)
-    };
+    let filtered_count = prefiltered_out_total + all_tests - not_filtered_total;
 
     ui.println(&TestsSummaryMessage::new(&summaries, filtered_count));
 

--- a/crates/forge/src/run_tests/workspace.rs
+++ b/crates/forge/src/run_tests/workspace.rs
@@ -16,7 +16,6 @@ use crate::{
 use anyhow::Result;
 use forge_runner::partition::PartitionConfig;
 use forge_runner::test_case_summary::AnyTestCaseSummary;
-use forge_runner::tests_summary::FilteredTestsCount;
 use forge_runner::{CACHE_DIR, test_target_summary::TestTargetSummary};
 use foundry_ui::UI;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
@@ -102,7 +101,7 @@ pub async fn execute_workspace(
 
     let block_number_map = BlockNumberMap::default();
     let mut all_tests = vec![];
-    let mut total_filtered_count = FilteredTestsCount::Exact(0);
+    let mut total_filtered_count = 0;
     let mut exit_first_channel = ExitFirstChannel::new();
 
     let workspace_root = &scarb_metadata.workspace.root;
@@ -142,9 +141,8 @@ pub async fn execute_workspace(
         )
         .await?;
 
-        let filtered = result.filtered();
+        total_filtered_count += result.filtered();
         all_tests.extend(result.summaries());
-        total_filtered_count = calculate_total_filtered_count(total_filtered_count, filtered);
         env::set_current_dir(&cwd)?;
     }
 
@@ -189,21 +187,6 @@ pub async fn execute_workspace(
     }
 
     Ok(WorkspaceExecutionSummary { all_tests })
-}
-
-fn calculate_total_filtered_count(
-    total_filtered_count: FilteredTestsCount,
-    filtered: FilteredTestsCount,
-) -> FilteredTestsCount {
-    // Sum exact filtered counts across packages. If any package reports `Other`,
-    // the workspace summary falls back to `Other` as well.
-    match (total_filtered_count, filtered) {
-        (FilteredTestsCount::Exact(total), FilteredTestsCount::Exact(filtered)) => {
-            FilteredTestsCount::Exact(total + filtered)
-        }
-        // TODO(#2574): Bring back "filtered out" number in tests summary when running with `--exact` flag
-        _ => FilteredTestsCount::Other,
-    }
 }
 
 fn get_partitioning_config(

--- a/crates/forge/tests/e2e/forking.rs
+++ b/crates/forge/tests/e2e/forking.rs
@@ -65,7 +65,7 @@ fn with_cache() {
         Failure data:
             0x42616c616e63652073686f756c642062652030 ('Balance should be 0')
 
-        Tests: 0 passed, 1 failed, 0 ignored, other filtered out
+        Tests: 0 passed, 1 failed, 0 ignored, 5 filtered out
 
         Failures:
             forking::tests::test_fork_simple
@@ -97,7 +97,7 @@ fn with_clean_cache() {
         Collected 1 test(s) from forking package
         Running 1 test(s) from src/
         [PASS] forking::tests::test_fork_simple [..]
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 5 filtered out
         "},
     );
 }
@@ -125,7 +125,7 @@ fn printing_latest_block_number() {
         Collected 1 test(s) from forking package
         Running 1 test(s) from src/
         [PASS] forking::tests::print_block_number_when_latest [..]
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 5 filtered out
 
         Latest block number = [..] for url = {node_rpc_url}
         "},

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -294,7 +294,7 @@ fn with_exact_filter() {
         Running 0 test(s) from src/
         Running 1 test(s) from tests/
         [PASS] simple_package_integrationtest::test_simple::test_two [..]
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 12 filtered out
         "},
     );
 }
@@ -318,7 +318,7 @@ fn exact_filter_does_not_resolve_config_for_filtered_out_tests() {
         Collected 1 test(s) from lazy_config_filtering package
         Running 1 test(s) from src/
         [PASS] lazy_config_filtering::tests::selected_exact [..]
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 1 filtered out
         "},
     );
 }
@@ -511,7 +511,7 @@ fn with_exact_filter_and_duplicated_test_names() {
         Running 0 test(s) from src/
         Running 1 test(s) from tests/
         [PASS] duplicated_test_names_integrationtest::tests_a::test_simple [..]
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 1 filtered out
         "},
     );
 }

--- a/crates/forge/tests/e2e/workspaces.rs
+++ b/crates/forge/tests/e2e/workspaces.rs
@@ -873,23 +873,23 @@ fn root_workspace_for_entire_workspace_with_exact() {
         Collected 0 test(s) from addition package
         Running 0 test(s) from src/
         Running 0 test(s) from tests/
-        Tests: 0 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 0 passed, 0 failed, 0 ignored, 5 filtered out
         
         
         Collected 0 test(s) from fibonacci package
         Running 0 test(s) from src/
         Running 0 test(s) from tests/
-        Tests: 0 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 0 passed, 0 failed, 0 ignored, 6 filtered out
         
         
         Collected 1 test(s) from hello_workspaces package
         Running 1 test(s) from src/
         [PASS] hello_workspaces::tests::test_simple [..]
         Running 0 test(s) from tests/
-        Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests: 1 passed, 0 failed, 0 ignored, 2 filtered out
         
 
-        Tests summary: 1 passed, 0 failed, 0 ignored, other filtered out
+        Tests summary: 1 passed, 0 failed, 0 ignored, 13 filtered out
         "},
     );
 }

--- a/docs/src/testing/running-tests.md
+++ b/docs/src/testing/running-tests.md
@@ -72,7 +72,7 @@ Collected 1 test(s) from hello_snforge package
 Running 1 test(s) from tests/
 [PASS] hello_snforge_integrationtest::test_contract::test_calling (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~40000)
 Running 0 test(s) from src/
-Tests: 1 passed, 0 failed, 0 ignored, other filtered out
+Tests: 1 passed, 0 failed, 0 ignored, 2 filtered out
 ```
 </details>
 <br>


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2574 

## Introduced changes

Display actual number of filtered out tests instead of `other`, when using `--exact` flag.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
