### PR TITLE
Stop creating `ContractsDataStore` in each test run

### DIFF
--- a/crates/forge-runner/src/debugging/mod.rs
+++ b/crates/forge-runner/src/debugging/mod.rs
@@ -31,11 +31,10 @@ pub fn build_contracts_data_store(
 #[must_use]
 pub fn build_debugging_trace(
     call_trace: &CallTrace,
-    trace_args: &TraceArgs,
+    components: debugging::Components,
     test_name: String,
     contracts_data_store: ContractsDataStore,
-) -> Option<debugging::Trace> {
-    let components = trace_args.to_components()?;
+) -> debugging::Trace {
     let context = debugging::Context::new(contracts_data_store, components);
-    Some(debugging::Trace::new(call_trace, &context, test_name))
+    debugging::Trace::new(call_trace, &context, test_name)
 }

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -501,16 +501,18 @@ fn extract_test_case_summary(
                     }),
                     fuzzer_args: run_error.fuzzer_args,
                     test_statistics: (),
-                    debugging_trace: build_debugging_trace(
-                        &run_error.call_trace.borrow(),
-                        trace_args,
-                        case.name.clone(),
-                        build_contracts_data_store(
-                            contracts_data,
-                            run_error.fork_data.as_ref(),
-                            case.config.disable_predeployed_contracts,
-                        ),
-                    ),
+                    debugging_trace: trace_args.to_components().map(|components| {
+                        build_debugging_trace(
+                            &run_error.call_trace.borrow(),
+                            components,
+                            case.name.clone(),
+                            build_contracts_data_store(
+                                contracts_data,
+                                run_error.fork_data.as_ref(),
+                                case.config.disable_predeployed_contracts,
+                            ),
+                        )
+                    }),
                 }
             }
         },

--- a/crates/forge-runner/src/test_case_summary.rs
+++ b/crates/forge-runner/src/test_case_summary.rs
@@ -303,26 +303,39 @@ impl TestCaseSummary<Single> {
         gas_report_enabled: bool,
     ) -> Self {
         let name = test_case.name.clone();
-        let contracts_data_store = build_contracts_data_store(
-            contracts_data,
-            fork_data.as_ref(),
-            test_case.config.disable_predeployed_contracts,
-        );
+        let trace_components = trace_args.to_components();
+        // `ContractsDataStore` is expensive to build and is needed only by gas report and debugging trace.
+        // Keep this lazy so normal test runs do not parse and extract contract artifacts for every test case.
+        let contracts_data_store = (gas_report_enabled || trace_components.is_some()).then(|| {
+            build_contracts_data_store(
+                contracts_data,
+                fork_data.as_ref(),
+                test_case.config.disable_predeployed_contracts,
+            )
+        });
 
         let empty = ForkData::default();
         let fork_data_ref = fork_data.as_ref().unwrap_or(&empty);
         let gas_info = SingleTestGasInfo::new(gas_used);
         let gas_info = if gas_report_enabled {
-            gas_info.get_with_report_data(&call_trace.borrow(), &contracts_data_store)
+            gas_info.get_with_report_data(
+                &call_trace.borrow(),
+                contracts_data_store
+                    .as_ref()
+                    .expect("contracts data store must be initialized for gas report"),
+            )
         } else {
             gas_info
         };
-        let debugging_trace = build_debugging_trace(
-            &call_trace.borrow(),
-            trace_args,
-            name.clone(),
-            contracts_data_store,
-        );
+        let debugging_trace = trace_components.map(|components| {
+            build_debugging_trace(
+                &call_trace.borrow(),
+                components,
+                name.clone(),
+                contracts_data_store
+                    .expect("contracts data store must be initialized for debugging trace"),
+            )
+        });
 
         match status {
             RunStatus::Success(data) => match &test_case.config.expected_result {


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/foundry-rs/starknet-foundry/pull/4399. Creating `ContractsDataStore` is expensive and it significantly affects total execution time, especially in packages containing many contracts.