### PR TITLE
Show gas difference on assertion failure

### DIFF
--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1,12 +1,9 @@
-use crate::utils::runner::{Contract, assert_gas, assert_passed, capture_assertion_panic};
+use crate::utils::runner::{Contract, assert_gas, assert_passed};
 use crate::utils::running_tests::run_test_case;
 use crate::utils::test_case;
 use forge_runner::forge_config::ForgeTrackedResource;
-use forge_runner::test_case_summary::{AnyTestCaseSummary, TestCaseSummary};
-use forge_runner::test_target_summary::TestTargetSummary;
 use indoc::{formatdoc, indoc};
 use shared::test_utils::node_url::node_rpc_url;
-use shared::test_utils::output_assert::assert_stdout_contains;
 use starknet_api::execution_resources::{GasAmount, GasVector};
 use std::path::Path;
 
@@ -23,155 +20,6 @@ use std::path::Path;
 // but must remain within a reasonable range
 //
 // Sierra syscall l2 gas: `n_steps * step_gas_cost + sum(builtin_count * builtin_gas_cost)`
-
-#[test]
-fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
-    let test = test_case!(indoc!(
-        r"
-            #[test]
-            fn gas_assertion_diagnostics() {
-                keccak::keccak_u256s_le_inputs(array![1].span());
-            }
-        "
-    ));
-
-    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
-
-    assert_passed(&result);
-
-    // Intentionally wrong expectation so that `assert_gas` fails and we can inspect the diagnostics.
-    let panic_message = capture_assertion_panic(|| {
-        assert_gas(
-            &result,
-            "gas_assertion_diagnostics",
-            GasVector {
-                l1_gas: GasAmount(1),
-                l1_data_gas: GasAmount(2),
-                l2_gas: GasAmount(3),
-            },
-        );
-    });
-
-    assert_stdout_contains(
-        panic_message.clone(),
-        indoc! {r"
-        Gas assertion failed for test case `test_package_integrationtest::test_case::gas_assertion_diagnostics`.
-        expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3
-        actual:   l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
-        diff:     l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
-        "},
-    );
-
-    // `diff` must equal the absolute difference between `expected` and `actual`.
-    let actual = parse_gas_line(&panic_message, "actual:");
-    let diff = parse_gas_line(&panic_message, "diff:");
-    assert_eq!(diff.l1_gas.0, actual.l1_gas.0.abs_diff(1));
-    assert_eq!(diff.l1_data_gas.0, actual.l1_data_gas.0.abs_diff(2));
-    assert_eq!(diff.l2_gas.0, actual.l2_gas.0.abs_diff(3));
-}
-
-#[test]
-fn assert_gas_reports_when_test_case_is_missing() {
-    let summaries = summaries(vec![
-        single_ignored("pkg::module::some_other_test"),
-        single_ignored("pkg::module::another_test"),
-    ]);
-
-    let panic_message = capture_assertion_panic(|| {
-        assert_gas(&summaries, "missing_test", GasVector::default());
-    });
-
-    assert_stdout_contains(
-        panic_message,
-        indoc! {r"
-        Gas assertion failed: test case `missing_test` was not found. Available test cases:
-         - pkg::module::some_other_test
-         - pkg::module::another_test
-        "},
-    );
-}
-
-#[test]
-fn assert_gas_rejects_fuzzing_test_case() {
-    let summaries = summaries(vec![fuzzing_ignored("pkg::module::fuzzed")]);
-
-    let panic_message = capture_assertion_panic(|| {
-        assert_gas(&summaries, "fuzzed", GasVector::default());
-    });
-
-    assert_eq!(panic_message, "Cannot use assert_gas! for fuzzing tests");
-}
-
-#[test]
-fn assert_gas_reports_non_passed_test_case() {
-    let summaries = summaries(vec![single_failed("pkg::module::failing")]);
-
-    let panic_message = capture_assertion_panic(|| {
-        assert_gas(&summaries, "failing", GasVector::default());
-    });
-
-    assert_eq!(
-        panic_message,
-        "Gas assertion failed for test case `pkg::module::failing`: expected passed test case with gas information, but test case was failed"
-    );
-}
-
-/// Parses a `l1_gas: <n>, l1_data_gas: <n>, l2_gas: <n>` line labelled with `label`
-/// out of an `assert_gas` diagnostic message.
-fn parse_gas_line(message: &str, label: &str) -> GasVector {
-    let line = message
-        .lines()
-        .find(|line| line.trim_start().starts_with(label))
-        .unwrap_or_else(|| panic!("no `{label}` line found in message:\n{message}"));
-
-    let value = |key: &str| -> u64 {
-        let after = line
-            .split(&format!("{key}: "))
-            .nth(1)
-            .unwrap_or_else(|| panic!("`{key}` not found in line: {line}"));
-        after
-            .split(|c: char| !c.is_ascii_digit())
-            .next()
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| panic!("no number after `{key}` in line: {line}"))
-            .parse()
-            .unwrap()
-    };
-
-    GasVector {
-        l1_gas: GasAmount(value("l1_gas")),
-        l1_data_gas: GasAmount(value("l1_data_gas")),
-        l2_gas: GasAmount(value("l2_gas")),
-    }
-}
-
-fn summaries(cases: Vec<AnyTestCaseSummary>) -> Vec<TestTargetSummary> {
-    vec![TestTargetSummary {
-        test_case_summaries: cases,
-    }]
-}
-
-fn single_failed(name: &str) -> AnyTestCaseSummary {
-    AnyTestCaseSummary::Single(TestCaseSummary::Failed {
-        name: name.to_string(),
-        msg: None,
-        debugging_trace: None,
-        fuzzer_args: Vec::new(),
-        test_statistics: (),
-    })
-}
-
-fn single_ignored(name: &str) -> AnyTestCaseSummary {
-    AnyTestCaseSummary::Single(TestCaseSummary::Ignored {
-        name: name.to_string(),
-    })
-}
-
-fn fuzzing_ignored(name: &str) -> AnyTestCaseSummary {
-    AnyTestCaseSummary::Fuzzing(TestCaseSummary::Ignored {
-        name: name.to_string(),
-    })
-}
 
 #[test]
 fn declare_cost_is_omitted_cairo_steps() {

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -76,8 +76,7 @@ fn assert_gas_failure_shows_expected_actual_and_test_case_name() {
 fn assert_gas_reports_when_test_case_is_missing() {
     let summaries = summaries(vec![single_ignored("pkg::module::some_other_test")]);
 
-    let panic_message =
-        capture_assert_gas_panic(&summaries, "missing_test", GasVector::default());
+    let panic_message = capture_assert_gas_panic(&summaries, "missing_test", GasVector::default());
 
     assert!(
         panic_message.contains("test case `missing_test` was not found"),

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -6,6 +6,7 @@ use forge_runner::test_case_summary::{AnyTestCaseSummary, TestCaseSummary};
 use forge_runner::test_target_summary::TestTargetSummary;
 use indoc::{formatdoc, indoc};
 use shared::test_utils::node_url::node_rpc_url;
+use shared::test_utils::output_assert::assert_stdout_contains;
 use starknet_api::execution_resources::{GasAmount, GasVector};
 use std::path::Path;
 
@@ -51,19 +52,14 @@ fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
         );
     });
 
-    // The name reported by the runner is fully qualified (e.g. `..::gas_assertion_diagnostics`),
-    // so we only assert on the suffix here.
-    assert!(
-        panic_message.contains("Gas assertion failed for test case `"),
-        "message was: {panic_message}"
-    );
-    assert!(
-        panic_message.contains("gas_assertion_diagnostics`"),
-        "message was: {panic_message}"
-    );
-    assert!(
-        panic_message.contains("expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3"),
-        "message was: {panic_message}"
+    assert_stdout_contains(
+        panic_message.clone(),
+        indoc! {r"
+        Gas assertion failed for test case `[..]gas_assertion_diagnostics`.
+        expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3
+        actual:   l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
+        diff:     l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
+        "},
     );
 
     // `diff` must equal the absolute difference between `expected` and `actual`.
@@ -85,15 +81,13 @@ fn assert_gas_reports_when_test_case_is_missing() {
         assert_gas(&summaries, "missing_test", GasVector::default());
     });
 
-    assert!(
-        panic_message.contains("test case `missing_test` was not found"),
-        "message was: {panic_message}"
-    );
-    assert!(
-        panic_message.contains(
-            "Available test cases:\n - pkg::module::some_other_test\n - pkg::module::another_test"
-        ),
-        "message was: {panic_message}"
+    assert_stdout_contains(
+        panic_message,
+        indoc! {r"
+        Gas assertion failed: test case `missing_test` was not found. Available test cases:
+         - pkg::module::some_other_test
+         - pkg::module::another_test
+        "},
     );
 }
 
@@ -105,10 +99,7 @@ fn assert_gas_rejects_fuzzing_test_case() {
         assert_gas(&summaries, "fuzzed", GasVector::default());
     });
 
-    assert!(
-        panic_message.contains("Cannot use assert_gas! for fuzzing tests"),
-        "message was: {panic_message}"
-    );
+    assert_eq!(panic_message, "Cannot use assert_gas! for fuzzing tests");
 }
 
 #[test]
@@ -119,13 +110,9 @@ fn assert_gas_reports_non_passed_test_case() {
         assert_gas(&summaries, "failing", GasVector::default());
     });
 
