### PR TITLE
Support backtrace on test-level 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Support for structs, enums, tuples, arrays and spans in [live debugging]((https://foundry-rs.github.io/starknet-foundry/snforge-advanced-features/debugging.html#live-debugging))
+- Backtrace support for panics that originate directly in a test function body, not only inside called contracts. Read more [here](https://foundry-rs.github.io/starknet-foundry/snforge-advanced-features/debugging.html#backtrace).
 
 #### Fixed
 

--- a/crates/cheatnet/tests/contracts/Scarb.toml
+++ b/crates/cheatnet/tests/contracts/Scarb.toml
@@ -3,7 +3,6 @@ name = "cheatnet_testing_contracts"
 version = "0.1.0"
 # TODO(#4091): Add edition once Scarb version in .tool-versions is at least 2.17
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest
 [[target.starknet-contract]]
 
 [dependencies]

--- a/crates/data-transformer/tests/data/data_transformer/Scarb.toml
+++ b/crates/data-transformer/tests/data/data_transformer/Scarb.toml
@@ -3,8 +3,6 @@ name = "data_transformer_contract"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.9.4"
 alexandria_data_structures = "0.5.0"

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::display::{Backtrace, BacktraceStack, render_fork_backtrace};
+use crate::backtrace::display::{Backtrace, BacktraceKind, BacktraceStack, render_fork_backtrace};
 use anyhow::Context;
 use anyhow::Result;
 use cairo_annotations::annotations::TryFromDebugInfo;
@@ -8,6 +8,7 @@ use cairo_annotations::annotations::coverage::{
 use cairo_annotations::annotations::profiler::{
     ProfilerAnnotationsV1, VersionedProfilerAnnotations,
 };
+use cairo_lang_sierra::debug_info::DebugInfo;
 use cairo_lang_sierra::program::StatementIdx;
 use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
@@ -69,61 +70,29 @@ impl ContractOrigin {
     }
 }
 
-struct ContractBacktraceData {
-    contract_name: String,
+struct BacktraceSourceData {
+    kind: BacktraceKind,
+    name: String,
     casm_debug_info_start_offsets: Vec<usize>,
     coverage_annotations: CoverageAnnotationsV1,
     profiler_annotations: ProfilerAnnotationsV1,
 }
 
-impl ContractBacktraceData {
-    fn new(class_hash: &ClassHash, contracts_data: &ContractsData) -> Result<Self> {
-        let module_path = contracts_data
-            .class_hashes
-            .get_by_right(class_hash)
-            .context(format!(
-                "module path not found for class hash: {class_hash}"
-            ))?;
-        let contract = contracts_data
-            .contracts
-            .get(module_path)
-            .context(format!("contract not found for module path: {module_path}"))?;
-
-        let contract_artifacts = &contract.artifacts;
-
-        let contract_class = serde_json::from_str::<ContractClass>(&contract_artifacts.sierra)?;
-
-        let sierra_debug_info = contract_class
-            .sierra_program_debug_info
-            .as_ref()
-            .context("debug info not found")?;
-
+impl BacktraceSourceData {
+    fn from_debug_info(
+        kind: BacktraceKind,
+        name: String,
+        casm_debug_info_start_offsets: Vec<usize>,
+        sierra_debug_info: &DebugInfo,
+    ) -> Result<Self> {
         let VersionedCoverageAnnotations::V1(coverage_annotations) =
-            VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)
-                .expect("this should not fail, as we are doing validation in the `can_backtrace_be_generated` function");
-
+            VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)?;
         let VersionedProfilerAnnotations::V1(profiler_annotations) =
-            VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info).expect("this should not fail, as we are doing validation in the `can_backtrace_be_generated` function");
-
-        let extracted_sierra = contract_class
-            .extract_sierra_program(false)
-            .expect("extraction should succeed");
-        // FIXME(https://github.com/software-mansion/universal-sierra-compiler/issues/98): Use CASM debug info from USC once it provides it.
-        let (_, debug_info) = CasmContractClass::from_contract_class_with_debug_info(
-            contract_class,
-            extracted_sierra,
-            true,
-            usize::MAX,
-        )?;
-
-        let casm_debug_info_start_offsets = debug_info
-            .sierra_statement_info
-            .iter()
-            .map(|statement_debug_info| statement_debug_info.start_offset)
-            .collect();
+            VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info)?;
 
         Ok(Self {
-            contract_name: contract_name_from_module_path(module_path).to_string(),
+            kind,
+            name,
             casm_debug_info_start_offsets,
             coverage_annotations,
             profiler_annotations,
@@ -183,10 +152,9 @@ impl ContractBacktraceData {
             .flatten_ok()
             .collect::<Result<Vec<_>>>()?;
 
-        let contract_name = &self.contract_name;
-
         let backtrace_stack = BacktraceStack {
-            contract_name,
+            kind: self.kind,
+            name: &self.name,
             stack,
         };
 
@@ -194,40 +162,91 @@ impl ContractBacktraceData {
     }
 }
 
-pub fn render_test_backtrace(
-    test_name: &str,
-    casm_start_offsets: Vec<usize>,
-    versioned_program_path: &Utf8Path,
-    pcs: &[usize],
-) -> Result<String> {
-    let raw = fs::read_to_string(versioned_program_path).with_context(|| {
-        format!("failed to read test sierra program at: {versioned_program_path}")
-    })?;
-    let program_artifact = match serde_json::from_str::<VersionedProgram>(&raw)? {
-        VersionedProgram::V1 { program, .. } => program,
-    };
+struct ContractBacktraceData(BacktraceSourceData);
 
-    let sierra_debug_info = program_artifact
-        .debug_info
-        .as_ref()
-        .context("debug info not found")?;
+impl ContractBacktraceData {
+    fn new(class_hash: &ClassHash, contracts_data: &ContractsData) -> Result<Self> {
+        let module_path = contracts_data
+            .class_hashes
+            .get_by_right(class_hash)
+            .context(format!(
+                "module path not found for class hash: {class_hash}"
+            ))?;
+        let contract = contracts_data
+            .contracts
+            .get(module_path)
+            .context(format!("contract not found for module path: {module_path}"))?;
 
-    let VersionedCoverageAnnotations::V1(coverage_annotations) =
-        VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)?;
-    let VersionedProfilerAnnotations::V1(profiler_annotations) =
-        VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info)?;
+        let contract_artifacts = &contract.artifacts;
 
-    let data = ContractBacktraceData {
-        contract_name: test_name.to_string(),
-        casm_debug_info_start_offsets: casm_start_offsets,
-        coverage_annotations,
-        profiler_annotations,
-    };
+        let contract_class = serde_json::from_str::<ContractClass>(&contract_artifacts.sierra)?;
 
-    let backtrace = data.render_backtrace(pcs)?;
-    Ok(backtrace.replacen(
-        "error occurred in contract '",
-        "error occurred in test '",
-        1,
-    ))
+        let sierra_debug_info = contract_class
+            .sierra_program_debug_info
+            .clone()
+            .context("debug info not found")?;
+
+        let extracted_sierra = contract_class
+            .extract_sierra_program(false)
+            .expect("extraction should succeed");
+        // FIXME(https://github.com/software-mansion/universal-sierra-compiler/issues/98): Use CASM debug info from USC once it provides it.
+        let (_, debug_info) = CasmContractClass::from_contract_class_with_debug_info(
+            contract_class,
+            extracted_sierra,
+            true,
+            usize::MAX,
+        )?;
+
+        let casm_debug_info_start_offsets = debug_info
+            .sierra_statement_info
+            .iter()
+            .map(|statement_debug_info| statement_debug_info.start_offset)
+            .collect();
+
+        Ok(Self(BacktraceSourceData::from_debug_info(
+            BacktraceKind::Contract,
+            contract_name_from_module_path(module_path).to_string(),
+            casm_debug_info_start_offsets,
+            &sierra_debug_info,
+        )?))
+    }
+
+    fn render_backtrace(&self, pcs: &[usize]) -> Result<String> {
+        self.0.render_backtrace(pcs)
+    }
+}
+
+pub struct TestBacktraceData(BacktraceSourceData);
+
+impl TestBacktraceData {
+    pub fn new(
+        test_name: &str,
+        casm_start_offsets: Vec<usize>,
+        versioned_program_path: &Utf8Path,
+    ) -> Result<Self> {
+        let raw = fs::read_to_string(versioned_program_path).with_context(|| {
+            format!("failed to read test sierra program at: {versioned_program_path}")
+        })?;
+        let program_artifact = match serde_json::from_str::<VersionedProgram>(&raw)? {
+            VersionedProgram::V1 { program, .. } => program,
+        };
+
+        let sierra_debug_info = program_artifact
+            .debug_info
+            .as_ref()
+            .context("debug info not found")?;
+
+        let source = BacktraceSourceData::from_debug_info(
+            BacktraceKind::Test,
+            test_name.to_string(),
+            casm_start_offsets,
+            sierra_debug_info,
+        )?;
+
+        Ok(Self(source))
+    }
+
+    pub fn render_backtrace(&self, pcs: &[usize]) -> Result<String> {
+        self.0.render_backtrace(pcs)
+    }
 }

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -225,5 +225,10 @@ pub fn render_test_backtrace(
         profiler_annotations,
     };
 
-    data.render_backtrace(pcs)
+    let backtrace = data.render_backtrace(pcs)?;
+    Ok(backtrace.replacen(
+        "error occurred in contract '",
+        "error occurred in test '",
+        1,
+    ))
 }

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -189,6 +189,7 @@ impl ContractBacktraceData {
         let extracted_sierra = contract_class
             .extract_sierra_program(false)
             .expect("extraction should succeed");
+
         // FIXME(https://github.com/software-mansion/universal-sierra-compiler/issues/98): Use CASM debug info from USC once it provides it.
         let (_, debug_info) = CasmContractClass::from_contract_class_with_debug_info(
             contract_class,

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -9,8 +9,10 @@ use cairo_annotations::annotations::profiler::{
     ProfilerAnnotationsV1, VersionedProfilerAnnotations,
 };
 use cairo_lang_sierra::program::StatementIdx;
+use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
+use camino::Utf8Path;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::contract_name_from_module_path;
 use itertools::Itertools;
@@ -18,6 +20,7 @@ use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 use starknet_api::core::ClassHash;
 use std::collections::{HashMap, HashSet};
+use std::fs;
 
 pub struct ContractBacktraceDataMapping(HashMap<ClassHash, ContractOrigin>);
 
@@ -189,4 +192,38 @@ impl ContractBacktraceData {
 
         Ok(backtrace_stack.to_string())
     }
+}
+
+
+pub fn render_test_backtrace(
+    test_name: &str,
+    casm_start_offsets: Vec<usize>,
+    versioned_program_path: &Utf8Path,
+    pcs: &[usize],
+) -> Result<String> {
+    let raw = fs::read_to_string(versioned_program_path).with_context(|| {
+        format!("failed to read test sierra program at: {versioned_program_path}")
+    })?;
+    let program_artifact = match serde_json::from_str::<VersionedProgram>(&raw)? {
+        VersionedProgram::V1 { program, .. } => program,
+    };
+
+    let sierra_debug_info = program_artifact
+        .debug_info
+        .as_ref()
+        .context("debug info not found")?;
+
+    let VersionedCoverageAnnotations::V1(coverage_annotations) =
+        VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)?;
+    let VersionedProfilerAnnotations::V1(profiler_annotations) =
+        VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info)?;
+
+    let data = ContractBacktraceData {
+        contract_name: test_name.to_string(),
+        casm_debug_info_start_offsets: casm_start_offsets,
+        coverage_annotations,
+        profiler_annotations,
+    };
+
+    data.render_backtrace(pcs)
 }

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -194,7 +194,6 @@ impl ContractBacktraceData {
     }
 }
 
-
 pub fn render_test_backtrace(
     test_name: &str,
     casm_start_offsets: Vec<usize>,

--- a/crates/forge-runner/src/backtrace/display.rs
+++ b/crates/forge-runner/src/backtrace/display.rs
@@ -10,8 +10,15 @@ pub struct Backtrace<'a> {
     pub inlined: bool,
 }
 
+#[derive(Clone, Copy)]
+pub enum BacktraceKind {
+    Contract,
+    Test,
+}
+
 pub struct BacktraceStack<'a> {
-    pub contract_name: &'a str,
+    pub kind: BacktraceKind,
+    pub name: &'a str,
     pub stack: Vec<Backtrace<'a>>,
 }
 
@@ -32,7 +39,11 @@ impl Display for Backtrace<'_> {
 
 impl Display for BacktraceStack<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "error occurred in contract '{}'", self.contract_name)?;
