### PR TITLE
Merge contract backtrace and test backtraces handling

### DIFF
--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -1,4 +1,6 @@
-use crate::backtrace::display::{Backtrace, BacktraceKind, BacktraceStack, render_fork_backtrace};
+use crate::backtrace::display::{
+    Backtrace, BacktraceKind, BacktraceStack, render_fork_backtrace,
+};
 use anyhow::Context;
 use anyhow::Result;
 use cairo_annotations::annotations::TryFromDebugInfo;

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -1,6 +1,4 @@
-use crate::backtrace::display::{
-    Backtrace, BacktraceKind, BacktraceStack, render_fork_backtrace,
-};
+use crate::backtrace::display::{Backtrace, BacktraceKind, BacktraceStack, render_fork_backtrace};
 use anyhow::Context;
 use anyhow::Result;
 use cairo_annotations::annotations::TryFromDebugInfo;

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -61,6 +61,8 @@ pub fn get_backtrace(
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> Option<String> {
+    let mut backtrace_parts = Vec::new();
+
     if !encountered_errors.is_empty() {
         let class_hashes = encountered_errors.keys().copied().collect();
 
@@ -74,7 +76,7 @@ pub fn get_backtrace(
             })
             .unwrap_or_else(|err| format!("failed to create backtrace: {err}"));
 
-        return Some(contract_part);
+        backtrace_parts.push(contract_part);
     }
 
     if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) {
@@ -86,10 +88,10 @@ pub fn get_backtrace(
         .and_then(|data| data.render_backtrace(&bt.pcs))
         .unwrap_or_else(|err| format!("failed to create test backtrace: {err}"));
 
-        return Some(test_part);
+        backtrace_parts.push(test_part);
     }
 
-    None
+    (!backtrace_parts.is_empty()).then(|| backtrace_parts.join("\n"))
 }
 
 #[must_use]

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -51,8 +51,6 @@ pub fn add_test_backtrace_footer(
     }
 }
 
