### PR TITLE
Properly resolve `tracked_resource` when present in `Scarb.toml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in forge debugging and `--gas-report` that caused panic in case of a call to non-existent selector
 - `snforge test` now fails fast and explicitly when `[cairo] enable-gas = false`. Read more in [`Scarb.toml` reference](https://foundry-rs.github.io/starknet-foundry/appendix/scarb-toml.html#enable-gas).
 - `#[test]` macro now expands correctly in `snforge_scarb_plugin` for cases involving block expressions (e.g. function code starting with `[`)
+- `tracked_resource` field from `Scarb.toml` is now taken into account when running `snforge test`
 
 #### Removed
 

--- a/crates/forge-runner/src/forge_config.rs
+++ b/crates/forge-runner/src/forge_config.rs
@@ -48,6 +48,7 @@ pub struct ExecutionDataToSave {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Deserialize, Eq, ValueEnum)]
+#[serde(rename_all = "kebab-case")]
 pub enum ForgeTrackedResource {
     CairoSteps,
     #[default]

--- a/crates/forge/src/combine_configs.rs
+++ b/crates/forge/src/combine_configs.rs
@@ -16,6 +16,10 @@ pub fn combine_configs(
     cache_dir: Utf8PathBuf,
     forge_config_from_scarb: &ForgeConfigFromScarb,
 ) -> ForgeConfig {
+    let tracked_resource = args
+        .tracked_resource
+        .unwrap_or(forge_config_from_scarb.tracked_resource);
+
     let execution_data_to_save = ExecutionDataToSave::from_flags(
         args.save_trace_data || forge_config_from_scarb.save_trace_data,
         args.build_profile || forge_config_from_scarb.build_profile,
@@ -39,7 +43,7 @@ pub fn combine_configs(
             is_vm_trace_needed: execution_data_to_save.is_vm_trace_needed(),
             cache_dir,
             contracts_data,
-            tracked_resource: args.tracked_resource,
+            tracked_resource,
             environment_variables: env::vars().collect(),
             launch_debugger: args.launch_debugger,
         }),
@@ -159,8 +163,6 @@ mod tests {
                     fuzzer_runs: NonZeroU32::new(1234).unwrap(),
                     fuzzer_seed: 500,
                     max_n_steps: Some(1_000_000),
-                    // tracked_resource comes from args only; ForgeConfigFromScarb.tracked_resource
-                    // is not used by combine_configs, so this stays at the args default.
                     tracked_resource: ForgeTrackedResource::SierraGas,
                     is_vm_trace_needed: true,
                     cache_dir: Utf8PathBuf::default(),

--- a/crates/forge/src/combine_configs.rs
+++ b/crates/forge/src/combine_configs.rs
@@ -163,7 +163,7 @@ mod tests {
                     fuzzer_runs: NonZeroU32::new(1234).unwrap(),
                     fuzzer_seed: 500,
                     max_n_steps: Some(1_000_000),
-                    tracked_resource: ForgeTrackedResource::SierraGas,
+                    tracked_resource: ForgeTrackedResource::CairoSteps,
                     is_vm_trace_needed: true,
                     cache_dir: Utf8PathBuf::default(),
                     contracts_data: ContractsData::default(),

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -217,9 +217,9 @@ pub struct TestArgs {
     #[arg(long)]
     no_optimization: bool,
 
-    /// Specify tracked resource type
-    #[arg(long, value_enum, default_value_t)]
-    tracked_resource: ForgeTrackedResource,
+    /// Specify tracked resource type. Overrides `Scarb.toml` when passed.
+    #[arg(long, value_enum)]
+    tracked_resource: Option<ForgeTrackedResource>,
 
     /// Display a table of L2 gas breakdown for each contract and selector
     #[arg(long)]
@@ -260,7 +260,7 @@ impl TestArgs {
         // as otherwise it would run on vm.
         #[cfg(feature = "cairo-native")]
         if self.run_native {
-            self.tracked_resource = ForgeTrackedResource::SierraGas;
+            self.tracked_resource = Some(ForgeTrackedResource::SierraGas);
         }
     }
 }

--- a/crates/forge/src/scarb/config.rs
+++ b/crates/forge/src/scarb/config.rs
@@ -12,6 +12,7 @@ pub const SCARB_MANIFEST_TEMPLATE_CONTENT: &str = r#"
 # exit_first = true                                          # Stop tests execution immediately upon the first failure
 # fuzzer_runs = 1234                                         # Number of runs of the random fuzzer
 # fuzzer_seed = 1111                                         # Seed for the random fuzzer
+# tracked_resource = "sierra-gas"                            # Resource tracked by `snforge`
 
 # [[tool.snforge.fork]]                                      # Used for fork testing
 # name = "SOME_NAME"                                         # Fork name

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1,5 +1,6 @@
 use super::common::runner::{
     get_current_branch, get_remote_url, setup_package, test_runner, test_runner_native,
+    test_runner_vm,
 };
 use crate::utils::get_snforge_std_entry;
 use assert_fs::fixture::{FileWriteStr, PathChild};
@@ -1182,6 +1183,84 @@ fn detailed_resources_flag_cairo_steps() {
                 steps: [..]
                 memory holes: [..]
                 builtins: ([..])
+                syscalls: ([..])
+                events: (count: [..], keys: [..], data size: [..])
+                messages: ([..])
+        Tests: 1 passed, 0 failed, 0 ignored, 0 filtered out
+        "},
+    );
+}
+
+#[test]
+fn detailed_resources_from_scarb_tracked_resource() {
+    let temp = setup_package("erc20_package");
+    let manifest_path = temp.child("Scarb.toml");
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+    scarb_toml["tool"]["snforge"]["tracked_resource"] = value("cairo-steps");
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    let output = test_runner_vm(&temp)
+        .arg("--detailed-resources")
+        .assert()
+        .success();
+
+    assert!(!output.as_stdout().contains("sierra gas:"));
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+        [..]Compiling[..]
+        [..]Finished[..]
+
+
+        Collected 1 test(s) from erc20_package package
+        Running 0 test(s) from src/
+        Running 1 test(s) from tests/
+        [PASS] erc20_package_integrationtest::test_complex::complex[..]
+                steps: [..]
+                memory holes: [..]
+                builtins: ([..])
+                syscalls: ([..])
+                events: (count: [..], keys: [..], data size: [..])
+                messages: ([..])
+        Tests: 1 passed, 0 failed, 0 ignored, 0 filtered out
+        "},
+    );
+}
+
+#[test]
+fn detailed_resources_cli_overrides_scarb_tracked_resource() {
+    let temp = setup_package("erc20_package");
+    let manifest_path = temp.child("Scarb.toml");
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+    scarb_toml["tool"]["snforge"]["tracked_resource"] = value("cairo-steps");
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
+
+    let output = test_runner_vm(&temp)
+        .arg("--detailed-resources")
+        .arg("--tracked-resource")
+        .arg("sierra-gas")
+        .assert()
+        .success();
+
+    assert!(!output.as_stdout().contains("steps:"));
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+        [..]Compiling[..]
+        [..]Finished[..]
+        Collected 1 test(s) from erc20_package package
+        Running 0 test(s) from src/
+        Running 1 test(s) from tests/
+        [PASS] erc20_package_integrationtest::test_complex::complex[..]
+                sierra gas: [..]
                 syscalls: ([..])
                 events: (count: [..], keys: [..], data size: [..])
                 messages: ([..])

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1256,6 +1256,8 @@ fn detailed_resources_cli_overrides_scarb_tracked_resource() {
         indoc! {r"
         [..]Compiling[..]
         [..]Finished[..]
+        
+        
         Collected 1 test(s) from erc20_package package
         Running 0 test(s) from src/
         Running 1 test(s) from tests/

--- a/crates/forge/tests/integration/config.rs
+++ b/crates/forge/tests/integration/config.rs
@@ -96,6 +96,32 @@ fn get_forge_config_for_package() {
 }
 
 #[test]
+fn get_forge_config_for_package_with_tracked_resource() {
+    let temp = setup_package_with_toml();
+    let manifest_path = temp.child("Scarb.toml");
+    let manifest_contents = fs::read_to_string(&manifest_path).unwrap();
+    let manifest_contents = formatdoc!(
+        r#"
+        {manifest_contents}
+
+        [tool.snforge]
+        tracked_resource = "cairo-steps"
+    "#
+    );
+    manifest_path.write_str(manifest_contents.as_str()).unwrap();
+
+    let scarb_metadata = metadata_for_dir(temp.path()).unwrap();
+
+    let config = load_package_config::<ForgeConfigFromScarb>(
+        &scarb_metadata,
+        &scarb_metadata.workspace.members[0],
+    )
+    .unwrap();
+
+    assert_eq!(config.tracked_resource, ForgeTrackedResource::CairoSteps);
+}
+
+#[test]
 fn get_forge_config_for_package_err_on_invalid_package() {
     let temp = setup_package_with_toml();
     let scarb_metadata = metadata_for_dir(temp.path()).unwrap();

--- a/crates/forge/tests/integration/config.rs
+++ b/crates/forge/tests/integration/config.rs
@@ -9,6 +9,7 @@ use indoc::{formatdoc, indoc};
 use scarb_api::metadata::metadata_for_dir;
 use scarb_metadata::PackageId;
 use std::{env, fs};
+use toml_edit::{DocumentMut, value};
 
 fn setup_package_with_toml() -> TempDir {
     let temp = setup_package("simple_package");
@@ -99,16 +100,12 @@ fn get_forge_config_for_package() {
 fn get_forge_config_for_package_with_tracked_resource() {
     let temp = setup_package_with_toml();
     let manifest_path = temp.child("Scarb.toml");
-    let manifest_contents = fs::read_to_string(&manifest_path).unwrap();
-    let manifest_contents = formatdoc!(
-        r#"
-        {manifest_contents}
-
-        [tool.snforge]
-        tracked_resource = "cairo-steps"
-    "#
-    );
-    manifest_path.write_str(manifest_contents.as_str()).unwrap();
+    let mut scarb_toml = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .parse::<DocumentMut>()
+        .unwrap();
+    scarb_toml["tool"]["snforge"]["tracked_resource"] = value("cairo-steps");
+    manifest_path.write_str(&scarb_toml.to_string()).unwrap();
 
     let scarb_metadata = metadata_for_dir(temp.path()).unwrap();
 

--- a/docs/src/appendix/scarb-toml.md
+++ b/docs/src/appendix/scarb-toml.md
@@ -35,6 +35,19 @@ fuzzer_runs = 1234
 fuzzer_seed = 1111
 ```
 
+#### `tracked_resource`
+The `tracked_resource` field specifies which execution resource `snforge` should track.
+When `--tracked-resource` is passed on the CLI, the CLI value takes precedence over `Scarb.toml`.
+
+Valid values are:
+- `sierra-gas`
+- `cairo-steps`
+
+```toml
+[tool.snforge]
+tracked_resource = "cairo-steps"
+```
+
 ### `[[tool.snforge.fork]]`
 ```toml
 [[tool.snforge.fork]]

--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -136,6 +136,7 @@ Enabling this flag will slow down the compilation process, but the built contrac
 Set tracked resource for test execution. Impacts overall test gas cost. Valid values:
 - `sierra-gas` (default): track sierra gas, uses cairo native `CallExecution` (sierra gas consumption) to describe computation resources consumed by the test.
 - `cairo-steps`: track cairo steps, uses vm `ExecutionResources` (steps, builtins, memory holes) to describe resources consumed by the test.
+When this flag is passed, it overrides `tracked_resource` from `Scarb.toml`.
 To learn more about fee calculation formula (and the impact of tracking sierra gas on it) please consult [starknet docs](https://docs.starknet.io/learn/protocol/fees#overall-fee)
 
 ## `--gas-report`


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4281

## Introduced changes

ATM setting `tracked_resource` in `Scarb.toml` does not affect the actual tracked resource which is displayed. This PR fixes that.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
