### PR TITLE
Add semicolon after config if (plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug in forge debugging and `--gas-report` that caused panic in case of a call to non-existent selector
 - `snforge test` now fails fast and explicitly when `[cairo] enable-gas = false`. Read more in [`Scarb.toml` reference](https://foundry-rs.github.io/starknet-foundry/appendix/scarb-toml.html#enable-gas).
-- Fixed `#[test]` macro expansion in `snforge_scarb_plugin` for cases involving block expressions (e.g. function code starting with `[`)
+- `#[test]` macro now expands correctly in `snforge_scarb_plugin` for cases involving block expressions (e.g. function code starting with `[`)
 
 ### Cast
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bug in forge debugging and `--gas-report` that caused panic in case of a call to non-existent selector
 - `snforge test` now fails fast and explicitly when `[cairo] enable-gas = false`. Read more in [`Scarb.toml` reference](https://foundry-rs.github.io/starknet-foundry/appendix/scarb-toml.html#enable-gas).
+- Fixed `#[test]` macro expansion in `snforge_scarb_plugin` for cases involving block expressions (e.g. function code starting with `[`)
 
 ### Cast
 

--- a/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/fuzzer/wrapper.rs
@@ -121,7 +121,7 @@ fn fuzzer_wrapper_internal(
                     #func_name(#blank_values_for_config_run);
 
                     return Default::default();
-                }
+                };
                 #fuzzer_assignments
                 #func_name(#arguments_list);
             }

--- a/crates/snforge-scarb-plugin/src/attributes/test.rs
+++ b/crates/snforge-scarb-plugin/src/attributes/test.rs
@@ -108,7 +108,7 @@ fn test_internal(
                    #if_content
 
                    return Default::default();
-               }
+               };
 
                #statements
            }

--- a/crates/snforge-scarb-plugin/src/config_statement.rs
+++ b/crates/snforge-scarb-plugin/src/config_statement.rs
@@ -81,7 +81,7 @@ pub fn append_config_statements(
                 #config_statements
 
                 return Default::default();
-            }
+            };
 
             #statements
         }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__max_permissible_value.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__max_permissible_value.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__work_with_number_all_set.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__work_with_number_all_set.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__work_with_number_some_set.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__work_with_number_some_set.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__works_with_empty.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__available_gas__works_with_empty.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__disable_predeployed_contracts__works_without_args.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__disable_predeployed_contracts__works_without_args.snap
@@ -9,5 +9,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_disable_contracts'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__accepts_inline_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__accepts_inline_config.snap
@@ -14,5 +14,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fork'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__accepts_string.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__accepts_string.snap
@@ -8,5 +8,5 @@ fn empty_fn() {
         snforge_std::_internals::config_types::ForkConfig::Named("test").serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fork'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__overriding_config_name_first.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__overriding_config_name_first.snap
@@ -14,5 +14,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fork'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__overriding_config_name_second.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fork__overriding_config_name_second.snap
@@ -14,5 +14,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fork'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_both_args.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_both_args.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_runs_only.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_runs_only.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_seed_only.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_works_with_seed_only.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_both_args@after_fuzzer_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_both_args@after_fuzzer_config.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_fn_with_params@after_fuzzer_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_fn_with_params@after_fuzzer_config.snap
@@ -11,5 +11,5 @@ fn empty_fn(f: felt252, u: u32) {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_fn_with_single_param@after_fuzzer_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_with_fn_with_single_param@after_fuzzer_config.snap
@@ -11,5 +11,5 @@ fn empty_fn(f: felt252) {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_without_args@after_fuzzer_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__fuzzer__config_wrapper_work_without_args@after_fuzzer_config.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__ignore__works_without_args.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__ignore__works_without_args.snap
@@ -9,5 +9,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_ignore'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__internal_config_statement__appends_config_statement.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__internal_config_statement__appends_config_statement.snap
@@ -5,5 +5,5 @@ expression: format_output(&result)
 fn empty_fn() {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_empty.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_empty.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_short_string.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_short_string.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_short_string_escaped.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_short_string_escaped.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_string.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_string.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_string_escaped.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_string_escaped.snap
@@ -13,5 +13,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_tuple.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__should_panic__work_with_expected_tuple.snap
@@ -13,5 +13,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_should_panic'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__test__appends_internal_config_and_executable.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/single_attributes/snapshots/integration__single_attributes__test__appends_internal_config_and_executable.snap
@@ -30,5 +30,5 @@ fn empty_fn__snforge_internal_test_generated(mut _data: Span<felt252>) -> Span<f
 fn empty_fn() {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_available_gas.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_available_gas.snap
@@ -11,5 +11,5 @@ fn empty_fn() {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_fork.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_fork.snap
@@ -14,5 +14,5 @@ fn empty_fn() {
         snforge_std::_internals::config_types::ForkConfig::Named("test").serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fork'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_test.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_few_attributes@after_test.snap
@@ -30,5 +30,5 @@ fn empty_fn__snforge_internal_test_generated(mut _data: Span<felt252>) -> Span<f
 fn empty_fn() {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer@after_fuzzer.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer@after_fuzzer.snap
@@ -7,5 +7,5 @@ expression: format_output(&result)
 fn empty_fn() {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer@after_test.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer@after_test.snap
@@ -30,5 +30,5 @@ fn empty_fn__snforge_internal_test_generated(mut _data: Span<felt252>) -> Span<f
 fn empty_fn() {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_before_test@after_test.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_before_test@after_test.snap
@@ -32,5 +32,5 @@ fn empty_fn__snforge_internal_test_generated(mut _data: Span<felt252>) -> Span<f
 fn empty_fn(f: felt252) {
     if snforge_std::_internals::is_config_run() {
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_available_gas.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_available_gas.snap
@@ -11,5 +11,5 @@ fn empty_fn(f: felt252) {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_fuzzer_config.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_fuzzer_config.snap
@@ -18,5 +18,5 @@ fn empty_fn(f: felt252) {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_fuzzer'>(data.span());
         return Default::default();
-    }
+    };
 }

--- a/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_test.snap
+++ b/crates/snforge-scarb-plugin/tests/integration/snapshots/integration__multiple_attributes__works_with_fuzzer_config_wrapper@after_test.snap
@@ -37,5 +37,5 @@ fn empty_fn(f: felt252) {
             .serialize(ref data);
         starknet::testing::cheatcode::<'set_config_available_gas'>(data.span());
         return Default::default();
-    }
+    };
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4132

## Introduces changes

Due do lack of `;` after config if, in snforge scarb plugin, `#[test]` macro failed to expand for cases involving block expressions (e.g. function code starting with `[`).

## Before
<img width="798" height="586" alt="image" src="https://github.com/user-attachments/assets/0f872c53-fe7d-455e-a5b5-3f3d2c311da5" />

## After
<img width="798" height="757" alt="image" src="https://github.com/user-attachments/assets/d755e81f-3340-4d40-8335-f3fdcee5834e" />



## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
