### PR TITLE
Handle prerelease RPC versions in compatibility checks

### DIFF
--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 
     #[test]
-    fn matches_expected_build_metadata_version() {
+    fn matches_expected_build_version() {
         assert!(is_expected_version(
             &Version::parse("0.10.3+build.1").unwrap()
         ));

--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -14,7 +14,7 @@ pub fn create_rpc_client(url: &Url) -> Result<JsonRpcClient<HttpTransport>> {
 
 #[must_use]
 pub fn is_expected_version(version: &Version) -> bool {
-    // TODO(#4412): Check only `EXPECTED_RPC_VERSION` and remove the fallback check for "0.10.3-rc.0".
+    // TODO(#4412): Remove the fallback check for "0.10.3-rc.0".
     VersionReq::from_str(EXPECTED_RPC_VERSION)
         .expect("Failed to parse the expected RPC version")
         .matches(version)

--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -14,13 +14,10 @@ pub fn create_rpc_client(url: &Url) -> Result<JsonRpcClient<HttpTransport>> {
 
 #[must_use]
 pub fn is_expected_version(version: &Version) -> bool {
-    // TODO(#4412): Remove the fallback check for "0.10.3-rc.0".
+    let core_version = Version::new(version.major, version.minor, version.patch);
     VersionReq::from_str(EXPECTED_RPC_VERSION)
         .expect("Failed to parse the expected RPC version")
-        .matches(version)
-        || VersionReq::from_str("0.10.3-rc.0")
-            .expect("Failed to parse the RPC version")
-            .matches(version)
+        .matches(&core_version)
 }
 
 pub async fn get_rpc_version(client: &JsonRpcClient<HttpTransport>) -> Result<Version> {
@@ -37,4 +34,34 @@ pub async fn get_starknet_version(client: &JsonRpcClient<HttpTransport>) -> Resu
         .starknet_version(BlockId::Tag(BlockTag::PreConfirmed))
         .await
         .context("Error while getting Starknet version from the RPC provider")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_expected_version;
+    use semver::Version;
+
+    #[test]
+    fn matches_expected_release_version() {
+        assert!(is_expected_version(&Version::parse("0.10.3").unwrap()));
+    }
+
+    #[test]
+    fn matches_expected_prerelease_version() {
+        assert!(is_expected_version(&Version::parse("0.10.3-rc.0").unwrap()));
+    }
+
+    #[test]
+    fn matches_expected_build_metadata_version() {
+        assert!(is_expected_version(
+            &Version::parse("0.10.3+build.1").unwrap()
+        ));
+    }
+
+    #[test]
+    fn rejects_incompatible_prerelease_version() {
+        assert!(!is_expected_version(
+            &Version::parse("0.11.0-rc.0").unwrap()
+        ));
+    }
 }

--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -14,9 +14,13 @@ pub fn create_rpc_client(url: &Url) -> Result<JsonRpcClient<HttpTransport>> {
 
 #[must_use]
 pub fn is_expected_version(version: &Version) -> bool {
+    // TODO(#4412): Check only `EXPECTED_RPC_VERSION` and remove the fallback check for "0.10.3-rc.0".
     VersionReq::from_str(EXPECTED_RPC_VERSION)
         .expect("Failed to parse the expected RPC version")
         .matches(version)
+        || VersionReq::from_str("0.10.3-rc.0")
+            .expect("Failed to parse the RPC version")
+            .matches(version)
 }
 
 pub async fn get_rpc_version(client: &JsonRpcClient<HttpTransport>) -> Result<Version> {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

This PR makes RPC version compatibility checks ignore prerelease/build and compare only the core `major.minor.patch` version.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
