### PR TITLE
Dedup and unify `get_or_create_global_config_path` logic

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,10 @@ filter = 'package(sncast) and test(=e2e::devnet_accounts::use_devnet_account_wit
 retries = { backoff = "exponential", count = 3, delay = "5s" }
 
 [[profile.default.overrides]]
+filter = 'package(sncast) and test(=e2e::script::general::test_incompatible_sncast_std_version)'
+retries = { backoff = "exponential", count = 3, delay = "5s" }
+
+[[profile.default.overrides]]
 filter = 'package(sncast) and test(=e2e::tx_status::test_incorrect_transaction_hash)'
 retries = 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - Unknown keys in `snfoundry.toml` (`[sncast.<profile>]`, `[sncast.<profile>.networks]`, `wait-params`) now emit a warning and are ignored instead of causing a hard error, so configs can be shared across `sncast` versions. Read more in [configuration](https://foundry-rs.github.io/starknet-foundry/projects/configuration.html).
-
+- `sncast account import/deploy` interactive "make default account" prompt now emits a warning when global `snfoundry.toml` cannot be accessed/created.
 
 ## [0.61.0] - 2026-05-26
 

--- a/crates/sncast/src/helpers/config.rs
+++ b/crates/sncast/src/helpers/config.rs
@@ -1,14 +1,16 @@
 use crate::ValidatedWaitParams;
 use crate::helpers::configuration::show_explorer_links_default;
 use crate::helpers::constants::DEFAULT_ACCOUNTS_FILE;
+use crate::response::ui::UI;
 use anyhow::Result;
 use camino::Utf8PathBuf;
+use foundry_ui::components::warning::WarningMessage;
 use indoc::formatdoc;
 use std::fs::File;
 use std::io::Write;
 use std::{env, fs};
 
-pub fn get_or_create_global_config_path() -> Result<Utf8PathBuf> {
+fn get_or_create_global_config_path() -> Result<Utf8PathBuf> {
     let global_config_dir = match env::var("SNFOUNDRY_GLOBAL_CONFIG").ok() {
         Some(dir) => Utf8PathBuf::from(shellexpand::tilde(&dir).to_string()).into_std_path_buf(),
         None => dirs::home_dir()
@@ -28,6 +30,19 @@ pub fn get_or_create_global_config_path() -> Result<Utf8PathBuf> {
     }
 
     Ok(global_config_path)
+}
+
+#[must_use]
+pub fn resolve_global_config_path_or_warn(ui: &UI) -> Option<Utf8PathBuf> {
+    match get_or_create_global_config_path() {
+        Ok(path) => Some(path),
+        Err(err) => {
+            ui.print_warning(WarningMessage::new(format!(
+                "Could not get or create global config file: {err:?}. Proceeding without global config."
+            )));
+            None
+        }
+    }
 }
 
 fn build_default_manifest() -> String {

--- a/crates/sncast/src/helpers/interactive.rs
+++ b/crates/sncast/src/helpers/interactive.rs
@@ -1,4 +1,5 @@
-use crate::helpers::config::get_or_create_global_config_path;
+use crate::helpers::config::resolve_global_config_path_or_warn;
+use crate::response::ui::UI;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use configuration::search_config_upwards_relative_to;
@@ -28,10 +29,10 @@ impl Display for PromptSelection {
     }
 }
 
-pub fn prompt_to_add_account_as_default(account: &str) -> Result<()> {
+pub fn prompt_to_add_account_as_default(account: &str, ui: &UI) -> Result<()> {
     let mut options = Vec::new();
 
-    if let Ok(global_path) = get_or_create_global_config_path() {
+    if let Some(global_path) = resolve_global_config_path_or_warn(ui) {
         options.push(PromptSelection::GlobalDefault(global_path));
     }
 

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -25,7 +25,7 @@ use foundry_ui::components::warning::WarningMessage;
 use mimalloc::MiMalloc;
 use shared::auto_completions::{Completions, generate_completions};
 use sncast::helpers::command::process_command_result;
-use sncast::helpers::config::get_or_create_global_config_path;
+use sncast::helpers::config::resolve_global_config_path_or_warn;
 use sncast::helpers::configuration::{
     CastConfig, CliConfigOpts, ConfigScope, MaybeConfig, PartialCastConfig, warn_unknown_keys,
 };
@@ -834,15 +834,7 @@ fn get_cast_config(cli: &Cli, ui: &UI) -> Result<CastConfig> {
     };
 
     let local_path = find_config_file().ok();
-    let global_path = match get_or_create_global_config_path() {
-        Ok(p) => Some(p),
-        Err(err) => {
-            ui.print_warning(WarningMessage::new(format!(
-                "Could not get or create global config file: {err:?}. Proceeding without global config."
-            )));
-            None
-        }
-    };
+    let global_path = resolve_global_config_path_or_warn(ui);
     let profile = opts.profile.as_deref();
 
     let global_default =

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -229,7 +229,7 @@ pub async fn account(
 
             if run_interactive_prompt
                 && let Some(account_name) = result.as_ref().ok().map(|r| r.account_name.clone())
-                && let Err(err) = prompt_to_add_account_as_default(account_name.as_str())
+                && let Err(err) = prompt_to_add_account_as_default(account_name.as_str(), ui)
             {
                 // TODO(#3436)
                 ui.print_error(
@@ -312,6 +312,7 @@ pub async fn account(
                         .name
                         .as_ref()
                         .expect("Must be provided when using accounts file"),
+                    ui,
                 )
             {
                 // TODO(#3436)

--- a/crates/sncast/src/starknet_commands/config_path.rs
+++ b/crates/sncast/src/starknet_commands/config_path.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use clap::Args;
 use configuration::find_config_file;
-use foundry_ui::components::warning::WarningMessage;
-use sncast::helpers::config::get_or_create_global_config_path;
+use sncast::helpers::config::resolve_global_config_path_or_warn;
 use sncast::response::config_path::ConfigPathResponse;
 use sncast::response::ui::UI;
 
@@ -16,16 +15,8 @@ pub fn config_path(ui: &UI) -> Result<ConfigPathResponse> {
         .ok()
         .map(|path| path.canonicalize_utf8().unwrap_or(path));
 
-    // TODO: consider adding a wrapper-helper for this logic
-    let global = match get_or_create_global_config_path() {
-        Ok(path) => Some(path.canonicalize_utf8().unwrap_or(path)),
-        Err(err) => {
-            ui.print_warning(WarningMessage::new(format!(
-                "Could not get or create global config file: {err:?}. Proceeding without global config."
-            )));
-            None
-        }
-    };
+    let global =
+        resolve_global_config_path_or_warn(ui).map(|path| path.canonicalize_utf8().unwrap_or(path));
 
     Ok(ConfigPathResponse {
         local_config: local,


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

### Stack
- #4401 
- this PR

## Introduced changes

<!-- A brief description of the changes -->

- dedup global config path resolution; centralize global-config fallback warning
- interactive account prompt now also warns on global config path failure

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
