### PR TITLE
Stop publishing test plugin in dependabot PRs

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -163,6 +163,8 @@ jobs:
 
   publish-plugin:
     needs: [ get-version, build-plugin-binaries ]
+    # Skip publishing on dependabot PRs with action updates.
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/_publish-plugin.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Dependabot action bumps always fail as dependabot triggered actions do not have access to secrets: 
* Example fail: https://github.com/foundry-rs/starknet-foundry/actions/runs/25431645032/job/74599444472?pr=4343
* https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions#restrictions-when-dependabot-triggers-events

We can disable this job in such cases as there is not much benefit of checking this (as a result also jobs `publish-std` and `test-binary` will not run)

