### PR TITLE
Fix formatting panic data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Forge
+
+#### Fixed
+
+- Fixed formatting of `#[should_panic(expected: (...))]` mismatch output for panic data containing byte array values inside tuples.
+
 ## [0.62.0] - 2026-06-25
 
 ### Forge

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -20,8 +20,11 @@ use conversions::serde::deserialize::BufferReader;
 use shared::utils::build_readable_text;
 use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
-use std::fmt;
-use std::option::Option;
+use std::{fmt, option::Option, sync::LazyLock};
+
+static BYTE_ARRAY_MAGIC_FELT: LazyLock<Felt> = LazyLock::new(|| {
+    Felt::from_hex(&format!("0x{BYTE_ARRAY_MAGIC}")).expect("BYTE_ARRAY_MAGIC should be a felt")
+});
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct GasFuzzingInfo {
@@ -431,7 +434,9 @@ fn format_panic_data_items(data: &[Felt]) -> String {
     let mut items = vec![];
 
     while let Some((felt, tail)) = rest.split_first() {
-        if *felt == byte_array_magic_felt()
+        // `should_panic` tuple data is untyped here, so `BYTE_ARRAY_MAGIC` is the only signal
+        // that the next felts should be shown as one ByteArray item.
+        if felt == byte_array_magic_felt()
             && let Some((byte_array, consumed)) = read_byte_array_item(rest)
         {
             items.push(byte_array.to_string());
@@ -466,8 +471,8 @@ fn is_readable_short_string(value: &str) -> bool {
             .all(|char| char == ' ' || char.is_ascii_graphic())
 }
 
-fn byte_array_magic_felt() -> Felt {
-    Felt::from_hex(&format!("0x{BYTE_ARRAY_MAGIC}")).expect("BYTE_ARRAY_MAGIC should be a felt")
+fn byte_array_magic_felt() -> &'static Felt {
+    &BYTE_ARRAY_MAGIC_FELT
 }
 
 fn is_matching_should_panic_data(data: &[Felt], pattern: &[Felt]) -> bool {
@@ -703,6 +708,30 @@ mod tests {
             format_readable_panic_data(&data),
             "this_string_is_longer_than_31_bytes, 0xb, hello, 0x5, short_string"
         );
+    }
+
+    #[test]
+    fn test_format_readable_panic_data_byte_array() {
+        let data = ByteArray::from("This will panic").serialize_with_magic();
+
+        assert_eq!(format_readable_panic_data(&data), "This will panic");
+    }
+
+    #[test]
+    fn test_format_readable_panic_data_malformed_byte_array_magic() {
+        let data = vec![byte_array_magic_felt().to_owned(), Felt::from(1_u8)];
+
+        assert_eq!(
+            format_readable_panic_data(&data),
+            format!("{:?}, 0x1", byte_array_magic_felt())
+        );
+    }
+
+    #[test]
+    fn test_format_readable_panic_data_zero_felt() {
+        let data = vec![Felt::ZERO];
+
+        assert_eq!(format_readable_panic_data(&data), "0x0");
     }
 
     #[test]

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -9,12 +9,14 @@ use crate::package_tests::with_config_resolved::TestCaseWithResolvedConfig;
 use crate::running::{RunCompleted, RunStatus};
 use blockifier::execution::syscalls::hint_processor::ENTRYPOINT_FAILED_ERROR_FELT;
 use cairo_annotations::trace_data::VersionedCallTrace as VersionedProfilerCallTrace;
+use cairo_lang_utils::byte_array::BYTE_ARRAY_MAGIC;
 use camino::Utf8Path;
 use cheatnet::forking::data::ForkData;
 use cheatnet::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
 use cheatnet::runtime_extensions::outer_call_runtime_extension::rpc::UsedResources;
 use conversions::byte_array::ByteArray;
 use conversions::felt::ToShortString;
+use conversions::serde::deserialize::BufferReader;
 use shared::utils::build_readable_text;
 use starknet_api::execution_resources::GasVector;
 use starknet_types_core::felt::Felt;
@@ -243,7 +245,7 @@ fn build_expected_panic_message(expected_panic_value: &ExpectedPanicValue) -> St
     match expected_panic_value {
         ExpectedPanicValue::Any => "\n    Expected to panic, but no panic occurred\n".into(),
         ExpectedPanicValue::Exact(panic_data) => {
-            let panic_string = join_short_strings(panic_data);
+            let panic_string = format_readable_panic_data(panic_data);
 
             format!(
                 "\n    Expected to panic, but no panic occurred\n    Expected panic data:  {panic_data:?} ({panic_string})\n"
@@ -266,10 +268,8 @@ fn check_if_matching_and_get_message(
             (true, None)
         }
         Some(expected) => {
-            let panic_string = convert_felts_to_byte_array_string(actual_panic_value)
-                .unwrap_or_else(|| join_short_strings(actual_panic_value));
-            let expected_string = convert_felts_to_byte_array_string(expected)
-                .unwrap_or_else(|| join_short_strings(expected));
+            let panic_string = format_readable_panic_data(actual_panic_value);
+            let expected_string = format_readable_panic_data(expected);
 
             let message = Some(format!(
                 "\n    Incorrect panic data\n    {}\n    {}\n",
@@ -422,11 +422,52 @@ impl TestCaseSummary<Single> {
     }
 }
 
-fn join_short_strings(data: &[Felt]) -> String {
-    data.iter()
-        .map(|felt| felt.to_short_string().unwrap_or_default())
-        .collect::<Vec<String>>()
-        .join(", ")
+fn format_readable_panic_data(data: &[Felt]) -> String {
+    convert_felts_to_byte_array_string(data).unwrap_or_else(|| format_panic_data_items(data))
+}
+
+fn format_panic_data_items(data: &[Felt]) -> String {
+    let mut rest = data;
+    let mut items = vec![];
+
+    while let Some((felt, tail)) = rest.split_first() {
+        if *felt == byte_array_magic_felt()
+            && let Some((byte_array, consumed)) = read_byte_array_item(rest)
+        {
+            items.push(byte_array.to_string());
+            rest = &rest[consumed..];
+        } else {
+            items.push(format_felt(felt));
+            rest = tail;
+        }
+    }
+
+    items.join(", ")
+}
+
+fn read_byte_array_item(data: &[Felt]) -> Option<(ByteArray, usize)> {
+    let mut reader = BufferReader::new(&data[1..]);
+    let byte_array = reader.read().ok()?;
+    let remaining = reader.into_remaining();
+    Some((byte_array, data.len() - remaining.len()))
+}
+
+fn format_felt(felt: &Felt) -> String {
+    felt.to_short_string()
+        .ok()
+        .filter(|value| is_readable_short_string(value))
+        .unwrap_or_else(|| format!("{felt:?}"))
+}
+
+fn is_readable_short_string(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|char| char == ' ' || char.is_ascii_graphic())
+}
+
+fn byte_array_magic_felt() -> Felt {
+    Felt::from_hex(&format!("0x{BYTE_ARRAY_MAGIC}")).expect("BYTE_ARRAY_MAGIC should be a felt")
 }
 
 fn is_matching_should_panic_data(data: &[Felt], pattern: &[Felt]) -> bool {
@@ -646,6 +687,22 @@ mod tests {
         non_matching_pattern.push(Felt::from_bytes_be_slice(b"short_string"));
 
         assert!(!is_matching_should_panic_data(&data, &non_matching_pattern));
+    }
+
+    #[test]
+    fn test_format_readable_panic_data_mixed_tuple() {
+        let byte_array = |s: &str| ByteArray::from(s).serialize_with_magic();
+
+        let mut data = byte_array("this_string_is_longer_than_31_bytes");
+        data.push(Felt::from(11_u8));
+        data.extend(byte_array("hello"));
+        data.push(Felt::from(5_u8));
+        data.push(Felt::from_bytes_be_slice(b"short_string"));
+
+        assert_eq!(
+            format_readable_panic_data(&data),
+            "this_string_is_longer_than_31_bytes, 0xb, hello, 0x5, short_string"
+        );
     }
 
     #[test]

--- a/crates/forge/tests/data/should_panic_test/tests/should_panic_test.cairo
+++ b/crates/forge/tests/data/should_panic_test/tests/should_panic_test.cairo
@@ -43,6 +43,23 @@ fn should_panic_mixed_tuple() {
 }
 
 #[test]
+#[should_panic(expected: ("this_string_is_longer_than_31_bytes", 11, "helloo", 5, 'short_string'))]
+fn should_panic_mixed_tuple_with_non_matching_data() {
+    let mut arr = ArrayTrait::new();
+    let first = "this_string_is_longer_than_31_bytes";
+    let second = "hello";
+
+    arr.append(BYTE_ARRAY_MAGIC);
+    Serde::<ByteArray>::serialize(@first, ref arr);
+    arr.append(11);
+    arr.append(BYTE_ARRAY_MAGIC);
+    Serde::<ByteArray>::serialize(@second, ref arr);
+    arr.append(5);
+    arr.append('short_string');
+    panic(arr);
+}
+
+#[test]
 #[should_panic(expected: (0,))]
 fn should_panic_with_non_matching_data() {
     panic_with_felt252('failing check');

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -1011,9 +1011,9 @@ fn should_panic() {
     assert_stdout_contains(
         output,
         indoc! { r"
-        Collected 16 test(s) from should_panic_test package
+        Collected 17 test(s) from should_panic_test package
         Running 0 test(s) from src/
-        Running 16 test(s) from tests/
+        Running 17 test(s) from tests/
         [FAIL] should_panic_test_integrationtest::should_panic_test::didnt_expect_panic
 
         Failure data:
@@ -1067,6 +1067,12 @@ fn should_panic() {
         [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_multiple_messages (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
         [FAIL] should_panic_test_integrationtest::should_panic_test::expected_panic_but_didnt_with_expected
         [PASS] should_panic_test_integrationtest::should_panic_test::should_panic_mixed_tuple (l1_gas: [..], l1_data_gas: [..], l2_gas: [..])
+        [FAIL] should_panic_test_integrationtest::should_panic_test::should_panic_mixed_tuple_with_non_matching_data
+
+        Failure data:
+            Incorrect panic data
+            Actual:    [0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x1, 0x746869735f737472696e675f69735f6c6f6e6765725f7468616e5f33315f62, 0x79746573, 0x4, 0xb, 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0, 0x68656c6c6f, 0x5, 0x5, 0x73686f72745f737472696e67] (this_string_is_longer_than_31_bytes, 0xb, hello, 0x5, short_string)
+            Expected:  [0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x1, 0x746869735f737472696e675f69735f6c6f6e6765725f7468616e5f33315f62, 0x79746573, 0x4, 0xb, 0x46a6158a16a947e5916b2a2ca68501a45e93d7110e81aa2d6438b1c57c879a3, 0x0, 0x68656c6c6f6f, 0x6, 0x5, 0x73686f72745f737472696e67] (this_string_is_longer_than_31_bytes, 0xb, helloo, 0x5, short_string)
 
         Failure data:
             Expected to panic, but no panic occurred
@@ -1077,9 +1083,9 @@ fn should_panic() {
         Failure data:
             Incorrect panic data
             Actual:    [0x6661696c696e6720636865636b] (failing check)
-            Expected:  [0x0] ()
+            Expected:  [0x0] (0x0)
 
-        Tests: 7 passed, 9 failed, 0 ignored, 0 filtered out
+        Tests: 7 passed, 10 failed, 0 ignored, 0 filtered out
 
         Failures:
             should_panic_test_integrationtest::should_panic_test::didnt_expect_panic
@@ -1090,6 +1096,7 @@ fn should_panic() {
             should_panic_test_integrationtest::should_panic_test::should_panic_not_matching_suffix
             should_panic_test_integrationtest::should_panic_test::should_panic_felt_with_byte_array
             should_panic_test_integrationtest::should_panic_test::expected_panic_but_didnt_with_expected
+            should_panic_test_integrationtest::should_panic_test::should_panic_mixed_tuple_with_non_matching_data
             should_panic_test_integrationtest::should_panic_test::should_panic_with_non_matching_data
         "},
     );


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Follow-up for https://github.com/foundry-rs/starknet-foundry/pull/4408#pullrequestreview-4563879714

Fixes badly formatted `should_panic` mismatch output for panic data containing mixed tuple values with embedded byte arrays.
Previously, encoded `ByteArray` data was formatted felt-by-felt, producing empty fields and split strings. This now decodes `BYTE_ARRAY_MAGIC` segments as complete byte arrays and formats remaining felts as short strings or hex values.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
