### PR TITLE
Remove `unstable` from `debug-info` features in docs and codebase

### DIFF
--- a/crates/forge/src/profile_validation/backtrace.rs
+++ b/crates/forge/src/profile_validation/backtrace.rs
@@ -43,8 +43,8 @@ fn check_profile(
             "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to run backtrace:
 
             [profile.{profile}.cairo]
-            unstable-add-statements-functions-debug-info = true
-            unstable-add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
             panic-backtrace = true
             ... other entries ...
             ",

--- a/crates/forge/src/profile_validation/coverage.rs
+++ b/crates/forge/src/profile_validation/coverage.rs
@@ -29,8 +29,8 @@ pub fn check_coverage_compatibility(
             "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to run coverage:
 
             [profile.{profile}.cairo]
-            unstable-add-statements-functions-debug-info = true
-            unstable-add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
             inlining-strategy = \"avoid\"
             ... other entries ...
             ",

--- a/crates/forge/src/profile_validation/debugger.rs
+++ b/crates/forge/src/profile_validation/debugger.rs
@@ -20,8 +20,8 @@ pub fn check_debugger_compatibility(
             "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to launch the debugger:
 
             [profile.{profile}.cairo]
-            unstable-add-statements-code-locations-debug-info = true
-            unstable-add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
             add-functions-debug-info = true
             skip-optimizations = true
             ... other entries ...

--- a/crates/forge/src/scarb/config.rs
+++ b/crates/forge/src/scarb/config.rs
@@ -30,8 +30,8 @@ pub const SCARB_MANIFEST_TEMPLATE_CONTENT: &str = r#"
 # block_id.hash = "0x123"                                    # Block to fork from (block hash)
 
 # [profile.dev.cairo]                                        # Configure Cairo compiler
-# unstable-add-statements-code-locations-debug-info = true   # Should be used if you want to use coverage
-# unstable-add-statements-functions-debug-info = true        # Should be used if you want to use coverage/profiler
+# add-statements-code-locations-debug-info = true            # Should be used if you want to use coverage
+# add-statements-functions-debug-info = true                 # Should be used if you want to use coverage/profiler
 # inlining-strategy = "avoid"                                # Should be used if you want to use coverage
 
 # [features]                                                 # Used for conditional compilation

--- a/crates/forge/tests/data/backtrace_panic/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_panic/Scarb.toml
@@ -18,6 +18,6 @@ sierra = true
 test = "snforge test"
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
-unstable-add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
 panic-backtrace = true

--- a/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
+++ b/crates/forge/tests/data/backtrace_vm_error/Scarb.toml
@@ -18,6 +18,6 @@ sierra = true
 test = "snforge test"
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
-unstable-add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
 panic-backtrace = true

--- a/crates/forge/tests/data/coverage_project/Scarb.toml
+++ b/crates/forge/tests/data/coverage_project/Scarb.toml
@@ -15,6 +15,6 @@ snforge_std = { path = "../../../../../snforge_std" }
 sierra = true
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true # Comment
-unstable-add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true # Comment
+add-statements-code-locations-debug-info = true
 inlining-strategy= "avoid" # Comment

--- a/crates/forge/tests/data/dispatchers/Scarb.toml
+++ b/crates/forge/tests/data/dispatchers/Scarb.toml
@@ -19,6 +19,6 @@ sierra = true
 test = "snforge test"
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
-unstable-add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
 panic-backtrace = true

--- a/crates/forge/tests/data/partitioning/Scarb.toml
+++ b/crates/forge/tests/data/partitioning/Scarb.toml
@@ -25,6 +25,6 @@ package_b = { path = "crates/package_b" }
 snforge_std.workspace = true
 
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
-unstable-add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
 inlining-strategy = "avoid"

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -104,7 +104,7 @@ fn test_wrong_scarb_toml_configuration() {
 
 // `add-statements-code-locations-debug-info` is available from Scarb 2.15.0
 #[test]
-fn test_complex_scarb_toml_configuration_without_unstable() {
+fn test_complex_scarb_toml_configuration_debug_info_in_cairo_section() {
     let temp = setup_package("backtrace_vm_error");
 
     let manifest_path = temp.child("Scarb.toml");
@@ -138,7 +138,7 @@ fn test_complex_scarb_toml_configuration_without_unstable() {
 }
 
 #[test]
-fn test_complex_scarb_toml_configuration() {
+fn test_complex_scarb_toml_configuration_unstable_debug_info_in_cairo_section() {
     let temp = setup_package("backtrace_vm_error");
 
     let manifest_path = temp.child("Scarb.toml");

--- a/crates/forge/tests/e2e/backtrace.rs
+++ b/crates/forge/tests/e2e/backtrace.rs
@@ -78,7 +78,7 @@ fn test_wrong_scarb_toml_configuration() {
         .parse::<DocumentMut>()
         .unwrap();
 
-    scarb_toml["profile"]["dev"]["cairo"]["unstable-add-statements-code-locations-debug-info"] =
+    scarb_toml["profile"]["dev"]["cairo"]["add-statements-code-locations-debug-info"] =
         value(false);
 
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
@@ -94,8 +94,8 @@ fn test_wrong_scarb_toml_configuration() {
            "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to run backtrace:
 
             [profile.dev.cairo]
-            unstable-add-statements-functions-debug-info = true
-            unstable-add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
             panic-backtrace = true
             ... other entries ..."
         },
@@ -117,7 +117,7 @@ fn test_complex_scarb_toml_configuration_without_unstable() {
     scarb_toml["profile"]["dev"]["cairo"]
         .as_table_like_mut()
         .unwrap()
-        .remove("unstable-add-statements-code-locations-debug-info")
+        .remove("add-statements-code-locations-debug-info")
         .unwrap();
     scarb_toml["cairo"]["add-statements-code-locations-debug-info"] = value(true);
 
@@ -151,7 +151,7 @@ fn test_complex_scarb_toml_configuration() {
     scarb_toml["profile"]["dev"]["cairo"]
         .as_table_like_mut()
         .unwrap()
-        .remove("unstable-add-statements-code-locations-debug-info")
+        .remove("add-statements-code-locations-debug-info")
         .unwrap();
     scarb_toml["cairo"]["unstable-add-statements-code-locations-debug-info"] = value(true);
 

--- a/crates/forge/tests/e2e/coverage.rs
+++ b/crates/forge/tests/e2e/coverage.rs
@@ -107,7 +107,7 @@ fn test_fail_wrong_set_up() {
         .parse::<DocumentMut>()
         .unwrap();
 
-    scarb_toml["profile"]["dev"]["cairo"]["unstable-add-statements-code-locations-debug-info"] =
+    scarb_toml["profile"]["dev"]["cairo"]["add-statements-code-locations-debug-info"] =
         value(false);
 
     manifest_path.write_str(&scarb_toml.to_string()).unwrap();
@@ -120,8 +120,8 @@ fn test_fail_wrong_set_up() {
             "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to run coverage:
 
             [profile.dev.cairo]
-            unstable-add-statements-functions-debug-info = true
-            unstable-add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
             inlining-strategy = \"avoid\"
             ... other entries ...
 

--- a/crates/forge/tests/e2e/debugger.rs
+++ b/crates/forge/tests/e2e/debugger.rs
@@ -24,8 +24,8 @@ fn test_fail_wrong_scarb_toml_configuration_for_launch_debugger() {
             "[ERROR] [..]/Scarb.toml must have the Cairo compiler configuration equivalent to the following one to launch the debugger:
 
             [profile.dev.cairo]
-            unstable-add-statements-code-locations-debug-info = true
-            unstable-add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
             add-functions-debug-info = true
             skip-optimizations = true
             ... other entries ...
@@ -46,8 +46,8 @@ fn test_launch_debugger_waits_for_connection() {
         .write_str(&formatdoc!(
             "{existing}
             [profile.dev.cairo]
-            unstable-add-statements-code-locations-debug-info = true
-            unstable-add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
             add-functions-debug-info = true
             skip-optimizations = true",
         ))
@@ -125,8 +125,8 @@ fn test_launch_debugger_fails_for_fuzzer_test() {
         .write_str(&formatdoc!(
             "{existing}
             [profile.dev.cairo]
-            unstable-add-statements-code-locations-debug-info = true
-            unstable-add-statements-functions-debug-info = true
+            add-statements-code-locations-debug-info = true
+            add-statements-functions-debug-info = true
             add-functions-debug-info = true
             skip-optimizations = true",
         ))

--- a/docs/src/appendix/scarb-toml.md
+++ b/docs/src/appendix/scarb-toml.md
@@ -111,19 +111,19 @@ Adjust Cairo compiler configuration parameters when compiling this package. Thes
 # ...
 ```
 
-#### `unstable-add-statements-code-locations-debug-info`
-See [`unstable-add-statements-code-locations-debug-info`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#unstable-add-statements-code-locations-debug-info) in Scarb documentation.
+#### `add-statements-code-locations-debug-info`
+See [`add-statements-code-locations-debug-info`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#add-statements-code-locations-debug-info) in Scarb documentation.
 
 ```toml
 [profile.dev.cairo]
-unstable-add-statements-code-locations-debug-info = true
+add-statements-code-locations-debug-info = true
 ```
 
-#### `unstable-add-statements-functions-debug-info`
-See [`unstable-add-statements-functions-debug-info`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#unstable-add-statements-functions-debug-info) in Scarb documentation.
+#### `add-statements-functions-debug-info`
+See [`add-statements-functions-debug-info`](https://docs.swmansion.com/scarb/docs/reference/manifest.html#add-statements-functions-debug-info) in Scarb documentation.
 ```toml
 [profile.dev.cairo]
-unstable-add-statements-functions-debug-info = true
+add-statements-functions-debug-info = true
 ```
 
 #### `inlining-strategy`
@@ -149,8 +149,8 @@ enable-gas = true
 #### Example of configuration which allows [coverage](https://foundry-rs.github.io/starknet-foundry/testing/coverage.html) report generation
 ```toml
 [profile.dev.cairo]
-unstable-add-statements-code-locations-debug-info = true
-unstable-add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
 ```
 
@@ -276,8 +276,8 @@ url = "http://your.third.rpc.url"
 block_id.hash = "0x123"
 
 [profile.dev.cairo]
-unstable-add-statements-code-locations-debug-info = true
-unstable-add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
 
 [features]

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -192,20 +192,20 @@ Here's what each tag in the trace represents:
 Backtrace feature relies on debug information provided by Scarb. To generate the necessary debug information, you need
 to have:
 
-1. [Scarb](https://github.com/software-mansion/scarb) version `2.12.0` or higher.
+1. [Scarb](https://github.com/software-mansion/scarb) version `2.15.0` or higher.
 2. `Scarb.toml` file with the following Cairo compiler configuration:
 
 ```toml
 [profile.dev.cairo]
-unstable-add-statements-code-locations-debug-info = true
-unstable-add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
 panic-backtrace = true
 ```
 
 > 📝 **Note**
 >
-> That `unstable-add-statements-code-locations-debug-info = true` and
-> `unstable-add-statements-functions-debug-info = true` will slow down the compilation and cause it to use more system
+> That `add-statements-code-locations-debug-info = true` and
+> `add-statements-functions-debug-info = true` will slow down the compilation and cause it to use more system
 > memory. It will also make the compilation artifacts larger. So it is only recommended to add these flags when you need
 > their functionality.
 

--- a/docs/src/testing/coverage.md
+++ b/docs/src/testing/coverage.md
@@ -10,15 +10,15 @@ To generate the necessary debug information, you need to have `Scarb.toml` file 
 
 ```toml
 [profile.dev.cairo]
-unstable-add-statements-code-locations-debug-info = true
-unstable-add-statements-functions-debug-info = true
+add-statements-code-locations-debug-info = true
+add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
 ```
 
 > 📝 **Note**
 >
-> That `unstable-add-statements-code-locations-debug-info = true` and
-`unstable-add-statements-functions-debug-info = true` will slow down the compilation and cause it to use more system
+> That `add-statements-code-locations-debug-info = true` and
+`add-statements-functions-debug-info = true` will slow down the compilation and cause it to use more system
 > memory. It will also make the compilation artifacts larger. So it is only recommended to add these flags when you need
 > their functionality.
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #4454 

## Introduced changes

<!-- A brief description of the changes -->

- The `debug-info` features were stabilized in scarb `2.15`. So it's now older than the latest version we support, so because of that I deleted every occurence instead of just fixing a few places in docs. If we don't want to get rid of this at the moment, I can limit the scope

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
