### PR TITLE
Add aliases in multicalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Aliases in `snfoundry.toml`. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snfoundry-toml.html#sncastprofile-namealiases).
-- `@alias` syntax for felt arguments in `sncast call`, `invoke`, `deploy`, `declare-from`, `account create`, `account import`, `get balance`, `get nonce`, `get class-hash-at`, `verify`, `utils serialize`, and `utils contract-address`. Read more [here](https://foundry-rs.github.io/starknet-foundry/starknet/aliases.html).
+- `@alias` syntax for felt arguments in `sncast call`, `invoke`, `deploy`, `declare-from`, `account create`, `account import`, `get balance`, `get nonce`, `get class-hash-at`, `verify`, `utils serialize`, `utils contract-address`, `multicall execute`, and `multicall run`. Read more [here](https://foundry-rs.github.io/starknet-foundry/starknet/aliases.html).
 - `sncast alias list` command for listing aliases. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/alias/list.html).
 - `sncast config-path` for printing the paths to the local and global `snfoundry.toml` config files. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/config_path.html).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`, `wait-params`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
 - `sncast account import/deploy` interactive "make default account" prompt now emits a warning when global `snfoundry.toml` cannot be accessed/created.
+- `sncast multicall run` TOML `inputs` now always require the `@` prefix for step id references. Bare step ids no longer resolve. Migration: update entries to new format (e.g. `"map"`->`"@map"`). Read more [here](https://foundry-rs.github.io/starknet-foundry/starknet/multicall.html#using-id-references).
 
 ## [0.61.0] - 2026-05-26
 

--- a/crates/sncast/src/starknet_commands/multicall/deploy.rs
+++ b/crates/sncast/src/starknet_commands/multicall/deploy.rs
@@ -1,7 +1,6 @@
-use crate::starknet_commands::utils::felt_or_id::{ClassHash, FeltOrId};
 use anyhow::{Context, Result};
 use clap::Args;
-use conversions::string::IntoHexStr;
+use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::UDC_ADDRESS;
 use sncast::{extract_or_generate_salt, udc_uniqueness};
 use starknet_rust::accounts::{Account, SingleOwnerAccount};
@@ -29,13 +28,16 @@ pub struct MulticallDeploy {
 }
 
 impl MulticallDeploy {
-    pub fn new_from_item(item: &DeployItem, contracts: &ContractRegistry) -> Result<Self> {
-        let constructor_calldata = parse_inputs(&item.inputs, contracts)?;
+    pub fn new_from_item(
+        item: &DeployItem,
+        contracts: &ContractRegistry,
+        config: &CastConfig,
+    ) -> Result<Self> {
+        let constructor_calldata = parse_inputs(&item.inputs, contracts, config)?;
         let deploy = MulticallDeploy {
             common: DeployCommonArgs {
                 contract_identifier: ContractIdentifier {
-                    // TODO: add full support for multicall id <> alias id resolution (will be done in next PR)
-                    class_hash: Some(ClassHash(FeltOrId::new(item.class_hash.into_hex_string()))),
+                    class_hash: Some(item.class_hash.clone()),
                     contract_name: None,
                 },
                 arguments: DeployArguments {
@@ -61,6 +63,7 @@ impl MulticallDeploy {
         &self,
         account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, S>,
         contract_registry: &mut ContractRegistry,
+        config: &CastConfig,
     ) -> Result<Call>
     where
         S: Signer + Sync + Send,
@@ -69,6 +72,7 @@ impl MulticallDeploy {
         let constructor_arguments = replaced_arguments(
             &Arguments::from(self.common.arguments.clone()),
             contract_registry,
+            config,
         )?;
 
         let constructor_selector = get_selector_from_name("constructor")?;
@@ -78,7 +82,7 @@ impl MulticallDeploy {
             .class_hash
             .as_ref()
             .context("Using deploy with multicall requires providing class hash")?
-            .try_into_felt()?;
+            .resolve_in_multicall(contract_registry, config)?;
         let constructor_calldata = if let Some(raw_calldata) = &constructor_arguments.calldata {
             calldata_to_felts(raw_calldata)?
         } else {

--- a/crates/sncast/src/starknet_commands/multicall/execute.rs
+++ b/crates/sncast/src/starknet_commands/multicall/execute.rs
@@ -3,7 +3,7 @@ use clap::{Args, Command, FromArgMatches};
 use conversions::IntoConv;
 use sncast::{
     WaitForTx,
-    helpers::{dry_run::DryRunArgs, fee::FeeArgs, rpc::RpcArgs},
+    helpers::{configuration::CastConfig, dry_run::DryRunArgs, fee::FeeArgs, rpc::RpcArgs},
     response::{
         errors::handle_starknet_command_error,
         multicall::run::{MulticallRunResponse, MulticallRunTransactionResponse},
@@ -51,6 +51,8 @@ pub struct Execute {
     ///
     /// Additionally, `deploy` supports `--id <ID>` argument to name the deployed contract in this multicall.
     /// In subsequent calls, `@<ID>` can be referenced in `--contract-address` and `--calldata` flags to reference the deployed contract address.
+    /// `@<ID>` is also resolved against `[sncast.<profile>.aliases]` in `snfoundry.toml`;
+    /// Multicall-local `@<ID>` always wins over a config alias of the same name.
     ///
     /// For more, read the documentation: `<https://foundry-rs.github.io/starknet-foundry/starknet/multicall.html#multicall-with-cli-arguments>`
     #[arg(allow_hyphen_values = true, num_args = 1..)]