-    assert!(
-        panic_message.contains("test case `pkg::module::failing`"),
-        "message was: {panic_message}"
-    );
-    assert!(
-        panic_message.contains("but test case was failed"),
-        "message was: {panic_message}"
+    assert_eq!(
+        panic_message,
+        "Gas assertion failed for test case `pkg::module::failing`: expected passed test case with gas information, but test case was failed"
     );
 }
 

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -130,7 +130,7 @@ fn capture_assert_gas_panic(
     let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         assert_gas(result, test_case_name, asserted_gas);
     }))
-    .expect_err("assert_gas should panic when the gas assertion cannot be satisfied");
+    .expect_err("`assert_gas` should panic when the gas assertion cannot be satisfied");
 
     if let Some(message) = payload.downcast_ref::<String>() {
         message.clone()

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -273,8 +273,8 @@ fn deploy_syscall_cost_cairo_steps() {
         "deploy_syscall_cost",
         GasVector {
             l1_gas: GasAmount(0),
-            l1_data_gas: GasAmount(123),
-            l2_gas: GasAmount(456),
+            l1_data_gas: GasAmount(96),
+            l2_gas: GasAmount(440_000),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 // Sierra syscall l2 gas: `n_steps * step_gas_cost + sum(builtin_count * builtin_gas_cost)`
 
 #[test]
-fn assert_gas_failure_shows_expected_actual_and_test_case_name() {
+fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
     let test = test_case!(indoc!(
         r#"
             #[test]
@@ -132,18 +132,12 @@ fn capture_assert_gas_panic(
     }))
     .expect_err("assert_gas should panic when the gas assertion cannot be satisfied");
 
-    panic_payload_to_string(payload)
-}
-
-fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
     if let Some(message) = payload.downcast_ref::<String>() {
         message.clone()
     } else if let Some(message) = payload.downcast_ref::<&str>() {
         (*message).to_string()
     } else {
-        // Fail loudly instead of returning a silent fallback so a broken payload type
-        // surfaces the real problem in `assert_gas` rather than a confusing mismatch later.
-        panic!("Unexpected panic payload type. Expected `String` or `&str` from assert_gas.");
+        panic!("Unexpected panic payload type. Expected `String` or `&str` from `assert_gas`.");
     }
 }
 

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -55,7 +55,7 @@ fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
     assert_stdout_contains(
         panic_message.clone(),
         indoc! {r"
-        Gas assertion failed for test case `[..]gas_assertion_diagnostics`.
+        Gas assertion failed for test case `test_package_integrationtest::test_case::gas_assertion_diagnostics`.
         expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3
         actual:   l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
         diff:     l1_gas: [..], l1_data_gas: [..], l2_gas: [..]

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -74,7 +74,10 @@ fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
 
 #[test]
 fn assert_gas_reports_when_test_case_is_missing() {
-    let summaries = summaries(vec![single_ignored("pkg::module::some_other_test")]);
+    let summaries = summaries(vec![
+        single_ignored("pkg::module::some_other_test"),
+        single_ignored("pkg::module::another_test"),
+    ]);
 
     let panic_message = capture_assert_gas_panic(&summaries, "missing_test", GasVector::default());
 
@@ -83,7 +86,9 @@ fn assert_gas_reports_when_test_case_is_missing() {
         "message was: {panic_message}"
     );
     assert!(
-        panic_message.contains("pkg::module::some_other_test"),
+        panic_message.contains(
+            "Available test cases:\n - pkg::module::some_other_test\n - pkg::module::another_test"
+        ),
         "message was: {panic_message}"
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -2,6 +2,8 @@ use crate::utils::runner::{Contract, assert_gas, assert_passed};
 use crate::utils::running_tests::run_test_case;
 use crate::utils::test_case;
 use forge_runner::forge_config::ForgeTrackedResource;
+use forge_runner::test_case_summary::{AnyTestCaseSummary, TestCaseSummary};
+use forge_runner::test_target_summary::TestTargetSummary;
 use indoc::{formatdoc, indoc};
 use shared::test_utils::node_url::node_rpc_url;
 use starknet_api::execution_resources::{GasAmount, GasVector};
@@ -20,6 +22,188 @@ use std::path::Path;
 // but must remain within a reasonable range
 //
 // Sierra syscall l2 gas: `n_steps * step_gas_cost + sum(builtin_count * builtin_gas_cost)`
+
+#[test]
+fn assert_gas_failure_shows_expected_actual_and_test_case_name() {
+    let test = test_case!(indoc!(
+        r#"
+            #[test]
+            fn gas_assertion_diagnostics() {
+                keccak::keccak_u256s_le_inputs(array![1].span());
+            }
+        "#
+    ));
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_passed(&result);
+
+    // Intentionally wrong expectation so that `assert_gas` fails and we can inspect the diagnostics.
+    let panic_message = capture_assert_gas_panic(
+        &result,
+        "gas_assertion_diagnostics",
+        GasVector {
+            l1_gas: GasAmount(1),
+            l1_data_gas: GasAmount(2),
+            l2_gas: GasAmount(3),
+        },
+    );
+
+    // The name reported by the runner is fully qualified (e.g. `..::gas_assertion_diagnostics`),
+    // so we only assert on the suffix here.
+    assert!(
+        panic_message.contains("Gas assertion failed for test case `"),
+        "message was: {panic_message}"
+    );
+    assert!(
+        panic_message.contains("gas_assertion_diagnostics`"),
+        "message was: {panic_message}"
+    );
+    assert!(
+        panic_message.contains("expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3"),
+        "message was: {panic_message}"
+    );
+
+    // `diff` must equal the absolute difference between `expected` and `actual`.
+    let actual = parse_gas_line(&panic_message, "actual:");
+    let diff = parse_gas_line(&panic_message, "diff:");
+    assert_eq!(diff.l1_gas.0, actual.l1_gas.0.abs_diff(1));
+    assert_eq!(diff.l1_data_gas.0, actual.l1_data_gas.0.abs_diff(2));
+    assert_eq!(diff.l2_gas.0, actual.l2_gas.0.abs_diff(3));
+}
+
+#[test]
+fn assert_gas_reports_when_test_case_is_missing() {
+    let summaries = summaries(vec![single_ignored("pkg::module::some_other_test")]);
+
+    let panic_message =
+        capture_assert_gas_panic(&summaries, "missing_test", GasVector::default());
+
+    assert!(
+        panic_message.contains("test case `missing_test` was not found"),
+        "message was: {panic_message}"
+    );
+    assert!(
+        panic_message.contains("pkg::module::some_other_test"),
+        "message was: {panic_message}"
+    );
+}
+
+#[test]
+fn assert_gas_rejects_fuzzing_test_case() {
+    let summaries = summaries(vec![fuzzing_ignored("pkg::module::fuzzed")]);
+
+    let panic_message = capture_assert_gas_panic(&summaries, "fuzzed", GasVector::default());
+
+    assert!(
+        panic_message.contains("Cannot use assert_gas! for fuzzing tests"),
+        "message was: {panic_message}"
+    );
+}
+
+#[test]
+fn assert_gas_reports_non_passed_test_case() {
+    let summaries = summaries(vec![single_failed("pkg::module::failing")]);
+
+    let panic_message = capture_assert_gas_panic(&summaries, "failing", GasVector::default());
+
+    assert!(
+        panic_message.contains("test case `pkg::module::failing`"),
+        "message was: {panic_message}"
+    );
+    assert!(
+        panic_message.contains("but test case was failed"),
+        "message was: {panic_message}"
+    );
+}
+
+/// Runs `assert_gas`, expects it to panic, and returns the panic message.
+///
+/// Note: we deliberately do *not* silence the global panic hook here. Integration tests run in
+/// parallel and `std::panic::set_hook`/`take_hook` are process-global, so swapping them could
+/// suppress (or leak past) unrelated failures. The panic backtrace printed to stderr is only
+/// cosmetic noise for these passing tests.
+fn capture_assert_gas_panic(
+    result: &[TestTargetSummary],
+    test_case_name: &str,
+    asserted_gas: GasVector,
+) -> String {
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        assert_gas(result, test_case_name, asserted_gas);
+    }))
+    .expect_err("assert_gas should panic when the gas assertion cannot be satisfied");
+
+    panic_payload_to_string(payload)
+}
+
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else {
+        // Fail loudly instead of returning a silent fallback so a broken payload type
+        // surfaces the real problem in `assert_gas` rather than a confusing mismatch later.
+        panic!("Unexpected panic payload type. Expected `String` or `&str` from assert_gas.");
+    }
+}
+
+/// Parses a `l1_gas: <n>, l1_data_gas: <n>, l2_gas: <n>` line labelled with `label`
+/// out of an `assert_gas` diagnostic message.
+fn parse_gas_line(message: &str, label: &str) -> GasVector {
+    let line = message
+        .lines()
+        .find(|line| line.trim_start().starts_with(label))
+        .unwrap_or_else(|| panic!("no `{label}` line found in message:\n{message}"));
+
+    let value = |key: &str| -> u64 {
+        let after = line
+            .split(&format!("{key}: "))
+            .nth(1)
+            .unwrap_or_else(|| panic!("`{key}` not found in line: {line}"));
+        after
+            .split(|c: char| !c.is_ascii_digit())
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| panic!("no number after `{key}` in line: {line}"))
+            .parse()
+            .unwrap()
+    };
+
+    GasVector {
+        l1_gas: GasAmount(value("l1_gas")),
+        l1_data_gas: GasAmount(value("l1_data_gas")),
+        l2_gas: GasAmount(value("l2_gas")),
+    }
+}
+
+fn summaries(cases: Vec<AnyTestCaseSummary>) -> Vec<TestTargetSummary> {
+    vec![TestTargetSummary {
+        test_case_summaries: cases,
+    }]
+}
+
+fn single_failed(name: &str) -> AnyTestCaseSummary {
+    AnyTestCaseSummary::Single(TestCaseSummary::Failed {
+        name: name.to_string(),
+        msg: None,
+        debugging_trace: None,
+        fuzzer_args: Vec::new(),
+        test_statistics: (),
+    })
+}
+
+fn single_ignored(name: &str) -> AnyTestCaseSummary {
+    AnyTestCaseSummary::Single(TestCaseSummary::Ignored {
+        name: name.to_string(),
+    })
+}
+
+fn fuzzing_ignored(name: &str) -> AnyTestCaseSummary {
+    AnyTestCaseSummary::Fuzzing(TestCaseSummary::Ignored {
+        name: name.to_string(),
+    })
+}
 
 #[test]
 fn declare_cost_is_omitted_cairo_steps() {

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -26,12 +26,12 @@ use std::path::Path;
 #[test]
 fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
     let test = test_case!(indoc!(
-        r#"
+        r"
             #[test]
             fn gas_assertion_diagnostics() {
                 keccak::keccak_u256s_le_inputs(array![1].span());
             }
-        "#
+        "
     ));
 
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
@@ -273,8 +273,8 @@ fn deploy_syscall_cost_cairo_steps() {
         "deploy_syscall_cost",
         GasVector {
             l1_gas: GasAmount(0),
-            l1_data_gas: GasAmount(96),
-            l2_gas: GasAmount(440_000),
+            l1_data_gas: GasAmount(123),
+            l2_gas: GasAmount(456),
         },
     );
 }

--- a/crates/forge/tests/integration/gas.rs
+++ b/crates/forge/tests/integration/gas.rs
@@ -1,4 +1,4 @@
-use crate::utils::runner::{Contract, assert_gas, assert_passed};
+use crate::utils::runner::{Contract, assert_gas, assert_passed, capture_assertion_panic};
 use crate::utils::running_tests::run_test_case;
 use crate::utils::test_case;
 use forge_runner::forge_config::ForgeTrackedResource;
@@ -39,15 +39,17 @@ fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
     assert_passed(&result);
 
     // Intentionally wrong expectation so that `assert_gas` fails and we can inspect the diagnostics.
-    let panic_message = capture_assert_gas_panic(
-        &result,
-        "gas_assertion_diagnostics",
-        GasVector {
-            l1_gas: GasAmount(1),
-            l1_data_gas: GasAmount(2),
-            l2_gas: GasAmount(3),
-        },
-    );
+    let panic_message = capture_assertion_panic(|| {
+        assert_gas(
+            &result,
+            "gas_assertion_diagnostics",
+            GasVector {
+                l1_gas: GasAmount(1),
+                l1_data_gas: GasAmount(2),
+                l2_gas: GasAmount(3),
+            },
+        );
+    });
 
     // The name reported by the runner is fully qualified (e.g. `..::gas_assertion_diagnostics`),
     // so we only assert on the suffix here.
@@ -79,7 +81,9 @@ fn assert_gas_reports_when_test_case_is_missing() {
         single_ignored("pkg::module::another_test"),
     ]);
 
