### PR TITLE
Backtrace perf refactor

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,6 +39,11 @@ retries = 2
 filter = 'package(forge) and test(=e2e::running::simple_package_with_git_dependency)'
 retries = { backoff = "exponential", count = 3, delay = "5s" }
 
+# TODO(#4440)
+[[profile.default.overrides]]
+filter = 'package(forge) and test(=e2e::fuzzing::fuzz_derive_fuzzable)'
+retries = 3
+
 # With the default alphabetical test order, this test can cause an "already declared" error. Run it last to avoid that.
 [[profile.default.overrides]]
 filter = 'package(sncast) and test(=e2e::declare_from::test_happy_case)'

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -266,3 +266,26 @@ impl TestBacktraceData {
         self.0.render_backtrace(pcs)
     }
 }
+
+/// Test-target backtrace annotations.
+#[derive(Clone)]
+pub enum TestAnnotations {
+    Parsed(Arc<BacktraceAnnotations>),
+    /// No backtrace can be produced: Backtrace is disabled, or the target has no sierra debug info.
+    Missing,
+    // Debug info present; Failed to parse.
+    Failed(String),
+}
+
+impl TestAnnotations {
+    #[must_use]
+    pub fn from_debug_info(sierra_debug_info: Option<&DebugInfo>) -> Self {
+        match sierra_debug_info {
+            None => Self::Missing,
+            Some(debug_info) => match BacktraceAnnotations::from_debug_info(debug_info) {
+                Ok(annotations) => Self::Parsed(Arc::new(annotations)),
+                Err(err) => Self::Failed(err.to_string()),
+            },
+        }
+    }
+}

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -19,8 +19,10 @@ use starknet_api::core::ClassHash;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+type ContractBacktraceCache = HashMap<ClassHash, Arc<ContractOrigin>>;
+
 #[derive(Default)]
