### PR TITLE
Allow specifying private key in account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - `--contract-address` flag to `get balance` command, allowing to check balance for any contract, not only accounts
+- Optional `--private-key` and `--private-key-file` in `account create` command to allow specifying a private key for the newly created account
 
 #### Changed
 

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -1,5 +1,6 @@
 use crate::starknet_commands::account::{
-    generate_add_profile_message, prepare_account_json, write_account_to_accounts_file,
+    generate_add_profile_message, get_private_key_from_file, prepare_account_json,
+    write_account_to_accounts_file,
 };
 use crate::starknet_commands::utils::felt_or_id::ClassHash;
 use anyhow::{Context, Result, anyhow, bail};
@@ -57,6 +58,22 @@ pub struct Create {
     #[arg(short, long, requires = "account_type")]
     pub class_hash: Option<ClassHash>,
 
+    /// Account private key. If omitted, a random private key is generated
+    #[arg(
+        long,
+        group = "private_key_input",
+        conflicts_with = "ledger_key_locator_account"
+    )]
+    pub private_key: Option<Felt>,
+
+    /// Path to the file holding account private key. If omitted, a random private key is generated
+    #[arg(
+        long = "private-key-file",
+        group = "private_key_input",
+        conflicts_with = "ledger_key_locator_account"
+    )]
+    pub private_key_file_path: Option<Utf8PathBuf>,
+
     #[command(flatten)]
     pub rpc: RpcArgs,
 
@@ -91,12 +108,22 @@ pub async fn create(
         });
     check_class_hash_exists(provider, class_hash).await?;
 
+    let private_key = match (&create.private_key, &create.private_key_file_path) {
+        (Some(key), _) => Some(*key),
+        (None, Some(path)) => Some(
+            get_private_key_from_file(path)
+                .with_context(|| format!("Failed to obtain private key from the file {path}"))?,
+        ),
+        (None, None) => None,
+    };
+
     let (account_json, estimated_fee) = generate_account(
         provider,
         salt,
         class_hash,
         create.account_type,
         signer_source,
+        private_key,
         chain_id,
         ui,
     )
@@ -174,12 +201,14 @@ pub async fn create(
     })
 }
 
