### PR TITLE
Don't return unnecessary diagnostics from macros

### DIFF
--- a/crates/forge/tests/e2e/plugin_diagnostics.rs
+++ b/crates/forge/tests/e2e/plugin_diagnostics.rs
@@ -78,32 +78,6 @@ fn syntax() {
         note: this error originates in the attribute macro: `fuzzer`
         note: this error originates in the attribute macro: `fork`
         
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:7:1
-        #[test]
-        ^^^^^^^
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:8:1
-        #[fuzzer]
-        ^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:9:1
-        #[fork(url: "http://127.0.0.1:3030", block_tag: latest)]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        note: this error originates in the attribute macro: `fuzzer`
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:10:1
-        #[ignore]
-        ^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        note: this error originates in the attribute macro: `fuzzer`
-        note: this error originates in the attribute macro: `fork`
-        
         error[E2103]: Mismatched types: pattern cannot match against type "core::result::Result::<(core::starknet::contract_address::ContractAddress, core::array::Span::<core::felt252>), core::array::Array::<core::felt252>>".
          --> [..]/tests/contract.cairo:14:9
             let (contract_address, _) = contract.deploy(constructor_calldata),unwrap();
@@ -120,7 +94,7 @@ fn syntax() {
         note: this error originates in the attribute macro: `fuzzer`
         note: this error originates in the attribute macro: `fork`
         
-        error: could not compile `syntax_integrationtest` due to 14 previous errors and 1 warning
+        error: could not compile `syntax_integrationtest` due to 10 previous errors and 1 warning
     "#},
     );
 }
@@ -183,7 +157,7 @@ fn parameters() {
 
     assert_stdout_contains(
         output,
-        indoc! {r#"
+        indoc! {"
         error[E1001]: Missing token ','.
          --> [..]/tests/contract.cairo:9:31
         fn call_and_invoke(_a: felt252; b: u256) {
@@ -206,19 +180,8 @@ fn parameters() {
                                       ^^
         note: this error originates in the attribute macro: `test`
         
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:7:1
-        #[test]
-        ^^^^^^^
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:8:1
-        #[fork("TESTNET")]
-        ^^^^^^^^^^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        
-        error: could not compile `parameters_integrationtest` due to 6 previous errors and 1 warning
-    "#},
+        error: could not compile `parameters_integrationtest` due to 4 previous errors and 1 warning
+    "},
     );
 }
 
@@ -236,7 +199,7 @@ fn multiple() {
 
     assert_stdout_contains(
         output,
-        indoc! {r#"
+        indoc! {"
         error[E1002]: Missing tokens. Expected an expression.
          --> [..]/tests/contract.cairo:19:22
             assert(balance === 0, 'balance == 0');
@@ -262,33 +225,7 @@ fn multiple() {
         note: this error originates in the attribute macro: `test`
         note: this error originates in the attribute macro: `fuzzer`
         note: this error originates in the attribute macro: `fork`
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:7:1
-        #[test]
-        ^^^^^^^
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:8:1
-        #[fuzzer]
-        ^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:9:1
-        #[fork(url: "http://127.0.0.1:3030", block_tag: latest)]
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        note: this error originates in the attribute macro: `fuzzer`
-        
-        error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-         --> [..]/tests/contract.cairo:10:1
-        #[ignore]
-        ^^^^^^^^^
-        note: this error originates in the attribute macro: `test`
-        note: this error originates in the attribute macro: `fuzzer`
-        note: this error originates in the attribute macro: `fork`
-        
+
         error[E2000]: Unsupported feature.
          --> [..]/tests/contract.cairo:19:22
             assert(balance === 0, 'balance == 0');
@@ -317,8 +254,8 @@ fn multiple() {
         note: this error originates in the attribute macro: `ignore`
         note: this error originates in the attribute macro: `__internal_config_statement`
         
-        error: could not compile `multiple_integrationtest` due to 11 previous errors and 1 warning
-    "#},
+        error: could not compile `multiple_integrationtest` due to 7 previous errors and 1 warning
+    "},
     );
 }
 
@@ -412,7 +349,6 @@ fn different_attributes() {
             .args(["build", "--test"])
             .assert()
             .failure();
-        let expected_underline = "^".repeat(attribute.len());
 
         case_assert_stdout_contains(
             attribute.clone(),
@@ -421,14 +357,8 @@ fn different_attributes() {
             error[E1001]: Missing token ';'.
              --> [..]/tests/contract.cairo:10:81
                 let (_contract_address1, _) = contract.deploy(constructor_calldata).unwrap()
-                                                                                            ^
-            
-            error[E2200]: Plugin diagnostic: Failed because of invalid syntax
-             --> [..]/tests/contract.cairo:6:1
-            {attribute}
-            {expected_underline}
-            
-            error: could not compile `attributes_integrationtest` due to 2 previous errors and 1 warning
+
+            error: could not compile `attributes_integrationtest` due to 1 previous error and 1 warning
     "},
         );
     }

--- a/crates/snforge-scarb-plugin/src/derives/fuzzable.rs
+++ b/crates/snforge-scarb-plugin/src/derives/fuzzable.rs
@@ -15,9 +15,8 @@ pub fn fuzzable_derive(item: &TokenStream) -> ProcMacroResult {
     let db = SimpleParserDatabase::default();
     let (parsed, diagnostics) = db.parse_token_stream(item);
 
-    if !diagnostics.is_empty() {
-        return ProcMacroResult::new(TokenStream::empty())
-            .with_diagnostics(Diagnostic::error("Failed because of invalid syntax").into());
+    if diagnostics.check_error_free().is_err() {
+        return ProcMacroResult::new(TokenStream::empty());
     }
 
     let syntax_db = db.upcast();

--- a/crates/snforge-scarb-plugin/src/parse.rs
+++ b/crates/snforge-scarb-plugin/src/parse.rs
@@ -12,12 +12,12 @@ use cairo_lang_utils::Upcast;
 
 pub fn parse<T: AttributeInfo>(
     code: &TokenStream,
-) -> Result<(SimpleParserDatabase, FunctionWithBody), Diagnostic> {
+) -> Result<(SimpleParserDatabase, FunctionWithBody), Vec<Diagnostic>> {
     let simple_db = SimpleParserDatabase::default();
     let (parsed_node, diagnostics) = simple_db.parse_token_stream(code);
 
-    if !diagnostics.is_empty() {
-        return Err(Diagnostic::error("Failed because of invalid syntax"));
+    if diagnostics.check_error_free().is_err() {
+        return Err(vec![]);
     }
 
     let db = simple_db.upcast();
@@ -34,7 +34,7 @@ pub fn parse<T: AttributeInfo>(
 
     match function {
         Some(func) => Ok((simple_db, func)),
-        None => Err(T::error("can be used only on a function")),
+        None => Err(vec![T::error("can be used only on a function")]),
     }
 }
 


### PR DESCRIPTION
## Introduced changes

- `check_error_free` instead of `is_empty` - https://github.com/foundry-rs/starknet-foundry/pull/4240#discussion_r3242641239
- stopped returning additional diags when parser error happen - this makes the UX better while writing the code. Now:

<img width="200" height="105" alt="image" src="https://github.com/user-attachments/assets/e41247ab-c945-4378-ab36-eafe09c8b48a" />

vs before: 

<img width="189" height="101" alt="image" src="https://github.com/user-attachments/assets/e6b375db-4cb9-4921-8572-525cd748bb15" />


## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