-pub struct LazyContractBacktraceDataMapping(Mutex<HashMap<ClassHash, Arc<ContractOrigin>>>);
+pub struct LazyContractBacktraceDataMapping(Mutex<ContractBacktraceCache>);
 
 impl LazyContractBacktraceDataMapping {
     #[must_use]
@@ -47,7 +49,7 @@ impl LazyContractBacktraceDataMapping {
             .clone())
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<ClassHash, Arc<ContractOrigin>>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, ContractBacktraceCache> {
         self.0
             .lock()
             .expect("contract backtrace mapping mutex poisoned")

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -10,38 +10,56 @@ use cairo_annotations::annotations::profiler::{
 };
 use cairo_lang_sierra::debug_info::DebugInfo;
 use cairo_lang_sierra::program::StatementIdx;
-use cairo_lang_sierra::program::VersionedProgram;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
-use camino::Utf8Path;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use itertools::Itertools;
-use rayon::iter::IntoParallelIterator;
-use rayon::iter::ParallelIterator;
 use shared::utils::contract_name_from_module_path;
 use starknet_api::core::ClassHash;
-use std::collections::{HashMap, HashSet};
-use std::fs;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
-pub struct ContractBacktraceDataMapping(HashMap<ClassHash, ContractOrigin>);
+#[derive(Default)]
+pub struct LazyContractBacktraceDataMapping(Mutex<HashMap<ClassHash, Arc<ContractOrigin>>>);
 
-impl ContractBacktraceDataMapping {
-    pub fn new(contracts_data: &ContractsData, class_hashes: HashSet<ClassHash>) -> Result<Self> {
-        Ok(Self(
-            class_hashes
-                .into_par_iter()
-                .map(|class_hash| {
-                    ContractOrigin::new(&class_hash, contracts_data)
-                        .map(|contract_data| (class_hash, contract_data))
-                })
-                .collect::<Result<_>>()?,
-        ))
+impl LazyContractBacktraceDataMapping {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub fn render_backtrace(&self, pcs: &[usize], class_hash: &ClassHash) -> Result<String> {
+    fn get_or_build(
+        &self,
+        class_hash: &ClassHash,
+        contracts_data: &ContractsData,
+    ) -> Result<Arc<ContractOrigin>> {
+        if let Some(existing) = self.lock().get(class_hash) {
+            return Ok(existing.clone());
+        }
+
+        // Build outside the lock so a slow CASM build doesn't block other threads;
+        // On a race both build, and the first insert wins.
+        let contract_origin = Arc::new(ContractOrigin::new(class_hash, contracts_data)?);
+        Ok(self
+            .lock()
+            .entry(*class_hash)
+            .or_insert(contract_origin)
+            .clone())
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<ClassHash, Arc<ContractOrigin>>> {
         self.0
-            .get(class_hash)
-            .expect("class hash should be present in the data mapping")
+            .lock()
+            .expect("contract backtrace mapping mutex poisoned")
+    }
+
+    pub fn render_backtrace(
+        &self,
+        class_hash: &ClassHash,
+        pcs: &[usize],
+        contracts_data: &ContractsData,
+    ) -> Result<String> {
+        self.get_or_build(class_hash, contracts_data)?
             .render_backtrace(pcs)
     }
 }
@@ -70,12 +88,27 @@ impl ContractOrigin {
     }
 }
 
+pub struct BacktraceAnnotations {
+    coverage: CoverageAnnotationsV1,
+    profiler: ProfilerAnnotationsV1,
+}
+
+impl BacktraceAnnotations {
+    pub fn from_debug_info(sierra_debug_info: &DebugInfo) -> Result<Self> {
+        let VersionedCoverageAnnotations::V1(coverage) =
+            VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)?;
+        let VersionedProfilerAnnotations::V1(profiler) =
+            VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info)?;
+
+        Ok(Self { coverage, profiler })
+    }
+}
+
 struct BacktraceSourceData {
     kind: BacktraceKind,
     name: String,
     casm_debug_info_start_offsets: Vec<usize>,
-    coverage_annotations: CoverageAnnotationsV1,
-    profiler_annotations: ProfilerAnnotationsV1,
+    annotations: Arc<BacktraceAnnotations>,
 }
 
 impl BacktraceSourceData {
@@ -85,17 +118,11 @@ impl BacktraceSourceData {
         casm_debug_info_start_offsets: Vec<usize>,
         sierra_debug_info: &DebugInfo,
     ) -> Result<Self> {
-        let VersionedCoverageAnnotations::V1(coverage_annotations) =
-            VersionedCoverageAnnotations::try_from_debug_info(sierra_debug_info)?;
-        let VersionedProfilerAnnotations::V1(profiler_annotations) =
-            VersionedProfilerAnnotations::try_from_debug_info(sierra_debug_info)?;
-
         Ok(Self {
             kind,
             name,
             casm_debug_info_start_offsets,
-            coverage_annotations,
-            profiler_annotations,
+            annotations: Arc::new(BacktraceAnnotations::from_debug_info(sierra_debug_info)?),
         })
     }
 
@@ -107,7 +134,8 @@ impl BacktraceSourceData {
         );
 
         let code_locations = self
-            .coverage_annotations
+            .annotations
+            .coverage
             .statements_code_locations
             .get(&sierra_statement_idx)
             .with_context(|| {
@@ -115,7 +143,8 @@ impl BacktraceSourceData {
             })?;
 
         let function_names = self
-            .profiler_annotations
+            .annotations
+            .profiler
             .statements_functions
             .get(&sierra_statement_idx)
             .with_context(|| {
@@ -221,30 +250,16 @@ pub struct TestBacktraceData(BacktraceSourceData);
 
 impl TestBacktraceData {
     pub fn new(
-        test_name: &str,
+        test_name: String,
+        annotations: &Arc<BacktraceAnnotations>,
         casm_start_offsets: Vec<usize>,
-        versioned_program_path: &Utf8Path,
-    ) -> Result<Self> {
-        let raw = fs::read_to_string(versioned_program_path).with_context(|| {
-            format!("failed to read test sierra program at: {versioned_program_path}")
-        })?;
-        let program_artifact = match serde_json::from_str::<VersionedProgram>(&raw)? {
-            VersionedProgram::V1 { program, .. } => program,
-        };
-
-        let sierra_debug_info = program_artifact
-            .debug_info
-            .as_ref()
-            .context("debug info not found")?;
-
-        let source = BacktraceSourceData::from_debug_info(
-            BacktraceKind::Test,
-            test_name.to_string(),
-            casm_start_offsets,
-            sierra_debug_info,
-        )?;
-
-        Ok(Self(source))
+    ) -> Self {
+        Self(BacktraceSourceData {
+            kind: BacktraceKind::Test,
+            name: test_name,
+            casm_debug_info_start_offsets: casm_start_offsets,
+            annotations: Arc::clone(annotations),
+        })
     }
 
     pub fn render_backtrace(&self, pcs: &[usize]) -> Result<String> {

--- a/crates/forge-runner/src/backtrace/data.rs
+++ b/crates/forge-runner/src/backtrace/data.rs
@@ -275,7 +275,7 @@ pub enum TestAnnotations {
     Parsed(Arc<BacktraceAnnotations>),
     /// No backtrace can be produced: Backtrace is disabled, or the target has no sierra debug info.
     Missing,
-    // Debug info present; Failed to parse.
+    /// Debug info present; Failed to parse.
     Failed(String),
 }
 

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -53,7 +53,7 @@ pub fn add_test_backtrace_footer(
     test_name: &str,
 ) -> String {
     // Include hint even if backtrace capture was skipped (due to backtrace being disabled).
-    // Note: `is_panic()` is treated as equivalent to non-empty backtrace (>= 1 pc), 
+    // Note: `is_panic()` is treated as equivalent to non-empty backtrace (>= 1 pc),
     // since `get_reversed_pc_traceback` always injects the current pc.
     let has_backtrace = test_backtrace.is_panic() || !encountered_errors.is_empty();
 
@@ -109,7 +109,7 @@ pub fn get_backtrace(
         backtrace_parts.push(contract_part);
     }
 
-   if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty())
+    if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty())
         && let Some(test_annotations) = test_annotations
     {
         let test_part = match test_annotations {

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -26,6 +26,11 @@ pub enum TestBacktraceOutcome {
     Panic(Option<TestBacktraceContext>),
 }
 
+pub struct BacktraceSources<'a> {
+    pub test_annotations: &'a TestAnnotations,
+    pub contract_backtrace_mapping: &'a LazyContractBacktraceDataMapping,
+}
+
 impl TestBacktraceOutcome {
     #[must_use]
     pub fn is_panic(&self) -> bool {
@@ -47,9 +52,8 @@ pub fn add_test_backtrace_footer(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: &TestBacktraceOutcome,
-    test_annotations: &TestAnnotations,
-    contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
+    sources: &BacktraceSources,
 ) -> String {
     // Include hint even if backtrace capture was skipped (due to backtrace being disabled).
     // Note: `is_panic()` is treated as equivalent to non-empty backtrace (>= 1 pc),
@@ -65,9 +69,8 @@ pub fn add_test_backtrace_footer(
             contracts_data,
             encountered_errors,
             test_backtrace.context(),
-            test_annotations,
-            contract_backtrace_mapping,
             test_name,
+            sources,
         )
     } else {
         Some(format!(
@@ -87,10 +90,14 @@ pub fn get_backtrace(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: Option<&TestBacktraceContext>,
-    test_annotations: &TestAnnotations,
-    contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
+    sources: &BacktraceSources,
 ) -> Option<String> {
+    let BacktraceSources {
+        test_annotations,
+        contract_backtrace_mapping,
+    } = *sources;
+
     let mut backtrace_parts = Vec::new();
 
     if !encountered_errors.is_empty() {

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -48,7 +48,7 @@ pub fn add_test_backtrace_footer(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: &TestBacktraceOutcome,
-    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> String {
@@ -86,7 +86,7 @@ pub fn get_backtrace(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: Option<&TestBacktraceContext>,
-    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> Option<String> {
@@ -107,16 +107,18 @@ pub fn get_backtrace(
         backtrace_parts.push(contract_part);
     }
 
-    if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) {
+   if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty())
+        && let Some(test_annotations) = test_annotations
+    {
         let test_part = match test_annotations {
-            Some(annotations) => TestBacktraceData::new(
+            Ok(annotations) => TestBacktraceData::new(
                 test_name.to_owned(),
                 annotations,
                 bt.casm_start_offsets.clone(),
             )
             .render_backtrace(&bt.pcs)
             .unwrap_or_else(|err| format!("failed to create test backtrace: {err}")),
-            None => "failed to create test backtrace: debug info not found".to_string(),
+            Err(err) => format!("failed to create test backtrace: {err}"),
         };
 
         backtrace_parts.push(test_part);

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -2,10 +2,9 @@ use anyhow::Result;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::state::EncounteredErrors;
 use std::env;
-use std::sync::Arc;
 
 use data::TestBacktraceData;
-pub use data::{BacktraceAnnotations, LazyContractBacktraceDataMapping};
+pub use data::{BacktraceAnnotations, LazyContractBacktraceDataMapping, TestAnnotations};
 
 mod data;
 mod display;
@@ -48,7 +47,7 @@ pub fn add_test_backtrace_footer(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: &TestBacktraceOutcome,
-    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: &TestAnnotations,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> String {
@@ -88,7 +87,7 @@ pub fn get_backtrace(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: Option<&TestBacktraceContext>,
-    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: &TestAnnotations,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> Option<String> {
@@ -109,18 +108,20 @@ pub fn get_backtrace(
         backtrace_parts.push(contract_part);
     }
 
-    if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty())
-        && let Some(test_annotations) = test_annotations
-    {
+    if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) {
         let test_part = match test_annotations {
-            Ok(annotations) => TestBacktraceData::new(
+            TestAnnotations::Parsed(annotations) => TestBacktraceData::new(
                 test_name.to_owned(),
                 annotations,
                 bt.casm_start_offsets.clone(),
             )
             .render_backtrace(&bt.pcs)
             .unwrap_or_else(|err| format!("failed to create test backtrace: {err}")),
-            Err(err) => format!("failed to create test backtrace: {err}"),
+            TestAnnotations::Failed(err) => format!("failed to create test backtrace: {err}"),
+            // In practice, this should never happen as debug info is prerequisite checked by `check_backtrace_compatibility`
+            TestAnnotations::Missing => {
+                "failed to create test backtrace: debug info not found".to_string()
+            }
         };
 
         backtrace_parts.push(test_part);

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -1,9 +1,11 @@
-use crate::backtrace::data::{ContractBacktraceDataMapping, TestBacktraceData};
 use anyhow::Result;
-use camino::Utf8Path;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::state::EncounteredErrors;
 use std::env;
+use std::sync::Arc;
+
+use data::TestBacktraceData;
+pub use data::{BacktraceAnnotations, LazyContractBacktraceDataMapping};
 
 mod data;
 mod display;
@@ -46,7 +48,8 @@ pub fn add_test_backtrace_footer(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: &TestBacktraceOutcome,
-    versioned_program_path: &Utf8Path,
+    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> String {
     // Include hint even if backtrace capture was skipped (due to backtrace being disabled).
@@ -61,7 +64,8 @@ pub fn add_test_backtrace_footer(
             contracts_data,
             encountered_errors,
             test_backtrace.context(),
-            versioned_program_path,
+            test_annotations,
+            contract_backtrace_mapping,
             test_name,
         )
     } else {
@@ -82,35 +86,38 @@ pub fn get_backtrace(
     contracts_data: &ContractsData,
     encountered_errors: &EncounteredErrors,
     test_backtrace: Option<&TestBacktraceContext>,
-    versioned_program_path: &Utf8Path,
+    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
     test_name: &str,
 ) -> Option<String> {
     let mut backtrace_parts = Vec::new();
 
     if !encountered_errors.is_empty() {
-        let class_hashes = encountered_errors.keys().copied().collect();
-
-        let contract_part = ContractBacktraceDataMapping::new(contracts_data, class_hashes)
-            .and_then(|data_mapping| {
-                encountered_errors
-                    .iter()
-                    .map(|(class_hash, pcs)| data_mapping.render_backtrace(pcs, class_hash))
-                    .collect::<Result<Vec<_>>>()
-                    .map(|backtrace| backtrace.join("\n"))
+        let contract_part = encountered_errors
+            .iter()
+            .map(|(class_hash, pcs)| {
+                contract_backtrace_mapping.render_backtrace(class_hash, pcs, contracts_data)
             })
-            .unwrap_or_else(|err| format!("failed to create backtrace: {err}"));
+            .collect::<Result<Vec<_>>>()
+            .map_or_else(
+                |err| format!("failed to create contract backtrace: {err}"),
+                |backtrace| backtrace.join("\n"),
+            );
 
         backtrace_parts.push(contract_part);
     }
 
     if let Some(bt) = test_backtrace.filter(|bt| !bt.pcs.is_empty()) {
-        let test_part = TestBacktraceData::new(
-            test_name,
-            bt.casm_start_offsets.clone(),
-            versioned_program_path,
-        )
-        .and_then(|data| data.render_backtrace(&bt.pcs))
-        .unwrap_or_else(|err| format!("failed to create test backtrace: {err}"));
+        let test_part = match test_annotations {
+            Some(annotations) => TestBacktraceData::new(
+                test_name.to_owned(),
+                annotations,
+                bt.casm_start_offsets.clone(),
+            )
+            .render_backtrace(&bt.pcs)
+            .unwrap_or_else(|err| format!("failed to create test backtrace: {err}")),
+            None => "failed to create test backtrace: debug info not found".to_string(),
+        };
 
         backtrace_parts.push(test_part);
     }

--- a/crates/forge-runner/src/backtrace/mod.rs
+++ b/crates/forge-runner/src/backtrace/mod.rs
@@ -53,6 +53,8 @@ pub fn add_test_backtrace_footer(
     test_name: &str,
 ) -> String {
     // Include hint even if backtrace capture was skipped (due to backtrace being disabled).
+    // Note: `is_panic()` is treated as equivalent to non-empty backtrace (>= 1 pc), 
+    // since `get_reversed_pc_traceback` always injects the current pc.
     let has_backtrace = test_backtrace.is_panic() || !encountered_errors.is_empty();
 
     if !has_backtrace {

--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -135,7 +135,7 @@ pub fn run_for_test_case(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<AnyTestCaseSummary>> {
@@ -179,7 +179,7 @@ fn run_with_fuzzing(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<TestCaseSummary<Fuzzing>>> {

--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::backtrace::{BacktraceAnnotations, LazyContractBacktraceDataMapping};
 use crate::coverage_api::run_coverage;
 use crate::forge_config::{ExecutionDataToSave, ForgeConfig};
 use crate::running::{run_fuzz_test, run_test};
@@ -134,6 +135,8 @@ pub fn run_for_test_case(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
+    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<AnyTestCaseSummary>> {
     if case.config.fuzzer_config.is_none() {
@@ -143,6 +146,8 @@ pub fn run_for_test_case(
                 casm_program,
                 forge_config,
                 versioned_program_path,
+                test_annotations,
+                contract_backtrace_mapping,
                 send,
             )
             .await?;
@@ -158,6 +163,8 @@ pub fn run_for_test_case(
                 casm_program,
                 forge_config.clone(),
                 versioned_program_path,
+                test_annotations,
+                contract_backtrace_mapping,
                 send,
             )
             .await??;
@@ -172,6 +179,8 @@ fn run_with_fuzzing(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
+    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<TestCaseSummary<Fuzzing>>> {
     tokio::task::spawn(async move {
@@ -206,6 +215,8 @@ fn run_with_fuzzing(
                 casm_program.clone(),
                 forge_config.clone(),
                 versioned_program_path.clone(),
+                test_annotations.clone(),
+                contract_backtrace_mapping.clone(),
                 send.clone(),
                 fuzzing_send.clone(),
                 rng.clone(),

--- a/crates/forge-runner/src/lib.rs
+++ b/crates/forge-runner/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::backtrace::{BacktraceAnnotations, LazyContractBacktraceDataMapping};
+use crate::backtrace::{LazyContractBacktraceDataMapping, TestAnnotations};
 use crate::coverage_api::run_coverage;
 use crate::forge_config::{ExecutionDataToSave, ForgeConfig};
 use crate::running::{run_fuzz_test, run_test};
@@ -135,7 +135,7 @@ pub fn run_for_test_case(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: TestAnnotations,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<AnyTestCaseSummary>> {
@@ -179,7 +179,7 @@ fn run_with_fuzzing(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: TestAnnotations,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<Result<TestCaseSummary<Fuzzing>>> {

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -73,7 +73,7 @@ pub fn run_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<TestCaseSummary<Single>> {
@@ -119,7 +119,7 @@ pub(crate) fn run_fuzz_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
     fuzzing_send: Sender<()>,
@@ -478,7 +478,7 @@ fn extract_test_case_summary(
     case: &TestCaseWithResolvedConfig,
     forge_config: &ForgeConfig,
     versioned_program_path: &Utf8Path,
-    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
 ) -> TestCaseSummary<Single> {
     let contracts_data = &forge_config.test_runner_config.contracts_data;

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,5 +1,6 @@
 use crate::backtrace::{
-    TestBacktraceContext, TestBacktraceOutcome, add_test_backtrace_footer, is_backtrace_enabled,
+    BacktraceAnnotations, LazyContractBacktraceDataMapping, TestBacktraceContext,
+    TestBacktraceOutcome, add_test_backtrace_footer, is_backtrace_enabled,
 };
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
@@ -72,6 +73,8 @@ pub fn run_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
+    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<TestCaseSummary<Single>> {
     tokio::task::spawn_blocking(move || {
@@ -97,7 +100,14 @@ pub fn run_test(
             return TestCaseSummary::Interrupted {};
         }
 
-        extract_test_case_summary(run_result, &case, &forge_config, &versioned_program_path)
+        extract_test_case_summary(
+            run_result,
+            &case,
+            &forge_config,
+            &versioned_program_path,
+            test_annotations.as_ref(),
+            &contract_backtrace_mapping,
+        )
     })
 }
 
@@ -109,6 +119,8 @@ pub(crate) fn run_fuzz_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
+    test_annotations: Option<Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
     fuzzing_send: Sender<()>,
     rng: Arc<Mutex<StdRng>>,
@@ -136,7 +148,14 @@ pub(crate) fn run_fuzz_test(
             return TestCaseSummary::Interrupted {};
         }
 
-        extract_test_case_summary(run_result, &case, &forge_config, &versioned_program_path)
+        extract_test_case_summary(
+            run_result,
+            &case,
+            &forge_config,
+            &versioned_program_path,
+            test_annotations.as_ref(),
+            &contract_backtrace_mapping,
+        )
     })
 }
 
@@ -459,6 +478,8 @@ fn extract_test_case_summary(
     case: &TestCaseWithResolvedConfig,
     forge_config: &ForgeConfig,
     versioned_program_path: &Utf8Path,
+    test_annotations: Option<&Arc<BacktraceAnnotations>>,
+    contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
 ) -> TestCaseSummary<Single> {
     let contracts_data = &forge_config.test_runner_config.contracts_data;
     let trace_args = &forge_config.output_config.trace_args;
@@ -469,6 +490,8 @@ fn extract_test_case_summary(
                 case,
                 contracts_data,
                 versioned_program_path,
+                test_annotations,
+                contract_backtrace_mapping,
                 trace_args,
                 forge_config.output_config.gas_report,
             ),
@@ -495,7 +518,8 @@ fn extract_test_case_summary(
                             contracts_data,
                             &run_error.encountered_errors,
                             &run_error.test_backtrace,
-                            versioned_program_path,
+                            test_annotations,
+                            contract_backtrace_mapping,
                             &case.name,
                         )
                     }),

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,6 +1,6 @@
 use crate::backtrace::{
-    LazyContractBacktraceDataMapping, TestAnnotations, TestBacktraceContext, TestBacktraceOutcome,
-    add_test_backtrace_footer, is_backtrace_enabled,
+    BacktraceSources, LazyContractBacktraceDataMapping, TestAnnotations, TestBacktraceContext,
+    TestBacktraceOutcome, add_test_backtrace_footer, is_backtrace_enabled,
 };
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
@@ -483,6 +483,10 @@ fn extract_test_case_summary(
 ) -> TestCaseSummary<Single> {
     let contracts_data = &forge_config.test_runner_config.contracts_data;
     let trace_args = &forge_config.output_config.trace_args;
+    let backtrace_sources = BacktraceSources {
+        test_annotations,
+        contract_backtrace_mapping,
+    };
     match run_result {
         Ok(run_result) => match run_result {
             RunResult::Completed(run_completed) => TestCaseSummary::from_run_completed(
@@ -490,8 +494,7 @@ fn extract_test_case_summary(
                 case,
                 contracts_data,
                 versioned_program_path,
-                test_annotations,
-                contract_backtrace_mapping,
+                &backtrace_sources,
                 trace_args,
                 forge_config.output_config.gas_report,
             ),
@@ -518,9 +521,8 @@ fn extract_test_case_summary(
                             contracts_data,
                             &run_error.encountered_errors,
                             &run_error.test_backtrace,
-                            test_annotations,
-                            contract_backtrace_mapping,
                             &case.name,
+                            &backtrace_sources,
                         )
                     }),
                     fuzzer_args: run_error.fuzzer_args,

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -1,6 +1,6 @@
 use crate::backtrace::{
-    BacktraceAnnotations, LazyContractBacktraceDataMapping, TestBacktraceContext,
-    TestBacktraceOutcome, add_test_backtrace_footer, is_backtrace_enabled,
+    LazyContractBacktraceDataMapping, TestAnnotations, TestBacktraceContext, TestBacktraceOutcome,
+    add_test_backtrace_footer, is_backtrace_enabled,
 };
 use crate::forge_config::{ForgeConfig, RuntimeConfig};
 use crate::gas::calculate_used_gas;
@@ -73,7 +73,7 @@ pub fn run_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: TestAnnotations,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
 ) -> JoinHandle<TestCaseSummary<Single>> {
@@ -105,7 +105,7 @@ pub fn run_test(
             &case,
             &forge_config,
             &versioned_program_path,
-            test_annotations.as_ref(),
+            &test_annotations,
             &contract_backtrace_mapping,
         )
     })
@@ -119,7 +119,7 @@ pub(crate) fn run_fuzz_test(
     casm_program: Arc<RawCasmProgram>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
-    test_annotations: Option<Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: TestAnnotations,
     contract_backtrace_mapping: Arc<LazyContractBacktraceDataMapping>,
     send: Sender<()>,
     fuzzing_send: Sender<()>,
@@ -153,7 +153,7 @@ pub(crate) fn run_fuzz_test(
             &case,
             &forge_config,
             &versioned_program_path,
-            test_annotations.as_ref(),
+            &test_annotations,
             &contract_backtrace_mapping,
         )
     })
@@ -478,7 +478,7 @@ fn extract_test_case_summary(
     case: &TestCaseWithResolvedConfig,
     forge_config: &ForgeConfig,
     versioned_program_path: &Utf8Path,
-    test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
+    test_annotations: &TestAnnotations,
     contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
 ) -> TestCaseSummary<Single> {
     let contracts_data = &forge_config.test_runner_config.contracts_data;

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -304,7 +304,7 @@ impl TestCaseSummary<Single> {
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
         versioned_program_path: &Utf8Path,
-        test_annotations: Option<&Arc<BacktraceAnnotations>>,
+        test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
         contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
         trace_args: &TraceArgs,
         gas_report_enabled: bool,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,4 +1,7 @@
-use crate::backtrace::{add_test_backtrace_footer, get_backtrace, is_backtrace_enabled};
+use crate::backtrace::{
+    BacktraceAnnotations, LazyContractBacktraceDataMapping, add_test_backtrace_footer,
+    get_backtrace, is_backtrace_enabled,
+};
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
 use crate::expected_result::{ExpectedPanicValue, ExpectedTestResult};
@@ -20,6 +23,7 @@ use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
 use std::fmt;
 use std::option::Option;
+use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct GasFuzzingInfo {
@@ -284,6 +288,7 @@ fn check_if_matching_and_get_message(
 
 impl TestCaseSummary<Single> {
     #[expect(clippy::too_many_lines)]
+    #[expect(clippy::too_many_arguments)]
     #[must_use]
     pub(crate) fn from_run_completed(
         RunCompleted {
@@ -299,6 +304,8 @@ impl TestCaseSummary<Single> {
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
         versioned_program_path: &Utf8Path,
+        test_annotations: Option<&Arc<BacktraceAnnotations>>,
+        contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
         trace_args: &TraceArgs,
         gas_report_enabled: bool,
     ) -> Self {
@@ -360,7 +367,8 @@ impl TestCaseSummary<Single> {
                             contracts_data,
                             &encountered_errors,
                             &test_backtrace,
-                            versioned_program_path,
+                            test_annotations,
+                            contract_backtrace_mapping,
                             &name,
                         )
                     }),
@@ -378,7 +386,8 @@ impl TestCaseSummary<Single> {
                                     contracts_data,
                                     &encountered_errors,
                                     test_backtrace.context(),
-                                    versioned_program_path,
+                                    test_annotations,
+                                    contract_backtrace_mapping,
                                     &name,
                                 )
                             })
@@ -407,7 +416,8 @@ impl TestCaseSummary<Single> {
                                     contracts_data,
                                     &encountered_errors,
                                     &test_backtrace,
-                                    versioned_program_path,
+                                    test_annotations,
+                                    contract_backtrace_mapping,
                                     &name,
                                 )
                             }),

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,6 +1,6 @@
 use crate::backtrace::{
-    BacktraceAnnotations, LazyContractBacktraceDataMapping, add_test_backtrace_footer,
-    get_backtrace, is_backtrace_enabled,
+    LazyContractBacktraceDataMapping, TestAnnotations, add_test_backtrace_footer, get_backtrace,
+    is_backtrace_enabled,
 };
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
@@ -23,7 +23,6 @@ use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
 use std::fmt;
 use std::option::Option;
-use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct GasFuzzingInfo {
@@ -304,7 +303,7 @@ impl TestCaseSummary<Single> {
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
         versioned_program_path: &Utf8Path,
-        test_annotations: Option<&Result<Arc<BacktraceAnnotations>, String>>,
+        test_annotations: &TestAnnotations,
         contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
         trace_args: &TraceArgs,
         gas_report_enabled: bool,

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -1,6 +1,5 @@
 use crate::backtrace::{
-    LazyContractBacktraceDataMapping, TestAnnotations, add_test_backtrace_footer, get_backtrace,
-    is_backtrace_enabled,
+    BacktraceSources, add_test_backtrace_footer, get_backtrace, is_backtrace_enabled,
 };
 use crate::build_trace_data::build_profiler_call_trace;
 use crate::debugging::{TraceArgs, build_contracts_data_store, build_debugging_trace};
@@ -287,7 +286,6 @@ fn check_if_matching_and_get_message(
 
 impl TestCaseSummary<Single> {
     #[expect(clippy::too_many_lines)]
-    #[expect(clippy::too_many_arguments)]
     #[must_use]
     pub(crate) fn from_run_completed(
         RunCompleted {
@@ -303,8 +301,7 @@ impl TestCaseSummary<Single> {
         test_case: &TestCaseWithResolvedConfig,
         contracts_data: &ContractsData,
         versioned_program_path: &Utf8Path,
-        test_annotations: &TestAnnotations,
-        contract_backtrace_mapping: &LazyContractBacktraceDataMapping,
+        backtrace_sources: &BacktraceSources,
         trace_args: &TraceArgs,
         gas_report_enabled: bool,
     ) -> Self {
@@ -366,9 +363,8 @@ impl TestCaseSummary<Single> {
                             contracts_data,
                             &encountered_errors,
                             &test_backtrace,
-                            test_annotations,
-                            contract_backtrace_mapping,
                             &name,
+                            backtrace_sources,
                         )
                     }),
                     fuzzer_args,
@@ -385,9 +381,8 @@ impl TestCaseSummary<Single> {
                                     contracts_data,
                                     &encountered_errors,
                                     test_backtrace.context(),
-                                    test_annotations,
-                                    contract_backtrace_mapping,
                                     &name,
+                                    backtrace_sources,
                                 )
                             })
                             .flatten();
@@ -415,9 +410,8 @@ impl TestCaseSummary<Single> {
                                     contracts_data,
                                     &encountered_errors,
                                     &test_backtrace,
-                                    test_annotations,
-                                    contract_backtrace_mapping,
                                     &name,
+                                    backtrace_sources,
                                 )
                             }),
                             fuzzer_args,

--- a/crates/forge/src/run_tests/test_target.rs
+++ b/crates/forge/src/run_tests/test_target.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use forge_runner::backtrace::{
-    BacktraceAnnotations, LazyContractBacktraceDataMapping, is_backtrace_enabled,
+    LazyContractBacktraceDataMapping, TestAnnotations, is_backtrace_enabled,
 };
 use forge_runner::filtering::{ExcludeReason, FilterResult, TestCaseFilter};
 use forge_runner::messages::TestResultMessage;
@@ -65,15 +65,12 @@ pub async fn run_for_test_target(
 ) -> Result<TestTargetRunResult> {
     let casm_program = tests.casm_program.clone();
 
-    // Propagate backtrace annotations, so failing test cases can avoid reparsing these.
-    let test_annotations =
-        is_backtrace_enabled().then(|| match tests.sierra_program.debug_info.as_ref() {
-            Some(debug_info) => BacktraceAnnotations::from_debug_info(debug_info)
-                .map(Arc::new)
-                .map_err(|err| err.to_string()),
-            // In practice, this should never happen as debug info is prerequisite checked by `check_backtrace_compatibility`
-            None => Err("debug info not found".to_string()),
-        });
+    // Built once per target and shared across all test case tasks, so failing test cases can avoid reparsing.
+    let test_annotations = TestAnnotations::from_debug_info(
+        is_backtrace_enabled()
+            .then_some(tests.sierra_program.debug_info.as_ref())
+            .flatten(),
+    );
 
     // Shared across all test case tasks, so each contract's backtrace data is built once and reused.
     let contract_backtrace_mapping = Arc::new(LazyContractBacktraceDataMapping::new());

--- a/crates/forge/src/run_tests/test_target.rs
+++ b/crates/forge/src/run_tests/test_target.rs
@@ -1,4 +1,7 @@
 use anyhow::Result;
+use forge_runner::backtrace::{
+    BacktraceAnnotations, LazyContractBacktraceDataMapping, is_backtrace_enabled,
+};
 use forge_runner::filtering::{ExcludeReason, FilterResult, TestCaseFilter};
 use forge_runner::messages::TestResultMessage;
 use forge_runner::{
@@ -62,6 +65,14 @@ pub async fn run_for_test_target(
 ) -> Result<TestTargetRunResult> {
     let casm_program = tests.casm_program.clone();
 
+    // Propagate backtrace annotations from debug info so failing test cases can avoid reparsing these.
+    let test_annotations = is_backtrace_enabled()
+        .then_some(tests.sierra_program.debug_info.as_ref())
+        .flatten()
+        .and_then(|d| BacktraceAnnotations::from_debug_info(d).ok().map(Arc::new));
+
+    let contract_backtrace_mapping = Arc::new(LazyContractBacktraceDataMapping::new());
+
     let mut tasks = FuturesUnordered::new();
 
     for case in tests.test_cases {
@@ -91,6 +102,8 @@ pub async fn run_for_test_target(
                     casm_program.clone(),
                     forge_config.clone(),
                     tests.sierra_program_path.clone(),
+                    test_annotations.clone(),
+                    contract_backtrace_mapping.clone(),
                     exit_first_channel.sender(),
                 ));
             }

--- a/crates/forge/src/run_tests/test_target.rs
+++ b/crates/forge/src/run_tests/test_target.rs
@@ -65,12 +65,17 @@ pub async fn run_for_test_target(
 ) -> Result<TestTargetRunResult> {
     let casm_program = tests.casm_program.clone();
 
-    // Propagate backtrace annotations from debug info so failing test cases can avoid reparsing these.
-    let test_annotations = is_backtrace_enabled()
-        .then_some(tests.sierra_program.debug_info.as_ref())
-        .flatten()
-        .and_then(|d| BacktraceAnnotations::from_debug_info(d).ok().map(Arc::new));
+    // Propagate backtrace annotations, so failing test cases can avoid reparsing these.
+    let test_annotations =
+        is_backtrace_enabled().then(|| match tests.sierra_program.debug_info.as_ref() {
+            Some(debug_info) => BacktraceAnnotations::from_debug_info(debug_info)
+                .map(Arc::new)
+                .map_err(|err| err.to_string()),
+            // In practice, this should never happen as debug info is prerequisite checked by `check_backtrace_compatibility`
+            None => Err("debug info not found".to_string()),
+        });
 
+    // Shared across all test case tasks, so each contract's backtrace data is built once and reused.
     let contract_backtrace_mapping = Arc::new(LazyContractBacktraceDataMapping::new());
 
     let mut tasks = FuturesUnordered::new();


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Addresses https://github.com/foundry-rs/starknet-foundry/pull/4400#discussion_r3465982524

## Stack
- #4400
- #4428
- #4442
- #4444 
- #4448


## Introduced changes

<!-- A brief description of the changes -->


Propagate necessary data instead of re-reading and re-parsing it at each failure case:
- Test-level backtrace: Re-use already parsed debug info and derived annotations
- Contract-level backtrace: Cache per-class-hash contract data

### Benchmark results

#### Test-level

- Setup:  1 package, 300 tests, all fail (panic in test body).

```
baseline   median real=6.05  user=30.64  sys=2.82
refactor   median real=1.39  user=3.69   sys=0.44
```

#### Contract-level 

- Setup: 1 package, 200 tests, all fail through the same contract / class hash.

```
baseline   median real=19.66  user=51.54  sys=54.51
refactor   median real=1.17   user=3.18   sys=0.40
```

<!-- Make sure all of these are complete -->
- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`