### PR TITLE
Adjust debugger config validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Support for structs, enums, tuples, arrays and spans in [live debugging]((https://foundry-rs.github.io/starknet-foundry/snforge-advanced-features/debugging.html#live-debugging))
+⚠️ These features work best with Scarb >= 2.19.0 and `[cairo] add-types-debug-info = true` config (or equivalent) in Scarb.toml. 
+You may still use other Scarb versions but names of structs, enums, their fields and variants will not be available.
+
 - Backtrace support for panics that originate directly in a test function body, not only inside called contracts. Read more [here](https://foundry-rs.github.io/starknet-foundry/snforge-advanced-features/debugging.html#backtrace).
 
 #### Changed

--- a/crates/forge/src/profile_validation/debugger.rs
+++ b/crates/forge/src/profile_validation/debugger.rs
@@ -2,6 +2,8 @@ use crate::profile_validation::{bool_field, bool_field_or_unstable, str_field};
 use anyhow::ensure;
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
+use scarb_api::version::scarb_version;
+use semver::Version;
 use serde_json::Value;
 
 pub fn check_debugger_compatibility(
@@ -9,10 +11,25 @@ pub fn check_debugger_compatibility(
     profile: &str,
     workspace_manifest_path: &Utf8PathBuf,
 ) -> anyhow::Result<()> {
-    let has_needed_entries = bool_field(compiler_config, "add_functions_debug_info")
+    let mut has_needed_entries = bool_field(compiler_config, "add_functions_debug_info")
         && bool_field_or_unstable(compiler_config, "add_statements_code_locations_debug_info")
         && bool_field_or_unstable(compiler_config, "add_statements_functions_debug_info")
         && str_field(compiler_config, "compiler_optimizations") == "Disabled";
+
+    let mut required_cairo_config_section = formatdoc! {
+        "skip-optimizations = true
+        unstable-add-statements-code-locations-debug-info = true
+        unstable-add-statements-functions-debug-info = true
+        add-functions-debug-info = true
+        "
+    };
+
+    // `add-types-debug-info` annotations are available from Scarb 2.19.0 onwards.
+    // Require them for **much** better UX.
+    if scarb_version().is_ok_and(|version| version.scarb >= Version::new(2, 19, 0)) {
+        has_needed_entries &= bool_field(compiler_config, "add_types_debug_info");
+        required_cairo_config_section += "\nadd-types-debug-info = true";
+    }
 
     ensure!(
         has_needed_entries,
@@ -20,10 +37,7 @@ pub fn check_debugger_compatibility(
             "{workspace_manifest_path} must have the Cairo compiler configuration equivalent to the following one to launch the debugger:
 
             [profile.{profile}.cairo]
-            unstable-add-statements-code-locations-debug-info = true
-            unstable-add-statements-functions-debug-info = true
-            add-functions-debug-info = true
-            skip-optimizations = true
+            {required_cairo_config_section}
             ... other entries ...
             ",
         },


### PR DESCRIPTION
## Introduced changes

- require`add-types-debug-info = true` when available (Scarb >= 2.19.0) when using debugger. While this is not explicitly required by debugger (it will still work, won't panic) it provides much better UX.

Without `add-types-debug-info = true`:
<img width="303" height="268" alt="image" src="https://github.com/user-attachments/assets/e120408c-a3d5-4c46-adaf-0c9aca2820a1" />
vs with:
<img width="284" height="260" alt="image" src="https://github.com/user-attachments/assets/48ba7b45-4cbe-4539-9af1-5b4f940e9f00" />

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
