### PR TITLE
Capture test-level backtrace on demand only

### DIFF
--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -20,11 +20,11 @@ pub fn add_test_backtrace_footer(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: Option<&TestBacktraceContext>,
+    test_panicked: bool,
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {
-    let has_backtrace =
-        !encountered_errors.is_empty() || test_backtrace.is_some_and(|bt| !bt.pcs.is_empty());
+    let has_backtrace = !encountered_errors.is_empty() || test_panicked;
 
     if !has_backtrace {
         return message;

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -14,17 +14,43 @@ pub struct TestBacktraceContext {
     pub casm_start_offsets: Vec<usize>,
 }
 
+/// Backtraces-scoped outcome of a test run.
+///
+/// This mirrors the VM-run outcome, not the test verdict.
+/// E.g. `#[should_panic]` test case that panics as expected is still `Panic` here.
+pub enum TestBacktraceOutcome {
+    /// No panic occurred, so there's no backtrace.
+    Success,
+    /// Panic occurred, backtrace is captured if enabled.
+    Panic(Option<TestBacktraceContext>),
+}
+
+impl TestBacktraceOutcome {
+    #[must_use]
+    pub fn is_panic(&self) -> bool {
+        matches!(self, Self::Panic(_))
+    }
+
+    #[must_use]
+    pub fn context(&self) -> Option<&TestBacktraceContext> {
+        match self {
+            Self::Panic(ctx) => ctx.as_ref(),
+            Self::Success => None,
+        }
+    }
+}
+
 #[must_use]
 pub fn add_test_backtrace_footer(
     message: String,
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
-    test_backtrace: Option<&TestBacktraceContext>,
-    test_panicked: bool,
+    test_backtrace: &TestBacktraceOutcome,
     versioned_program_path: &Utf8Path,
     test_name: &str,
 ) -> String {
-    let has_backtrace = !encountered_errors.is_empty() || test_panicked;
+    // Include hint even if backtrace capture was skipped (due to backtrace being disabled).
+    let has_backtrace = test_backtrace.is_panic() || !encountered_errors.is_empty();
 
     if !has_backtrace {
         return message;
@@ -34,7 +60,7 @@ pub fn add_test_backtrace_footer(
         get_backtrace(
             contracts_data,
             encountered_errors,
-            test_backtrace,
+            test_backtrace.context(),
             versioned_program_path,
             test_name,
         )

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -427,7 +427,7 @@ fn capture_test_backtrace(
     if !panicked {
         return TestBacktraceOutcome::Success;
     }
-    
+
     let context = is_backtrace_enabled().then(|| {
         let casm_start_offsets = casm_program
             .debug_info
@@ -444,7 +444,7 @@ fn capture_test_backtrace(
                 .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback()),
             Err(_) => runner.vm.get_reversed_pc_traceback(),
         };
-        
+
         TestBacktraceContext {
             pcs,
             casm_start_offsets,

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,4 +1,6 @@
-use crate::backtrace::{TestBacktraceContext, add_test_backtrace_footer, is_backtrace_enabled};
+use crate::backtrace::{
+    TestBacktraceContext, TestBacktraceOutcome, add_test_backtrace_footer, is_backtrace_enabled,
+};
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
 use crate::package_tests::with_config_resolved::{ResolvedForkConfig, TestCaseWithResolvedConfig};
@@ -151,8 +153,7 @@ pub struct RunCompleted {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
-    pub(crate) test_backtrace: Option<TestBacktraceContext>,
-    pub(crate) test_panicked: bool,
+    pub(crate) test_backtrace: TestBacktraceOutcome,
 }
 
 pub struct RunError {
@@ -161,8 +162,7 @@ pub struct RunError {
     pub(crate) encountered_errors: EncounteredErrors,
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
-    pub(crate) test_backtrace: Option<TestBacktraceContext>,
-    pub(crate) test_panicked: bool,
+    pub(crate) test_backtrace: TestBacktraceOutcome,
 }
 
 pub enum RunResult {
@@ -352,12 +352,7 @@ pub fn run_test_case(
         .encountered_errors
         .clone();
 
-    let test_panicked = matches!(&result, Err(_))
-        || matches!(&result, Ok(call_info) if call_info.execution.failed);
-
-    let test_backtrace = is_backtrace_enabled()
-        .then(|| capture_test_backtrace(&result, &forge_runtime, &runner, casm_program))
-        .flatten();
+    let test_backtrace = capture_test_backtrace(&result, &forge_runtime, &runner, casm_program);
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
@@ -401,7 +396,6 @@ pub fn run_test_case(
                 fuzzer_args,
                 fork_data,
                 test_backtrace,
-                test_panicked,
             }))
         }
         Err(error) => RunResult::Error(Box::new(RunError {
@@ -411,46 +405,53 @@ pub fn run_test_case(
             fuzzer_args,
             fork_data,
             test_backtrace,
-            test_panicked,
         })),
     })
 }
 
-// Capture PCs for a panic that originates in the test body itself.
-// Mirrors the contract-level logic in `cairo1_execution.rs` (`execute_entry_point_call_cairo1`) and `entry_point.rs` (`extract_trace_and_register_errors`).
-// Note: the test target is not a deployed contract, so instead of `register_error` PCs are returned in a `TestBacktraceContext`.
+/// Capture PCs for a panic that originates in the test body itself.
+/// Captures backtrace only if **test panics** and **backtrace is enabled**.
+/// Mirrors the contract-level logic in `cairo1_execution.rs` (`execute_entry_point_call_cairo1`) and `entry_point.rs` (`extract_trace_and_register_errors`).
+/// Note: the test target is not a deployed contract, so instead of `register_error` PCs are returned in a `TestBacktraceContext`.
+#[must_use]
 fn capture_test_backtrace(
     result: &Result<CallInfo, CairoRunError>,
     forge_runtime: &ForgeRuntime,
     runner: &CairoRunner,
     casm_program: &RawCasmProgram,
-) -> Option<TestBacktraceContext> {
-    let casm_start_offsets = casm_program
-        .debug_info
-        .iter()
-        .map(|(offset, _)| *offset)
-        .collect();
-
-    match result {
-        Ok(call_info) if call_info.execution.failed => {
-            let pcs = forge_runtime
+) -> TestBacktraceOutcome {
+    let panicked = match result {
+        Ok(call_info) => call_info.execution.failed,
+        Err(_) => true,
+    };
+    if !panicked {
+        return TestBacktraceOutcome::Success;
+    }
+    
+    let context = is_backtrace_enabled().then(|| {
+        let casm_start_offsets = casm_program
+            .debug_info
+            .iter()
+            .map(|(offset, _)| *offset)
+            .collect();
+        let pcs = match result {
+            Ok(_) => forge_runtime
                 .extended_runtime
                 .extended_runtime
                 .extended_runtime
                 .panic_traceback
                 .clone()
-                .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback());
-            Some(TestBacktraceContext {
-                pcs,
-                casm_start_offsets,
-            })
-        }
-        Err(_) => Some(TestBacktraceContext {
-            pcs: runner.vm.get_reversed_pc_traceback(),
+                .unwrap_or_else(|| runner.vm.get_reversed_pc_traceback()),
+            Err(_) => runner.vm.get_reversed_pc_traceback(),
+        };
+        
+        TestBacktraceContext {
+            pcs,
             casm_start_offsets,
-        }),
-        Ok(_) => None,
-    }
+        }
+    });
+
+    TestBacktraceOutcome::Panic(context)
 }
 
 fn extract_test_case_summary(
@@ -493,8 +494,7 @@ fn extract_test_case_summary(
                             msg,
                             contracts_data,
                             &run_error.encountered_errors,
-                            run_error.test_backtrace.as_ref(),
-                            run_error.test_panicked,
+                            &run_error.test_backtrace,
                             versioned_program_path,
                             &case.name,
                         )

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::{TestBacktraceContext, add_test_backtrace_footer};
+use crate::backtrace::{TestBacktraceContext, add_test_backtrace_footer, is_backtrace_enabled};
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
 use crate::package_tests::with_config_resolved::{ResolvedForkConfig, TestCaseWithResolvedConfig};
@@ -152,6 +152,7 @@ pub struct RunCompleted {
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
     pub(crate) test_backtrace: Option<TestBacktraceContext>,
+    pub(crate) test_panicked: bool,
 }
 
 pub struct RunError {
@@ -161,6 +162,7 @@ pub struct RunError {
     pub(crate) fuzzer_args: Vec<String>,
     pub(crate) fork_data: Option<ForkData>,
     pub(crate) test_backtrace: Option<TestBacktraceContext>,
+    pub(crate) test_panicked: bool,
 }
 
 pub enum RunResult {
@@ -350,7 +352,12 @@ pub fn run_test_case(
         .encountered_errors
         .clone();
 
-    let test_backtrace = capture_test_backtrace(&result, &forge_runtime, &runner, casm_program);
+    let test_panicked = matches!(&result, Err(_))
+        || matches!(&result, Ok(call_info) if call_info.execution.failed);
+
+    let test_backtrace = is_backtrace_enabled()
+        .then(|| capture_test_backtrace(&result, &forge_runtime, &runner, casm_program))
+        .flatten();
 
     let call_trace_ref = get_call_trace_ref(&mut forge_runtime);
 
@@ -394,6 +401,7 @@ pub fn run_test_case(
                 fuzzer_args,
                 fork_data,
                 test_backtrace,
+                test_panicked,
             }))
         }
         Err(error) => RunResult::Error(Box::new(RunError {
@@ -403,6 +411,7 @@ pub fn run_test_case(
             fuzzer_args,
             fork_data,
             test_backtrace,
+            test_panicked,
         })),
     })
 }
@@ -485,6 +494,7 @@ fn extract_test_case_summary(
                             contracts_data,
                             &run_error.encountered_errors,
                             run_error.test_backtrace.as_ref(),
+                            run_error.test_panicked,
                             versioned_program_path,
                             &case.name,
                         )

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -295,7 +295,6 @@ impl TestCaseSummary<Single> {
             fuzzer_args,
             fork_data,
             test_backtrace,
-            test_panicked,
         }: RunCompleted,
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
@@ -360,8 +359,7 @@ impl TestCaseSummary<Single> {
                             msg,
                             contracts_data,
                             &encountered_errors,
-                            test_backtrace.as_ref(),
-                            test_panicked,
+                            &test_backtrace,
                             versioned_program_path,
                             &name,
                         )
@@ -379,7 +377,7 @@ impl TestCaseSummary<Single> {
                                 get_backtrace(
                                     contracts_data,
                                     &encountered_errors,
-                                    test_backtrace.as_ref(),
+                                    test_backtrace.context(),
                                     versioned_program_path,
                                     &name,
                                 )
@@ -408,8 +406,7 @@ impl TestCaseSummary<Single> {
                                     msg,
                                     contracts_data,
                                     &encountered_errors,
-                                    test_backtrace.as_ref(),
-                                    test_panicked,
+                                    &test_backtrace,
                                     versioned_program_path,
                                     &name,
                                 )

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -295,6 +295,7 @@ impl TestCaseSummary<Single> {
             fuzzer_args,
             fork_data,
             test_backtrace,
+            test_panicked,
         }: RunCompleted,
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
@@ -360,6 +361,7 @@ impl TestCaseSummary<Single> {
                             contracts_data,
                             &encountered_errors,
                             test_backtrace.as_ref(),
+                            test_panicked,
                             versioned_program_path,
                             &name,
                         )
@@ -407,6 +409,7 @@ impl TestCaseSummary<Single> {
                                     contracts_data,
                                     &encountered_errors,
                                     test_backtrace.as_ref(),
+                                    test_panicked,
                                     versioned_program_path,
                                     &name,
                                 )

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1402,11 +1402,13 @@ fn exact_printing_fail() {
         Failure data:
             0x73696d706c6520636865636b ('simple check')
 
+        note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
         [FAIL] deterministic_output::test::second_test_fail_y
 
         Failure data:
             0x73696d706c6520636865636b ('simple check')
 
+        note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
         Tests: 0 passed, 2 failed, 0 ignored, 2 filtered out
 
         Failures:
@@ -1432,6 +1434,7 @@ fn exact_printing_mixed() {
         Failure data:
             0x73696d706c6520636865636b ('simple check')
 
+        note: run with `SNFORGE_BACKTRACE=1` environment variable to display a backtrace
         [PASS] deterministic_output::test::second_test_pass_x [..]
         Tests: 1 passed, 1 failed, 0 ignored, 2 filtered out
 


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #3610 

## Stack
- #4400
- #4428
- #4442
- #4444 



## Introduced changes

<!-- A brief description of the changes -->

Addresses https://github.com/foundry-rs/starknet-foundry/pull/4400#discussion_r3451073907

Refactor test-level backtrace capture. Now, instead of always collecting casm debug offsets and PCs, we only do so if:
- test panics
- backtrace is enabled

The hint (``note: run with `{BACKTRACE_ENV}=1` environment variable to display a backtrace``) is included even if backtrace capture was skipped


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