-    let panic_message = capture_assert_gas_panic(&summaries, "missing_test", GasVector::default());
+    let panic_message = capture_assertion_panic(|| {
+        assert_gas(&summaries, "missing_test", GasVector::default());
+    });
 
     assert!(
         panic_message.contains("test case `missing_test` was not found"),
@@ -97,7 +101,9 @@ fn assert_gas_reports_when_test_case_is_missing() {
 fn assert_gas_rejects_fuzzing_test_case() {
     let summaries = summaries(vec![fuzzing_ignored("pkg::module::fuzzed")]);
 
-    let panic_message = capture_assert_gas_panic(&summaries, "fuzzed", GasVector::default());
+    let panic_message = capture_assertion_panic(|| {
+        assert_gas(&summaries, "fuzzed", GasVector::default());
+    });
 
     assert!(
         panic_message.contains("Cannot use assert_gas! for fuzzing tests"),
@@ -109,7 +115,9 @@ fn assert_gas_rejects_fuzzing_test_case() {
 fn assert_gas_reports_non_passed_test_case() {
     let summaries = summaries(vec![single_failed("pkg::module::failing")]);
 
-    let panic_message = capture_assert_gas_panic(&summaries, "failing", GasVector::default());
+    let panic_message = capture_assertion_panic(|| {
+        assert_gas(&summaries, "failing", GasVector::default());
+    });
 
     assert!(
         panic_message.contains("test case `pkg::module::failing`"),
@@ -119,31 +127,6 @@ fn assert_gas_reports_non_passed_test_case() {
         panic_message.contains("but test case was failed"),
         "message was: {panic_message}"
     );
-}
-
-/// Runs `assert_gas`, expects it to panic, and returns the panic message.
-///
-/// Note: we deliberately do *not* silence the global panic hook here. Integration tests run in
-/// parallel and `std::panic::set_hook`/`take_hook` are process-global, so swapping them could
-/// suppress (or leak past) unrelated failures. The panic backtrace printed to stderr is only
-/// cosmetic noise for these passing tests.
-fn capture_assert_gas_panic(
-    result: &[TestTargetSummary],
-    test_case_name: &str,
-    asserted_gas: GasVector,
-) -> String {
-    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        assert_gas(result, test_case_name, asserted_gas);
-    }))
-    .expect_err("`assert_gas` should panic when the gas assertion cannot be satisfied");
-
-    if let Some(message) = payload.downcast_ref::<String>() {
-        message.clone()
-    } else if let Some(message) = payload.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else {
-        panic!("Unexpected panic payload type. Expected `String` or `&str` from `assert_gas`.");
-    }
 }
 
 /// Parses a `l1_gas: <n>, l1_data_gas: <n>, l2_gas: <n>` line labelled with `label`

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -10,7 +10,7 @@ use blockifier::execution::syscalls::vm_syscall_utils::{SyscallSelector, Syscall
 use cairo_vm::types::builtin_name::BuiltinName;
 use camino::Utf8PathBuf;
 use forge_runner::{
-    test_case_summary::{AnyTestCaseSummary, TestCaseSummary},
+    test_case_summary::{AnyTestCaseSummary, Single, TestCaseSummary},
     test_target_summary::TestTargetSummary,
 };
 use foundry_ui::UI;
@@ -29,6 +29,11 @@ use std::{
     process::{Command, Stdio},
     str::FromStr,
 };
+
+// Allowed absolute gas differences when `non_exact_gas_assertions` is enabled.
+const MARGIN_L1_GAS: u64 = 10;
+const MARGIN_L1_DATA_GAS: u64 = 10;
+const MARGIN_L2_GAS: u64 = 200_000;
 
 /// Represents a dependency of a Cairo project
 #[derive(Debug, Clone)]
@@ -292,23 +297,60 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
 
     let result = TestCase::find_test_result(result);
 
-    assert!(result.test_case_summaries.iter().any(|any_case| {
-        match any_case {
-            AnyTestCaseSummary::Fuzzing(_) => {
-                panic!("Cannot use assert_gas! for fuzzing tests")
-            }
-            AnyTestCaseSummary::Single(case) => match case {
-                TestCaseSummary::Passed { gas_info: gas, .. } => {
-                    assert_gas_with_margin(gas.gas_used, asserted_gas)
-                        && any_case
-                            .name()
-                            .unwrap()
-                            .ends_with(test_name_suffix.as_str())
-                }
-                _ => false,
-            },
+    let any_case = result
+        .test_case_summaries
+        .iter()
+        .find(|any_case| {
+            any_case
+                .name()
+                .is_some_and(|name| name.ends_with(test_name_suffix.as_str()))
+        })
+        .unwrap_or_else(|| {
+            let available_test_cases = result
+                .test_case_summaries
+                .iter()
+                .filter_map(AnyTestCaseSummary::name)
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            panic!(
+                "Gas assertion failed: test case `{test_case_name}` was not found. Available test cases: {available_test_cases}"
+            )
+        });
+
+    match any_case {
+        AnyTestCaseSummary::Fuzzing(_) => {
+            panic!("Cannot use assert_gas! for fuzzing tests")
         }
-    }));
+        AnyTestCaseSummary::Single(case) => match case {
+            TestCaseSummary::Passed {
+                name,
+                gas_info: gas,
+                ..
+            } => {
+                let actual_gas = gas.gas_used;
+
+                if !assert_gas_with_margin(actual_gas, asserted_gas) {
+                    let diff = gas_vector_abs_diff(&actual_gas, &asserted_gas);
+                    panic!(
+                        "Gas assertion failed for test case `{name}`.\nexpected: {}\nactual:   {}\ndiff:     {}{}",
+                        format_gas_vector(&asserted_gas),
+                        format_gas_vector(&actual_gas),
+                        format_gas_vector(&diff),
+                        gas_assertion_margin_message(),
+                    );
+                }
+            }
+            _ => {
+                // The case was located by matching on its name, so `name()` is always `Some`.
+                let name = any_case.name().expect("matched test case must have a name");
+                panic!(
+                    "Gas assertion failed for test case `{name}`: expected passed test case with gas information, but test case was {}",
+                    test_case_status(case)
+                );
+            }
+        },
+    }
 }
 
 // This logic is used to assert exact gas values in CI for the minimal supported Scarb version
@@ -317,7 +359,9 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
 fn assert_gas_with_margin(gas: GasVector, asserted_gas: GasVector) -> bool {
     if cfg!(feature = "non_exact_gas_assertions") {
         let diff = gas_vector_abs_diff(&gas, &asserted_gas);
-        diff.l1_gas.0 <= 10 && diff.l1_data_gas.0 <= 10 && diff.l2_gas.0 <= 200_000
+        diff.l1_gas.0 <= MARGIN_L1_GAS
+            && diff.l1_data_gas.0 <= MARGIN_L1_DATA_GAS
+            && diff.l2_gas.0 <= MARGIN_L2_GAS
     } else {
         gas == asserted_gas
     }
@@ -328,6 +372,33 @@ fn gas_vector_abs_diff(a: &GasVector, b: &GasVector) -> GasVector {
         l1_gas: GasAmount(a.l1_gas.0.abs_diff(b.l1_gas.0)),
         l1_data_gas: GasAmount(a.l1_data_gas.0.abs_diff(b.l1_data_gas.0)),
         l2_gas: GasAmount(a.l2_gas.0.abs_diff(b.l2_gas.0)),
+    }
+}
+
+fn format_gas_vector(gas: &GasVector) -> String {
+    format!(
+        "l1_gas: {}, l1_data_gas: {}, l2_gas: {}",
+        gas.l1_gas.0, gas.l1_data_gas.0, gas.l2_gas.0
+    )
+}
+
+fn gas_assertion_margin_message() -> String {
+    if cfg!(feature = "non_exact_gas_assertions") {
+        format!(
+            "\nallowed diff: l1_gas <= {MARGIN_L1_GAS}, l1_data_gas <= {MARGIN_L1_DATA_GAS}, l2_gas <= {MARGIN_L2_GAS}"
+        )
+    } else {
+        String::new()
+    }
+}
+
+fn test_case_status(case: &TestCaseSummary<Single>) -> &'static str {
+    match case {
+        TestCaseSummary::Passed { .. } => "passed",
+        TestCaseSummary::Failed { .. } => "failed",
+        TestCaseSummary::Ignored { .. } => "ignored",
+        TestCaseSummary::Interrupted { .. } => "interrupted",
+        TestCaseSummary::ExcludedFromPartition { .. } => "excluded from partition",
     }
 }
 

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -310,11 +310,12 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
                 .test_case_summaries
                 .iter()
                 .filter_map(AnyTestCaseSummary::name)
+                .map(|name| format!(" - {name}"))
                 .collect::<Vec<_>>()
-                .join(", ");
+                .join("\n");
 
             panic!(
-                "Gas assertion failed: test case `{test_case_name}` was not found. Available test cases: {available_test_cases}"
+                "Gas assertion failed: test case `{test_case_name}` was not found. Available test cases:\n{available_test_cases}"
             )
         });
 

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -322,12 +322,13 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
         AnyTestCaseSummary::Fuzzing(_) => {
             panic!("Cannot use assert_gas! for fuzzing tests")
         }
-        AnyTestCaseSummary::Single(case) => match case {
-            TestCaseSummary::Passed {
+        AnyTestCaseSummary::Single(case) => {
+            if let TestCaseSummary::Passed {
                 name,
                 gas_info: gas,
                 ..
-            } => {
+            } = case
+            {
                 let actual_gas = gas.gas_used;
 
                 if !assert_gas_with_margin(actual_gas, asserted_gas) {
@@ -340,8 +341,7 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
                         gas_assertion_margin_message(),
                     );
                 }
-            }
-            _ => {
+            } else {
                 // The case was located by matching on its name, so `name()` is always `Some`.
                 let name = any_case.name().expect("matched test case must have a name");
                 panic!(
@@ -349,7 +349,7 @@ pub fn assert_gas(result: &[TestTargetSummary], test_case_name: &str, asserted_g
                     test_case_status(case)
                 );
             }
-        },
+        }
     }
 }
 

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -271,6 +271,25 @@ pub fn assert_failed(result: &[TestTargetSummary]) {
     );
 }
 