+        let kind = match self.kind {
+            BacktraceKind::Contract => "contract",
+            BacktraceKind::Test => "test",
+        };
+        writeln!(f, "error occurred in {kind} '{}'", self.name)?;
         writeln!(f, "stack backtrace:")?;
         for (i, backtrace) in self.stack.iter().enumerate() {
             writeln!(f, "   {i}: {backtrace}")?;

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::data::ContractBacktraceDataMapping;
+use crate::backtrace::data::{ContractBacktraceDataMapping, TestBacktraceData};
 use anyhow::Result;
 use camino::Utf8Path;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
@@ -89,13 +89,13 @@ pub fn get_test_backtrace(
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {
-    data::render_test_backtrace(
+    TestBacktraceData::new(
         test_name,
         test_backtrace.casm_start_offsets.clone(),
         versioned_program_path,
-        &test_backtrace.pcs,
     )
-    .unwrap_or_else(|err| format!("failed to create backtrace: {err}"))
+    .and_then(|data| data.render_backtrace(&test_backtrace.pcs))
+    .unwrap_or_else(|err| format!("failed to create test backtrace: {err}"))
 }
 
 #[must_use]

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -14,7 +14,6 @@ pub struct TestBacktraceContext {
     pub casm_start_offsets: Vec<usize>,
 }
 
-/// Appends a backtrace footer for a failure.
 #[must_use]
 pub fn add_test_backtrace_footer(
     message: String,

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -14,46 +14,48 @@ pub struct TestBacktraceContext {
     pub casm_start_offsets: Vec<usize>,
 }
 
-#[must_use]
-pub fn add_backtrace_footer(
-    message: String,
-    contracts_data: &ContractsData,
-    encountered_errors: &EncounteredErrors,
-) -> String {
-    if encountered_errors.is_empty() {
-        return message;
-    }
-
-    let backtrace = if is_backtrace_enabled() {
-        get_backtrace(contracts_data, encountered_errors)
-    } else {
-        format!("note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace")
-    };
-
-    format!("{message}\n{backtrace}")
-}
-
+/// When any contract registered an error, prefers the contract-level backtrace.
+/// Otherwise, when the panic originates in the test body itself, renders a test-level backtrace.
 #[must_use]
 pub fn get_backtrace(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
-) -> String {
-    let class_hashes = encountered_errors.keys().copied().collect();
+    test_backtrace: Option<&TestBacktraceContext>,
+    versioned_program_path: &Utf8Path,
+    test_name: &str,
+) -> Option<String> {
+    if !encountered_errors.is_empty() {
+        let class_hashes = encountered_errors.keys().copied().collect();
 
-    ContractBacktraceDataMapping::new(contracts_data, class_hashes)
-        .and_then(|data_mapping| {
-            encountered_errors
-                .iter()
-                .map(|(class_hash, pcs)| data_mapping.render_backtrace(pcs, class_hash))
-                .collect::<Result<Vec<_>>>()
-                .map(|backtrace| backtrace.join("\n"))
-        })
-        .unwrap_or_else(|err| format!("failed to create backtrace: {err}"))
+        let contract_part = ContractBacktraceDataMapping::new(contracts_data, class_hashes)
+            .and_then(|data_mapping| {
+                encountered_errors
+                    .iter()
+                    .map(|(class_hash, pcs)| data_mapping.render_backtrace(pcs, class_hash))
+                    .collect::<Result<Vec<_>>>()
+                    .map(|backtrace| backtrace.join("\n"))
+            })
+            .unwrap_or_else(|err| format!("failed to create backtrace: {err}"));
+
+        return Some(contract_part);
+    }
+
+    if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) {
+        let test_part = TestBacktraceData::new(
+            test_name,
+            bt.casm_start_offsets.clone(),
+            versioned_program_path,
+        )
+        .and_then(|data| data.render_backtrace(&bt.pcs))
+        .unwrap_or_else(|err| format!("failed to create test backtrace: {err}"));
+
+        return Some(test_part);
+    }
+
+    None
 }
 
 /// Appends a backtrace footer for a failure.
-/// When any contract registered an error, prefers the contract-level backtrace.
-/// Otherwise, when the panic originates in the test body itself, renders a test-level backtrace.
 #[must_use]
 pub fn add_test_backtrace_footer(
     message: String,
@@ -63,36 +65,32 @@ pub fn add_test_backtrace_footer(
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {
-    if !encountered_errors.is_empty() {
-        return add_backtrace_footer(message, contracts_data, encountered_errors);
+    let has_backtrace =
+        !encountered_errors.is_empty() || test_backtrace.is_some_and(|bt| !bt.pcs.is_empty());
+
+    if !has_backtrace {
+        return message;
     }
 
-    let Some(test_backtrace) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) else {
-        return message;
-    };
-
     let backtrace = if is_backtrace_enabled() {
-        get_test_backtrace(test_backtrace, versioned_program_path, test_name)
+        get_backtrace(
+            contracts_data,
+            encountered_errors,
+            test_backtrace,
+            versioned_program_path,
+            test_name,
+        )
     } else {
-        format!("note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace")
+        Some(format!(
+            "note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace"
+        ))
     };
 
-    format!("{message}\n{backtrace}")
-}
-
-#[must_use]
-pub fn get_test_backtrace(
-    test_backtrace: &TestBacktraceContext,
-    versioned_program_path: &Utf8Path,
-    test_name: &str,
-) -> String {
-    TestBacktraceData::new(
-        test_name,
-        test_backtrace.casm_start_offsets.clone(),
-        versioned_program_path,
-    )
-    .and_then(|data| data.render_backtrace(&test_backtrace.pcs))
-    .unwrap_or_else(|err| format!("failed to create test backtrace: {err}"))
+    if let Some(backtrace) = backtrace {
+        format!("{message}\n{backtrace}")
+    } else {
+        message
+    }
 }
 
 #[must_use]

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -14,6 +14,44 @@ pub struct TestBacktraceContext {
     pub casm_start_offsets: Vec<usize>,
 }
 
+/// Appends a backtrace footer for a failure.
+#[must_use]
+pub fn add_test_backtrace_footer(
+    message: String,
+    contracts_data: &ContractsData,
+    encountered_errors: &EncounteredErrors,
+    test_backtrace: Option<&TestBacktraceContext>,
+    versioned_program_path: &Utf8Path,
+    test_name: &str,
+) -> String {
+    let has_backtrace =
+        !encountered_errors.is_empty() || test_backtrace.is_some_and(|bt| !bt.pcs.is_empty());
+
+    if !has_backtrace {
+        return message;
+    }
+
+    let backtrace = if is_backtrace_enabled() {
+        get_backtrace(
+            contracts_data,
+            encountered_errors,
+            test_backtrace,
+            versioned_program_path,
+            test_name,
+        )
+    } else {
+        Some(format!(
+            "note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace"
+        ))
+    };
+
+    if let Some(backtrace) = backtrace {
+        format!("{message}\n{backtrace}")
+    } else {
+        message
+    }
+}
+
 /// When any contract registered an error, prefers the contract-level backtrace.
 /// Otherwise, when the panic originates in the test body itself, renders a test-level backtrace.
 #[must_use]
@@ -53,44 +91,6 @@ pub fn get_backtrace(
     }
 
     None
-}
-
-/// Appends a backtrace footer for a failure.
-#[must_use]
-pub fn add_test_backtrace_footer(
-    message: String,
-    contracts_data: &ContractsData,
-    encountered_errors: &EncounteredErrors,
-    test_backtrace: Option<&TestBacktraceContext>,
-    versioned_program_path: &Utf8Path,
-    test_name: &str,
-) -> String {
-    let has_backtrace =
-        !encountered_errors.is_empty() || test_backtrace.is_some_and(|bt| !bt.pcs.is_empty());
-
-    if !has_backtrace {
-        return message;
-    }
-
-    let backtrace = if is_backtrace_enabled() {
-        get_backtrace(
-            contracts_data,
-            encountered_errors,
-            test_backtrace,
-            versioned_program_path,
-            test_name,
-        )
-    } else {
-        Some(format!(
-            "note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace"
-        ))
-    };
-
-    if let Some(backtrace) = backtrace {
-        format!("{message}\n{backtrace}")
-    } else {
-        message
-    }
 }
 
 #[must_use]

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -1,5 +1,6 @@
 use crate::backtrace::data::ContractBacktraceDataMapping;
 use anyhow::Result;
+use camino::Utf8Path;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::state::EncounteredErrors;
 use std::env;
@@ -7,6 +8,14 @@ use std::env;
 mod data;
 mod display;
 const BACKTRACE_ENV: &str = "SNFORGE_BACKTRACE";
+
+pub struct TestBacktrace {
+    /// Program counters of the panic.
+    pub pcs: Vec<usize>,
+
+    /// Sierra-statement -> CASM offset mapping
+    pub casm_start_offsets: Vec<usize>,
+}
 
 #[must_use]
 pub fn add_backtrace_footer(
@@ -43,6 +52,50 @@ pub fn get_backtrace(
                 .map(|backtrace| backtrace.join("\n"))
         })
         .unwrap_or_else(|err| format!("failed to create backtrace: {err}"))
+}
+
+/// Appends a backtrace footer for a failure.
+/// When any contract registered an error, prefers the contract-level backtrace.
+/// Otherwise, when the panic originates in the test body itself, renders a test-level backtrace.
+#[must_use]
+pub fn add_test_backtrace_footer(
+    message: String,
+    contracts_data: &ContractsData,
+    encountered_errors: &EncounteredErrors,
+    test_backtrace: Option<&TestBacktrace>,
+    versioned_program_path: &Utf8Path,
+    test_name: &str,
+) -> String {
+    if !encountered_errors.is_empty() {
+        return add_backtrace_footer(message, contracts_data, encountered_errors);
+    }
+
+    let Some(test_backtrace) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) else {
+        return message;
+    };
+
+    let backtrace = if is_backtrace_enabled() {
+        get_test_backtrace(test_backtrace, versioned_program_path, test_name)
+    } else {
+        format!("note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace")
+    };
+
+    format!("{message}\n{backtrace}")
+}
+
+#[must_use]
+pub fn get_test_backtrace(
+    test_backtrace: &TestBacktrace,
+    versioned_program_path: &Utf8Path,
+    test_name: &str,
+) -> String {
+    data::render_test_backtrace(
+        test_name,
+        test_backtrace.casm_start_offsets.clone(),
+        versioned_program_path,
+        &test_backtrace.pcs,
+    )
+    .unwrap_or_else(|err| format!("failed to create backtrace: {err}"))
 }
 
 #[must_use]

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -9,11 +9,8 @@ mod data;
 mod display;
 const BACKTRACE_ENV: &str = "SNFORGE_BACKTRACE";
 
-pub struct TestBacktrace {
-    /// Program counters of the panic.
+pub struct TestBacktraceContext {
     pub pcs: Vec<usize>,
-
-    /// Sierra-statement -> CASM offset mapping
     pub casm_start_offsets: Vec<usize>,
 }
 
@@ -62,7 +59,7 @@ pub fn add_test_backtrace_footer(
     message: String,
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
-    test_backtrace: Option<&TestBacktrace>,
+    test_backtrace: Option<&TestBacktraceContext>,
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {
@@ -85,7 +82,7 @@ pub fn add_test_backtrace_footer(
 
 #[must_use]
 pub fn get_test_backtrace(
-    test_backtrace: &TestBacktrace,
+    test_backtrace: &TestBacktraceContext,
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::add_backtrace_footer;
+use crate::backtrace::{TestBacktrace, add_test_backtrace_footer};
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
 use crate::package_tests::with_config_resolved::{ResolvedForkConfig, TestCaseWithResolvedConfig};
@@ -36,6 +36,7 @@ use rand::prelude::StdRng;
 use runtime::starknet::context::{build_context, set_max_steps};
 use runtime::{ExtendedRuntime, StarknetRuntime};
 use scarb_oracle_hint_service::OracleHintService;
+use shared::vm::VirtualMachineExt;
 use starknet_api::execution_resources::GasVector;
 use std::cell::RefCell;
 use std::default::Default;
@@ -149,6 +150,7 @@ pub struct RunCompleted {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
+    pub(crate) test_backtrace: Option<TestBacktrace>,
 }
 
 pub struct RunError {
@@ -157,11 +159,12 @@ pub struct RunError {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
+    pub(crate) test_backtrace: Option<TestBacktrace>,
 }
 
 pub enum RunResult {
     Completed(Box<RunCompleted>),
-    Error(RunError),
+    Error(Box<RunError>),
 }
 
 #[expect(clippy::too_many_lines)]
@@ -346,6 +349,38 @@ pub fn run_test_case(
         .encountered_errors
         .clone();
 
+    // Capture PCs for a panic that originates in the test body itself.
+    // Mirrors the contract-level logic in `cairo1_execution.rs`,
+    // Note: test target is not deployed contract, so the PCs are carried separately instead of `register_error`.
+    let test_backtrace = {
+        let casm_start_offsets: Vec<usize> = casm_program
+            .debug_info
+            .iter()
+            .map(|(offset, _)| *offset)
+            .collect();
+
+        match &result {
+            Ok(call_info) if call_info.execution.failed => {
+                let pcs = forge_runtime
+                    .extended_runtime
+                    .extended_runtime
+                    .extended_runtime
+                    .panic_traceback
+                    .clone()
+                    .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback());
+                Some(TestBacktrace {
+                    pcs,
+                    casm_start_offsets,
+                })
+            }
+            Err(_) => Some(TestBacktrace {
+                pcs: runner.vm.get_reversed_pc_traceback(),
+                casm_start_offsets,
+            }),
+            Ok(_) => None,
+        }
+    };
+
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
     update_top_call_resources(&mut forge_runtime, tracked_resource);
@@ -387,15 +422,17 @@ pub fn run_test_case(
                 encountered_errors,
                 fuzzer_args,
                 fork_data,
+                test_backtrace,
             }))
         }
-        Err(error) => RunResult::Error(RunError {
+        Err(error) => RunResult::Error(Box::new(RunError {
             error: Box::new(error),
             call_trace: call_trace_ref,
             encountered_errors,
             fuzzer_args,
             fork_data,
-        }),
+            test_backtrace,
+        })),
     })
 }
 
@@ -435,7 +472,14 @@ fn extract_test_case_summary(
                 TestCaseSummary::Failed {
                     name: case.name.clone(),
                     msg: Some(message).map(|msg| {
-                        add_backtrace_footer(msg, contracts_data, &run_error.encountered_errors)
+                        add_test_backtrace_footer(
+                            msg,
+                            contracts_data,
+                            &run_error.encountered_errors,
+                            run_error.test_backtrace.as_ref(),
+                            versioned_program_path,
+                            &case.name,
+                        )
                     }),
                     fuzzer_args: run_error.fuzzer_args,
                     test_statistics: (),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -14,6 +14,7 @@ use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::cached_state::CachedState;
 use cairo_vm::Felt252;
 use cairo_vm::types::program::Program;
+use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -349,37 +350,8 @@ pub fn run_test_case(
         .encountered_errors
         .clone();
 
-    // Capture PCs for a panic that originates in the test body itself.
-    // Mirrors the contract-level logic in `cairo1_execution.rs`,
-    // Note: test target is not deployed contract, so the PCs are carried separately instead of `register_error`.
-    let test_backtrace = {
-        let casm_start_offsets = casm_program
-            .debug_info
-            .iter()
-            .map(|(offset, _)| *offset)
-            .collect();
-
-        match &result {
-            Ok(call_info) if call_info.execution.failed => {
-                let pcs = forge_runtime
-                    .extended_runtime
-                    .extended_runtime
-                    .extended_runtime
-                    .panic_traceback
-                    .clone()
-                    .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback());
-                Some(TestBacktraceContext {
-                    pcs,
-                    casm_start_offsets,
-                })
-            }
-            Err(_) => Some(TestBacktraceContext {
-                pcs: runner.vm.get_reversed_pc_traceback(),
-                casm_start_offsets,
-            }),
-            Ok(_) => None,
-        }
-    };
+    let test_backtrace =
+        capture_test_backtrace(&result, &forge_runtime, &runner, casm_program);
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
@@ -434,6 +406,43 @@ pub fn run_test_case(
             test_backtrace,
         })),
     })
