### PR TITLE
Add missing snaps for `data-transformer` events

### DIFF
--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_empty_list@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_empty_list@2.16.1.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_eventless_success (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~276810)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_eventless_success
+└─ [selector] do_not_emit
+   └─ [events] []

--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_empty_list@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_empty_list@2.17.0.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_eventless_success (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~276810)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_eventless_success
+└─ [selector] do_not_emit
+   └─ [events] []

--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_only@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_only@2.16.1.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_events_component (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~305070)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_events_component
+└─ [selector] emit_event
+   └─ [events] [ValueEmitted { value: 0x2a }]

--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_only@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_events_component_only@2.17.0.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_events_component (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~305070)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_events_component
+└─ [selector] emit_event
+   └─ [events] [ValueEmitted { value: 0x2a }]

--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_multiple_events_component@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_multiple_events_component@2.16.1.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_multiple_events (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~333130)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_multiple_events
+└─ [selector] emit_two_events
+   └─ [events] [ValueEmitted { value: 0x2a }, ValueEmitted { value: 0x2b }]

--- a/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_multiple_events_component@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/debugging/main__e2e__debugging__debugging_trace_multiple_events_component@2.17.0.snap
@@ -1,0 +1,11 @@
+---
+source: crates/forge/tests/e2e/debugging.rs
+expression: stdout
+---
+
+
+
+[PASS] debugging_events_integrationtest::test_trace::test_debugging_trace_multiple_events (l1_gas: ~0, l1_data_gas: ~96, l2_gas: ~333130)
+[test name] debugging_events_integrationtest::test_trace::test_debugging_trace_multiple_events
+└─ [selector] emit_two_events
+   └─ [events] [ValueEmitted { value: 0x2a }, ValueEmitted { value: 0x2b }]

--- a/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__snap_recursive_calls@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__snap_recursive_calls@2.16.1.snap
@@ -4,13 +4,14 @@ expression: stdout
 ---
 
 
-[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1382600)
+
+[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1519900)
 ╭-------------------------+-------+--------+--------+---------+---------╮
 | SimpleContract Contract |       |        |        |         |         |
 +=======================================================================+
 | Function Name           | Min   | Max    | Avg    | Std Dev | # Calls |
 |-------------------------+-------+--------+--------+---------+---------|
-| execute_calls           | 11660 | 609380 | 184000 | 235987  | 5       |
+| execute_calls           | 39120 | 746680 | 244412 | 279862  | 5       |
 |-------------------------+-------+--------+--------+---------+---------|
 | fail                    | 17950 | 17950  | 17950  | 0       | 1       |
 ╰-------------------------+-------+--------+--------+---------+---------╯

--- a/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__snap_recursive_calls@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/gas_report/main__e2e__gas_report__snap_recursive_calls@2.17.0.snap
@@ -5,13 +5,13 @@ expression: stdout
 
 
 
-[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1382600)
+[PASS] debugging_integrationtest::test_trace::test_debugging_trace_success (l1_gas: ~0, l1_data_gas: ~288, l2_gas: ~1519900)
 ╭-------------------------+-------+--------+--------+---------+---------╮
 | SimpleContract Contract |       |        |        |         |         |
 +=======================================================================+
 | Function Name           | Min   | Max    | Avg    | Std Dev | # Calls |
 |-------------------------+-------+--------+--------+---------+---------|
-| execute_calls           | 11660 | 609380 | 184000 | 235987  | 5       |
+| execute_calls           | 39120 | 746680 | 244412 | 279862  | 5       |
 |-------------------------+-------+--------+--------+---------+---------|
 | fail                    | 17950 | 17950  | 17950  | 0       | 1       |
 ╰-------------------------+-------+--------+--------+---------+---------╯


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

<!-- A brief description of the changes -->

- Fix missing snaps for 2.16.1 and 2.17.0 related to recent `data-transformer` events changes

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
