### PR TITLE
Warn on unknown keys in config (instead of error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
-- Unknown keys inside `wait-params` in `snfoundry.toml` now emit a warning.
+- Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`, `wait-params`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- Unknown keys in `snfoundry.toml` now, instead of causing hard error, emit a warning and are ignored, so configs can be used across `sncast` versions.
+- Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
+- Unknown keys inside `wait-params` in `snfoundry.toml` now emit a warning.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--contract-address @alias` syntax in `sncast call` and `sncast invoke`.
 - `sncast alias list` command for listing aliases. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/sncast/alias/list.html).
 
+#### Changed
+
+- Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`, `wait-params`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
+
+
 ## [0.61.0] - 2026-05-26
 
 ### Forge
@@ -51,10 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-abi` flag for `declare`, `declare-from`, and `deploy`, erasing the ABI before class declaration.
 - `sncast get spec-version` command that returns the version of the Starknet JSON-RPC specification used by the node
 - `sncast get tx-receipt` (alias: `get transaction-receipt`) command that returns the receipt of a transaction
-
-#### Changed
-
-- Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`, `wait-params`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast get spec-version` command that returns the version of the Starknet JSON-RPC specification used by the node
 - `sncast get tx-receipt` (alias: `get transaction-receipt`) command that returns the receipt of a transaction
 
+#### Changed
+
+- Unknown keys in `snfoundry.toml` now, instead of causing hard error, emit a warning and are ignored, so configs can be used across `sncast` versions.
+
 #### Fixed
 
 - `sncast completions` no longer fails due to invalid local or global `snfoundry.toml` config.

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -4,7 +4,7 @@ use crate::helpers::constants::DEFAULT_ACCOUNTS_FILE;
 use crate::response::ui::UI;
 use crate::{Network, PartialWaitParams, ValidatedWaitParams};
 use anyhow::{Context, Result};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use configuration::{Config, Override, load_config, override_optional};
 use foundry_ui::components::warning::WarningMessage;
 use serde::de::IntoDeserializer;
@@ -275,20 +275,54 @@ impl PartialCastConfig {
     }
 }
 
