### PR TITLE
Bring back debugger requirement for types debug info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Actual` and `Expected` panic data in the `#[should_panic]` mismatch message now labels rendered values inline, making it clear whether each value is a `ByteArray` or a `felt252`.
 - Minimal recommended `Scarb` version is now `2.18.0` (updated from `2.17.0`)
+- Re-enabled the `add-types-debug-info = true` requirement for `--launch-debugger` on Scarb `>= 2.20.0`
 
 #### Fixed
 

--- a/crates/forge/src/profile_validation/debugger.rs
+++ b/crates/forge/src/profile_validation/debugger.rs
@@ -2,6 +2,8 @@ use crate::profile_validation::{bool_field, bool_field_or_unstable, str_field};
 use anyhow::ensure;
 use camino::Utf8PathBuf;
 use indoc::formatdoc;
+use scarb_api::version::scarb_version;
+use semver::Version;
 use serde_json::Value;
 
 pub fn check_debugger_compatibility(
@@ -9,12 +11,12 @@ pub fn check_debugger_compatibility(
     profile: &str,
     workspace_manifest_path: &Utf8PathBuf,
 ) -> anyhow::Result<()> {
-    let has_needed_entries = bool_field(compiler_config, "add_functions_debug_info")
+    let mut has_needed_entries = bool_field(compiler_config, "add_functions_debug_info")
         && bool_field_or_unstable(compiler_config, "add_statements_code_locations_debug_info")
         && bool_field_or_unstable(compiler_config, "add_statements_functions_debug_info")
         && str_field(compiler_config, "compiler_optimizations") == "Disabled";
 
-    let required_cairo_config_section = formatdoc! {
+    let mut required_cairo_config_section = formatdoc! {
         "skip-optimizations = true
         unstable-add-statements-code-locations-debug-info = true
         unstable-add-statements-functions-debug-info = true
@@ -22,13 +24,12 @@ pub fn check_debugger_compatibility(
         "
     };
 
-    // TODO(#4476): disabled for now due to `add-types-debug-info = true` causing compile error.
-    // `add-types-debug-info` annotations are available from Scarb 2.19.0 onwards.
+    // `add-types-debug-info` annotations are available and bug-free from Scarb 2.20.0 onwards.
     // Require them for **much** better UX.
-    // if scarb_version().is_ok_and(|version| version.scarb >= Version::new(2, 19, 0)) {
-    //     has_needed_entries &= bool_field(compiler_config, "add_types_debug_info");
-    //     required_cairo_config_section += "\nadd-types-debug-info = true";
-    // }
+    if scarb_version().is_ok_and(|version| version.scarb >= Version::new(2, 20, 0)) {
+        has_needed_entries &= bool_field(compiler_config, "add_types_debug_info");
+        required_cairo_config_section += "\nadd-types-debug-info = true";
+    }
 
     ensure!(
         has_needed_entries,

--- a/crates/forge/tests/e2e/debugger.rs
+++ b/crates/forge/tests/e2e/debugger.rs
@@ -49,7 +49,9 @@ fn test_launch_debugger_waits_for_connection() {
             unstable-add-statements-code-locations-debug-info = true
             unstable-add-statements-functions-debug-info = true
             add-functions-debug-info = true
-            skip-optimizations = true",
+            skip-optimizations = true
+            add-types-debug-info = true
+            ",
         ))
         .unwrap();
 
@@ -73,6 +75,7 @@ fn test_launch_debugger_waits_for_connection_with_complex_config() {
             [cairo]
             skip-optimizations = true
             unstable-add-statements-code-locations-debug-info = true
+            add-types-debug-info = true
             ",
         ))
         .unwrap();
@@ -128,7 +131,9 @@ fn test_launch_debugger_fails_for_fuzzer_test() {
             unstable-add-statements-code-locations-debug-info = true
             unstable-add-statements-functions-debug-info = true
             add-functions-debug-info = true
-            skip-optimizations = true",
+            skip-optimizations = true
+            add-types-debug-info = true
+            ",
         ))
         .unwrap();
 

--- a/docs/src/snforge-advanced-features/debugging.md
+++ b/docs/src/snforge-advanced-features/debugging.md
@@ -32,13 +32,12 @@ to have:
 
 ```toml
 [profile.dev.cairo]
+skip-optimizations = true
 add-statements-code-locations-debug-info = true
 add-statements-functions-debug-info = true
 add-functions-debug-info = true
-skip-optimizations = true
+add-types-debug-info = true
 ```
-
-<!-- TODO(#4476): Update docs once `add-types-debug-info` requirement is re-introduced -->
 
 ### Debugging in VSCode
 


### PR DESCRIPTION
Closes #4476 

## Introduced changes

- self-explanatory

## Checklist

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