+/// Runs an assertion, expects it to panic, and returns the panic message.
+///
+/// This deliberately does not silence the global panic hook. Integration tests run in parallel and
+/// `std::panic::set_hook`/`take_hook` are process-global, so swapping them could suppress or leak
+/// past unrelated failures. The panic backtrace printed to stderr is only cosmetic noise for these
+/// passing tests.
+pub fn capture_assertion_panic(assertion: impl FnOnce()) -> String {
+    let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(assertion))
+        .expect_err("assertion should panic");
+
+    if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else {
+        panic!("Unexpected panic payload type. Expected `String` or `&str`.");
+    }
+}
+
 pub fn assert_case_output_contains(
     result: &[TestTargetSummary],
     test_case_name: &str,

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -30,6 +30,7 @@ use std::{
 };
 
 // Allowed absolute gas differences when `non_exact_gas_assertions` is enabled.
+// TODO(#4516): Investigate and potentially tighten these gas assertion margins
 const MARGIN_L1_GAS: u64 = 10;
 const MARGIN_L1_DATA_GAS: u64 = 10;
 const MARGIN_L2_GAS: u64 = 200_000;

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -9,10 +9,9 @@ use assert_fs::{
 use blockifier::execution::syscalls::vm_syscall_utils::{SyscallSelector, SyscallUsage};
 use cairo_vm::types::builtin_name::BuiltinName;
 use camino::Utf8PathBuf;
-use forge_runner::{
-    test_case_summary::{AnyTestCaseSummary, Single, TestCaseSummary},
-    test_target_summary::TestTargetSummary,
-};
+use forge_runner::test_case_summary::Single;
+use forge_runner::test_case_summary::{AnyTestCaseSummary, TestCaseSummary};
+use forge_runner::test_target_summary::TestTargetSummary;
 use foundry_ui::UI;
 use indoc::formatdoc;
 use scarb_api::metadata::metadata_for_dir;
@@ -497,4 +496,169 @@ pub fn assert_builtin(
             },
         }
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::{
+        runner::{assert_gas, assert_passed, capture_assertion_panic},
+        running_tests::run_test_case,
+    };
+    use forge_runner::{
+        forge_config::ForgeTrackedResource,
+        test_case_summary::{AnyTestCaseSummary, TestCaseSummary},
+        test_target_summary::TestTargetSummary,
+    };
+    use indoc::indoc;
+    use shared::test_utils::output_assert::assert_stdout_contains;
+    use starknet_api::execution_resources::{GasAmount, GasVector};
+
+    #[test]
+    fn assert_gas_failure_shows_gas_diff_and_test_case_name() {
+        let test = test_case!(indoc!(
+            r"
+            #[test]
+            fn gas_assertion_diagnostics() {
+                keccak::keccak_u256s_le_inputs(array![1].span());
+            }
+        "
+        ));
+
+        let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+        assert_passed(&result);
+
+        // Intentionally wrong expectation so that `assert_gas` fails and we can inspect the diagnostics.
+        let panic_message = capture_assertion_panic(|| {
+            assert_gas(
+                &result,
+                "gas_assertion_diagnostics",
+                GasVector {
+                    l1_gas: GasAmount(1),
+                    l1_data_gas: GasAmount(2),
+                    l2_gas: GasAmount(3),
+                },
+            );
+        });
+
+        assert_stdout_contains(
+            panic_message.clone(),
+            indoc! {r"
+        Gas assertion failed for test case `test_package_integrationtest::test_case::gas_assertion_diagnostics`.
+        expected: l1_gas: 1, l1_data_gas: 2, l2_gas: 3
+        actual:   l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
+        diff:     l1_gas: [..], l1_data_gas: [..], l2_gas: [..]
+        "},
+        );
+
+        // `diff` must equal the absolute difference between `expected` and `actual`.
+        let actual = parse_gas_line(&panic_message, "actual:");
+        let diff = parse_gas_line(&panic_message, "diff:");
+        assert_eq!(diff.l1_gas.0, actual.l1_gas.0.abs_diff(1));
+        assert_eq!(diff.l1_data_gas.0, actual.l1_data_gas.0.abs_diff(2));
+        assert_eq!(diff.l2_gas.0, actual.l2_gas.0.abs_diff(3));
+    }
+
+    #[test]
+    fn assert_gas_reports_when_test_case_is_missing() {
+        let summaries = summaries(vec![
+            single_ignored("pkg::module::some_other_test"),
+            single_ignored("pkg::module::another_test"),
+        ]);
+
+        let panic_message = capture_assertion_panic(|| {
+            assert_gas(&summaries, "missing_test", GasVector::default());
+        });
+
+        assert_stdout_contains(
+            panic_message,
+            indoc! {r"
+        Gas assertion failed: test case `missing_test` was not found. Available test cases:
+         - pkg::module::some_other_test
+         - pkg::module::another_test
+        "},
+        );
+    }
+
+    #[test]
+    fn assert_gas_rejects_fuzzing_test_case() {
+        let summaries = summaries(vec![fuzzing_ignored("pkg::module::fuzzed")]);
+
+        let panic_message = capture_assertion_panic(|| {
+            assert_gas(&summaries, "fuzzed", GasVector::default());
+        });
+
+        assert_eq!(panic_message, "Cannot use assert_gas! for fuzzing tests");
+    }
+
+    #[test]
+    fn assert_gas_reports_non_passed_test_case() {
+        let summaries = summaries(vec![single_failed("pkg::module::failing")]);
+
+        let panic_message = capture_assertion_panic(|| {
+            assert_gas(&summaries, "failing", GasVector::default());
+        });
+
+        assert_eq!(
+            panic_message,
+            "Gas assertion failed for test case `pkg::module::failing`: expected passed test case with gas information, but test case was failed"
+        );
+    }
+
+    fn summaries(cases: Vec<AnyTestCaseSummary>) -> Vec<TestTargetSummary> {
+        vec![TestTargetSummary {
+            test_case_summaries: cases,
+        }]
+    }
+
+    fn single_failed(name: &str) -> AnyTestCaseSummary {
+        AnyTestCaseSummary::Single(TestCaseSummary::Failed {
+            name: name.to_string(),
+            msg: None,
+            debugging_trace: None,
+            fuzzer_args: Vec::new(),
+            test_statistics: (),
+        })
+    }
+
+    fn single_ignored(name: &str) -> AnyTestCaseSummary {
+        AnyTestCaseSummary::Single(TestCaseSummary::Ignored {
+            name: name.to_string(),
+        })
+    }
+
+    fn fuzzing_ignored(name: &str) -> AnyTestCaseSummary {
+        AnyTestCaseSummary::Fuzzing(TestCaseSummary::Ignored {
+            name: name.to_string(),
+        })
+    }
+
+    /// Parses a `l1_gas: <n>, l1_data_gas: <n>, l2_gas: <n>` line labelled with `label`
+    /// out of an `assert_gas` diagnostic message.
+    fn parse_gas_line(message: &str, label: &str) -> GasVector {
+        let line = message
+            .lines()
+            .find(|line| line.trim_start().starts_with(label))
+            .unwrap_or_else(|| panic!("no `{label}` line found in message:\n{message}"));
+
+        let value = |key: &str| -> u64 {
+            let after = line
+                .split(&format!("{key}: "))
+                .nth(1)
+                .unwrap_or_else(|| panic!("`{key}` not found in line: {line}"));
+            after
+                .split(|c: char| !c.is_ascii_digit())
+                .next()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| panic!("no number after `{key}` in line: {line}"))
+                .parse()
+                .unwrap()
+        };
+
+        GasVector {
+            l1_gas: GasAmount(value("l1_gas")),
+            l1_data_gas: GasAmount(value("l1_data_gas")),
+            l2_gas: GasAmount(value("l2_gas")),
+        }
+    }
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Towards #4484

## Introduced changes

Show gas diff on [`assert_gas`](https://github.com/foundry-rs/starknet-foundry/blob/0f1ce2a1e5531b32a73601b4d98f7237bc1d015f/crates/forge/tests/utils/runner.rs#L290-L312) failure.

### Before

<img width="1246" height="859" alt="image" src="https://github.com/user-attachments/assets/4e417437-6cc7-4922-a819-e713b508da3f" />

### After

<img width="1254" height="837" alt="image" src="https://github.com/user-attachments/assets/2db5599f-e430-469b-a998-12409e1e8c39" />


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
