### PR TITLE
docs: add stateful invariant testing pattern recipe

### DIFF
--- a/docs/listings/invariant_testing_pattern/Scarb.toml
+++ b/docs/listings/invariant_testing_pattern/Scarb.toml
@@ -1,0 +1,17 @@
+[package]
+name = "invariant_testing_pattern"
+version = "0.1.0"
+edition = "2024_07"
+
+[dependencies]
+starknet = "2.8.5"
+assert_macros = "2.8.5"
+
+[dev-dependencies]
+snforge_std = { path = "../../../snforge_std" }
+
+[[target.starknet-contract]]
+sierra = true
+
+[scripts]
+test = "snforge test"

--- a/docs/listings/invariant_testing_pattern/src/lib.cairo
+++ b/docs/listings/invariant_testing_pattern/src/lib.cairo
@@ -1,0 +1,34 @@
+#[starknet::interface]
+pub trait IVault<TContractState> {
+    fn deposit(ref self: TContractState, amount: u64);
+    fn withdraw(ref self: TContractState, amount: u64);
+    fn balance(self: @TContractState) -> u64;
+}
+
+#[starknet::contract]
+pub mod Vault {
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+
+    #[storage]
+    struct Storage {
+        balance: u64,
+    }
+
+    #[abi(embed_v0)]
+    impl VaultImpl of super::IVault<ContractState> {
+        fn deposit(ref self: ContractState, amount: u64) {
+            let prev = self.balance.read();
+            self.balance.write(prev + amount);
+        }
+
+        fn withdraw(ref self: ContractState, amount: u64) {
+            let prev = self.balance.read();
+            assert(prev >= amount, 'insufficient balance');
+            self.balance.write(prev - amount);
+        }
+
+        fn balance(self: @ContractState) -> u64 {
+            self.balance.read()
+        }
+    }
+}