-/// When any contract registered an error, prefers the contract-level backtrace.
-/// Otherwise, when the panic originates in the test body itself, renders a test-level backtrace.
 #[must_use]
 pub fn get_backtrace(
     contracts_data: &ContractsData,

--- a/crates/forge/tests/e2e/common/output.rs
+++ b/crates/forge/tests/e2e/common/output.rs
@@ -52,6 +52,7 @@ macro_rules! assert_cleaned_output {
                 (r"(?m)^\s*(Updating crates\.io index|warning:.*|This may prevent.*|database is locked.*|Caused by:.*|  Error code.*).*\n", ""), // cargo warnings and errors
                 (r"(?m)^\s*(Downloading crates|Downloaded).*\n", ""), // cargo download output
                 (r"at /[^\s:]+/src/", "at [..]"), // absolute paths in backtrace
+                (r"at /[^\s:]+/tests/test\.cairo", "at [..]tests/test.cairo"), // integration test paths in backtrace
                 (r"Graph saved to: \/.*", "Graph saved to: [..]") // Inlining optimizer graph saved line
             ]},
             {

--- a/crates/forge/tests/e2e/common/output.rs
+++ b/crates/forge/tests/e2e/common/output.rs
@@ -52,7 +52,7 @@ macro_rules! assert_cleaned_output {
                 (r"(?m)^\s*(Updating crates\.io index|warning:.*|This may prevent.*|database is locked.*|Caused by:.*|  Error code.*).*\n", ""), // cargo warnings and errors
                 (r"(?m)^\s*(Downloading crates|Downloaded).*\n", ""), // cargo download output
                 (r"at /[^\s:]+/src/", "at [..]"), // absolute paths in backtrace
-                (r"at /[^\s:]+/tests/test\.cairo", "at [..]tests/test.cairo"), // integration test paths in backtrace
+                (r"at /[^\s:]+/tests/", "at [..]tests/"), // integration test paths in backtrace
                 (r"Graph saved to: \/.*", "Graph saved to: [..]") // Inlining optimizer graph saved line
             ]},
             {

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.16.1.snap
@@ -24,6 +24,15 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -50,6 +59,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.17.0.snap
@@ -24,6 +24,15 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -50,6 +59,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace@2.18.0.snap
@@ -2,6 +2,8 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+
+
 [FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
 
 Failure data:
@@ -21,6 +23,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
 
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
@@ -48,6 +59,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: (inlined) backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.16.1.snap
@@ -23,6 +23,15 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   2: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -35,6 +44,15 @@ error occurred in contract 'OuterContract'
 stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   2: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.17.0.snap
@@ -23,6 +23,15 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   2: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -35,6 +44,15 @@ error occurred in contract 'OuterContract'
 stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   2: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic@2.18.0.snap
@@ -2,6 +2,8 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+
+
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -21,6 +23,15 @@ stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   2: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -33,6 +44,15 @@ error occurred in contract 'OuterContract'
 stack backtrace:
    0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   2: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.16.1.snap
@@ -33,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -51,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.17.0.snap
@@ -33,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -51,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_inlines@2.18.0.snap
@@ -2,6 +2,8 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+
+
 [FAIL] backtrace_panic::Test::test_contract_panics
 
 Failure data:
@@ -31,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -49,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.16.1.snap
@@ -33,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -51,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.17.0.snap
@@ -33,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -51,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_panic_without_optimizations@2.18.0.snap
@@ -33,6 +33,17 @@ stack backtrace:
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+
 [IGNORE] backtrace_panic::Test::test_contract_panics_with_should_panic
 [FAIL] backtrace_panic::Test::test_fork_contract_panics
 
@@ -51,6 +62,17 @@ stack backtrace:
        at [..]lib.cairo:17:13
    3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_fork_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_fork_contract_panics
+       at [..]lib.cairo:90:9
+   3: backtrace_panic::Test::test_fork_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:76:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.16.1.snap
@@ -27,6 +27,15 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -59,6 +68,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.17.0.snap
@@ -27,6 +27,15 @@ stack backtrace:
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
 
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
+
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
 Failure data:
@@ -59,6 +68,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_backtrace_without_inlines@2.18.0.snap
@@ -2,6 +2,8 @@
 source: crates/forge/tests/e2e/backtrace.rs
 expression: stdout
 ---
+
+
 [FAIL] backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
 
 Failure data:
@@ -24,6 +26,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall
+       at [..]lib.cairo:84:9
+   2: backtrace_vm_error::Test::test_fork_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:70:5
 
 [FAIL] backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
 
@@ -57,6 +68,15 @@ stack backtrace:
        at [..]lib.cairo:17:13
    2: backtrace_vm_error::OuterContract::__wrapper__OuterContract__outer
        at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_vm_error::Test::test_unwrapped_call_contract_syscall'
+stack backtrace:
+   0: backtrace_vm_error::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall
+       at [..]lib.cairo:67:9
+   2: backtrace_vm_error::Test::test_unwrapped_call_contract_syscall__snforge_internal_test_generated
+       at [..]lib.cairo:58:5
 
 
 Failures:

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.16.1.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.16.1.snap
@@ -17,3 +17,12 @@ stack backtrace:
        at [..]error_handler.cairo:50:21
    3: dispatchers::error_handler::ErrorHandler::__wrapper__ErrorHandler__catch_panic_and_fail
        at [..]error_handler.cairo:27:5
+
+error occurred in test 'dispatchers_integrationtest::test::test_handle_and_panic'
+stack backtrace:
+   0: (inlined) dispatchers::error_handler::IErrorHandlerDispatcherImpl::catch_panic_and_fail
+       at [..]error_handler.cairo:1:1
+   1: (inlined) dispatchers_integrationtest::test::test_handle_and_panic
+       at [..]tests/test.cairo:34:5
+   2: dispatchers_integrationtest::test::test_handle_and_panic__snforge_internal_test_generated
+       at [..]tests/test.cairo:28:1

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.17.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.17.0.snap
@@ -17,3 +17,12 @@ stack backtrace:
        at [..]error_handler.cairo:50:21
    3: dispatchers::error_handler::ErrorHandler::__wrapper__ErrorHandler__catch_panic_and_fail
        at [..]error_handler.cairo:27:5
+
+error occurred in test 'dispatchers_integrationtest::test::test_handle_and_panic'
+stack backtrace:
+   0: (inlined) dispatchers::error_handler::IErrorHandlerDispatcherImpl::catch_panic_and_fail
+       at [..]error_handler.cairo:1:1
+   1: (inlined) dispatchers_integrationtest::test::test_handle_and_panic
+       at [..]tests/test.cairo:34:5
+   2: dispatchers_integrationtest::test::test_handle_and_panic__snforge_internal_test_generated
+       at [..]tests/test.cairo:28:1

--- a/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.18.0.snap
+++ b/crates/forge/tests/e2e/snapshots/backtrace/main__e2e__backtrace__snap_test_handled_error_not_display@2.18.0.snap
@@ -17,3 +17,12 @@ stack backtrace:
        at [..]error_handler.cairo:50:21
    3: dispatchers::error_handler::ErrorHandler::__wrapper__ErrorHandler__catch_panic_and_fail
        at [..]error_handler.cairo:27:5
+
+error occurred in test 'dispatchers_integrationtest::test::test_handle_and_panic'
+stack backtrace:
+   0: (inlined) dispatchers::error_handler::IErrorHandlerDispatcherImpl::catch_panic_and_fail
+       at [..]error_handler.cairo:1:1
+   1: (inlined) dispatchers_integrationtest::test::test_handle_and_panic
+       at [..]tests/test.cairo:34:5
+   2: dispatchers_integrationtest::test::test_handle_and_panic__snforge_internal_test_generated
+       at [..]tests/test.cairo:28:1

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -294,7 +294,7 @@ Learn more about this option in the [Scarb documentation](https://docs.swmansion
 
 #### Inlining
 
-The single optimization that matters most for backtraces is **inlining**, which is enabled by default.
+The single optimization that matters most for backtraces is inlining, which is enabled by default.
 Therefore, inlined backtrace frames either disappear or collapse into a single `(inlined)` entry. 
 
 If you want fuller backtraces **without turning off every optimization**, you can target inlining directly with the [`inlining-strategy`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#inlining-strategy) field. 
@@ -305,9 +305,11 @@ Setting it to `"avoid"` makes the compiler inline only functions annotated with 
 inlining-strategy = "avoid"
 ```
 
-> 📝 **Note**
+> 📝 **Note:**
 > Setting `skip-optimizations = true` already implies `inlining-strategy = "avoid"`.
 
+
+#### Example
 <!-- TODO(#2713) -->
 
 <!-- { "ignored": true, "package_name": "backtrace_panic" } -->
@@ -362,5 +364,4 @@ stack backtrace:
 <!-- TODO(#4434) -->
 
 > ⚠️ **Note**:
-> Disabling inlining gives fuller backtraces, but `snforge` can currently sometime render an **incorrect frames** when inlining is disabled.
-> A frame can point to a wrong function or line.
+> Disabling inlining gives fuller backtraces, but `snforge` can currently sometime render [**wrong frames**](https://github.com/foundry-rs/starknet-foundry/issues/4434) when inlining is disabled.

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -234,12 +234,12 @@ note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
 
 To enable backtrace, simply set the `SNFORGE_BACKTRACE=1` environment variable and rerun the operation.
 
-When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in test
-code or contracts where the errors occurred. Here's an example of what you might see:
+When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in test code and contracts where the errors occurred. 
+Here's an example of what you might see:
 
 <!-- TODO(#2713) -->
 
-<!-- { "ignored": true, "package_name": "backtrace_vm_error" } -->
+<!-- { "ignored": true, "package_name": "backtrace_panic" } -->
 ```shell
 $ SNFORGE_BACKTRACE=1 snforge test
 ```
@@ -247,31 +247,31 @@ $ SNFORGE_BACKTRACE=1 snforge test
 <summary>Output:</summary>
 
 ```shell
-"Failure data:
+Failure data:
     (0x417373657274206661696c6564 ('Assert failed'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'))
+
 error occurred in contract 'InnerContract'
 stack backtrace:
-   0: (inlined) core::array::ArrayImpl::append
-       at [..]array.cairo:135:9
-   1: core::array_inline_macro
-       at [..]lib.cairo:364:11
-   2: (inlined) core::Felt252PartialEq::eq
-       at [..]lib.cairo:231:9
-   3: (inlined) backtrace_panic::InnerContract::inner_call
-       at [..]traits.cairo:442:10
-   4: (inlined) backtrace_panic::InnerContract::InnerContract::inner
-       at [..]lib.cairo:40:16
-   5: backtrace_panic::InnerContract::__wrapper__InnerContract__inner
-       at [..]lib.cairo:35:13
+   0: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   1: core::panic_with_const_felt252
+       at [..]lib.cairo:360:5
+   2: backtrace_panic::InnerContract::__wrapper__InnerContract__inner
+       at [..]lib.cairo:32:5
 
 error occurred in contract 'OuterContract'
 stack backtrace:
-   0: (inlined) backtrace_panic::IInnerContractDispatcherImpl::inner
-       at [..]lib.cairo:22:1
-   1: (inlined) backtrace_panic::OuterContract::OuterContract::outer
-       at [..]lib.cairo:17:13
-   2: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
-       at [..]lib.cairo:15:9"
+   0: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: (inlined) backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   1: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   2: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
 ```
 </details>
 <br>
@@ -291,3 +291,76 @@ Learn more about this option in the [Scarb documentation](https://docs.swmansion
 > ⚠️ **Warning**: Setting `skip-optimizations = true` may result in faster compilation, but **much** slower execution
 > of the compiled code. If you need to deploy your contracts on Starknet, you should **never** compile them with this
 > field set to `true`.
+
+#### Inlining
+
+The single optimization that matters most for backtraces is **inlining**, which is enabled by default.
+Therefore, inlined backtrace frames either disappear or collapse into a single `(inlined)` entry. 
+
+If you want fuller backtraces **without turning off every optimization**, you can target inlining directly with the [`inlining-strategy`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#inlining-strategy) field. 
+Setting it to `"avoid"` makes the compiler inline only functions annotated with `#[inline(always)]`:
+
+```toml
+[profile.dev.cairo]
+inlining-strategy = "avoid"
+```
+
+> 📝 **Note**
+> Setting `skip-optimizations = true` already implies `inlining-strategy = "avoid"`.
+
+<!-- TODO(#2713) -->
+
+<!-- { "ignored": true, "package_name": "backtrace_panic" } -->
+```shell
+$ SNFORGE_BACKTRACE=1 snforge test
+```
+<details>
+<summary>Output:</summary>
+
+```shell
+Failure data:
+    (0x417373657274206661696c6564 ('Assert failed'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'), 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'))
+
+error occurred in contract 'InnerContract'
+stack backtrace:
+   0: core::array_inline_macro
+       at [..]lib.cairo:346:11
+   1: core::assert
+       at [..]lib.cairo:373:9
+   2: backtrace_panic::InnerContract::inner_call
+       at [..]lib.cairo:40:9
+   3: backtrace_panic::InnerContract::unsafe_new_contract_state
+       at [..]lib.cairo:29:5
+   4: backtrace_panic::InnerContract::__wrapper__InnerContract__inner
+       at [..]lib.cairo:32:5
+
+error occurred in contract 'OuterContract'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IInnerContractDispatcherImpl::inner
+       at [..]lib.cairo:22:1
+   2: backtrace_panic::OuterContract::OuterContract::outer
+       at [..]lib.cairo:17:13
+   3: backtrace_panic::OuterContract::__wrapper__OuterContract__outer
+       at [..]lib.cairo:13:5
+
+error occurred in test 'backtrace_panic::Test::test_contract_panics'
+stack backtrace:
+   0: core::starknet::SyscallResultTraitImpl::unwrap_syscall
+       at [..]starknet.cairo:135:52
+   1: backtrace_panic::IOuterContractDispatcherImpl::outer
+       at [..]lib.cairo:1:1
+   2: backtrace_panic::Test::test_contract_panics
+       at [..]lib.cairo:59:9
+   3: backtrace_panic::Test::test_contract_panics__snforge_internal_test_generated
+       at [..]lib.cairo:50:5
+```
+</details>
+<br>
+
+<!-- TODO(#4434) -->
+
+> ⚠️ **Note**:
+> Disabling inlining gives fuller backtraces, but `snforge` can currently sometime render an **incorrect frames** when inlining is disabled.
+> A frame can point to a wrong function or line.

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -234,7 +234,7 @@ note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
 
 To enable backtrace, simply set the `SNFORGE_BACKTRACE=1` environment variable and rerun the operation.
 
-When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in test code and contracts where the errors occurred. 
+When enabled, the backtrace will display the call tree of the execution, including the specific line numbers in test code and contracts where the errors occurred.
 Here's an example of what you might see:
 
 <!-- TODO(#2713) -->

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -295,7 +295,7 @@ Learn more about this option in the [Scarb documentation](https://docs.swmansion
 #### Inlining
 
 The single optimization that matters most for backtraces is inlining, which is enabled by default.
-Therefore, inlined backtrace frames either disappear or collapse into a single `(inlined)` entry. 
+Therefore, inlined backtrace frames either disappear or collapse into a single `(inlined)` entry.
 
 If you want fuller backtraces **without turning off every optimization**, you can target inlining directly with the [`inlining-strategy`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#inlining-strategy) field. 
 Setting it to `"avoid"` makes the compiler inline only functions annotated with `#[inline(always)]`:

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -364,4 +364,4 @@ stack backtrace:
 <!-- TODO(#4434) -->
 
 > ⚠️ **Note**:
-> Disabling inlining gives fuller backtraces, but `snforge` can currently sometime render [**wrong frames**](https://github.com/foundry-rs/starknet-foundry/issues/4434) when inlining is disabled.
+> Disabling inlining gives fuller backtraces, but `snforge` can currently sometimes render [**wrong frames**](https://github.com/foundry-rs/starknet-foundry/issues/4434) when inlining is disabled.

--- a/docs/src/testing/testing.md
+++ b/docs/src/testing/testing.md
@@ -65,7 +65,7 @@ Failures:
 </details>
 <br>
 
-When a test or contract fails, you can get backtrace information by setting the `SNFORGE_BACKTRACE=1` environment variable. Read more about it [here](../snforge-advanced-features/debugging.md).
+When a test or contract call fails, you can get backtrace information by setting the `SNFORGE_BACKTRACE=1` environment variable. Read more about it [here](../snforge-advanced-features/debugging.md).
 
 ## Expected Failures
 

--- a/docs/src/testing/testing.md
+++ b/docs/src/testing/testing.md
@@ -65,7 +65,7 @@ Failures:
 </details>
 <br>
 
-When contract fails, you can get backtrace information by setting the `SNFORGE_BACKTRACE=1` environment variable. Read more about it [here](../snforge-advanced-features/debugging.md).
+When a test or contract fails, you can get backtrace information by setting the `SNFORGE_BACKTRACE=1` environment variable. Read more about it [here](../snforge-advanced-features/debugging.md).
 
 ## Expected Failures
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3610 


## Stack
- #4400
- #4428
- #4442
- #4444 



## Introduced changes

<!-- A brief description of the changes -->

Now, both contract and test-level backtrace is displayed at once 

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