+#[expect(clippy::too_many_arguments)]
 async fn generate_account(
     provider: &JsonRpcClient<HttpTransport>,
     salt: Felt,
     class_hash: Felt,
     account_type: AccountType,
     signer_source: &SignerSource,
+    private_key: Option<Felt>,
     chain_id: Felt,
     ui: &UI,
 ) -> Result<(serde_json::Value, u128)> {
@@ -200,7 +229,8 @@ async fn generate_account(
         )
         .await
     } else {
-        let private_key = SigningKey::from_random();
+        let private_key =
+            private_key.map_or_else(SigningKey::from_random, SigningKey::from_secret_scalar);
         let signer = LocalWallet::from_signing_key(private_key.clone());
         let signer_type = SignerType::Local {
             private_key: private_key.secret_scalar(),

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -109,12 +109,15 @@ pub async fn create(
     check_class_hash_exists(provider, class_hash).await?;
 
     let private_key = match (&create.private_key, &create.private_key_file_path) {
-        (Some(key), _) => Some(*key),
+        (Some(key), None) => Some(*key),
         (None, Some(path)) => Some(
             get_private_key_from_file(path)
                 .with_context(|| format!("Failed to obtain private key from the file {path}"))?,
         ),
         (None, None) => None,
+        (Some(_), Some(_)) => {
+            unreachable!("`--private-key` and `--private-key-file` are mutually exclusive")
+        }
     };
 
     let (account_json, estimated_fee) = generate_account(

--- a/crates/sncast/src/starknet_commands/account/import.rs
+++ b/crates/sncast/src/starknet_commands/account/import.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use crate::starknet_commands::account::{
-    compute_account_address, generate_add_profile_message, prepare_account_json,
-    write_account_to_accounts_file,
+    compute_account_address, generate_add_profile_message, get_private_key_from_file,
+    prepare_account_json, write_account_to_accounts_file,
 };
 use crate::starknet_commands::utils::felt_or_id::{ClassHash, ContractAddress};
 use anyhow::{Context, Result, bail, ensure};
@@ -202,11 +202,6 @@ pub async fn import(
         add_profile: add_profile_message,
         account_name,
     })
-}
-
-fn get_private_key_from_file(file_path: &Utf8PathBuf) -> Result<Felt> {
-    let private_key_string = std::fs::read_to_string(file_path.clone())?;
-    Ok(private_key_string.parse()?)
 }
 
 fn parse_input_to_felt(input: &str) -> Result<Felt> {

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -94,6 +94,11 @@ pub fn prepare_account_json(
     account_json
 }
 
+fn get_private_key_from_file(file_path: &Utf8PathBuf) -> Result<Felt> {
+    let private_key_string = std::fs::read_to_string(file_path.clone())?;
+    Ok(private_key_string.parse()?)
+}
+
 pub fn write_account_to_accounts_file(
     account: &str,
     accounts_file: &Utf8PathBuf,

--- a/crates/sncast/tests/e2e/account/create.rs
+++ b/crates/sncast/tests/e2e/account/create.rs
@@ -1,4 +1,6 @@
-use crate::helpers::constants::{ACCOUNT_FILE_PATH, DEVNET_OZ_CLASS_HASH_CAIRO_0, URL};
+use crate::helpers::constants::{
+    ACCOUNT_FILE_PATH, DEVNET_OZ_CLASS_HASH_CAIRO_0, DEVNET_OZ_CLASS_HASH_CAIRO_1, URL,
+};
 use crate::helpers::fixtures::copy_file;
 use crate::helpers::runner::runner;
 use configuration::test_utils::copy_config_to_tempdir;
@@ -84,6 +86,159 @@ pub async fn test_happy_case(account_type: &str) {
     );
 
     assert_data_eq!(contents, to_string_pretty(&expected).unwrap());
+}
+
+#[tokio::test]
+pub async fn test_create_with_private_key() {
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "accounts.json";
+    let class_hash = DEVNET_OZ_CLASS_HASH_CAIRO_1.into_hex_string();
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--url",
+        URL,
+        "--name",
+        "my_account",
+        "--salt",
+        "0x1",
+        "--type",
+        "oz",
+        "--class-hash",
+        &class_hash,
+        "--private-key",
+        "0x456",
+    ];
+
+    runner(&args)
+        .current_dir(temp_dir.path())
+        .assert()
+        .success();
+
+    let contents = fs::read_to_string(temp_dir.path().join(accounts_file))
+        .expect("Unable to read created file");
+
+    let expected = json!(
+        {
+            "alpha-sepolia": {
+                "my_account": {
+                    "address": "0x[..]",
+                    "class_hash": &class_hash,
+                    "deployed": false,
+                    "legacy": false,
+                    "private_key": "0x456",
+                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
+                    "salt": "0x1",
+                    "type": "open_zeppelin"
+                }
+            }
+        }
+    );
+
+    assert_data_eq!(contents, to_string_pretty(&expected).unwrap());
+}
+
+#[tokio::test]
+pub async fn test_create_with_private_key_from_file() {
+    let temp_dir = tempdir().expect("Unable to create a temporary directory");
+    let accounts_file = "accounts.json";
+    let private_key_file = "my_private_key";
+    let class_hash = DEVNET_OZ_CLASS_HASH_CAIRO_1.into_hex_string();
+
+    fs::write(temp_dir.path().join(private_key_file), "0x456").unwrap();
+
+    let args = vec![
+        "--accounts-file",
+        accounts_file,
+        "account",
+        "create",
+        "--url",
+        URL,
+        "--name",
+        "my_account",
+        "--salt",
+        "0x1",
+        "--type",
+        "oz",
+        "--class-hash",
+        &class_hash,
+        "--private-key-file",
+        private_key_file,
+    ];
+
+    runner(&args)
+        .current_dir(temp_dir.path())
+        .assert()
+        .success();
+
+    let contents = fs::read_to_string(temp_dir.path().join(accounts_file))
+        .expect("Unable to read created file");
+
+    let expected = json!(
+        {
+            "alpha-sepolia": {
+                "my_account": {
+                    "address": "0x[..]",
+                    "class_hash": &class_hash,
+                    "deployed": false,
+                    "legacy": false,
+                    "private_key": "0x456",
+                    "public_key": "0x5f679dacd8278105bd3b84a15548fe84079068276b0e84d6cc093eb5430f063",
+                    "salt": "0x1",
+                    "type": "open_zeppelin"
+                }
+            }
+        }
+    );
+
+    assert_data_eq!(contents, to_string_pretty(&expected).unwrap());
+}
+
+#[tokio::test]
+pub async fn test_create_accept_only_one_private_key() {
+    let args = vec![
+        "account",
+        "create",
+        "--private-key",
+        "0x456",
+        "--private-key-file",
+        "my_private_key",
+    ];
+
+    let output = runner(&args).assert().failure();
+
+    assert_stderr_contains(
+        output,
+        "error: the argument '--private-key <PRIVATE_KEY>' cannot be used with '--private-key-file <PRIVATE_KEY_FILE_PATH>'",
+    );
+}
+
+#[tokio::test]
+pub async fn test_create_invalid_private_key_file_path() {
+    let args = vec![
+        "account",
+        "create",
+        "--url",
+        URL,
+        "--private-key-file",
+        "my_private_key",
+    ];
+
+    let output = runner(&args).assert().failure();
+
+    assert_stderr_contains(
+        output,
+        formatdoc! {r"
+        Command: account create
+        Error: Failed to obtain private key from the file my_private_key
+
+        Caused by:
+            No such file or directory [..]
+        "},
+    );
 }
 
 #[tokio::test]

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -57,6 +57,20 @@ Class hash of a custom openzeppelin account contract declared to the network. It
 - Felt in hex (prefixed with `0x`) or decimal representation.
 - `@alias` defined in `[sncast.<profile>.aliases]` in `snfoundry.toml`. See [aliases](../../../starknet/aliases.md).
 
+## `--private-key <PRIVATE_KEY>`
+Optional. If neither `--private-key` nor `--private-key-file` is passed, a random private key will be generated.
+
+Account private key.
+
+Conflicts with: [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
+
+## `--private-key-file <PRIVATE_KEY_FILE_PATH>`
+Optional. If neither `--private-key` nor `--private-key-file` is passed, a random private key will be generated.
+
+Path to the file holding account private key.
+
+Conflicts with: [`--private-key`](#--private-key-private_key), [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
+
 ## `--ledger-path <HD_PATH>`
 Optional.
 
@@ -64,7 +78,7 @@ Optional.
 
 When provided, the public key is read from the Ledger device.
 
-Conflicts with: [`--ledger-account-id`](#--ledger-account-id-account_id)
+Conflicts with: [`--private-key`](#--private-key-private_key), [`--private-key-file`](#--private-key-file-private_key_file_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
 
 See [Ledger Hardware Wallet](../../../starknet/ledger.md) for details.
 
@@ -73,6 +87,6 @@ Optional.
 
 Shorthand for `--ledger-path`. The account ID is used to derive the path `m//starknet'/sncast'/0'/<account-id>'/0`.
 
-Conflicts with: [`--ledger-path`](#--ledger-path-hd_path)
+Conflicts with: [`--ledger-path`](#--ledger-path-hd_path), [`--private-key`](#--private-key-private_key), [`--private-key-file`](#--private-key-file-private_key_file_path)
 
 See [Ledger Hardware Wallet](../../../starknet/ledger.md) for details.

--- a/docs/src/appendix/sncast/account/create.md
+++ b/docs/src/appendix/sncast/account/create.md
@@ -62,7 +62,7 @@ Optional. If neither `--private-key` nor `--private-key-file` is passed, a rando
 
 Account private key.
 
-Conflicts with: [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
+Conflicts with: [`--private-key-file`](#--private-key-file-private_key_file_path), [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
 
 ## `--private-key-file <PRIVATE_KEY_FILE_PATH>`
 Optional. If neither `--private-key` nor `--private-key-file` is passed, a random private key will be generated.

--- a/docs/src/appendix/sncast/account/import.md
+++ b/docs/src/appendix/sncast/account/import.md
@@ -49,6 +49,8 @@ Optional.
 
 Account private key.
 
+Conflicts with: [`--private-key-file`](#--private-key-file-private_key_file_path), [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
+
 ## `--ledger-path <HD_PATH>`
 Optional.
 
@@ -73,6 +75,8 @@ See [Ledger Hardware Wallet](../../../starknet/ledger.md) for details.
 Optional. If neither `--private-key` nor `--private-key-file` is passed, the user will be prompted to enter the account private key.
 
 Path to the file holding account private key.
+
+Conflicts with: [`--private-key`](#--private-key-private_key), [`--ledger-path`](#--ledger-path-hd_path), [`--ledger-account-id`](#--ledger-account-id-account_id)
 
 ## `--salt, -s <SALT>`
 Optional.


### PR DESCRIPTION
Allow speciyfing private key, if not provided generate a random pair as it worked so far.