+}
+
+// Capture PCs for a panic that originates in the test body itself.
+// Mirrors the contract-level logic in `cairo1_execution.rs`,
+// Note: test target is not deployed contract, so the PCs are carried separately instead of `register_error`.
+fn capture_test_backtrace(
+    result: &Result<CallInfo, CairoRunError>,
+    forge_runtime: &ForgeRuntime,
+    runner: &CairoRunner,
+    casm_program: &RawCasmProgram,
+) -> Option<TestBacktraceContext> {
+    let casm_start_offsets = casm_program
+        .debug_info
+        .iter()
+        .map(|(offset, _)| *offset)
+        .collect();
+
+    match result {
+        Ok(call_info) if call_info.execution.failed => {
+            let pcs = forge_runtime
+                .extended_runtime
+                .extended_runtime
+                .extended_runtime
+                .panic_traceback
+                .clone()
+                .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback());
+            Some(TestBacktraceContext {
+                pcs,
+                casm_start_offsets,
+            })
+        }
+        Err(_) => Some(TestBacktraceContext {
+            pcs: runner.vm.get_reversed_pc_traceback(),
+            casm_start_offsets,
+        }),
+        Ok(_) => None,
+    }
 }
 
 fn extract_test_case_summary(

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -353,7 +353,7 @@ pub fn run_test_case(
     // Mirrors the contract-level logic in `cairo1_execution.rs`,
     // Note: test target is not deployed contract, so the PCs are carried separately instead of `register_error`.
     let test_backtrace = {
-        let casm_start_offsets: Vec<usize> = casm_program
+        let casm_start_offsets = casm_program
             .debug_info
             .iter()
             .map(|(offset, _)| *offset)

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -14,9 +14,9 @@ use blockifier::execution::errors::EntryPointExecutionError;
 use blockifier::state::cached_state::CachedState;
 use cairo_vm::Felt252;
 use cairo_vm::types::program::Program;
-use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::errors::vm_errors::VirtualMachineError;
+use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use camino::{Utf8Path, Utf8PathBuf};
 use cheatnet::constants as cheatnet_constants;
 use cheatnet::forking::data::ForkData;
@@ -350,8 +350,7 @@ pub fn run_test_case(
         .encountered_errors
         .clone();
 
-    let test_backtrace =
-        capture_test_backtrace(&result, &forge_runtime, &runner, casm_program);
+    let test_backtrace = capture_test_backtrace(&result, &forge_runtime, &runner, casm_program);
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::{TestBacktrace, add_test_backtrace_footer};
+use crate::backtrace::{TestBacktraceContext, add_test_backtrace_footer};
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
 use crate::package_tests::with_config_resolved::{ResolvedForkConfig, TestCaseWithResolvedConfig};
@@ -150,7 +150,7 @@ pub struct RunCompleted {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
-    pub(crate) test_backtrace: Option<TestBacktrace>,
+    pub(crate) test_backtrace: Option<TestBacktraceContext>,
 }
 
 pub struct RunError {
@@ -159,7 +159,7 @@ pub struct RunError {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
-    pub(crate) test_backtrace: Option<TestBacktrace>,
+    pub(crate) test_backtrace: Option<TestBacktraceContext>,
 }
 
 pub enum RunResult {
@@ -368,12 +368,12 @@ pub fn run_test_case(
                     .panic_traceback
                     .clone()
                     .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback());
-                Some(TestBacktrace {
+                Some(TestBacktraceContext {
                     pcs,
                     casm_start_offsets,
                 })
             }
-            Err(_) => Some(TestBacktrace {
+            Err(_) => Some(TestBacktraceContext {
                 pcs: runner.vm.get_reversed_pc_traceback(),
                 casm_start_offsets,
             }),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -409,8 +409,8 @@ pub fn run_test_case(
 }
 
 // Capture PCs for a panic that originates in the test body itself.
-// Mirrors the contract-level logic in `cairo1_execution.rs`,
-// Note: test target is not deployed contract, so the PCs are carried separately instead of `register_error`.
+// Mirrors the contract-level logic in `cairo1_execution.rs` (`execute_entry_point_call_cairo1`) and `entry_point.rs` (`extract_trace_and_register_errors`).
+// Note: the test target is not a deployed contract, so instead of `register_error` PCs are returned in a `TestBacktraceContext`.
 fn capture_test_backtrace(
     result: &Result<CallInfo, CairoRunError>,
     forge_runtime: &ForgeRuntime,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,6 +1,4 @@
-use crate::backtrace::{
-    add_test_backtrace_footer, get_backtrace, get_test_backtrace, is_backtrace_enabled,
-};
+use crate::backtrace::{add_test_backtrace_footer, get_backtrace, is_backtrace_enabled};
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
@@ -376,13 +374,13 @@ impl TestCaseSummary<Single> {
                     if matching {
                         let backtrace_msg = is_backtrace_enabled()
                             .then(|| {
-                                if encountered_errors.is_empty() {
-                                    test_backtrace.as_ref().map(|bt| {
-                                        get_test_backtrace(bt, versioned_program_path, &name)
-                                    })
-                                } else {
-                                    Some(get_backtrace(contracts_data, &encountered_errors))
-                                }
+                                get_backtrace(
+                                    contracts_data,
+                                    &encountered_errors,
+                                    test_backtrace.as_ref(),
+                                    versioned_program_path,
+                                    &name,
+                                )
                             })
                             .flatten();
 

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,4 +1,6 @@
-use crate::backtrace::{add_test_backtrace_footer, get_backtrace, is_backtrace_enabled};
+use crate::backtrace::{
+    add_test_backtrace_footer, get_backtrace, get_test_backtrace, is_backtrace_enabled,
+};
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
@@ -371,10 +373,20 @@ impl TestCaseSummary<Single> {
                     let (matching, msg) =
                         check_if_matching_and_get_message(&value, expected_panic_value);
                     if matching {
+                        let backtrace_msg = is_backtrace_enabled().then(|| {
+                            if !encountered_errors.is_empty() {
+                                Some(get_backtrace(contracts_data, &encountered_errors))
+                            } else {
+                                test_backtrace.as_ref().map(|bt| {
+                                    get_test_backtrace(bt, versioned_program_path, &name)
+                                })
+                            }
+                        }).flatten();
+                   
+
                         TestCaseSummary::Passed {
                             name,
-                            msg: is_backtrace_enabled()
-                                .then(|| get_backtrace(contracts_data, &encountered_errors)),
+                            msg: backtrace_msg,
                             test_statistics: (),
                             gas_info,
                             used_resources,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -373,16 +373,17 @@ impl TestCaseSummary<Single> {
                     let (matching, msg) =
                         check_if_matching_and_get_message(&value, expected_panic_value);
                     if matching {
-                        let backtrace_msg = is_backtrace_enabled().then(|| {
-                            if !encountered_errors.is_empty() {
-                                Some(get_backtrace(contracts_data, &encountered_errors))
-                            } else {
-                                test_backtrace.as_ref().map(|bt| {
-                                    get_test_backtrace(bt, versioned_program_path, &name)
-                                })
-                            }
-                        }).flatten();
-                   
+                        let backtrace_msg = is_backtrace_enabled()
+                            .then(|| {
+                                if !encountered_errors.is_empty() {
+                                    Some(get_backtrace(contracts_data, &encountered_errors))
+                                } else {
+                                    test_backtrace.as_ref().map(|bt| {
+                                        get_test_backtrace(bt, versioned_program_path, &name)
+                                    })
+                                }
+                            })
+                            .flatten();
 
                         TestCaseSummary::Passed {
                             name,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::{add_backtrace_footer, get_backtrace, is_backtrace_enabled};
+use crate::backtrace::{add_test_backtrace_footer, get_backtrace, is_backtrace_enabled};
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
@@ -293,6 +293,7 @@ impl TestCaseSummary<Single> {
             encountered_errors,
             fuzzer_args,
             fork_data,
+            test_backtrace,
         }: RunCompleted,
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
@@ -351,9 +352,17 @@ impl TestCaseSummary<Single> {
             },
             RunStatus::Panic(value) => match &test_case.config.expected_result {
                 ExpectedTestResult::Success => TestCaseSummary::Failed {
-                    name,
-                    msg: build_readable_text(&value)
-                        .map(|msg| add_backtrace_footer(msg, contracts_data, &encountered_errors)),
+                    name: name.clone(),
+                    msg: build_readable_text(&value).map(|msg| {
+                        add_test_backtrace_footer(
+                            msg,
+                            contracts_data,
+                            &encountered_errors,
+                            test_backtrace.as_ref(),
+                            versioned_program_path,
+                            &name,
+                        )
+                    }),
                     fuzzer_args,
                     test_statistics: (),
                     debugging_trace,
@@ -379,9 +388,16 @@ impl TestCaseSummary<Single> {
                         }
                     } else {
                         TestCaseSummary::Failed {
-                            name,
+                            name: name.clone(),
                             msg: msg.map(|msg| {
-                                add_backtrace_footer(msg, contracts_data, &encountered_errors)
+                                add_test_backtrace_footer(
+                                    msg,
+                                    contracts_data,
+                                    &encountered_errors,
+                                    test_backtrace.as_ref(),
+                                    versioned_program_path,
+                                    &name,
+                                )
                             }),
                             fuzzer_args,
                             test_statistics: (),

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -283,7 +283,7 @@ fn check_if_matching_and_get_message(
 }
 
 impl TestCaseSummary<Single> {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     #[must_use]
     pub(crate) fn from_run_completed(
         RunCompleted {

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -285,6 +285,7 @@ fn check_if_matching_and_get_message(
 }
 
 impl TestCaseSummary<Single> {
+    #[allow(clippy::too_many_lines)]
     #[must_use]
     pub(crate) fn from_run_completed(
         RunCompleted {

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -375,12 +375,12 @@ impl TestCaseSummary<Single> {
                     if matching {
                         let backtrace_msg = is_backtrace_enabled()
                             .then(|| {
-                                if !encountered_errors.is_empty() {
-                                    Some(get_backtrace(contracts_data, &encountered_errors))
-                                } else {
+                                if encountered_errors.is_empty() {
                                     test_backtrace.as_ref().map(|bt| {
                                         get_test_backtrace(bt, versioned_program_path, &name)
                                     })
+                                } else {
+                                    Some(get_backtrace(contracts_data, &encountered_errors))
                                 }
                             })
                             .flatten();

--- a/crates/forge/tests/data/backtrace_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_panic/Scarb.toml
@@ -3,8 +3,6 @@ name = "backtrace_panic"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.8.5"
 

--- a/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.8.5"
+starknet = "2.16.0"
 
 [dev-dependencies]
 snforge_std = { path = "../../../../../snforge_std" }

--- a/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
@@ -10,7 +10,6 @@ starknet = "2.16.0"
 snforge_std = { path = "../../../../../snforge_std" }
 
 [[target.starknet-contract]]
-sierra = true
 
 [scripts]
 test = "snforge test"

--- a/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
@@ -1,0 +1,23 @@
+[package]
+name = "backtrace_test_panic"
+version = "0.1.0"
+edition = "2024_07"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
+
+[dependencies]
+starknet = "2.8.5"
+
+[dev-dependencies]
+snforge_std = { path = "../../../../../snforge_std" }
+
+[[target.starknet-contract]]
+sierra = true
+
+[scripts]
+test = "snforge test"
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+panic-backtrace = true

--- a/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_panic/Scarb.toml
@@ -3,8 +3,6 @@ name = "backtrace_test_panic"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.16.0"
 

--- a/crates/forge/tests/data/backtrace_test_panic/src/lib.cairo
+++ b/crates/forge/tests/data/backtrace_test_panic/src/lib.cairo
@@ -1,0 +1,17 @@
+pub fn fail_deep() {
+    assert(1 != 1, 'Assert failed');
+}
+
+pub fn fail() {
+    fail_deep();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fail;
+
+    #[test]
+    fn test_panics_in_test_body() {
+        fail();
+    }
+}

--- a/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
@@ -6,7 +6,7 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
-starknet = "2.8.5"
+starknet = "2.16.0"
 
 [dev-dependencies]
 snforge_std = { path = "../../../../../snforge_std" }

--- a/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
@@ -10,7 +10,6 @@ starknet = "2.16.0"
 snforge_std = { path = "../../../../../snforge_std" }
 
 [[target.starknet-contract]]
-sierra = true
 
 [scripts]
 test = "snforge test"

--- a/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
@@ -3,8 +3,6 @@ name = "backtrace_test_should_panic"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.16.0"
 

--- a/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic/Scarb.toml
@@ -1,0 +1,23 @@
+[package]
+name = "backtrace_test_should_panic"
+version = "0.1.0"
+edition = "2024_07"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
+
+[dependencies]
+starknet = "2.8.5"
+
+[dev-dependencies]
+snforge_std = { path = "../../../../../snforge_std" }
+
+[[target.starknet-contract]]
+sierra = true
+
+[scripts]
+test = "snforge test"
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+panic-backtrace = true

--- a/crates/forge/tests/data/backtrace_test_should_panic/src/lib.cairo
+++ b/crates/forge/tests/data/backtrace_test_should_panic/src/lib.cairo
@@ -1,0 +1,18 @@
+pub fn fail_deep() {
+    assert(1 != 1, 'Assert failed');
+}
+
+pub fn fail() {
+    fail_deep();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fail;
+
+    #[should_panic]
+    #[test]
+    fn test_panics_in_test_body_with_should_panic() {
+        fail();
+    }
+}

--- a/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
@@ -12,7 +12,6 @@ starknet = "2.16.0"
 snforge_std = { path = "../../../../../snforge_std" }
 
 [[target.starknet-contract]]
-sierra = true
 
 [scripts]
 test = "snforge test"

--- a/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
@@ -1,0 +1,23 @@
+[package]
+name = "backtrace_test_should_panic_mismatch"
+version = "0.1.0"
+edition = "2024_07"
+
+# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
+
+[dependencies]
+starknet = "2.16.0"
+
+[dev-dependencies]
+snforge_std = { path = "../../../../../snforge_std" }
+
+[[target.starknet-contract]]
+sierra = true
+
+[scripts]
+test = "snforge test"
+
+[profile.dev.cairo]
+unstable-add-statements-functions-debug-info = true
+unstable-add-statements-code-locations-debug-info = true
+panic-backtrace = true

--- a/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_test_should_panic_mismatch/Scarb.toml
@@ -3,8 +3,6 @@ name = "backtrace_test_should_panic_mismatch"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.16.0"
 

--- a/crates/forge/tests/data/backtrace_test_should_panic_mismatch/src/lib.cairo
+++ b/crates/forge/tests/data/backtrace_test_should_panic_mismatch/src/lib.cairo
@@ -1,0 +1,18 @@
+pub fn fail_deep() {
+    assert(1 != 1, 'Assert failed');
+}
+
+pub fn fail() {
+    fail_deep();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fail;
+
+    #[should_panic(expected: 'wrong msg')]
+    #[test]
+    fn test_panics_in_test_body_with_should_panic_mismatch() {
+        fail();
+    }
+}

--- a/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
@@ -3,8 +3,6 @@ name = "backtrace_vm_error"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.8.5"
 

--- a/crates/forge/tests/data/collection_with_lib/Scarb.toml
+++ b/crates/forge/tests/data/collection_with_lib/Scarb.toml
@@ -3,8 +3,6 @@ name = "collection_with_lib"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 # foo = { path = "vendor/foo" }
 

--- a/crates/forge/tests/data/collection_without_lib/Scarb.toml
+++ b/crates/forge/tests/data/collection_without_lib/Scarb.toml
@@ -3,8 +3,6 @@ name = "collection_without_lib"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 # foo = { path = "vendor/foo" }
 

--- a/crates/forge/tests/data/component_macros/Scarb.toml
+++ b/crates/forge/tests/data/component_macros/Scarb.toml
@@ -3,8 +3,6 @@ name = "component_macros"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/coverage_project/Scarb.toml
+++ b/crates/forge/tests/data/coverage_project/Scarb.toml
@@ -3,8 +3,6 @@ name = "coverage_project"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/dispatchers/Scarb.toml
+++ b/crates/forge/tests/data/dispatchers/Scarb.toml
@@ -3,8 +3,6 @@ name = "dispatchers"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.9.4"
 assert_macros = "2.9.4"

--- a/crates/forge/tests/data/empty/Scarb.toml
+++ b/crates/forge/tests/data/empty/Scarb.toml
@@ -3,8 +3,6 @@ name = "empty"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/forking/Scarb.toml
+++ b/crates/forge/tests/data/forking/Scarb.toml
@@ -3,8 +3,6 @@ name = "forking"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/fuzzing/Scarb.toml
+++ b/crates/forge/tests/data/fuzzing/Scarb.toml
@@ -3,8 +3,6 @@ name = "fuzzing"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/nonexistent_selector/Scarb.toml
+++ b/crates/forge/tests/data/nonexistent_selector/Scarb.toml
@@ -3,8 +3,6 @@ name = "nonexistent_selector"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/data/steps/Scarb.toml
+++ b/crates/forge/tests/data/steps/Scarb.toml
@@ -3,8 +3,6 @@ name = "steps"
 version = "0.1.0"
 edition = "2024_07"
 
-# See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
-
 [dependencies]
 starknet = "2.4.0"
 

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -271,6 +271,19 @@ fn snap_test_backtrace_test_level_should_panic() {
 }
 
 #[test]
+fn snap_test_backtrace_test_level_should_panic_expected_mismatch() {
+    let temp = setup_package("backtrace_test_should_panic_mismatch");
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
+        .assert()
+        .failure();
+
+    assert_cleaned_output!(output);
+}
+
+#[test]
 fn snap_test_handled_error_not_display() {
     let temp = setup_package("dispatchers");
 

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -244,6 +244,19 @@ fn snap_test_backtrace_test_level() {
 }
 
 #[test]
+fn snap_test_backtrace_test_level_should_panic() {
+    let temp = setup_package("backtrace_test_should_panic");
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
+        .assert()
+        .success();
+
+    assert_cleaned_output!(output);
+}
+
+#[test]
 fn snap_test_handled_error_not_display() {
     let temp = setup_package("dispatchers");
 

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -221,6 +221,45 @@ fn snap_test_backtrace_panic_without_inlines() {
     assert_cleaned_output!(output);
 }
 
+// A panic that originates directly in the test body (no contract involved) should still
+// prompt for `SNFORGE_BACKTRACE=1`, which previously only happened for contract-level panics.
+#[test]
+fn test_backtrace_test_level_missing_env() {
+    let temp = setup_package("backtrace_test_panic");
+
+    let output = test_runner(&temp).assert().failure();
+
+    assert_stdout_contains(
+        output,
+        indoc! {r"
+            Failure data:
+                0x417373657274206661696c6564 ('Assert failed')
+            note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
+       "},
+   
+    );
+}
+
+// With the env var set, the backtrace for a test-level panic points at the test source itself.
+#[test]
+fn test_backtrace_test_level() {
+    let temp = setup_package("backtrace_test_panic");
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .assert()
+        .failure();
+
+    assert_stdout_contains(
+        output,
+        indoc! {
+           "error occurred in contract 'backtrace_test_panic::tests::test_panics_in_test_body'
+            stack backtrace:
+            [..]at [..]src/lib.cairo:13:5"
+        },
+    );
+}
+
 #[test]
 fn snap_test_handled_error_not_display() {
     let temp = setup_package("dispatchers");

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -244,6 +244,20 @@ fn snap_test_backtrace_test_level() {
 }
 
 #[test]
+fn snap_test_backtrace_test_level_without_inlines() {
+    let temp = setup_package("backtrace_test_panic");
+    without_inlines(&temp);
+
+    let output = test_runner(&temp)
+        .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
+        .assert()
+        .failure();
+
+    assert_cleaned_output!(output);
+}
+
+#[test]
 fn snap_test_backtrace_test_level_should_panic() {
     let temp = setup_package("backtrace_test_should_panic");
 

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -221,43 +221,26 @@ fn snap_test_backtrace_panic_without_inlines() {
     assert_cleaned_output!(output);
 }
 
-// A panic that originates directly in the test body (no contract involved) should still
-// prompt for `SNFORGE_BACKTRACE=1`, which previously only happened for contract-level panics.
 #[test]
-fn test_backtrace_test_level_missing_env() {
+fn snap_test_backtrace_test_level_missing_env() {
     let temp = setup_package("backtrace_test_panic");
 
     let output = test_runner(&temp).assert().failure();
 
-    assert_stdout_contains(
-        output,
-        indoc! {r"
-            Failure data:
-                0x417373657274206661696c6564 ('Assert failed')
-            note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
-       "},
-   
-    );
+    assert_cleaned_output!(output);
 }
 
-// With the env var set, the backtrace for a test-level panic points at the test source itself.
 #[test]
-fn test_backtrace_test_level() {
+fn snap_test_backtrace_test_level() {
     let temp = setup_package("backtrace_test_panic");
 
     let output = test_runner(&temp)
         .env("SNFORGE_BACKTRACE", "1")
+        .env("SNFORGE_DETERMINISTIC_OUTPUT", "1")
         .assert()
         .failure();
 
-    assert_stdout_contains(
-        output,
-        indoc! {
-           "error occurred in contract 'backtrace_test_panic::tests::test_panics_in_test_body'
-            stack backtrace:
-            [..]at [..]src/lib.cairo:13:5"
-        },
-    );
+    assert_cleaned_output!(output);
 }
 
 #[test]

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -271,7 +271,7 @@ fn snap_test_backtrace_test_level_should_panic() {
 }
 
 #[test]
-fn snap_test_backtrace_test_level_should_panic_expected_mismatch() {
+fn snap_test_backtrace_test_level_should_panic_mismatch() {
     let temp = setup_package("backtrace_test_should_panic_mismatch");
 
     let output = test_runner(&temp)

--- a/crates/forge/tests/e2e/plugin_versions.rs
+++ b/crates/forge/tests/e2e/plugin_versions.rs
@@ -4,7 +4,6 @@ use camino::Utf8PathBuf;
 use indoc::{formatdoc, indoc};
 use scarb_api::ScarbCommand;
 use shared::test_utils::output_assert::assert_stdout_contains;
-use snapbox::cmd::Command;
 use toml_edit::Document;
 
 #[test]

--- a/crates/forge/tests/e2e/plugin_versions.rs
+++ b/crates/forge/tests/e2e/plugin_versions.rs
@@ -4,6 +4,7 @@ use camino::Utf8PathBuf;
 use indoc::{formatdoc, indoc};
 use scarb_api::ScarbCommand;
 use shared::test_utils::output_assert::assert_stdout_contains;
+use snapbox::cmd::Command;
 use toml_edit::Document;
 
 #[test]

--- a/crates/forge/tests/e2e/plugin_versions.rs
+++ b/crates/forge/tests/e2e/plugin_versions.rs
@@ -4,7 +4,6 @@ use camino::Utf8PathBuf;
 use indoc::{formatdoc, indoc};
 use scarb_api::ScarbCommand;
 use shared::test_utils::output_assert::assert_stdout_contains;
-use snapbox::cmd::Command;
 use toml_edit::Document;
 
 #[test]
@@ -32,6 +31,8 @@ fn new_with_new_scarb() {
 #[cfg(feature = "scarb_2_13_1")]
 #[test]
 fn new_with_minimal_scarb() {
+    use snapbox::cmd::Command;
+
     let temp = tempdir_with_tool_versions().unwrap();
     Command::new("asdf")
         .current_dir(&temp)

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.16.1.snap
@@ -1,0 +1,25 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   3: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.17.0.snap
@@ -1,0 +1,25 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   3: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level@2.18.0.snap
@@ -1,0 +1,25 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   3: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.16.1.snap
@@ -1,0 +1,16 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.17.0.snap
@@ -1,0 +1,16 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_missing_env@2.18.0.snap
@@ -1,0 +1,16 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.16.1.snap
@@ -1,0 +1,18 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[PASS] backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~14440)
+
+error occurred in test 'backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic__snforge_internal_test_generated
+       at [..]lib.cairo:14:5

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.17.0.snap
@@ -1,0 +1,18 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[PASS] backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~14440)
+
+error occurred in test 'backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic__snforge_internal_test_generated
+       at [..]lib.cairo:14:5

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic@2.18.0.snap
@@ -1,0 +1,18 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[PASS] backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic (l1_gas: ~0, l1_data_gas: ~0, l2_gas: ~14440)
+
+error occurred in test 'backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic::tests::test_panics_in_test_body_with_should_panic__snforge_internal_test_generated
+       at [..]lib.cairo:14:5

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.16.1.snap
@@ -1,0 +1,27 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+
+Failure data:
+    Incorrect panic data
+    Actual:    [0x417373657274206661696c6564] (Assert failed)
+    Expected:  [0x77726f6e67206d7367] (wrong msg)
+
+error occurred in test 'backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch__snforge_internal_test_generated
+       at [..]lib.cairo:14:5
+
+
+Failures:
+    backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.17.0.snap
@@ -1,0 +1,27 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+
+Failure data:
+    Incorrect panic data
+    Actual:    [0x417373657274206661696c6564] (Assert failed)
+    Expected:  [0x77726f6e67206d7367] (wrong msg)
+
+error occurred in test 'backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch__snforge_internal_test_generated
+       at [..]lib.cairo:14:5
+
+
+Failures:
+    backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_should_panic_mismatch@2.18.0.snap
@@ -1,0 +1,27 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+
+Failure data:
+    Incorrect panic data
+    Actual:    [0x417373657274206661696c6564] (Assert failed)
+    Expected:  [0x77726f6e67206d7367] (wrong msg)
+
+error occurred in test 'backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch'
+stack backtrace:
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: (inlined) backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch
+       at [..]lib.cairo:14:5
+   3: backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch__snforge_internal_test_generated
+       at [..]lib.cairo:14:5
+
+
+Failures:
+    backtrace_test_should_panic_mismatch::tests::test_panics_in_test_body_with_should_panic_mismatch

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.16.1.snap
@@ -1,0 +1,29 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::array_inline_macro
+       at [..]lib.cairo:346:11
+   1: core::assert
+       at [..]lib.cairo:373:9
+   2: backtrace_test_panic::fail_deep
+       at [..]lib.cairo:2:5
+   3: snforge_std::cheatcode::is_config_run
+       at [..]cheatcode.cairo:31:5
+   4: backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   5: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.17.0.snap
@@ -1,0 +1,29 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::array_inline_macro
+       at [..]lib.cairo:346:11
+   1: core::assert
+       at [..]lib.cairo:373:9
+   2: backtrace_test_panic::fail_deep
+       at [..]lib.cairo:2:5
+   3: snforge_std::cheatcode::is_config_run
+       at [..]cheatcode.cairo:31:5
+   4: backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   5: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_test_level_without_inlines@2.18.0.snap
@@ -1,0 +1,29 @@
+---
+source: crates/forge/tests/e2e/backtrace.rs
+expression: stdout
+---
+
+
+[FAIL] backtrace_test_panic::tests::test_panics_in_test_body
+
+Failure data:
+    0x417373657274206661696c6564 ('Assert failed')
+
+error occurred in test 'backtrace_test_panic::tests::test_panics_in_test_body'
+stack backtrace:
+   0: core::array_inline_macro
+       at [..]lib.cairo:346:11
+   1: core::assert
+       at [..]lib.cairo:373:9
+   2: backtrace_test_panic::fail_deep
+       at [..]lib.cairo:2:5
+   3: snforge_std::cheatcode::is_config_run
+       at [..]cheatcode.cairo:31:5
+   4: backtrace_test_panic::tests::test_panics_in_test_body
+       at [..]lib.cairo:13:5
+   5: backtrace_test_panic::tests::test_panics_in_test_body__snforge_internal_test_generated
+       at [..]lib.cairo:13:5
+
+
+Failures:
+    backtrace_test_panic::tests::test_panics_in_test_body

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -211,7 +211,7 @@ panic-backtrace = true
 
 ### Usage
 
-If your test or contract fails and a backtrace can be generated, `snforge` will prompt you to run the operation again with the
+If your test or contract call fails and a backtrace can be generated, `snforge` will prompt you to run the operation again with the
 `SNFORGE_BACKTRACE=1` environment variable (if it’s not already configured). For example, you may see failure data like
 this:
 

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -211,7 +211,7 @@ panic-backtrace = true
 
 ### Usage
 
-If your contract fails and a backtrace can be generated, `snforge` will prompt you to run the operation again with the
+If your test or contract fails and a backtrace can be generated, `snforge` will prompt you to run the operation again with the
 `SNFORGE_BACKTRACE=1` environment variable (if it’s not already configured). For example, you may see failure data like
 this:
 
@@ -234,8 +234,8 @@ note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
 
 To enable backtrace, simply set the `SNFORGE_BACKTRACE=1` environment variable and rerun the operation.
 
-When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in the
-contracts where the errors occurred. Here's an example of what you might see:
+When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in test
+code or contracts where the errors occurred. Here's an example of what you might see:
 
 <!-- TODO(#2713) -->
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #3610 

## Stack
- #4400
- #4428
- #4442
- #4444 


## Introduced changes

<!-- A brief description of the changes -->

- Add backtrace support for panics that originate directly in a test function body, not only inside called contracts
- Note: this PR is minimal change, for now contract backtraces take priority. Next PR merges them, so both contract backtrace and test backtrace are displayed
- This also fixes some unnecessary extra whitespace: https://github.com/foundry-rs/starknet-foundry/pull/4400#discussion_r3435468682
  

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