-pub fn warn_unknown_keys(maybe_configs: &[&MaybeConfig], ui: &UI) {
+pub struct ConfigSource<'a> {
+    pub path: Option<&'a Utf8Path>,
+    pub config: &'a MaybeConfig,
+}
+
+impl<'a> ConfigSource<'a> {
+    pub fn new(path: Option<&'a Utf8PathBuf>, config: &'a MaybeConfig) -> Self {
+        Self {
+            path: path.map(|p| p.as_path()),
+            config,
+        }
+    }
+}
+
+pub fn warn_unknown_keys(sources: &[ConfigSource<'_>], ui: &UI) {
     let mut keys = Vec::new();
+    let mut affected_paths = Vec::new();
 
-    for config in maybe_configs.iter().filter_map(|c| c.as_loaded()) {
-        keys.extend(config.get_unknown_keys());
+    for source in sources {
+        if let Some(config) = source.config.as_loaded() {
+            let unknown = config.get_unknown_keys();
+            if !unknown.is_empty() {
+                keys.extend(unknown);
+                if let Some(path) = source.path {
+                    affected_paths.push(path);
+                }
+            }
+        }
     }
 
-    if !keys.is_empty() {
-        keys.sort();
-        keys.dedup();
-        ui.print_warning(WarningMessage::new(format!(
-            "unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast)"
-        )));
+    if keys.is_empty() {
+        return;
     }
+
+    keys.sort();
+    keys.dedup();
+    affected_paths.dedup();
+
+    let affected = affected_paths
+        .iter()
+        .map(|path| path.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    ui.print_warning(WarningMessage::new(indoc::formatdoc! {"
+        unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast).
+        Affected config(s): {affected}"
+    }));
 }
 
 impl Override for PartialCastConfig {

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -562,20 +562,17 @@ mod tests {
     }
 
     #[test]
-    fn test_warn_ignored_unknown_keys_dedupes_across_slices() {
+    fn test_warn_ignored_unknown_keys_dedupes_across_configs() {
         let config = PartialCastConfig {
             unknown_fields: HashMap::from([("foo".to_string(), serde_json::Value::Null)]),
             ..Default::default()
         };
-        let slices = [
+        let configs = [
             MaybeConfig::Loaded(Box::new(config.clone())),
             MaybeConfig::Loaded(Box::new(config)),
             MaybeConfig::NoFile,
         ];
 
-        warn_unknown_keys(
-            &[&slices[0], &slices[1], &slices[2]],
-            &UI::default(),
-        );
+        warn_unknown_keys(&[&configs[0], &configs[1], &configs[2]], &UI::default());
     }
 }

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -266,6 +266,9 @@ impl PartialCastConfig {
         if let Some(networks) = &self.networks {
             keys.extend(networks.unknown_fields.keys().cloned());
         }
+        if let Some(wait_params) = &self.wait_params {
+            keys.extend(wait_params.unknown_fields.keys().cloned());
+        }
         keys.sort();
         keys.dedup();
         keys
@@ -297,7 +300,7 @@ impl Override for PartialCastConfig {
             account: other.account.or_else(|| self.account.clone()),
             accounts_file: other.accounts_file.or_else(|| self.accounts_file.clone()),
             keystore: other.keystore.or_else(|| self.keystore.clone()),
-            wait_params: override_optional(self.wait_params, other.wait_params),
+            wait_params: override_optional(self.wait_params.clone(), other.wait_params),
             block_explorer: other.block_explorer.or(self.block_explorer),
             show_explorer_links: other.show_explorer_links.or(self.show_explorer_links),
             networks: override_optional(self.networks.clone(), other.networks),

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -1,10 +1,12 @@
 use super::block_explorer;
 use super::felt::felt_from_string;
 use crate::helpers::constants::DEFAULT_ACCOUNTS_FILE;
+use crate::response::ui::UI;
 use crate::{Network, PartialWaitParams, ValidatedWaitParams};
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use configuration::{Config, Override, load_config, override_optional};
+use foundry_ui::components::warning::WarningMessage;
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -61,11 +63,15 @@ impl Override for NetworkParams {
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
-#[serde(deny_unknown_fields)]
 pub struct NetworksConfig {
     pub mainnet: Option<Url>,
     pub sepolia: Option<Url>,
     pub devnet: Option<Url>,
+
+    /// Additional data not captured by deserializer.
+    #[doc(hidden)]
+    #[serde(flatten, default, skip_serializing)]
+    pub unknown_fields: HashMap<String, serde_json::Value>,
 }
 
 impl NetworksConfig {
@@ -85,6 +91,7 @@ impl Override for NetworksConfig {
             mainnet: other.mainnet.or_else(|| self.mainnet.clone()),
             sepolia: other.sepolia.or_else(|| self.sepolia.clone()),
             devnet: other.devnet.or_else(|| self.devnet.clone()),
+            unknown_fields: HashMap::default(),
         }
     }
 }
@@ -245,11 +252,6 @@ impl Config for PartialCastConfig {
 
 impl PartialCastConfig {
     pub fn validate(&self) -> anyhow::Result<()> {
-        if !self.unknown_fields.is_empty() {
-            let mut keys: Vec<&String> = self.unknown_fields.keys().collect();
-            keys.sort();
-            anyhow::bail!("unknown field(s) {keys:?}");
-        }
         block_explorer::Service::validate_for_config(self.block_explorer)?;
         if let Some(ref wp) = self.wait_params {
             wp.validate()?;
@@ -257,6 +259,28 @@ impl PartialCastConfig {
         self.network_params.validate()?;
         Ok(())
     }
+
+}
+
+pub fn warn_unknown_keys(maybe_configs: &[&MaybeConfig], ui: &UI) {
+    let mut keys = Vec::new();
+
+    for config in maybe_configs.iter().filter_map(|c| c.as_loaded()) {
+        keys.extend(config.unknown_fields.keys().cloned());
+        if let Some(networks) = &config.networks {
+            keys.extend(networks.unknown_fields.keys().cloned());
+        }
+    }
+
+    keys.sort();
+    keys.dedup();
+    if keys.is_empty() {
+        return;
+    }
+
+    ui.print_warning(WarningMessage::new(format!(
+        "unknown config key(s) {keys:?} ignored (key is incorrect or may require newer/older sncast)"
+    )));
 }
 
 impl Override for PartialCastConfig {
@@ -290,6 +314,14 @@ impl MaybeConfig {
         match self {
             Self::NoFile | Self::NoProfile => PartialCastConfig::default(),
             Self::Loaded(config) => *config,
+        }
+    }
+
+    #[must_use]
+    pub fn as_loaded(&self) -> Option<&PartialCastConfig> {
+        match self {
+            Self::NoFile | Self::NoProfile => None,
+            Self::Loaded(config) => Some(config),
         }
     }
 }
@@ -383,6 +415,7 @@ mod tests {
             mainnet: Some(Url::parse("https://mainnet.example.com").unwrap()),
             sepolia: Some(Url::parse("https://sepolia.example.com").unwrap()),
             devnet: Some(Url::parse("https://devnet.example.com").unwrap()),
+            ..Default::default()
         };
 
         assert_eq!(
@@ -405,11 +438,13 @@ mod tests {
             mainnet: Some(Url::parse("https://global-mainnet.example.com").unwrap()),
             sepolia: Some(Url::parse("https://global-sepolia.example.com").unwrap()),
             devnet: None,
+            ..Default::default()
         };
         let local = NetworksConfig {
             mainnet: Some(Url::parse("https://local-mainnet.example.com").unwrap()),
             sepolia: None,
             devnet: None,
+            ..Default::default()
         };
 
         let overridden = global.override_with(local);
@@ -503,16 +538,34 @@ mod tests {
     }
 
     #[test]
-    fn test_networks_config_rejects_unknown_fields_and_typos() {
-        // Unknown fields should cause an error
+    fn test_networks_config_collects_unknown_fields() {
         let toml_str = r#"
             mainnet = "https://mainnet.example.com"
             custom = "https://custom.example.com"
             wrong_key = "https://sepolia.example.com"
         "#;
 
-        let result: Result<NetworksConfig, _> = toml::from_str(toml_str);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unknown field"));
+        let config: NetworksConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.unknown_fields.len(), 2);
+        assert!(config.unknown_fields.contains_key("custom"));
+        assert!(config.unknown_fields.contains_key("wrong_key"));
+    }
+
+    #[test]
+    fn test_warn_ignored_unknown_keys_dedupes_across_slices() {
+        let config = PartialCastConfig {
+            unknown_fields: HashMap::from([("foo".to_string(), serde_json::Value::Null)]),
+            ..Default::default()
+        };
+        let slices = [
+            MaybeConfig::Loaded(Box::new(config.clone())),
+            MaybeConfig::Loaded(Box::new(config)),
+            MaybeConfig::NoFile,
+        ];
+
+        warn_unknown_keys(
+            &[&slices[0], &slices[1], &slices[2]],
+            &UI::default(),
+        );
     }
 }

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use configuration::{Config, Override, load_config, override_optional};
 use foundry_ui::components::warning::WarningMessage;
+use indoc::formatdoc;
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -303,7 +304,7 @@ pub fn warn_unknown_keys(configs: &[&MaybeConfig], ui: &UI) {
         .collect::<Vec<_>>()
         .join(", ");
 
-    ui.print_warning(WarningMessage::new(indoc::formatdoc! {"
+    ui.print_warning(WarningMessage::new(formatdoc! {"
         unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast).
         Affected config(s): {affected}"
     }));

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -279,7 +279,7 @@ pub fn warn_unknown_keys(maybe_configs: &[&MaybeConfig], ui: &UI) {
     }
 
     ui.print_warning(WarningMessage::new(format!(
-        "unknown config key(s) {keys:?} ignored (key is incorrect or may require newer/older sncast)"
+        "unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast)"
     )));
 }
 

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -282,15 +282,13 @@ pub fn warn_unknown_keys(maybe_configs: &[&MaybeConfig], ui: &UI) {
         keys.extend(config.get_unknown_keys());
     }
 
-    keys.sort();
-    keys.dedup();
-    if keys.is_empty() {
-        return;
+    if !keys.is_empty() {
+        keys.sort();
+        keys.dedup();
+        ui.print_warning(WarningMessage::new(format!(
+            "unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast)"
+        )));
     }
-
-    ui.print_warning(WarningMessage::new(format!(
-        "unknown config key(s) {keys:?} ignored (incorrect key, or may require newer/older sncast)"
-    )));
 }
 
 impl Override for PartialCastConfig {

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -260,16 +260,23 @@ impl PartialCastConfig {
         Ok(())
     }
 
+    #[must_use]
+    pub fn get_unknown_keys(&self) -> Vec<String> {
+        let mut keys: Vec<String> = self.unknown_fields.keys().cloned().collect();
+        if let Some(networks) = &self.networks {
+            keys.extend(networks.unknown_fields.keys().cloned());
+        }
+        keys.sort();
+        keys.dedup();
+        keys
+    }
 }
 
 pub fn warn_unknown_keys(maybe_configs: &[&MaybeConfig], ui: &UI) {
     let mut keys = Vec::new();
 
     for config in maybe_configs.iter().filter_map(|c| c.as_loaded()) {
-        keys.extend(config.unknown_fields.keys().cloned());
-        if let Some(networks) = &config.networks {
-            keys.extend(networks.unknown_fields.keys().cloned());
-        }
+        keys.extend(config.get_unknown_keys());
     }
 
     keys.sort();

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -4,7 +4,7 @@ use crate::helpers::constants::DEFAULT_ACCOUNTS_FILE;
 use crate::response::ui::UI;
 use crate::{Network, PartialWaitParams, ValidatedWaitParams};
 use anyhow::{Context, Result};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use configuration::{Config, Override, load_config, override_optional};
 use foundry_ui::components::warning::WarningMessage;
 use serde::de::IntoDeserializer;
@@ -275,32 +275,16 @@ impl PartialCastConfig {
     }
 }
 
-pub struct ConfigSource<'a> {
-    pub path: Option<&'a Utf8Path>,
-    pub config: &'a MaybeConfig,
-}
-
-impl<'a> ConfigSource<'a> {
-    pub fn new(path: Option<&'a Utf8PathBuf>, config: &'a MaybeConfig) -> Self {
-        Self {
-            path: path.map(|p| p.as_path()),
-            config,
-        }
-    }
-}
-
-pub fn warn_unknown_keys(sources: &[ConfigSource<'_>], ui: &UI) {
+pub fn warn_unknown_keys(configs: &[&MaybeConfig], ui: &UI) {
     let mut keys = Vec::new();
     let mut affected_paths = Vec::new();
 
-    for source in sources {
-        if let Some(config) = source.config.as_loaded() {
+    for config in configs {
+        if let MaybeConfig::Loaded { path, config } = config {
             let unknown = config.get_unknown_keys();
             if !unknown.is_empty() {
                 keys.extend(unknown);
-                if let Some(path) = source.path {
-                    affected_paths.push(path);
-                }
+                affected_paths.push(path.as_path());
             }
         }
     }
@@ -347,7 +331,10 @@ impl Override for PartialCastConfig {
 pub enum MaybeConfig {
     NoFile,
     NoProfile,
-    Loaded(Box<PartialCastConfig>),
+    Loaded {
+        path: Utf8PathBuf,
+        config: Box<PartialCastConfig>,
+    },
 }
 
 impl MaybeConfig {
@@ -355,15 +342,7 @@ impl MaybeConfig {
     pub fn unwrap_or_default(self) -> PartialCastConfig {
         match self {
             Self::NoFile | Self::NoProfile => PartialCastConfig::default(),
-            Self::Loaded(config) => *config,
-        }
-    }
-
-    #[must_use]
-    pub fn as_loaded(&self) -> Option<&PartialCastConfig> {
-        match self {
-            Self::NoFile | Self::NoProfile => None,
-            Self::Loaded(config) => Some(config),
+            Self::Loaded { config, .. } => *config,
         }
     }
 }
@@ -398,7 +377,10 @@ impl PartialCastConfig {
             None => Ok(MaybeConfig::NoFile),
             Some(p) => match Self::load(p, profile, scope)? {
                 None => Ok(MaybeConfig::NoProfile),
-                Some(config) => Ok(MaybeConfig::Loaded(Box::from(config))),
+                Some(config) => Ok(MaybeConfig::Loaded {
+                    path: p.clone(),
+                    config: Box::from(config),
+                }),
             },
         }
     }

--- a/crates/sncast/src/helpers/configuration.rs
+++ b/crates/sncast/src/helpers/configuration.rs
@@ -558,19 +558,4 @@ mod tests {
         assert!(config.unknown_fields.contains_key("custom"));
         assert!(config.unknown_fields.contains_key("wrong_key"));
     }
-
-    #[test]
-    fn test_warn_ignored_unknown_keys_dedupes_across_configs() {
-        let config = PartialCastConfig {
-            unknown_fields: HashMap::from([("foo".to_string(), serde_json::Value::Null)]),
-            ..Default::default()
-        };
-        let configs = [
-            MaybeConfig::Loaded(Box::new(config.clone())),
-            MaybeConfig::Loaded(Box::new(config)),
-            MaybeConfig::NoFile,
-        ];
-
-        warn_unknown_keys(&[&configs[0], &configs[1], &configs[2]], &UI::default());
-    }
 }

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -149,7 +149,7 @@ pub struct WaitForTx {
     pub show_ui_outputs: bool,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Copy, PartialEq, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
 pub struct PartialWaitParams {
     pub timeout: Option<NonZeroU16>,
     #[serde(
@@ -157,6 +157,11 @@ pub struct PartialWaitParams {
         rename(serialize = "retry-interval", deserialize = "retry-interval")
     )]
     pub retry_interval: Option<NonZeroU8>,
+
+    /// Additional data not captured by deserializer.
+    #[doc(hidden)]
+    #[serde(flatten, default, skip_serializing)]
+    pub unknown_fields: HashMap<String, Value>,
 }
 
 impl Override for PartialWaitParams {
@@ -164,6 +169,7 @@ impl Override for PartialWaitParams {
         PartialWaitParams {
             timeout: other.timeout.or(self.timeout),
             retry_interval: other.retry_interval.or(self.retry_interval),
+            unknown_fields: HashMap::default(),
         }
     }
 }
@@ -1030,10 +1036,12 @@ mod tests {
         let base = PartialWaitParams {
             timeout: NonZeroU16::new(200),
             retry_interval: NonZeroU8::new(5),
+            ..Default::default()
         };
         let other = PartialWaitParams {
             timeout: NonZeroU16::new(300),
             retry_interval: None,
+            ..Default::default()
         };
         let overridden = base.override_with(other);
         assert_eq!(overridden.timeout, NonZeroU16::new(300));
@@ -1042,10 +1050,12 @@ mod tests {
         let base2 = PartialWaitParams {
             timeout: None,
             retry_interval: NonZeroU8::new(5),
+            ..Default::default()
         };
         let other2 = PartialWaitParams {
             timeout: NonZeroU16::new(200),
             retry_interval: None,
+            ..Default::default()
         };
         let overridden2 = base2.override_with(other2);
         assert_eq!(overridden2.timeout, NonZeroU16::new(200));
@@ -1057,23 +1067,26 @@ mod tests {
         let base = PartialWaitParams {
             timeout: NonZeroU16::new(200),
             retry_interval: NonZeroU8::new(5),
+            ..Default::default()
         };
         let other = PartialWaitParams {
             timeout: None,
             retry_interval: NonZeroU8::new(5),
+            ..Default::default()
         };
         assert_eq!(
-            override_optional(Some(base), Some(other)),
+            override_optional(Some(base.clone()), Some(other.clone())),
             Some(PartialWaitParams {
                 timeout: NonZeroU16::new(200),
                 retry_interval: NonZeroU8::new(5),
+                ..Default::default()
             })
         );
         assert_eq!(
-            override_optional::<PartialWaitParams>(None, Some(other)),
+            override_optional::<PartialWaitParams>(None, Some(other.clone())),
             Some(other)
         );
-        assert_eq!(override_optional(Some(base), None), Some(base));
+        assert_eq!(override_optional(Some(base.clone()), None), Some(base));
         assert_eq!(override_optional::<PartialWaitParams>(None, None), None);
     }
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -28,6 +28,7 @@ use sncast::helpers::command::process_command_result;
 use sncast::helpers::config::get_or_create_global_config_path;
 use sncast::helpers::configuration::{
     CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig,
+    warn_unknown_keys,
 };
 use sncast::helpers::felt::felt_from_string;
 use sncast::helpers::output_format::output_format_from_json_flag;
@@ -882,6 +883,16 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
         }
         _ => {}
     }
+
+    warn_unknown_keys(
+        &[
+            &global_default,
+            &global_profile,
+            &local_default,
+            &local_profile,
+        ],
+        ui,
+    );
 
     let cli_config = cli.to_partial_config()?;
     let partial_config = PartialCastConfig::default()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -884,15 +884,13 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
         _ => {}
     }
 
-    warn_unknown_keys(
-        &[
-            &global_default,
-            &global_profile,
-            &local_default,
-            &local_profile,
-        ],
-        ui,
-    );
+    let configs = vec![
+        &global_default,
+        &global_profile,
+        &local_default,
+        &local_profile,
+    ];
+    warn_unknown_keys(&configs, ui);
 
     let cli_config = cli.to_partial_config()?;
     let partial_config = PartialCastConfig::default()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -27,8 +27,7 @@ use shared::auto_completions::{Completions, generate_completions};
 use sncast::helpers::command::process_command_result;
 use sncast::helpers::config::get_or_create_global_config_path;
 use sncast::helpers::configuration::{
-    CastConfig, CliConfigOpts, ConfigScope, ConfigSource, MaybeConfig, PartialCastConfig,
-    warn_unknown_keys,
+    CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig, warn_unknown_keys,
 };
 use sncast::helpers::felt::felt_from_string;
 use sncast::helpers::output_format::output_format_from_json_flag;
@@ -885,13 +884,15 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
         _ => {}
     }
 
-    let sources = vec![
-        ConfigSource::new(global_path.as_ref(), &global_default),
-        ConfigSource::new(global_path.as_ref(), &global_profile),
-        ConfigSource::new(local_path.as_ref(), &local_default),
-        ConfigSource::new(local_path.as_ref(), &local_profile),
-    ];
-    warn_unknown_keys(&sources, ui);
+    warn_unknown_keys(
+        &[
+            &global_default,
+            &global_profile,
+            &local_default,
+            &local_profile,
+        ],
+        ui,
+    );
 
     let cli_config = cli.to_partial_config()?;
     let partial_config = PartialCastConfig::default()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -27,7 +27,8 @@ use shared::auto_completions::{Completions, generate_completions};
 use sncast::helpers::command::process_command_result;
 use sncast::helpers::config::get_or_create_global_config_path;
 use sncast::helpers::configuration::{
-    CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig, warn_unknown_keys,
+    CastConfig, CliConfigOpts, ConfigScope, ConfigSource, MaybeConfig, PartialCastConfig,
+    warn_unknown_keys,
 };
 use sncast::helpers::felt::felt_from_string;
 use sncast::helpers::output_format::output_format_from_json_flag;
@@ -884,15 +885,13 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
         _ => {}
     }
 
-    warn_unknown_keys(
-        &[
-            &global_default,
-            &global_profile,
-            &local_default,
-            &local_profile,
-        ],
-        ui,
-    );
+    let sources = vec![
+        ConfigSource::new(global_path.as_ref(), &global_default),
+        ConfigSource::new(global_path.as_ref(), &global_profile),
+        ConfigSource::new(local_path.as_ref(), &local_default),
+        ConfigSource::new(local_path.as_ref(), &local_profile),
+    ];
+    warn_unknown_keys(&sources, ui);
 
     let cli_config = cli.to_partial_config()?;
     let partial_config = PartialCastConfig::default()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -150,6 +150,7 @@ impl Cli {
             wait_params: Some(PartialWaitParams {
                 timeout: self.wait_timeout,
                 retry_interval: self.wait_retry_interval,
+                ..Default::default()
             }),
             scarb_profile: self.scarb_profile.clone(),
             ..Default::default()

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -27,8 +27,7 @@ use shared::auto_completions::{Completions, generate_completions};
 use sncast::helpers::command::process_command_result;
 use sncast::helpers::config::get_or_create_global_config_path;
 use sncast::helpers::configuration::{
-    CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig,
-    warn_unknown_keys,
+    CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig, warn_unknown_keys,
 };
 use sncast::helpers::felt::felt_from_string;
 use sncast::helpers::output_format::output_format_from_json_flag;

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -515,7 +515,7 @@ async fn test_default_global_profile_with_invalid_values() {
 }
 
 #[tokio::test]
-async fn test_default_global_profile_with_unsupported_field() {
+async fn test_global_config_with_unknown_field() {
     let global_dir = copy_config_to_tempdir(
         "tests/data/files/snfoundry_invalid_unknown_field.toml",
         None,
@@ -540,7 +540,7 @@ async fn test_default_global_profile_with_unsupported_field() {
 }
 
 #[tokio::test]
-async fn test_local_config_with_unsupported_fields() {
+async fn test_local_config_with_unknown_fields() {
     let global_dir = tempdir().unwrap();
     fs::write(
         global_dir.path().join("snfoundry.toml"),
@@ -574,7 +574,51 @@ async fn test_local_config_with_unsupported_fields() {
 }
 
 #[tokio::test]
-async fn test_local_config_with_unknown_wait_params() {
+async fn test_global_and_local_unknown_fields() {
+    let global_dir = tempdir().unwrap();
+    fs::write(
+        global_dir.path().join("snfoundry.toml"),
+        indoc! {r#"
+            [sncast.default]
+            url = "http://127.0.0.1:5055/rpc"
+            account = "user1"
+            shared = "shared"
+            global_only = true
+        "#},
+    )
+    .unwrap();
+    let local_dir = tempdir().unwrap();
+    fs::write(
+        local_dir.path().join("snfoundry.toml"),
+        indoc! {r#"
+            [sncast.default]
+            url = "http://127.0.0.1:5055/rpc"
+            account = "user1"
+            shared = "shared"
+            local_only = "local"
+        "#},
+    )
+    .unwrap();
+    let args = vec!["show-config"];
+
+    let snapbox = Cast::new()
+        .config_dir(global_dir.path())
+        .command()
+        .args(&args)
+        .current_dir(local_dir.path());
+
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! { r#"
+            [WARNING] unknown config key(s) ["global_only", "local_only", "shared"] ignored (incorrect key, or may require newer/older sncast)
+        "# },
+    );
+}
+
+#[tokio::test]
+async fn test_unknown_wait_params() {
     let local_dir = tempdir().unwrap();
     fs::write(
         local_dir.path().join("snfoundry.toml"),
@@ -599,7 +643,7 @@ async fn test_local_config_with_unknown_wait_params() {
 }
 
 #[tokio::test]
-async fn test_local_config_with_unknown_networks_field_warns_and_succeeds() {
+async fn test_unknown_networks() {
     let local_dir = tempdir().unwrap();
     fs::write(
         local_dir.path().join("snfoundry.toml"),

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -574,6 +574,31 @@ async fn test_local_config_with_unsupported_fields() {
 }
 
 #[tokio::test]
+async fn test_local_config_with_unknown_wait_params() {
+    let local_dir = tempdir().unwrap();
+    fs::write(
+        local_dir.path().join("snfoundry.toml"),
+        indoc! {r#"
+            [sncast.default]
+            url = "http://127.0.0.1:5055/rpc"
+            account = "user1"
+            wait-params = { timeout = 10, retry-interval = 5, future-wait-flag = true }
+        "#},
+    )
+    .unwrap();
+    let args = vec!["show-config"];
+
+    let snapbox = runner(&args).current_dir(local_dir.path());
+
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        r#"[WARNING] unknown config key(s) ["future-wait-flag"] ignored (incorrect key, or may require newer/older sncast)"#,
+    );
+}
+
+#[tokio::test]
 async fn test_local_config_with_unknown_networks_field_warns_and_succeeds() {
     let local_dir = tempdir().unwrap();
     fs::write(

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -534,7 +534,8 @@ async fn test_global_config_with_unknown_field() {
     assert_stdout_contains(
         output,
         indoc! { r#"
-            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast)
+            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast).
+            Affected config(s): [..]snfoundry.toml
         "# },
     );
 }
@@ -568,7 +569,8 @@ async fn test_local_config_with_unknown_fields() {
     assert_stdout_contains(
         output,
         indoc! { r#"
-            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast)
+            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast).
+            Affected config(s): [..]snfoundry.toml
         "# },
     );
 }
@@ -612,7 +614,8 @@ async fn test_global_and_local_unknown_fields() {
     assert_stdout_contains(
         output,
         indoc! { r#"
-            [WARNING] unknown config key(s) ["global_only", "local_only", "shared"] ignored (incorrect key, or may require newer/older sncast)
+            [WARNING] unknown config key(s) ["global_only", "local_only", "shared"] ignored (incorrect key, or may require newer/older sncast).
+            Affected config(s): [..]snfoundry.toml, [..]snfoundry.toml
         "# },
     );
 }
@@ -638,7 +641,10 @@ async fn test_unknown_wait_params() {
 
     assert_stdout_contains(
         output,
-        r#"[WARNING] unknown config key(s) ["future-wait-flag"] ignored (incorrect key, or may require newer/older sncast)"#,
+        indoc! { r#"
+            [WARNING] unknown config key(s) ["future-wait-flag"] ignored (incorrect key, or may require newer/older sncast).
+            Affected config(s): [..]snfoundry.toml
+        "# },
     );
 }
 
@@ -666,7 +672,10 @@ async fn test_unknown_networks() {
 
     assert_stdout_contains(
         output,
-        r#"[WARNING] unknown config key(s) ["custom"] ignored (incorrect key, or may require newer/older sncast)"#,
+        indoc! { r#"
+            [WARNING] unknown config key(s) ["custom"] ignored (incorrect key, or may require newer/older sncast).
+            Affected config(s): [..]snfoundry.toml
+        "# },
     );
 }
 

--- a/crates/sncast/tests/e2e/show_config.rs
+++ b/crates/sncast/tests/e2e/show_config.rs
@@ -529,17 +529,75 @@ async fn test_default_global_profile_with_unsupported_field() {
         .args(&args)
         .current_dir(t.path());
 
-    let output = snapbox.assert().failure();
+    let output = snapbox.assert().success();
 
-    assert_stderr_contains(
+    assert_stdout_contains(
         output,
         indoc! { r#"
-            Command: show-config
-            Error: Failed to load global config at [..]snfoundry.toml
-
-            Caused by:
-                unknown field(s) ["bar", "baz", "foo"]
+            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast)
         "# },
+    );
+}
+
+#[tokio::test]
+async fn test_local_config_with_unsupported_fields() {
+    let global_dir = tempdir().unwrap();
+    fs::write(
+        global_dir.path().join("snfoundry.toml"),
+        indoc! {r#"
+            [sncast.default]
+            url = "http://127.0.0.1:5055/rpc"
+            account = "user1"
+        "#},
+    )
+    .unwrap();
+    let local_dir = copy_config_to_tempdir(
+        "tests/data/files/snfoundry_invalid_unknown_field.toml",
+        None,
+    );
+    let args = vec!["show-config"];
+
+    let snapbox = Cast::new()
+        .config_dir(global_dir.path())
+        .command()
+        .args(&args)
+        .current_dir(local_dir.path());
+
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        indoc! { r#"
+            [WARNING] unknown config key(s) ["bar", "baz", "foo"] ignored (incorrect key, or may require newer/older sncast)
+        "# },
+    );
+}
+
+#[tokio::test]
+async fn test_local_config_with_unknown_networks_field_warns_and_succeeds() {
+    let local_dir = tempdir().unwrap();
+    fs::write(
+        local_dir.path().join("snfoundry.toml"),
+        indoc! {r#"
+            [sncast.default]
+            url = "http://127.0.0.1:5055/rpc"
+            account = "user1"
+
+            [sncast.default.networks]
+            mainnet = "https://mainnet.example.com"
+            custom = "https://custom.example.com"
+        "#},
+    )
+    .unwrap();
+    let args = vec!["show-config"];
+
+    let snapbox = runner(&args).current_dir(local_dir.path());
+
+    let output = snapbox.assert().success();
+
+    assert_stdout_contains(
+        output,
+        r#"[WARNING] unknown config key(s) ["custom"] ignored (incorrect key, or may require newer/older sncast)"#,
     );
 }
 

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -18,6 +18,15 @@ If it is not found, default values will be used.
 All fields are optional and do not have to be provided. In case a field is not defined in a manifest file, it must be provided in CLI when executing a relevant `sncast` command.
 Profiles allow you to define different sets of configurations for various environments or use cases. For more details, see the [profiles explanation](../projects/configuration.md).
 
+> 📝 **Tip**
+> 
+> If this `sncast` version does not recognize a key, this key will be ignored with a warning:
+> ```toml
+> [sncast.myprofile]
+> unknown-key = "some value"
+> ```
+> To avoid these warnings, use latest `sncast` version and update your config to the latest format.
+
 #### `url`
 
 The `url` field specifies the address of RPC provider. It's mutually exclusive with the `network` field.

--- a/docs/src/appendix/snfoundry-toml.md
+++ b/docs/src/appendix/snfoundry-toml.md
@@ -20,12 +20,12 @@ Profiles allow you to define different sets of configurations for various enviro
 
 > 📝 **Tip**
 > 
-> If this `sncast` version does not recognize a key, this key will be ignored with a warning:
+> Keys unrecognized by the currently used `sncast` version are ignored with a warning:
 > ```toml
 > [sncast.myprofile]
 > unknown-key = "some value"
 > ```
-> To avoid these warnings, use latest `sncast` version and update your config to the latest format.
+> To avoid these warnings, use the latest `sncast` version and update your config to the latest format.
 
 #### `url`
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4378 

## Introduced changes

<!-- A brief description of the changes -->

Now, instead of unknown config keys being hard error, a warning will be emmited:
- List of unknown keys
- Affected config files

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