@@ -61,6 +63,7 @@ pub async fn execute<S>(
     execute: Execute,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, S>,
     provider: &JsonRpcClient<HttpTransport>,
+    config: &CastConfig,
     wait_config: WaitForTx,
     ui: &UI,
 ) -> Result<MulticallRunResponse>
@@ -79,13 +82,13 @@ where
         match cmd_name.as_str() {
             "deploy" => {
                 let call = parse_args::<MulticallDeploy>(cmd_name, cmd_args)?
-                    .build_call(account, &mut contract_registry)
+                    .build_call(account, &mut contract_registry, config)
                     .await?;
                 calls.push(call);
             }
             "invoke" => {
                 let call = parse_args::<MulticallInvoke>(cmd_name, cmd_args)?
-                    .build_call(&mut contract_registry)
+                    .build_call(&mut contract_registry, config)
                     .await?;
                 calls.push(call);
             }

--- a/crates/sncast/src/starknet_commands/multicall/invoke.rs
+++ b/crates/sncast/src/starknet_commands/multicall/invoke.rs
@@ -1,5 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Args;
+use sncast::helpers::configuration::CastConfig;
 use starknet_rust::core::{types::Call, utils::get_selector_from_name};
 
 use crate::{
@@ -22,8 +23,12 @@ pub struct MulticallInvoke {
 }
 
 impl MulticallInvoke {
-    pub fn new_from_item(item: &InvokeItem, contracts: &ContractRegistry) -> Result<Self> {
-        let calldata = parse_inputs(&item.inputs, contracts)?;
+    pub fn new_from_item(
+        item: &InvokeItem,
+        contracts: &ContractRegistry,
+        config: &CastConfig,
+    ) -> Result<Self> {
+        let calldata = parse_inputs(&item.inputs, contracts, config)?;
         let invoke = MulticallInvoke {
             common: InvokeCommonArgs {
                 contract_address: ContractAddress(item.contract_address.clone()),
@@ -37,17 +42,17 @@ impl MulticallInvoke {
         Ok(invoke)
     }
 
-    pub async fn build_call(&self, contract_registry: &mut ContractRegistry) -> Result<Call> {
+    pub async fn build_call(
+        &self,
+        contract_registry: &mut ContractRegistry,
+        config: &CastConfig,
+    ) -> Result<Call> {
         let selector = get_selector_from_name(&self.common.function)?;
-        let arguments = replaced_arguments(&self.common.arguments, contract_registry)?;
-        // TODO: add full support for multicall id <> alias id resolution (will be done in next PR)
-        let contract_address = if let Some(id) = self.common.contract_address.0.as_id() {
-            contract_registry
-                .get_address_by_id(id)
-                .with_context(|| format!("Failed to find contract address for id: {id}"))
-        } else {
-            self.common.contract_address.try_into_felt()
-        }?;
+        let arguments = replaced_arguments(&self.common.arguments, contract_registry, config)?;
+        let contract_address = self
+            .common
+            .contract_address
+            .resolve_in_multicall(contract_registry, config)?;
 
         let calldata = if let Some(raw_calldata) = &arguments.calldata {
             calldata_to_felts(raw_calldata)?

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::{Args, Subcommand};
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -89,6 +89,7 @@ pub async fn multicall(
                     run.clone(),
                     account,
                     &provider,
+                    &config,
                     wait_config,
                     ui,
                 )
@@ -113,6 +114,7 @@ pub async fn multicall(
                     *execute.clone(),
                     account,
                     &provider,
+                    &config,
                     wait_config,
                     ui,
                 )
@@ -130,11 +132,17 @@ pub async fn multicall(
     }
 }
 
-/// Replaces arguments that reference user-defined ids with their corresponding values from the contract registry.
-// TODO: add full support for multicall id <> alias id resolution (will be done in next PR)
+/// Replaces arguments that reference `@ID`s with their corresponding felt values.
+///
+/// If `@ID`, attempt to resolve felt value from, in the following order:
+/// 1. [`ContractRegistry`]
+/// 2. Aliases from config
+///
+/// Non-`@` values are left unchanged.
 pub fn replaced_arguments(
     arguments: &Arguments,
     contracts: &ContractRegistry,
+    config: &CastConfig,
 ) -> Result<Arguments> {
     Ok(match (&arguments.calldata, &arguments.arguments) {
         (Some(calldata), None) => {
@@ -142,12 +150,9 @@ pub fn replaced_arguments(
                 .iter()
                 .map(|raw_input| {
                     let input = FeltOrId::new(raw_input.clone());
-                    if let Some(id) = input.as_id() {
-                        contracts
-                            .get_address_by_id(id)
-                            .with_context(|| {
-                                format!("Failed to find contract address for id: {id}")
-                            })
+                    if input.as_id().is_some() {
+                        input
+                            .resolve_for_multicall(contracts, config)
                             .map(|f| f.to_string())
                     } else {
                         Ok(raw_input.clone())

--- a/crates/sncast/src/starknet_commands/multicall/run.rs
+++ b/crates/sncast/src/starknet_commands/multicall/run.rs
@@ -3,7 +3,7 @@ use crate::starknet_commands::invoke::execute_calls;
 use crate::starknet_commands::multicall::contract_registry::ContractRegistry;
 use crate::starknet_commands::multicall::deploy::MulticallDeploy;
 use crate::starknet_commands::multicall::invoke::MulticallInvoke;
-use crate::starknet_commands::utils::felt_or_id::FeltOrId;
+use crate::starknet_commands::utils::felt_or_id::{ClassHash, FeltOrId, ID_PREFIX};
 use anyhow::{Context, Result, anyhow};
 use camino::Utf8PathBuf;
 use clap::Args;
@@ -11,6 +11,7 @@ use conversions::IntoConv;
 use serde::Deserialize;
 use serde_json::Number;
 use sncast::WaitForTx;
+use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::dry_run::DryRunArgs;
 use sncast::helpers::fee::FeeArgs;
 use sncast::helpers::felt::felt_from_string;
@@ -70,8 +71,7 @@ struct MulticallFile {
 
 #[derive(Deserialize, Debug)]
 pub struct DeployItem {
-    // TODO: add full support for multicall id <> alias id resolution (will be done in next PR)
-    pub class_hash: Felt,
+    pub class_hash: ClassHash,
     pub inputs: Vec<Input>,
     pub unique: bool,
     pub salt: Option<Felt>,
@@ -89,6 +89,7 @@ pub async fn run<S>(
     run: Box<Run>,
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, S>,
     provider: &JsonRpcClient<HttpTransport>,
+    config: &CastConfig,
     wait_config: WaitForTx,
     ui: &UI,
 ) -> Result<MulticallRunResponse>
@@ -109,14 +110,14 @@ where
     for call in multicall.calls {
         match call {
             CallItem::Deploy(item) => {
-                let call = MulticallDeploy::new_from_item(&item, &contracts)?
-                    .build_call(account, &mut contracts)
+                let call = MulticallDeploy::new_from_item(&item, &contracts, config)?
+                    .build_call(account, &mut contracts, config)
                     .await?;
                 parsed_calls.push(call);
             }
             CallItem::Invoke(item) => {
-                let call = MulticallInvoke::new_from_item(&item, &contracts)?
-                    .build_call(&mut contracts)
+                let call = MulticallInvoke::new_from_item(&item, &contracts, config)?
+                    .build_call(&mut contracts, config)
                     .await?;
                 parsed_calls.push(call);
             }
@@ -151,15 +152,29 @@ where
     .map_err(handle_starknet_command_error)
 }
 
-pub fn parse_inputs(inputs: &[Input], contract_registry: &ContractRegistry) -> Result<Vec<Felt>> {
+// Note: Unlike other id cases, we allow bare-name `id` here (rather than `@id`)
+// TODO: Consider requiring `@` consistently here too and deprecating the bare-name path so calldata, contract addresses, and class hashes share same syntax.
+pub fn parse_inputs(
+    inputs: &[Input],
+    contract_registry: &ContractRegistry,
+    config: &CastConfig,
+) -> Result<Vec<Felt>> {
     let mut parsed_inputs = Vec::new();
+
     for input in inputs {
         let felt_value = match input {
-            Input::String(s) => contract_registry
-                .get_address_by_id(s)
-                .map_or_else(|| felt_from_string(s), Ok)?,
+            Input::String(s) => {
+                if s.starts_with(ID_PREFIX) {
+                    FeltOrId::new(s.clone()).resolve_for_multicall(contract_registry, config)?
+                } else if let Some(addr) = contract_registry.get_address_by_id(s) {
+                    addr
+                } else {
+                    felt_from_string(s)?
+                }
+            }
             Input::Number(n) => felt_from_string(&n.to_string())?,
         };
+
         parsed_inputs.push(felt_value);
     }
 

--- a/crates/sncast/src/starknet_commands/multicall/run.rs
+++ b/crates/sncast/src/starknet_commands/multicall/run.rs
@@ -164,10 +164,6 @@ pub fn parse_inputs(
             Input::String(s) => {
                 if s.starts_with(ID_PREFIX) {
                     FeltOrId::new(s.clone()).resolve_for_multicall(contract_registry, config)?
-                // Note: Unlike other id cases, we allow bare-name `id` here (rather than `@id`)
-                // TODO: Consider requiring `@` consistently here too and deprecating the bare-name path so calldata, contract addresses, and class hashes share same syntax.
-                } else if let Some(addr) = contract_registry.get_address_by_id(s) {
-                    addr
                 } else {
                     felt_from_string(s)?
                 }

--- a/crates/sncast/src/starknet_commands/multicall/run.rs
+++ b/crates/sncast/src/starknet_commands/multicall/run.rs
@@ -152,8 +152,6 @@ where
     .map_err(handle_starknet_command_error)
 }
 
-// Note: Unlike other id cases, we allow bare-name `id` here (rather than `@id`)
-// TODO: Consider requiring `@` consistently here too and deprecating the bare-name path so calldata, contract addresses, and class hashes share same syntax.
 pub fn parse_inputs(
     inputs: &[Input],
     contract_registry: &ContractRegistry,
@@ -166,6 +164,8 @@ pub fn parse_inputs(
             Input::String(s) => {
                 if s.starts_with(ID_PREFIX) {
                     FeltOrId::new(s.clone()).resolve_for_multicall(contract_registry, config)?
+                // Note: Unlike other id cases, we allow bare-name `id` here (rather than `@id`)
+                // TODO: Consider requiring `@` consistently here too and deprecating the bare-name path so calldata, contract addresses, and class hashes share same syntax.
                 } else if let Some(addr) = contract_registry.get_address_by_id(s) {
                     addr
                 } else {

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -5,7 +5,7 @@ use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::felt::felt_from_string;
 use starknet_types_core::felt::Felt;
 
-const ID_PREFIX: char = '@';
+pub const ID_PREFIX: char = '@';
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct FeltOrId(String);

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -1,3 +1,4 @@
+use crate::starknet_commands::multicall::contract_registry::ContractRegistry;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use sncast::helpers::configuration::CastConfig;
@@ -38,6 +39,33 @@ impl FeltOrId {
             self.try_into_felt()
         }
     }
+
+    /// If `@ID`, attempt to resolve felt value from, in the following order:
+    /// 1. [`ContractRegistry`]
+    /// 2. Aliases from config
+    ///
+    /// Otherwise, parse it as felt.
+    pub fn resolve_for_multicall(
+        &self,
+        registry: &ContractRegistry,
+        config: &CastConfig,
+    ) -> Result<Felt> {
+        if let Some(name) = self.as_id() {
+            if name.is_empty() {
+                bail!("Alias name cannot be empty");
+            }
+            if let Some(addr) = registry.get_address_by_id(name) {
+                return Ok(addr);
+            }
+            config.aliases.get(name).copied().with_context(|| {
+                format!(
+                    "`@{name}`: not found as multicall step id or in [sncast.<profile>.aliases]"
+                )
+            })
+        } else {
+            self.try_into_felt()
+        }
+    }
 }
 
 impl std::str::FromStr for FeltOrId {
@@ -68,6 +96,16 @@ macro_rules! felt_or_id_newtype {
                 config: &CastConfig,
             ) -> Result<Option<Felt>> {
                 value.map(|v| v.resolve(config)).transpose()
+            }
+
+            pub fn resolve_in_multicall(
+                &self,
+                registry: &ContractRegistry,
+                config: &CastConfig,
+            ) -> Result<Felt> {
+                self.0
+                    .resolve_for_multicall(registry, config)
+                    .context($context)
             }
         }
 

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -50,21 +50,22 @@ impl FeltOrId {
         registry: &ContractRegistry,
         config: &CastConfig,
     ) -> Result<Felt> {
-        if let Some(name) = self.as_id() {
-            if name.is_empty() {
-                bail!("Alias name cannot be empty");
-            }
-            if let Some(addr) = registry.get_address_by_id(name) {
-                return Ok(addr);
-            }
-            config.aliases.get(name).copied().with_context(|| {
+        let Some(name) = self.as_id() else {
+            return self.try_into_felt();
+        };
+
+        if name.is_empty() {
+            bail!("Alias name cannot be empty");
+        }
+
+        registry
+            .get_address_by_id(name)
+            .or_else(|| config.aliases.get(name).copied())
+            .with_context(|| {
                 format!(
                     "`@{name}`: not found as multicall step id or in [sncast.<profile>.aliases]"
                 )
             })
-        } else {
-            self.try_into_felt()
-        }
     }
 }
 

--- a/crates/sncast/tests/data/files/snfoundry_aliases.toml
+++ b/crates/sncast/tests/data/files/snfoundry_aliases.toml
@@ -10,3 +10,4 @@ example-class = "0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a
 data-transformer = "0x00351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"
 data-transformer-class = "0x0786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"
 deployer-123 = "0x123"
+shadowed = "0xdead"

--- a/crates/sncast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
+++ b/crates/sncast/tests/data/multicall_configs/deploy_invoke_calldata_ids.toml
@@ -9,11 +9,11 @@ unique = false
 call_type = "invoke"
 contract_address = "0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"
 function = "put"
-inputs = ["0x123", "map_contract"]
+inputs = ["0x123", "@map_contract"]
 
 [[call]]
 call_type = "deploy"
 class_hash = "0x059426c817fb8103edebdbf1712fa084c6744b2829db9c62d1ea4dce14ee6ded"
-inputs = ["map_contract", "0x1", "0x1"]
+inputs = ["@map_contract", "0x1", "0x1"]
 id = "constructor-params"
 unique = false

--- a/crates/sncast/tests/data/multicall_configs/multicall_id_overrides_alias.toml
+++ b/crates/sncast/tests/data/multicall_configs/multicall_id_overrides_alias.toml
@@ -1,0 +1,12 @@
+[[call]]
+call_type = "deploy"
+class_hash = "0x02a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321"
+inputs = []
+id = "shadowed"
+unique = false
+
+[[call]]
+call_type = "invoke"
+contract_address = "@shadowed"
+function = "put"
+inputs = ["0x123", "234"]

--- a/crates/sncast/tests/data/multicall_configs/multicall_with_alias_from_config.toml
+++ b/crates/sncast/tests/data/multicall_configs/multicall_with_alias_from_config.toml
@@ -1,0 +1,5 @@
+[[call]]
+call_type = "invoke"
+contract_address = "@map"
+function = "put"
+inputs = ["0x123", "234"]

--- a/crates/sncast/tests/e2e/alias/list.rs
+++ b/crates/sncast/tests/e2e/alias/list.rs
@@ -23,6 +23,7 @@ fn test_alias_list_happy_case() {
             map-class:              0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321
             map:                    0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008
             oz-devnet:              0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f
+            shadowed:      0xdead
             strk-token:             0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
         "},
     );
@@ -50,7 +51,7 @@ fn test_alias_list_json() {
 
     assert_stdout_contains(
         output,
-        r#"{"aliases":[{"name":"data-transformer","value":"0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"},{"name":"data-transformer-class","value":"0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"},{"name":"deployer-123","value":"0x123"},{"name":"example-class","value":"0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a0e"},{"name":"map","value":"0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"},{"name":"map-class","value":"0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321"},{"name":"oz-devnet","value":"0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"},{"name":"strk-token","value":"0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"}],"command":"alias list","type":"response"}"#,
+        r#"{"aliases":[{"name":"data-transformer","value":"0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"},{"name":"data-transformer-class","value":"0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"},{"name":"deployer-123","value":"0x123"},{"name":"example-class","value":"0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a0e"},{"name":"map","value":"0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"},{"name":"map-class","value":"0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321"},{"name":"oz-devnet","value":"0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"},{"name":"shadowed","value":"0xdead"},{"name":"strk-token","value":"0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"}],"command":"alias list","type":"response"}"#,
     );
 }
 

--- a/crates/sncast/tests/e2e/alias/list.rs
+++ b/crates/sncast/tests/e2e/alias/list.rs
@@ -23,8 +23,8 @@ fn test_alias_list_happy_case() {
             map-class:              0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321
             map:                    0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008
             oz-devnet:              0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f
-            shadowed:      0xdead
             strk-token:             0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
+            shadowed:               0xdead
         "},
     );
 }

--- a/crates/sncast/tests/e2e/multicall/execute.rs
+++ b/crates/sncast/tests/e2e/multicall/execute.rs
@@ -1,8 +1,9 @@
 use crate::helpers::constants::{
     MAP_CONTRACT_ADDRESS_SEPOLIA, MAP_CONTRACT_CLASS_HASH_SEPOLIA, URL,
 };
-use crate::helpers::fixtures::create_and_deploy_account;
+use crate::helpers::fixtures::{create_and_deploy_account, join_tempdirs};
 use crate::helpers::runner::runner;
+use configuration::test_utils::copy_config_to_tempdir;
 use indoc::indoc;
 use shared::test_utils::output_assert::{assert_stderr_contains, assert_stdout_contains};
 use sncast::AccountType;
@@ -229,7 +230,10 @@ async fn test_non_existent_id() {
         output,
         indoc! {
             "
-            Error: Failed to find contract address for id: non_existent_id
+            Error: Invalid contract address
+
+            Caused by:
+                `@non_existent_id`: not found as multicall step id or in [sncast.<profile>.aliases]
             "
         },
     );
@@ -411,6 +415,56 @@ async fn test_dry_run_detailed() {
             L2 Gas Price:         [..]
             L1 Data Gas Consumed: [..]
             L1 Data Gas Price:    [..]
+            "
+        },
+    );
+}
+
+#[tokio::test]
+async fn test_execute_alias_precedence_step_wins() {
+    let account_dir = create_and_deploy_account(OZ_CLASS_HASH, AccountType::OpenZeppelin).await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "execute",
+        "--url",
+        URL,
+        "deploy",
+        "--class-hash",
+        MAP_CONTRACT_CLASS_HASH_SEPOLIA,
+        "--id",
+        "shadowed",
+        "/",
+        "invoke",
+        "--contract-address",
+        "@shadowed",
+        "--function",
+        "put",
+        "--calldata",
+        "0x123 0x234",
+    ];
+
+    let snapbox = runner(&args)
+        .current_dir(config_dir.path())
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1");
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! {
+            "
+            Success: Multicall completed
+
+            Transaction Hash: 0x[..]
+
+            To see invocation details, visit:
+            transaction: [..]
             "
         },
     );

--- a/crates/sncast/tests/e2e/multicall/run.rs
+++ b/crates/sncast/tests/e2e/multicall/run.rs
@@ -1,6 +1,7 @@
 use crate::helpers::constants::{ACCOUNT_FILE_PATH, MULTICALL_CONFIGS_DIR, URL};
-use crate::helpers::fixtures::create_and_deploy_oz_account;
+use crate::helpers::fixtures::{create_and_deploy_oz_account, join_tempdirs};
 use crate::helpers::runner::runner;
+use configuration::test_utils::copy_config_to_tempdir;
 use indoc::{formatdoc, indoc};
 use shared::test_utils::output_assert::{AsOutput, assert_stderr_contains, assert_stdout_contains};
 use std::path::Path;
@@ -316,6 +317,100 @@ async fn test_deploy_success_invoke_fails() {
         Error: Transaction execution error [..]
         "},
     );
+}
+
+#[tokio::test]
+async fn test_run_id_overrides_alias() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let path = project_root::get_project_root().expect("failed to get project root path");
+    // IDs defined in multicall file take precedence over the aliases defined in `snfoundry.toml`
+    // Otherwise this test would fail as `shadowed` defined in config aliases points to non-existent address
+    let path = Path::new(&path)
+        .join(MULTICALL_CONFIGS_DIR)
+        .join("multicall_id_overrides_alias.toml");
+    let path = path.to_str().expect("failed converting path to str");
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "run",
+        "--url",
+        URL,
+        "--path",
+        path,
+    ];
+
+    let snapbox = runner(&args)
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(config_dir.path());
+    let output = snapbox.assert();
+
+    let stderr_str = output.as_stderr();
+    assert!(
+        stderr_str.is_empty(),
+        "Multicall error, stderr: \n{stderr_str}",
+    );
+
+    output.stdout_eq(indoc! {r"
+        Success: Multicall completed
+
+        Transaction Hash: 0x[..]
+
+        To see invocation details, visit:
+        transaction: [..]
+    "});
+}
+
+#[tokio::test]
+async fn test_run_alias_from_config_only() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let path = project_root::get_project_root().expect("failed to get project root path");
+    let path = Path::new(&path)
+        .join(MULTICALL_CONFIGS_DIR)
+        .join("multicall_with_alias_from_config.toml");
+    let path = path.to_str().expect("failed converting path to str");
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "run",
+        "--url",
+        URL,
+        "--path",
+        path,
+    ];
+
+    let snapbox = runner(&args)
+        .env("SNCAST_FORCE_SHOW_EXPLORER_LINKS", "1")
+        .current_dir(config_dir.path());
+    let output = snapbox.assert();
+
+    let stderr_str = output.as_stderr();
+    assert!(
+        stderr_str.is_empty(),
+        "Multicall error, stderr: \n{stderr_str}",
+    );
+
+    output.stdout_eq(indoc! {r"
+        Success: Multicall completed
+
+        Transaction Hash: 0x[..]
+
+        To see invocation details, visit:
+        transaction: [..]
+    "});
 }
 
 #[tokio::test]

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -38,7 +38,7 @@ fn test_show_config_displays_aliases_count() {
 
     assert_stdout_contains(
         output,
-        "Alias Count:         8 (use `sncast alias list` to display)",
+        "Alias Count:         9 (use `sncast alias list` to display)",
     );
 }
 

--- a/docs/src/appendix/sncast/multicall/run.md
+++ b/docs/src/appendix/sncast/multicall/run.md
@@ -108,13 +108,13 @@ inputs = ["0x123", "234"]
 
 [[call]]
 call_type = "invoke"
-contract_address = "map_contract"
+contract_address = "@map_contract"
 function = "put"
 inputs = ["0x123", "234"]
 
 [[call]]
 call_type = "deploy"
 class_hash = "0x2bb3d35dba2984b3d0cd0901b4e7de5411daff6bff5e072060bcfadbbd257b1"
-inputs = ["0x123", "map_contract"]
+inputs = ["0x123", "@map_contract"]
 unique = false
 ```

--- a/docs/src/starknet/aliases.md
+++ b/docs/src/starknet/aliases.md
@@ -77,8 +77,7 @@ map-class: 0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321
 
 ## `@alias` interaction with multicall `@id`
 
-<!-- TODO: explain @alias_id vs @id precedence -->
-TBD
+See [alias interaction with id](../starknet/multicall.md#alias-interaction-with-id).
 
 ## Supported commands
 
@@ -96,4 +95,6 @@ Currently, aliases are supported for:
 - `sncast verify`: `--class-hash`, `--contract-address`
 - `sncast utils serialize`: `--class-hash`, `--contract-address`
 - `sncast utils contract-address`: `--class-hash`, `--deployer-address`
+- `sncast multicall execute`: `--class-hash`, `--contract-address`, and `@<name>` in `--calldata` (see [multicall](../starknet/multicall.md#alias-interaction-with-id))
+- `sncast multicall run`: `class_hash`, `contract_address`, and `@<name>` in `inputs` (see [multicall](../starknet/multicall.md#alias-interaction-with-id))
 

--- a/docs/src/starknet/multicall.md
+++ b/docs/src/starknet/multicall.md
@@ -47,6 +47,44 @@ Similarly in both `sncast multicall execute` and `sncast multicall run`, you can
   - As the `contract address` in `invoke` calls
   - Inside `deploy`/`invoke` inputs (constructor calldata / calldata), to reference outputs of previous calls
 
+## `@alias` interaction with `@id`
+
+As other `sncast` commands, `sncast multicall` supports `snfoundry.toml` config aliases. See [Aliases](../starknet/aliases.md) for more details.
+
+Aliases can be used in both CLI-based (`sncast multicall execute`) and file-based (`sncast multicall run`) multicalls.
+
+> 📝 **Note**
+> 
+> Aliases and multicall step ids share the same `@<name>` syntax.
+> If a multicall step `id` and a config alias use the same name, the multicall step `id` takes precedence.
+
+
+Given `snfoundry.toml`:
+
+```toml
+[sncast.default.aliases]
+map = "0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"
+```
+
+
+#### Example: Multicall with CLI
+
+<!-- { "ignored": true } -->
+```shell
+$ sncast multicall execute \
+    invoke --contract-address @map --function put --calldata 0x123 234
+```
+
+#### Example: Multicall with file 
+
+```toml
+[[call]]
+call_type = "invoke"
+contract_address = "@map"
+function = "put"
+inputs = ["0x123", 234]
+```
+
 ## Multicall with file
 
 You need to pass `--path` flag with a `.toml` file which contains desired operations that you want to execute.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #2240

## Stack
- #4365 
- #4366
- #4376 
- #4382
- #4383

## Introduced changes

<!-- A brief description of the changes -->

## Introduced changes

- `@alias` in multicall (`execute`, `run`)
- `id` overrides alias when both set


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [ ] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
