### PR TITLE
Support aliases in calldata

### DIFF
--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -7,6 +7,7 @@ use crate::starknet_commands::get::Get;
 use crate::starknet_commands::get::balance::Balance;
 use crate::starknet_commands::invoke::InvokeCommonArgs;
 use crate::starknet_commands::script::run_script_command;
+use crate::starknet_commands::utils::felt_or_id::resolve_calldata_to_felts;
 use crate::starknet_commands::utils::{self, Utils};
 use crate::starknet_commands::{
     account, account::Account as AccountCommand, alias::Alias, call::Call, config_path::ConfigPath,
@@ -57,7 +58,6 @@ use starknet_rust::providers::Provider;
 use starknet_types_core::felt::Felt;
 use std::process::ExitCode;
 use tokio::runtime::Runtime;
-use crate::starknet_commands::utils::felt_or_id::resolve_calldata_to_felts;
 
 mod starknet_commands;
 
@@ -238,7 +238,12 @@ fn abi_from_contract_class(contract_class: &ContractClass) -> Result<Vec<AbiEntr
 }
 
 impl Arguments {
-    fn try_into_calldata(self, abi: &[AbiEntry], selector: &Felt, config: &CastConfig) -> Result<Vec<Felt>> {
+    fn try_into_calldata(
+        self,
+        abi: &[AbiEntry],
+        selector: &Felt,
+        config: &CastConfig,
+    ) -> Result<Vec<Felt>> {
         if let Some(calldata) = self.calldata {
             return resolve_calldata_to_felts(&calldata, config);
         }
@@ -674,8 +679,11 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
             let selector = get_selector_from_name(&function)
                 .context("Failed to convert entry point selector to FieldElement")?;
 
-            let calldata = arguments
-                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector, &config)?;
+            let calldata = arguments.try_into_calldata(
+                &abi_from_contract_class(&contract_class)?,
+                &selector,
+                &config,
+            )?;
 
             let result = starknet_commands::call::call(
                 contract_address,
@@ -728,8 +736,11 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
             let class_hash = get_class_hash_by_address(&provider, contract_address).await?;
             let contract_class = get_contract_class(class_hash, &provider).await?;
 
-            let calldata = arguments
-                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector, &config)?;
+            let calldata = arguments.try_into_calldata(
+                &abi_from_contract_class(&contract_class)?,
+                &selector,
+                &config,
+            )?;
 
             let result = with_account!(&account, |account| {
                 starknet_commands::invoke::invoke(

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -29,7 +29,6 @@ use sncast::helpers::config::resolve_global_config_path_or_warn;
 use sncast::helpers::configuration::{
     CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig, warn_unknown_keys,
 };
-use sncast::helpers::felt::felt_from_string;
 use sncast::helpers::output_format::output_format_from_json_flag;
 use sncast::helpers::rpc::generate_network_flag;
 use sncast::helpers::scarb_utils::{
@@ -58,6 +57,7 @@ use starknet_rust::providers::Provider;
 use starknet_types_core::felt::Felt;
 use std::process::ExitCode;
 use tokio::runtime::Runtime;
+use crate::starknet_commands::utils::felt_or_id::resolve_calldata_to_felts;
 
 mod starknet_commands;
 
@@ -238,17 +238,13 @@ fn abi_from_contract_class(contract_class: &ContractClass) -> Result<Vec<AbiEntr
 }
 
 impl Arguments {
-    fn try_into_calldata(self, abi: &[AbiEntry], selector: &Felt) -> Result<Vec<Felt>> {
+    fn try_into_calldata(self, abi: &[AbiEntry], selector: &Felt, config: &CastConfig) -> Result<Vec<Felt>> {
         if let Some(calldata) = self.calldata {
-            return calldata_to_felts(&calldata);
+            return resolve_calldata_to_felts(&calldata, config);
         }
 
         transform(&self.arguments.unwrap_or_default(), abi, selector)
     }
-}
-
-pub fn calldata_to_felts(calldata: &[String]) -> Result<Vec<Felt>> {
-    calldata.iter().map(|data| felt_from_string(data)).collect()
 }
 
 impl From<DeployArguments> for Arguments {
@@ -620,7 +616,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 let contract_class = get_contract_class(class_hash, &provider).await?;
                 abi_from_contract_class(&contract_class)?
             };
-            let calldata = arguments.try_into_calldata(&abi, &selector)?;
+            let calldata = arguments.try_into_calldata(&abi, &selector, &config)?;
 
             let result = with_account!(&account, |account| {
                 starknet_commands::deploy::deploy(
@@ -679,7 +675,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
                 .context("Failed to convert entry point selector to FieldElement")?;
 
             let calldata = arguments
-                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector)?;
+                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector, &config)?;
 
             let result = starknet_commands::call::call(
                 contract_address,
@@ -733,7 +729,7 @@ async fn run_async_command(cli: Cli, config: CastConfig, ui: &UI) -> Result<Exit
             let contract_class = get_contract_class(class_hash, &provider).await?;
 
             let calldata = arguments
-                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector)?;
+                .try_into_calldata(&abi_from_contract_class(&contract_class)?, &selector, &config)?;
 
             let result = with_account!(&account, |account| {
                 starknet_commands::invoke::invoke(

--- a/crates/sncast/src/starknet_commands/multicall/deploy.rs
+++ b/crates/sncast/src/starknet_commands/multicall/deploy.rs
@@ -14,9 +14,8 @@ use starknet_types_core::felt::Felt;
 use crate::starknet_commands::deploy::{ContractIdentifier, DeployArguments, DeployCommonArgs};
 use crate::starknet_commands::multicall::contract_registry::ContractRegistry;
 use crate::starknet_commands::multicall::run::{DeployItem, parse_inputs};
-use crate::{Arguments, abi_from_contract_class, calldata_to_felts};
 use crate::starknet_commands::utils::felt_or_id::resolve_multicall_calldata_to_felts;
-use crate::Arguments;
+use crate::{Arguments, abi_from_contract_class};
 
 #[derive(Args)]
 pub struct MulticallDeploy {

--- a/crates/sncast/src/starknet_commands/multicall/deploy.rs
+++ b/crates/sncast/src/starknet_commands/multicall/deploy.rs
@@ -13,9 +13,10 @@ use starknet_types_core::felt::Felt;
 
 use crate::starknet_commands::deploy::{ContractIdentifier, DeployArguments, DeployCommonArgs};
 use crate::starknet_commands::multicall::contract_registry::ContractRegistry;
-use crate::starknet_commands::multicall::replaced_arguments;
 use crate::starknet_commands::multicall::run::{DeployItem, parse_inputs};
 use crate::{Arguments, abi_from_contract_class, calldata_to_felts};
+use crate::starknet_commands::utils::felt_or_id::resolve_multicall_calldata_to_felts;
+use crate::Arguments;
 
 #[derive(Args)]
 pub struct MulticallDeploy {
@@ -69,11 +70,7 @@ impl MulticallDeploy {
         S: Signer + Sync + Send,
     {
         let salt = extract_or_generate_salt(self.common.salt);
-        let constructor_arguments = replaced_arguments(
-            &Arguments::from(self.common.arguments.clone()),
-            contract_registry,
-            config,
-        )?;
+        let constructor_arguments = Arguments::from(self.common.arguments.clone());
 
         let constructor_selector = get_selector_from_name("constructor")?;
         let class_hash = self
@@ -84,7 +81,7 @@ impl MulticallDeploy {
             .context("Using deploy with multicall requires providing class hash")?
             .resolve_in_multicall(contract_registry, config)?;
         let constructor_calldata = if let Some(raw_calldata) = &constructor_arguments.calldata {
-            calldata_to_felts(raw_calldata)?
+            resolve_multicall_calldata_to_felts(raw_calldata, config, contract_registry)?
         } else {
             let contract_class = contract_registry
                 .get_contract_class_by_class_hash(&class_hash)
@@ -92,6 +89,7 @@ impl MulticallDeploy {
             constructor_arguments.try_into_calldata(
                 &abi_from_contract_class(contract_class)?,
                 &constructor_selector,
+                config,
             )?
         };
 

--- a/crates/sncast/src/starknet_commands/multicall/invoke.rs
+++ b/crates/sncast/src/starknet_commands/multicall/invoke.rs
@@ -9,10 +9,9 @@ use crate::{
         invoke::InvokeCommonArgs,
         multicall::{
             contract_registry::ContractRegistry,
-            replaced_arguments,
             run::{InvokeItem, parse_inputs},
         },
-        utils::felt_or_id::ContractAddress,
+        utils::felt_or_id::{ContractAddress, resolve_multicall_calldata_to_felts},
     },
 };
 
@@ -48,14 +47,14 @@ impl MulticallInvoke {
         config: &CastConfig,
     ) -> Result<Call> {
         let selector = get_selector_from_name(&self.common.function)?;
-        let arguments = replaced_arguments(&self.common.arguments, contract_registry, config)?;
+        let arguments = &self.common.arguments;
         let contract_address = self
             .common
             .contract_address
             .resolve_in_multicall(contract_registry, config)?;
 
         let calldata = if let Some(raw_calldata) = &arguments.calldata {
-            calldata_to_felts(raw_calldata)?
+            resolve_multicall_calldata_to_felts(raw_calldata, config, contract_registry)?
         } else {
             let class_hash = contract_registry
                 .get_class_hash_by_address(&contract_address)
@@ -63,7 +62,9 @@ impl MulticallInvoke {
             let contract_class = contract_registry
                 .get_contract_class_by_class_hash(&class_hash)
                 .await?;
-            arguments.try_into_calldata(&abi_from_contract_class(contract_class)?, &selector)?
+            arguments
+                .clone()
+                .try_into_calldata(&abi_from_contract_class(contract_class)?, &selector, config)?
         };
 
         Ok(Call {

--- a/crates/sncast/src/starknet_commands/multicall/invoke.rs
+++ b/crates/sncast/src/starknet_commands/multicall/invoke.rs
@@ -4,7 +4,7 @@ use sncast::helpers::configuration::CastConfig;
 use starknet_rust::core::{types::Call, utils::get_selector_from_name};
 
 use crate::{
-    Arguments, abi_from_contract_class, calldata_to_felts,
+    Arguments, abi_from_contract_class,
     starknet_commands::{
         invoke::InvokeCommonArgs,
         multicall::{
@@ -62,9 +62,11 @@ impl MulticallInvoke {
             let contract_class = contract_registry
                 .get_contract_class_by_class_hash(&class_hash)
                 .await?;
-            arguments
-                .clone()
-                .try_into_calldata(&abi_from_contract_class(contract_class)?, &selector, config)?
+            arguments.clone().try_into_calldata(
+                &abi_from_contract_class(contract_class)?,
+                &selector,
+                config,
+            )?
         };
 
         Ok(Call {

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -11,10 +11,8 @@ pub mod invoke;
 pub mod new;
 pub mod run;
 
-use crate::starknet_commands::multicall::contract_registry::ContractRegistry;
 use crate::starknet_commands::multicall::execute::Execute;
-use crate::starknet_commands::utils::felt_or_id::FeltOrId;
-use crate::{Arguments, process_command_result, starknet_commands};
+use crate::{process_command_result, starknet_commands};
 use foundry_ui::Message;
 use new::New;
 use run::Run;
@@ -130,44 +128,4 @@ pub async fn multicall(
             ))
         }
     }
-}
-
-/// Replaces arguments that reference `@ID`s with their corresponding felt values.
-///
-/// If `@ID`, attempt to resolve felt value from, in the following order:
-/// 1. [`ContractRegistry`]
-/// 2. Aliases from config
-///
-/// Non-`@` values are left unchanged.
-pub fn replaced_arguments(
-    arguments: &Arguments,
-    contracts: &ContractRegistry,
-    config: &CastConfig,
-) -> Result<Arguments> {
-    Ok(match (&arguments.calldata, &arguments.arguments) {
-        (Some(calldata), None) => {
-            let replaced_calldata = calldata
-                .iter()
-                .map(|raw_input| {
-                    let input = FeltOrId::new(raw_input.clone());
-                    if input.as_id().is_some() {
-                        input
-                            .resolve_for_multicall(contracts, config)
-                            .map(|f| f.to_string())
-                    } else {
-                        Ok(raw_input.clone())
-                    }
-                })
-                .collect::<Result<Vec<String>>>()?;
-
-            Arguments {
-                calldata: Some(replaced_calldata),
-                arguments: None,
-            }
-        }
-        (None, _) => arguments.clone(),
-        (Some(_), Some(_)) => {
-            unreachable!("Only one of `calldata` or `arguments` can be provided, but both are set.")
-        }
-    })
 }

--- a/crates/sncast/src/starknet_commands/utils/contract_address.rs
+++ b/crates/sncast/src/starknet_commands/utils/contract_address.rs
@@ -15,10 +15,11 @@ use starknet_rust::core::types::contract::AbiEntry;
 use starknet_rust::core::utils::{get_selector_from_name, get_udc_deployed_address};
 use std::collections::HashMap;
 
-use crate::calldata_to_felts;
 use crate::starknet_commands::deploy::DeployCommonArgs;
 use crate::starknet_commands::utils::class_hash::sierra_class_from_artifacts;
-use crate::starknet_commands::utils::felt_or_id::DeployerAccountAddress;
+use crate::starknet_commands::utils::felt_or_id::{
+    DeployerAccountAddress, resolve_calldata_to_felts,
+};
 use crate::starknet_commands::utils::serialize::{Location, resolve_abi};
 
 #[derive(Args, Debug)]
@@ -80,7 +81,7 @@ pub async fn get_contract_address(
 
     let deploy_args = args.common.arguments;
     let calldata = if let Some(raw) = deploy_args.constructor_calldata {
-        calldata_to_felts(&raw)?
+        resolve_calldata_to_felts(&raw, &config)?
     } else if let Some(ref arguments_str) = deploy_args.arguments {
         let selector =
             get_selector_from_name("constructor").context("Failed to get constructor selector")?;

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -77,6 +77,49 @@ impl std::str::FromStr for FeltOrId {
     }
 }
 
+/// If `@ID`, attempt to resolve the felt value from aliases in config.
+///
+/// Non-`@` values are parsed as felts (hex or decimal).
+pub fn resolve_calldata_to_felts(
+    calldata: &[String],
+    config: &CastConfig,
+) -> Result<Vec<Felt>> {
+    calldata
+        .iter()
+        .map(|raw_input| {
+            let input = FeltOrId::new(raw_input.clone());
+            if input.as_id().is_some() {
+                input.resolve_alias_or_felt(config)
+            } else {
+                input.try_into_felt()
+            }
+        })
+        .collect()
+}
+
+/// If `@ID`, attempt to resolve the felt value from, in the following order:
+/// 1. [`ContractRegistry`]
+/// 2. Aliases from config
+///
+/// Non-`@` values are parsed as felts (hex or decimal).
+pub fn resolve_multicall_calldata_to_felts(
+    calldata: &[String],
+    config: &CastConfig,
+    registry: &ContractRegistry,
+) -> Result<Vec<Felt>> {
+    calldata
+        .iter()
+        .map(|raw_input| {
+            let input = FeltOrId::new(raw_input.clone());
+            if input.as_id().is_some() {
+                input.resolve_for_multicall(registry, config)
+            } else {
+                input.try_into_felt()
+            }
+        })
+        .collect()
+}
+
 macro_rules! felt_or_id_newtype {
     ($name:ident, $context:literal) => {
         #[derive(Clone, Debug, Deserialize)]

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -80,10 +80,7 @@ impl std::str::FromStr for FeltOrId {
 /// If `@ID`, attempt to resolve the felt value from aliases in config.
 ///
 /// Non-`@` values are parsed as felts (hex or decimal).
-pub fn resolve_calldata_to_felts(
-    calldata: &[String],
-    config: &CastConfig,
-) -> Result<Vec<Felt>> {
+pub fn resolve_calldata_to_felts(calldata: &[String], config: &CastConfig) -> Result<Vec<Felt>> {
     calldata
         .iter()
         .map(|raw_input| {

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -82,16 +82,9 @@ impl std::str::FromStr for FeltOrId {
 /// Non-`@` values are parsed as felts (hex or decimal).
 pub fn resolve_calldata_to_felts(calldata: &[String], config: &CastConfig) -> Result<Vec<Felt>> {
     calldata
-        .iter()
-        .map(|raw_input| {
-            let input = FeltOrId::new(raw_input.clone());
-            if input.as_id().is_some() {
-                input.resolve_alias_or_felt(config)
-            } else {
-                input.try_into_felt()
-            }
-        })
-        .collect()
+          .iter()
+          .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_alias_or_felt(config))
+          .collect()
 }
 
 /// If `@ID`, attempt to resolve the felt value from, in the following order:
@@ -104,17 +97,11 @@ pub fn resolve_multicall_calldata_to_felts(
     config: &CastConfig,
     registry: &ContractRegistry,
 ) -> Result<Vec<Felt>> {
-    calldata
-        .iter()
-        .map(|raw_input| {
-            let input = FeltOrId::new(raw_input.clone());
-            if input.as_id().is_some() {
-                input.resolve_for_multicall(registry, config)
-            } else {
-                input.try_into_felt()
-            }
-        })
-        .collect()
+      calldata
+          .iter()
+          .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_for_multicall(registry, config))
+          .collect()
+
 }
 
 macro_rules! felt_or_id_newtype {

--- a/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
+++ b/crates/sncast/src/starknet_commands/utils/felt_or_id.rs
@@ -82,9 +82,9 @@ impl std::str::FromStr for FeltOrId {
 /// Non-`@` values are parsed as felts (hex or decimal).
 pub fn resolve_calldata_to_felts(calldata: &[String], config: &CastConfig) -> Result<Vec<Felt>> {
     calldata
-          .iter()
-          .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_alias_or_felt(config))
-          .collect()
+        .iter()
+        .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_alias_or_felt(config))
+        .collect()
 }
 
 /// If `@ID`, attempt to resolve the felt value from, in the following order:
@@ -97,11 +97,10 @@ pub fn resolve_multicall_calldata_to_felts(
     config: &CastConfig,
     registry: &ContractRegistry,
 ) -> Result<Vec<Felt>> {
-      calldata
-          .iter()
-          .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_for_multicall(registry, config))
-          .collect()
-
+    calldata
+        .iter()
+        .map(|raw_input| FeltOrId::new(raw_input.clone()).resolve_for_multicall(registry, config))
+        .collect()
 }
 
 macro_rules! felt_or_id_newtype {

--- a/crates/sncast/tests/data/files/snfoundry_aliases.toml
+++ b/crates/sncast/tests/data/files/snfoundry_aliases.toml
@@ -10,4 +10,7 @@ example-class = "0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a
 data-transformer = "0x00351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"
 data-transformer-class = "0x0786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"
 deployer-123 = "0x123"
+zero = "0x0"
+one = "0x1"
+two = "0x2"
 shadowed = "0xdead"

--- a/crates/sncast/tests/data/multicall_configs/multicall_with_unknown_alias_in_inputs.toml
+++ b/crates/sncast/tests/data/multicall_configs/multicall_with_unknown_alias_in_inputs.toml
@@ -1,0 +1,5 @@
+[[call]]
+call_type = "invoke"
+contract_address = "@map"
+function = "put"
+inputs = ["@unknown", "0x2"]

--- a/crates/sncast/tests/e2e/alias/list.rs
+++ b/crates/sncast/tests/e2e/alias/list.rs
@@ -11,11 +11,11 @@ fn test_alias_list_happy_case() {
     let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
     let args = vec!["alias", "list"];
 
-    let output = runner(&args).current_dir(tempdir.path()).assert().success();
-
-    assert_stdout_contains(
-        output,
-        indoc! {r"
+    runner(&args)
+        .current_dir(tempdir.path())
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r"
             data-transformer:       0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed
             data-transformer-class: 0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0
             deployer-123:           0x123
@@ -28,8 +28,7 @@ fn test_alias_list_happy_case() {
             strk-token:             0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
             two:                    0x2
             zero:                   0x0
-        "},
-    );
+        "});
 }
 
 #[test]

--- a/crates/sncast/tests/e2e/alias/list.rs
+++ b/crates/sncast/tests/e2e/alias/list.rs
@@ -16,15 +16,18 @@ fn test_alias_list_happy_case() {
     assert_stdout_contains(
         output,
         indoc! {r"
-            data-transformer-class: 0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0
             data-transformer:       0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed
+            data-transformer-class: 0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0
             deployer-123:           0x123
             example-class:          0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a0e
-            map-class:              0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321
             map:                    0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008
+            map-class:              0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321
+            one:                    0x1
             oz-devnet:              0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f
-            strk-token:             0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
             shadowed:               0xdead
+            strk-token:             0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
+            two:                    0x2
+            zero:                   0x0
         "},
     );
 }
@@ -51,7 +54,7 @@ fn test_alias_list_json() {
 
     assert_stdout_contains(
         output,
-        r#"{"aliases":[{"name":"data-transformer","value":"0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"},{"name":"data-transformer-class","value":"0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"},{"name":"deployer-123","value":"0x123"},{"name":"example-class","value":"0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a0e"},{"name":"map","value":"0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"},{"name":"map-class","value":"0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321"},{"name":"oz-devnet","value":"0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"},{"name":"shadowed","value":"0xdead"},{"name":"strk-token","value":"0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"}],"command":"alias list","type":"response"}"#,
+        r#"{"aliases":[{"name":"data-transformer","value":"0x351c816183324878714973f3da1a43c1a40d661b8dac5cb69294cc333342ed"},{"name":"data-transformer-class","value":"0x786d1f010d66f838837290e472415186ba6a789fb446e7f92e444bed7b5d9c0"},{"name":"deployer-123","value":"0x123"},{"name":"example-class","value":"0x66802613e2cd02ea21430a56181d9ee83c54d4ccdc45efa497d41fe1dc55a0e"},{"name":"map","value":"0xcd8f9ab31324bb93251837e4efb4223ee195454f6304fcfcb277e277653008"},{"name":"map-class","value":"0x2a09379665a749e609b4a8459c86fe954566a6beeaddd0950e43f6c700ed321"},{"name":"one","value":"0x1"},{"name":"oz-devnet","value":"0x4d07e40e93398ed3c76981e72dd1fd22557a78ce36c0515f679e27f0bb5bc5f"},{"name":"shadowed","value":"0xdead"},{"name":"strk-token","value":"0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d"},{"name":"two","value":"0x2"},{"name":"zero","value":"0x0"}],"command":"alias list","type":"response"}"#,
     );
 }
 

--- a/crates/sncast/tests/e2e/call.rs
+++ b/crates/sncast/tests/e2e/call.rs
@@ -67,6 +67,59 @@ fn test_call_with_alias() {
 }
 
 #[test]
+fn test_call_with_calldata_alias() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    let args = vec![
+        "call",
+        "--function",
+        "get",
+        "--calldata",
+        "@zero",
+        "--block-id",
+        "latest",
+        "--contract-address",
+        "@map",
+    ];
+
+    runner(&args)
+        .current_dir(tempdir.path())
+        .assert()
+        .success()
+        .stdout_eq(indoc! {r"
+        Success: Call completed
+
+        Response:     0x0
+        Response Raw: [0x0]
+    "});
+}
+
+#[test]
+fn test_call_with_unknown_calldata_alias() {
+    let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    let args = vec![
+        "call",
+        "--function",
+        "get",
+        "--calldata",
+        "@missing",
+        "--block-id",
+        "latest",
+        "--contract-address",
+        "@map",
+    ];
+
+    let output = runner(&args).current_dir(tempdir.path()).assert().failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+            Command: call
+            Error: Alias `missing` not found in config
+        "},
+    );
+}
+
+#[test]
 fn test_call_with_unknown_alias() {
     let tempdir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
     let args = vec![

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -129,6 +129,42 @@ async fn test_deploy_with_constructor_calldata_alias() {
 }
 
 #[tokio::test]
+async fn test_deploy_with_unknown_alias_in_constructor_calldata() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "deploy",
+        "--url",
+        URL,
+        "--class-hash",
+        CONSTRUCTOR_WITH_PARAMS_CONTRACT_CLASS_HASH_SEPOLIA,
+        "--constructor-calldata",
+        "@one @unknown @zero",
+        "--salt",
+        "0x2",
+    ];
+
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+            Command: deploy
+            Error: Alias `unknown` not found in config
+        "},
+    );
+}
+
+#[tokio::test]
 async fn test_deploy_with_unknown_alias() {
     let account_dir = create_and_deploy_oz_account().await;
     let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);

--- a/crates/sncast/tests/e2e/deploy.rs
+++ b/crates/sncast/tests/e2e/deploy.rs
@@ -99,6 +99,36 @@ async fn test_deploy_with_alias() {
 }
 
 #[tokio::test]
+async fn test_deploy_with_constructor_calldata_alias() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "deploy",
+        "--url",
+        URL,
+        "--class-hash",
+        CONSTRUCTOR_WITH_PARAMS_CONTRACT_CLASS_HASH_SEPOLIA,
+        "--constructor-calldata",
+        "@one @one @zero",
+        "--salt",
+        "0x2",
+    ];
+
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .success();
+
+    assert_stdout_contains(output, "Success: Deployment completed");
+}
+
+#[tokio::test]
 async fn test_deploy_with_unknown_alias() {
     let account_dir = create_and_deploy_oz_account().await;
     let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -152,6 +152,40 @@ async fn test_invoke_with_calldata_alias() {
 }
 
 #[tokio::test]
+async fn test_invoke_with_unknown_alias_in_calldata() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "invoke",
+        "--contract-address",
+        "@map",
+        "--function",
+        "put",
+        "--calldata",
+        "0x1 @unknown",
+    ];
+
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+            Command: invoke
+            Error: Alias `unknown` not found in config
+        "},
+    );
+}
+
+#[tokio::test]
 async fn test_invoke_with_unknown_alias() {
     let account_dir = create_and_deploy_oz_account().await;
     let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);

--- a/crates/sncast/tests/e2e/invoke.rs
+++ b/crates/sncast/tests/e2e/invoke.rs
@@ -124,6 +124,34 @@ async fn test_invoke_with_alias() {
 }
 
 #[tokio::test]
+async fn test_invoke_with_calldata_alias() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "invoke",
+        "--contract-address",
+        "@map",
+        "--function",
+        "put",
+        "--calldata",
+        "0x1 @deployer-123",
+    ];
+
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .success();
+
+    assert_stdout_contains(output, "Success: Invoke completed");
+}
+
+#[tokio::test]
 async fn test_invoke_with_unknown_alias() {
     let account_dir = create_and_deploy_oz_account().await;
     let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);

--- a/crates/sncast/tests/e2e/multicall/execute.rs
+++ b/crates/sncast/tests/e2e/multicall/execute.rs
@@ -469,3 +469,75 @@ async fn test_execute_alias_precedence_step_wins() {
         },
     );
 }
+
+#[tokio::test]
+async fn test_execute_invoke_with_unknown_alias_in_calldata() {
+    let account_dir = create_and_deploy_account(OZ_CLASS_HASH, AccountType::OpenZeppelin).await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "execute",
+        "--url",
+        URL,
+        "invoke",
+        "--contract-address",
+        "@map",
+        "--function",
+        "put",
+        "--calldata",
+        "0x1 @unknown",
+    ];
+
+    let output = runner(&args).current_dir(config_dir.path()).assert().failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {
+            "
+            Command: multicall execute
+            Error: `@unknown`: not found as multicall step id or in [sncast.<profile>.aliases]
+            "
+        },
+    );
+}
+
+#[tokio::test]
+async fn test_execute_deploy_with_unknown_alias_in_constructor_calldata() {
+    let account_dir = create_and_deploy_account(OZ_CLASS_HASH, AccountType::OpenZeppelin).await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "execute",
+        "--url",
+        URL,
+        "deploy",
+        "--class-hash",
+        MAP_CONTRACT_CLASS_HASH_SEPOLIA,
+        "--constructor-calldata",
+        "@unknown 0x1",
+    ];
+
+    let output = runner(&args).current_dir(config_dir.path()).assert().failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {
+            "
+            Command: multicall execute
+            Error: `@unknown`: not found as multicall step id or in [sncast.<profile>.aliases]
+            "
+        },
+    );
+}

--- a/crates/sncast/tests/e2e/multicall/execute.rs
+++ b/crates/sncast/tests/e2e/multicall/execute.rs
@@ -494,7 +494,10 @@ async fn test_execute_invoke_with_unknown_alias_in_calldata() {
         "0x1 @unknown",
     ];
 
-    let output = runner(&args).current_dir(config_dir.path()).assert().failure();
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .failure();
 
     assert_stderr_contains(
         output,
@@ -529,7 +532,10 @@ async fn test_execute_deploy_with_unknown_alias_in_constructor_calldata() {
         "@unknown 0x1",
     ];
 
-    let output = runner(&args).current_dir(config_dir.path()).assert().failure();
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .failure();
 
     assert_stderr_contains(
         output,

--- a/crates/sncast/tests/e2e/multicall/run.rs
+++ b/crates/sncast/tests/e2e/multicall/run.rs
@@ -414,6 +414,45 @@ async fn test_run_alias_from_config_only() {
 }
 
 #[tokio::test]
+async fn test_run_with_unknown_alias_in_inputs() {
+    let account_dir = create_and_deploy_oz_account().await;
+    let config_dir = copy_config_to_tempdir("tests/data/files/snfoundry_aliases.toml", None);
+    join_tempdirs(&account_dir, &config_dir);
+
+    let path = project_root::get_project_root().expect("failed to get project root path");
+    let path = Path::new(&path)
+        .join(MULTICALL_CONFIGS_DIR)
+        .join("multicall_with_unknown_alias_in_inputs.toml");
+    let path = path.to_str().expect("failed converting path to str");
+
+    let args = vec![
+        "--accounts-file",
+        "accounts.json",
+        "--account",
+        "my_account",
+        "multicall",
+        "run",
+        "--url",
+        URL,
+        "--path",
+        path,
+    ];
+
+    let output = runner(&args)
+        .current_dir(config_dir.path())
+        .assert()
+        .failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+            Command: multicall run
+            Error: `@unknown`: not found as multicall step id or in [sncast.<profile>.aliases]
+        "},
+    );
+}
+
+#[tokio::test]
 async fn test_numeric_inputs() {
     let tempdir = create_and_deploy_oz_account().await;
 

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -38,7 +38,7 @@ fn test_show_config_displays_aliases_count() {
 
     assert_stdout_contains(
         output,
-        "Alias Count:         9 (use `sncast alias list` to display)",
+        "Alias Count:         12 (use `sncast alias list` to display)",
     );
 }
 

--- a/docs/src/appendix/sncast/call.md
+++ b/docs/src/appendix/sncast/call.md
@@ -34,7 +34,9 @@ Optional.
 Conflicts with: [`--arguments`](#--arguments)
 
 Inputs to the function, represented by a list of space-delimited values, e.g. `0x1 2 0x3`.
-Calldata arguments may be either 0x hex or decimal felts.
+Each token may be:
+- Felt in hex (prefixed with `0x`) or decimal representation.
+- `@alias` defined in `[sncast.<profile>.aliases]` in `snfoundry.toml`. See [aliases](../../starknet/aliases.md).
 
 ## `--arguments`
 Optional.

--- a/docs/src/appendix/sncast/deploy.md
+++ b/docs/src/appendix/sncast/deploy.md
@@ -44,7 +44,9 @@ Overrides network from `snfoundry.toml`.
 Optional.
 Conflicts with: [`--arguments`](#--arguments)
 
-Calldata for the contract constructor.
+Calldata for the contract constructor. Each token may be:
+- Felt in hex (prefixed with `0x`) or decimal representation.
+- `@alias` defined in `[sncast.<profile>.aliases]` in `snfoundry.toml`. See [aliases](../../starknet/aliases.md).
 
 ## `--arguments`
 Optional.

--- a/docs/src/appendix/sncast/invoke.md
+++ b/docs/src/appendix/sncast/invoke.md
@@ -21,8 +21,10 @@ The name of the function to call.
 Optional.
 Conflicts with: [`--arguments`](#--arguments)
 
-Inputs to the function, represented by a list of space-delimited values `0x1 2 0x3`.
-Calldata arguments may be either 0x hex or decimal felts.
+Inputs to the function, represented by a list of space-delimited values, e.g. `0x1 2 0x3`.
+Each token may be:
+- Felt in hex (prefixed with `0x`) or decimal representation.
+- `@alias` defined in `[sncast.<profile>.aliases]` in `snfoundry.toml`. See [aliases](../../starknet/aliases.md).
 
 ## `--arguments`
 Optional.

--- a/docs/src/appendix/sncast/utils/contract_address.md
+++ b/docs/src/appendix/sncast/utils/contract_address.md
@@ -20,7 +20,9 @@ The class hash is derived from the locally built artifact.
 Optional.
 Conflicts with: [`--arguments`](#--arguments)
 
-Constructor calldata as a series of felts.
+Constructor calldata as a series of felts. Each token may be:
+- Felt in hex (prefixed with `0x`) or decimal representation.
+- `@alias` defined in `[sncast.<profile>.aliases]` in `snfoundry.toml`. See [aliases](../../../starknet/aliases.md).
 
 Requires `--url` or `--network` to fetch the contract ABI when used together with `--class-hash`.
 

--- a/docs/src/starknet/aliases.md
+++ b/docs/src/starknet/aliases.md
@@ -83,9 +83,9 @@ See [alias interaction with id](../starknet/multicall.md#alias-interaction-with-
 
 Currently, aliases are supported for:
 
-- `sncast call`: `--contract-address`
-- `sncast invoke`: `--contract-address`
-- `sncast deploy`: `--class-hash`
+- `sncast call`: `--contract-address`, `--calldata`
+- `sncast invoke`: `--contract-address`, `--calldata`
+- `sncast deploy`: `--class-hash`, `--constructor-calldata`
 - `sncast declare-from`: `--class-hash`
 - `sncast account create`: `--class-hash`
 - `sncast account import`: `--address`, `--class-hash`
@@ -94,7 +94,7 @@ Currently, aliases are supported for:
 - `sncast get class-hash-at`: `<CONTRACT_ADDRESS>`
 - `sncast verify`: `--class-hash`, `--contract-address`
 - `sncast utils serialize`: `--class-hash`, `--contract-address`
-- `sncast utils contract-address`: `--class-hash`, `--deployer-address`
+- `sncast utils contract-address`: `--class-hash`, `--deployer-address`, `--constructor-calldata`
 - `sncast multicall execute`: `--class-hash`, `--contract-address`, and `@<name>` in `--calldata` (see [multicall](../starknet/multicall.md#alias-interaction-with-id))
 - `sncast multicall run`: `class_hash`, `contract_address`, and `@<name>` in `inputs` (see [multicall](../starknet/multicall.md#alias-interaction-with-id))
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2240

## Stack
- #4365 
- #4366
- #4376 
- #4382
- #4383


## Introduced changes

- `@alias` in `--calldata` and `--constructor-calldata` (`call`, `invoke`, `deploy`, `multicall deploy/invoke`)
- **tests:** calldata alias on `call`, `deploy`, `invoke`, `utils contract-address`


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [ ] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
