### PR TITLE
chore: group weekly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,20 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: weekly
     ignore:
-      - dependency-name: "cairo-*"
+      - dependency-name: cairo-*
     groups:
-      all-dependencies:
+      cargo-weekly:
         patterns:
-          - "*"
-
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
+          - '*'
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: weekly
     groups:
-      actions:
+      ci-weekly:
         patterns:
-          - "*"
+          - '*'


### PR DESCRIPTION
## Summary
- run all Dependabot ecosystems on a weekly schedule
- group dependency updates with a catch-all pattern
- group GitHub Actions/CI updates as `ci-weekly`

## Testing
- validated `.github/dependabot.yml` parses as YAML and every update entry is weekly with a dependency group