--- a/docs/listings/invariant_testing_pattern/tests/lib.cairo
+++ b/docs/listings/invariant_testing_pattern/tests/lib.cairo
@@ -1,0 +1,55 @@
+use snforge_std::{ContractClassTrait, DeclareResultTrait, declare};
+use invariant_testing_pattern::{IVaultDispatcher, IVaultDispatcherTrait};
+
+// Stateful invariant pattern (recipe).
+//
+// The fuzzer generates a u256 seed. The test slices the seed into per-step
+// action bytes, walks a call sequence against the contract under test, and
+// asserts an invariant between every transition.
+//
+// Invariant: the contract's reported balance equals the deposits-minus-
+// withdrawals the test has applied so far. A regression on either branch
+// (e.g. withdraw decrementing by amount + 1) drifts the ledger and is
+// caught within a few seeds.
+
+const STEPS: u32 = 16;
+
+#[test]
+#[fuzzer(runs: 256)]
+fn invariant_vault_ledger_matches_contract(seed: u256) {
+    let contract = declare("Vault").unwrap().contract_class();
+    let (contract_address, _) = contract.deploy(@array![]).unwrap();
+    let dispatcher = IVaultDispatcher { contract_address };
+
+    let mut remaining: u256 = seed;
+    let mut ledger: u64 = 0;
+    let mut step: u32 = 0;
+
+    while step < STEPS {
+        let action_byte: u64 = (remaining & 0xff).try_into().unwrap();
+        remaining = remaining / 256;
+
+        // Cap the amount well below u64::MAX to keep the test ledger arithmetic
+        // free of overflow; the pattern is independent of this clamp.
+        let amount: u64 = action_byte / 4;
+        let is_deposit: bool = (action_byte % 2) == 0;
+
+        if is_deposit {
+            dispatcher.deposit(amount);
+            ledger = ledger + amount;
+        } else if ledger >= amount {
+            dispatcher.withdraw(amount);
+            ledger = ledger - amount;
+        }
+        // No-op when the withdraw would underflow the ledger; the contract
+        // also rejects that case, so skipping keeps both sides in sync.
+
+        // Invariant — runs after every transition.
+        assert!(
+            dispatcher.balance() == ledger,
+            "vault balance drifted from ledger after step",
+        );
+
+        step = step + 1;
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -34,6 +34,7 @@
 
 * [Fork Testing](snforge-advanced-features/fork-testing.md)
 * [Fuzz Testing](snforge-advanced-features/fuzz-testing.md)
+* [Stateful Invariant Testing Pattern](snforge-advanced-features/invariant-testing-pattern.md)
 * [Direct Storage Access](snforge-advanced-features/storage-cheatcodes.md)
 * [Profiling](snforge-advanced-features/profiling.md)
 * [Debugging](snforge-advanced-features/debugging.md)

--- a/docs/src/snforge-advanced-features/invariant-testing-pattern.md
+++ b/docs/src/snforge-advanced-features/invariant-testing-pattern.md
@@ -1,0 +1,49 @@
+# Stateful Invariant Testing Pattern
+
+Many protocol bugs only surface after a particular sequence of external calls. A vault balance can drift after a deposit followed by two withdrawals of the same amount; an access-control flag can flip if a privileged setter is called between two user actions. Random per-argument fuzzing (the existing `#[fuzzer]` mode) does not exercise these orderings on its own.
+
+This page documents a small user-land pattern for running call sequences against a contract under test and asserting a global property between every transition, using primitives `snforge` already exposes.
+
+> ℹ️ **Roadmap**
+> Native support for invariant and differential testing is tracked in [#2464](https://github.com/foundry-rs/starknet-foundry/issues/2464). The recipe below is a way to do this in user-land against today's `snforge`.
+
+## The recipe
+
+Pick a single fuzzer-supported scalar (a `u256` works well) as the seed. Slice it into per-step action bytes. For each step:
+
+1. Decode the byte into an action selector (which method to call) and per-call arguments.
+2. Perform one external call against the contract under test.
+3. Reconcile against a test-side ledger that mirrors what the contract should look like under that call.
+4. Assert the invariant between the contract's reported state and the ledger.
+
+The fuzzer runs the test many times against random seeds; each seed unfolds a different sequence of calls. A drift between contract and ledger after any transition is a violation.
+
+## Worked example
+
+The test:
+
+```rust
+{{#include ../../listings/invariant_testing_pattern/tests/lib.cairo}}
+```
+
+The contract under test is a minimal `Vault` with `deposit`, `withdraw`, and a `balance()` view:
+
+```rust
+{{#include ../../listings/invariant_testing_pattern/src/lib.cairo}}
+```
+
+Run with:
+
+```shell
+$ snforge test
+```
+
+A regression injected on either branch (for example, a `withdraw` that decrements by `amount + 1` instead of `amount`) drifts the ledger and is flagged within the first dozen seeds. Increase `runs:` on the `#[fuzzer]` attribute for higher coverage.
+
+## Rotating callers
+
+When the invariant depends on which actor performed each call (admin vs user), wrap the dispatch in a [`start_cheat_caller_address`](./../testing/using-cheatcodes.md) / `stop_cheat_caller_address` pair. Bit-pack the caller selector into the same action byte that selects the method.
+
+## Limits of this pattern
+
+This is a user-land workaround, not a replacement for native invariant testing. The fuzzer still generates only scalar seeds; decoding the call sequence is the test author's job. Action shrinking and per-property statistics are not provided. Issue [#2464](https://github.com/foundry-rs/starknet-foundry/issues/2464) tracks the design for native support.


### PR DESCRIPTION
Adds a small user-land recipe for stateful invariant testing under
docs/src/snforge-advanced-features/, with a worked example listing under
docs/listings/invariant_testing_pattern/. The pattern uses a single u256
fuzzer seed sliced into per-step action bytes, walks a call sequence
against a minimal Vault contract, and asserts a ledger invariant between
every transition.

I left a comment on #2464 a few days ago about a sidecar tool we built for
this same problem on Cairo 2.x. A worked recipe in the book felt more
useful than another comment, since the pattern works against existing
snforge primitives today (#[fuzzer] + dispatcher calls, optionally
start_cheat_caller_address for caller rotation). No new attributes, no
runner changes. The doc page is explicit that this is a user-land pattern
and that native support is tracked in #2464.

Changes:
- docs/listings/invariant_testing_pattern/ contains the Scarb package
  with the Vault contract and the invariant test.
- docs/src/snforge-advanced-features/invariant-testing-pattern.md is the
  recipe walkthrough.
- docs/src/SUMMARY.md gets one new entry under "snforge Advanced Features".

Happy to adjust the framing, the file layout, or the example contract to
fit your conventions. If you'd rather the recipe live somewhere else, or
not in the book until #2464 lands, I can also pull this.

Michael Moffett
michael@caliperforge.com
caliperforge.com/ai-disclosure
