### PR TITLE
[wip] accounts / signer refactor

### DIFF
--- a/crates/sncast/src/helpers/account.rs
+++ b/crates/sncast/src/helpers/account.rs
@@ -1,19 +1,16 @@
+use crate::response::ui::UI;
 use crate::{
-    NestedMap, build_account, check_account_file_exists, helpers::devnet::provider::DevnetProvider,
+    AccountVariant, NestedMap, build_account_variant, build_signer, check_account_file_exists,
+    helpers::devnet::provider::DevnetProvider,
 };
-use anyhow::{Result, ensure};
+use anyhow::{Context, Result, ensure};
 use camino::Utf8PathBuf;
-use starknet_rust::{
-    accounts::SingleOwnerAccount,
-    providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport},
-    signers::LocalWallet,
-};
+use starknet_rust::providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use url::Url;
 
 use crate::{AccountData, read_and_parse_json_file};
-use anyhow::Context;
 use serde_json::{Value, json};
 
 pub fn generate_account_name(accounts_file: &Utf8PathBuf) -> Result<String> {
@@ -93,7 +90,8 @@ pub async fn get_account_from_devnet<'a>(
     account: &str,
     provider: &'a JsonRpcClient<HttpTransport>,
     url: &Url,
-) -> Result<SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>> {
+    ui: &UI,
+) -> Result<AccountVariant<'a>> {
     let account_number: u8 = account
         .strip_prefix("devnet-")
         .map(|s| s.parse::<u8>().expect("Invalid devnet account number"))
@@ -124,5 +122,6 @@ pub async fn get_account_from_devnet<'a>(
 
     let account_data = AccountData::from(predeployed_account);
     let chain_id = provider.chain_id().await?;
-    build_account(account_data, chain_id, provider).await
+    let signer = build_signer(&account_data.signer_type, ui, false).await?;
+    build_account_variant(signer, account_data, chain_id, provider).await
 }

--- a/crates/sncast/src/helpers/devnet/provider.rs
+++ b/crates/sncast/src/helpers/devnet/provider.rs
@@ -129,6 +129,7 @@ impl From<&PredeployedAccount> for AccountData {
             signer_type: SignerType::Local {
                 private_key: predeployed_account.private_key,
             },
+            unknown_fields: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/sncast/src/helpers/signer.rs
+++ b/crates/sncast/src/helpers/signer.rs
@@ -1,23 +1,64 @@
 use crate::helpers::ledger;
+use crate::response::ui::UI;
 use anyhow::{Result, bail};
 use camino::Utf8PathBuf;
-use serde::{Deserialize, Serialize};
+use serde::ser::Error as SerError;
+use serde::{Deserialize, Serialize, Serializer};
+use serde_with::skip_serializing_none;
 use starknet_rust::{
     accounts::SingleOwnerAccount,
     providers::jsonrpc::{HttpTransport, JsonRpcClient},
-    signers::{DerivationPath, LedgerSigner, LocalWallet},
+    signers::{DerivationPath, LedgerSigner, LocalWallet, SigningKey},
 };
 use starknet_types_core::felt::Felt;
 
-/// Represents the type of signer stored in the accounts file
-// Uses `untagged` + `flatten` for backward compatibility with the existing accounts file format.
-// Downside: deserialization errors are less descriptive than with tagged variants,
-// and field name collisions across variants would silently misbehave.
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(untagged)]
+/// Signer type representation used in the accounts file.
+/// For internal purposes, it should be converted to [`SignerType`].
+#[skip_serializing_none]
+#[derive(Deserialize, Serialize, Debug, Default)]
+#[serde(default)]
+struct SignerTypeParams {
+    private_key: Option<Felt>,
+    ledger_path: Option<DerivationPath>,
+}
+
+/// Internal representation of a signer type.
+/// [`SignerType::Ambiguous`] corresponds to zero or more than one signer types being specified.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(from = "SignerTypeParams")]
 pub enum SignerType {
     Local { private_key: Felt },
     Ledger { ledger_path: DerivationPath },
+    Ambiguous,
+}
+
+impl From<SignerTypeParams> for SignerType {
+    fn from(params: SignerTypeParams) -> Self {
+        match (params.private_key, params.ledger_path) {
+            (Some(private_key), None) => Self::Local { private_key },
+            (None, Some(ledger_path)) => Self::Ledger { ledger_path },
+            _ => Self::Ambiguous,
+        }
+    }
+}
+
+impl Serialize for SignerType {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let raw = match self {
+            SignerType::Local { private_key } => SignerTypeParams {
+                private_key: Some(*private_key),
+                ..Default::default()
+            },
+            SignerType::Ledger { ledger_path } => SignerTypeParams {
+                ledger_path: Some(ledger_path.clone()),
+                ..Default::default()
+            },
+            SignerType::Ambiguous => {
+                return Err(S::Error::custom("cannot serialize ambiguous signer"));
+            }
+        };
+        raw.serialize(serializer)
+    }
 }
 
 impl SignerType {
@@ -25,7 +66,7 @@ impl SignerType {
     pub fn private_key(&self) -> Option<Felt> {
         match self {
             SignerType::Local { private_key } => Some(*private_key),
-            SignerType::Ledger { .. } => None,
+            SignerType::Ledger { .. } | SignerType::Ambiguous => None,
         }
     }
 
@@ -33,8 +74,33 @@ impl SignerType {
     pub fn ledger_path(&self) -> Option<&DerivationPath> {
         match self {
             SignerType::Ledger { ledger_path } => Some(ledger_path),
-            SignerType::Local { .. } => None,
+            SignerType::Local { .. } | SignerType::Ambiguous => None,
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum SignerBackend {
+    Local(LocalWallet),
+    Ledger(LedgerSigner<ledger::SncastLedgerTransport>),
+}
+
+pub async fn build_signer(
+    signer_type: &SignerType,
+    ui: &UI,
+    // TODO: unused in non-ledger context, consider refactor
+    print_ledger_message: bool,
+) -> Result<SignerBackend> {
+    match signer_type {
+        SignerType::Local { private_key } => Ok(SignerBackend::Local(LocalWallet::from(
+            SigningKey::from_secret_scalar(*private_key),
+        ))),
+        SignerType::Ledger { ledger_path } => {
+            let signer =
+                ledger::create_ledger_signer(ledger_path, ui, print_ledger_message).await?;
+            Ok(SignerBackend::Ledger(signer))
+        }
+        SignerType::Ambiguous => bail!("only one of `private_key`, `ledger_path` may be specified"),
     }
 }
 

--- a/crates/sncast/src/helpers/signer.rs
+++ b/crates/sncast/src/helpers/signer.rs
@@ -171,3 +171,45 @@ impl SignerSource {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AccountData;
+
+    #[test]
+    fn unknown_fields_captured_on_account_data() {
+        let data: AccountData = serde_json::from_str(
+            r#"{
+                "public_key": "0x1",
+                "address": "0x2",
+                "private_key": "0x3",
+                "typo_field": 1
+            }"#,
+        )
+        .unwrap();
+        assert!(data.unknown_fields.contains_key("typo_field"));
+    }
+
+    #[tokio::test]
+    async fn build_signer_rejects_ambiguous() {
+        let ui = UI::default();
+        let err = build_signer(&SignerType::Ambiguous, &ui, false)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "only one of `private_key`, `ledger_path` may be specified"
+        );
+    }
+
+    #[test]
+    fn serialize_ambiguous_hard_fails() {
+        let err = serde_json::to_string(&SignerType::Ambiguous).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("cannot serialize ambiguous signer"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -37,7 +37,7 @@ use starknet_rust::{
         ProviderError::StarknetError,
         jsonrpc::{HttpTransport, JsonRpcClient},
     },
-    signers::{DerivationPath, LocalWallet, SigningKey},
+    signers::SigningKey,
 };
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
@@ -53,11 +53,10 @@ pub mod helpers;
 pub mod response;
 pub mod state;
 
-use crate::helpers::ledger;
 use crate::response::ui::UI;
 use conversions::byte_array::ByteArray;
 use foundry_ui::components::warning::WarningMessage;
-pub use helpers::signer::{AccountVariant, SignerSource, SignerType};
+pub use helpers::signer::{AccountVariant, SignerBackend, SignerSource, SignerType, build_signer};
 
 pub type NestedMap<T> = HashMap<String, HashMap<String, T>>;
 
@@ -142,6 +141,11 @@ pub struct AccountData {
 
     #[serde(flatten)]
     pub signer_type: SignerType,
+
+    // TODO: considering warn / hard-error on all unknown fields
+    #[doc(hidden)]
+    #[serde(flatten, default, skip_serializing)]
+    pub unknown_fields: HashMap<String, Value>,
 }
 
 #[derive(Clone, Copy)]
@@ -365,8 +369,7 @@ pub async fn get_account<'a>(
                 .get_url(config)
                 .await
                 .context("Failed to get url")?;
-            let local_account = get_account_from_devnet(account, provider, &url).await?;
-            Ok(AccountVariant::LocalWallet(local_account))
+            get_account_from_devnet(account, provider, &url, ui).await
         }
         _ => {
             get_account_from_accounts_file(
@@ -395,14 +398,48 @@ pub async fn get_account_from_accounts_file<'a>(
         get_account_data_from_accounts_file(account, chain_id, accounts_file)?
     };
 
-    if let SignerSource::Ledger(ledger_path) =
-        SignerSource::new(keystore.cloned(), Some(&account_data.signer_type))?
-    {
-        return build_ledger_account(ledger_path, account_data, chain_id, provider, ui).await;
-    }
+    // Reject keystore + ledger conflict early.
+    let _ = SignerSource::new(keystore.cloned(), Some(&account_data.signer_type))?;
 
-    let account = build_account(account_data, chain_id, provider).await?;
-    Ok(AccountVariant::LocalWallet(account))
+    let signer = build_signer(&account_data.signer_type, ui, true).await?;
+
+    build_account_variant(signer, account_data, chain_id, provider).await
+}
+
+pub(crate) async fn build_account_variant<'a>(
+    signer: SignerBackend,
+    account_data: AccountData,
+    chain_id: Felt,
+    provider: &'a JsonRpcClient<HttpTransport>,
+) -> Result<AccountVariant<'a>> {
+    let address = account_data
+        .address
+        .context("Failed to get account address")?;
+
+    verify_account_address(address, chain_id, provider).await?;
+
+    let account_encoding = get_account_encoding(
+        account_data.legacy,
+        account_data.class_hash,
+        address,
+        provider,
+    )
+    .await?;
+
+    match signer {
+        SignerBackend::Local(signer) => {
+            let mut account =
+                SingleOwnerAccount::new(provider, signer, address, chain_id, account_encoding);
+            account.set_block_id(BlockId::Tag(PreConfirmed));
+            Ok(AccountVariant::LocalWallet(account))
+        }
+        SignerBackend::Ledger(signer) => {
+            let mut account =
+                SingleOwnerAccount::new(provider, signer, address, chain_id, account_encoding);
+            account.set_block_id(BlockId::Tag(PreConfirmed));
+            Ok(AccountVariant::Ledger(account))
+        }
+    }
 }
 
 pub async fn get_contract_class(
@@ -427,64 +464,6 @@ pub async fn get_contract_class(
     }
 
     result.map_err(handle_rpc_error)
-}
-
-async fn build_account(
-    account_data: AccountData,
-    chain_id: Felt,
-    provider: &JsonRpcClient<HttpTransport>,
-) -> Result<SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>> {
-    let private_key = account_data
-        .signer_type
-        .private_key()
-        .context("Private key not found")?;
-
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(private_key));
-
-    let address = account_data
-        .address
-        .context("Failed to get account address")?;
-
-    verify_account_address(address, chain_id, provider).await?;
-
-    let class_hash = account_data.class_hash;
-
-    let account_encoding =
-        get_account_encoding(account_data.legacy, class_hash, address, provider).await?;
-
-    let mut account =
-        SingleOwnerAccount::new(provider, signer, address, chain_id, account_encoding);
-
-    account.set_block_id(BlockId::Tag(PreConfirmed));
-
-    Ok(account)
-}
-
-async fn build_ledger_account<'a>(
-    ledger_path: DerivationPath,
-    account_data: AccountData,
-    chain_id: Felt,
-    provider: &'a JsonRpcClient<HttpTransport>,
-    ui: &UI,
-) -> Result<AccountVariant<'a>> {
-    let address = account_data
-        .address
-        .context("Failed to get account address")?;
-
-    verify_account_address(address, chain_id, provider).await?;
-
-    let encoding = get_account_encoding(
-        account_data.legacy,
-        account_data.class_hash,
-        address,
-        provider,
-    )
-    .await?;
-
-    let account =
-        ledger::ledger_account(&ledger_path, address, chain_id, encoding, provider, ui).await?;
-
-    Ok(AccountVariant::Ledger(account))
 }
 
 async fn verify_account_address(
@@ -579,6 +558,7 @@ pub fn get_account_data_from_keystore(
         legacy,
         account_type,
         signer_type: SignerType::Local { private_key },
+        unknown_fields: HashMap::new(),
     })
 }
 fn get_braavos_account_public_key(account_info: &Value) -> Result<Option<Felt>> {

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -14,9 +14,9 @@ use sncast::response::account::deploy::AccountDeployResponse;
 use sncast::response::invoke::{InvokeResponse, InvokeTransactionResponse};
 use sncast::response::ui::UI;
 use sncast::{
-    AccountData, AccountType, SignerType, WaitForTx, apply_optional_fields,
-    chain_id_to_network_name, check_account_file_exists, get_account_data_from_accounts_file,
-    get_account_data_from_keystore, handle_rpc_error, handle_wait_for_tx,
+    AccountData, AccountType, WaitForTx, apply_optional_fields, chain_id_to_network_name,
+    check_account_file_exists, get_account_data_from_accounts_file, get_account_data_from_keystore,
+    handle_rpc_error, handle_wait_for_tx,
 };
 use starknet_rust::accounts::{AccountDeploymentV3, AccountFactory, OpenZeppelinAccountFactory};
 use starknet_rust::accounts::{AccountFactoryError, ArgentAccountFactory};
@@ -166,10 +166,10 @@ async fn deploy_from_accounts_file(
     let account_data = get_account_data_from_accounts_file(&name, chain_id, accounts_file)?;
     let (account_type, class_hash, salt) = extract_deployment_fields(&account_data)?;
 
-    let (_, result) = match &account_data.signer_type {
-        SignerType::Ledger { ledger_path } => {
-            let signer = ledger::create_ledger_signer(ledger_path, ui, true).await?;
+    let signer = sncast::build_signer(&account_data.signer_type, ui, true).await?;
 
+    let (_, result) = match signer {
+        sncast::SignerBackend::Ledger(signer) => {
             ledger::verify_ledger_public_key(
                 signer.get_public_key().await?.scalar(),
                 account_data.public_key,
@@ -189,10 +189,7 @@ async fn deploy_from_accounts_file(
             )
             .await?
         }
-        SignerType::Local { private_key } => {
-            let signer =
-                LocalWallet::from_signing_key(SigningKey::from_secret_scalar(*private_key));
-
+        sncast::SignerBackend::Local(signer) => {
             create_factory_and_deploy(
                 provider,
                 account_type,

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -51,33 +51,45 @@ pub struct AccountDataRepresentationMessage {
 
 /// Display-only signer representation.
 #[derive(Clone, Debug)]
-enum SignerDisplay {
-    HiddenLocal,
-    Visible(SignerType),
-    Ambiguous,
+struct SignerDisplay {
+    signer_type: SignerType,
+    hide_private_key: bool,
+}
+
+impl SignerDisplay {
+    fn type_label(&self) -> &'static str {
+        match &self.signer_type {
+            SignerType::Local { .. } => "private_key",
+            SignerType::Ledger { .. } => "ledger",
+            SignerType::Ambiguous => "ambiguous",
+        }
+    }
 }
 
 impl Serialize for SignerDisplay {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            SignerDisplay::HiddenLocal => serializer.serialize_map(Some(0))?.end(),
-            SignerDisplay::Visible(signer_type) => signer_type.serialize(serializer),
-            SignerDisplay::Ambiguous => {
-                let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry("signer", "ambiguous")?;
-                map.end()
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("signer_type", self.type_label())?;
+
+        match &self.signer_type {
+            SignerType::Local { private_key } if !self.hide_private_key => {
+                map.serialize_entry("private_key", &private_key.into_hex_string())?;
             }
+            SignerType::Ledger { ledger_path } => {
+                map.serialize_entry("ledger_path", &ledger_path.derivation_string())?;
+            }
+            SignerType::Local { .. } | SignerType::Ambiguous => {}
         }
+        map.end()
     }
 }
 
 impl AccountDataRepresentationMessage {
     fn new(account: &AccountData, display_private_key: bool) -> Self {
         Self {
-            signer: match &account.signer_type {
-                SignerType::Local { .. } if !display_private_key => SignerDisplay::HiddenLocal,
-                SignerType::Ambiguous => SignerDisplay::Ambiguous,
-                other => SignerDisplay::Visible(other.clone()),
+            signer: SignerDisplay {
+                signer_type: account.signer_type.clone(),
+                hide_private_key: !display_private_key,
             },
             public_key: account.public_key.into_hex_string(),
             network: None,
@@ -124,23 +136,27 @@ impl Message for AccountDataRepresentationMessage {
 
         let _ = writeln!(result, "  public key: {}", self.public_key);
 
-        match &self.signer {
-            SignerDisplay::Visible(SignerType::Local { private_key }) => {
-                let _ = writeln!(result, "  private key: {}", private_key.into_hex_string());
-            }
-            SignerDisplay::Visible(SignerType::Ledger { ledger_path }) => {
-                let _ = writeln!(result, "  ledger path: {}", ledger_path.derivation_string());
-            }
-            SignerDisplay::Visible(SignerType::Ambiguous) => {
-                unreachable!("ambiguous signer is represented by SignerDisplay::Ambiguous");
-            }
-            SignerDisplay::Ambiguous => {
+        match &self.signer.signer_type {
+            SignerType::Ambiguous => {
                 let _ = writeln!(
                     result,
-                    "  signer: ambiguous (only one of `private_key`, `ledger_path` may be specified)"
+                    "  signer type: {} (only one of `private_key`, `ledger_path` may be specified)",
+                    self.signer.type_label()
                 );
             }
-            SignerDisplay::HiddenLocal => {}
+            _ => {
+                let _ = writeln!(result, "  signer type: {}", self.signer.type_label());
+            }
+        }
+
+        match &self.signer.signer_type {
+            SignerType::Local { private_key } if !self.signer.hide_private_key => {
+                let _ = writeln!(result, "  private key: {}", private_key.into_hex_string());
+            }
+            SignerType::Ledger { ledger_path } => {
+                let _ = writeln!(result, "  ledger path: {}", ledger_path.derivation_string());
+            }
+            SignerType::Local { .. } | SignerType::Ambiguous => {}
         }
         if let Some(ref address) = self.address {
             let _ = writeln!(result, "  address: {address}");

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -4,8 +4,8 @@ use clap::Args;
 use conversions::string::IntoHexStr;
 use foundry_ui::Message;
 use itertools::Itertools;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::ser::SerializeMap;
+use serde::{Serialize, Serializer};
 use serde_json::Value;
 use serde_json::json;
 use sncast::AccountType;
@@ -27,11 +27,11 @@ pub struct List {
     pub display_private_keys: bool,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
 pub struct AccountDataRepresentationMessage {
     pub public_key: String,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub signer_type: Option<SignerType>,
+    #[serde(flatten)]
+    signer: SignerDisplay,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,12 +49,35 @@ pub struct AccountDataRepresentationMessage {
     pub account_type: Option<AccountType>,
 }
 
+/// Display-only signer representation.
+#[derive(Clone, Debug)]
+enum SignerDisplay {
+    HiddenLocal,
+    Visible(SignerType),
+    Ambiguous,
+}
+
+impl Serialize for SignerDisplay {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            SignerDisplay::HiddenLocal => serializer.serialize_map(Some(0))?.end(),
+            SignerDisplay::Visible(signer_type) => signer_type.serialize(serializer),
+            SignerDisplay::Ambiguous => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("signer", "ambiguous")?;
+                map.end()
+            }
+        }
+    }
+}
+
 impl AccountDataRepresentationMessage {
     fn new(account: &AccountData, display_private_key: bool) -> Self {
         Self {
-            signer_type: match &account.signer_type {
-                SignerType::Local { .. } if !display_private_key => None,
-                other => Some(other.clone()),
+            signer: match &account.signer_type {
+                SignerType::Local { .. } if !display_private_key => SignerDisplay::HiddenLocal,
+                SignerType::Ambiguous => SignerDisplay::Ambiguous,
+                other => SignerDisplay::Visible(other.clone()),
             },
             public_key: account.public_key.into_hex_string(),
             network: None,
@@ -101,14 +124,23 @@ impl Message for AccountDataRepresentationMessage {
 
         let _ = writeln!(result, "  public key: {}", self.public_key);
 
-        match &self.signer_type {
-            Some(SignerType::Local { private_key }) => {
+        match &self.signer {
+            SignerDisplay::Visible(SignerType::Local { private_key }) => {
                 let _ = writeln!(result, "  private key: {}", private_key.into_hex_string());
             }
-            Some(SignerType::Ledger { ledger_path }) => {
+            SignerDisplay::Visible(SignerType::Ledger { ledger_path }) => {
                 let _ = writeln!(result, "  ledger path: {}", ledger_path.derivation_string());
             }
-            None => {}
+            SignerDisplay::Visible(SignerType::Ambiguous) => {
+                unreachable!("ambiguous signer is represented by SignerDisplay::Ambiguous");
+            }
+            SignerDisplay::Ambiguous => {
+                let _ = writeln!(
+                    result,
+                    "  signer: ambiguous (only one of `private_key`, `ledger_path` may be specified)"
+                );
+            }
+            SignerDisplay::HiddenLocal => {}
         }
         if let Some(ref address) = self.address {
             let _ = writeln!(result, "  address: {address}");

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -17,7 +17,6 @@ use sncast::helpers::configuration::{
 };
 use sncast::helpers::constants::BRAAVOS_BASE_ACCOUNT_CLASS_HASH;
 use sncast::helpers::interactive::prompt_to_add_account_as_default;
-use sncast::helpers::ledger;
 use sncast::helpers::rpc::RpcArgs;
 use sncast::response::explorer_link::block_explorer_link_if_allowed;
 use sncast::response::ui::UI;
@@ -26,7 +25,6 @@ use sncast::{SignerSource, SignerType, WaitForTx, get_chain_id};
 use starknet_rust::accounts::{AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory};
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
-use starknet_rust::signers::{LocalWallet, SigningKey};
 use starknet_types_core::felt::Felt;
 use std::collections::BTreeMap;
 use std::io::{self, IsTerminal};
@@ -81,6 +79,9 @@ pub fn prepare_account_json(
         SignerType::Ledger { ledger_path } => {
             account_json["ledger_path"] =
                 serde_json::Value::String(ledger_path.derivation_string());
+        }
+        SignerType::Ambiguous => {
+            unreachable!("ambiguous signer must not be written to accounts file");
         }
     }
 
@@ -365,20 +366,16 @@ pub async fn compute_account_address(
     provider: &JsonRpcClient<HttpTransport>,
     ui: &UI,
 ) -> Result<Felt> {
-    let address = match signer_type {
-        SignerType::Local { private_key } => {
-            let signer =
-                LocalWallet::from_signing_key(SigningKey::from_secret_scalar(*private_key));
+    match sncast::build_signer(signer_type, ui, false).await? {
+        sncast::SignerBackend::Local(signer) => {
             compute_address_with_signer(salt, class_hash, account_type, chain_id, signer, provider)
-                .await?
+                .await
         }
-        SignerType::Ledger { ledger_path } => {
-            let signer = ledger::create_ledger_signer(ledger_path, ui, false).await?;
+        sncast::SignerBackend::Ledger(signer) => {
             compute_address_with_signer(salt, class_hash, account_type, chain_id, signer, provider)
-                .await?
+                .await
         }
-    };
-    Ok(address)
+    }
 }
 
 async fn compute_address_with_signer<S>(

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -349,7 +349,7 @@ pub async fn account(
 
         Commands::List(options) => {
             ui.print_message(
-                "account delete",
+                "account list",
                 AccountsListMessage::new(config.accounts_file, options.display_private_keys)?,
             );
             Ok(ExitCode::SUCCESS)

--- a/crates/sncast/tests/e2e/account/list.rs
+++ b/crates/sncast/tests/e2e/account/list.rs
@@ -2,9 +2,45 @@ use anyhow::Context;
 use indoc::formatdoc;
 use serde_json::{Value, json};
 use shared::test_utils::output_assert::{AsOutput, assert_stderr_contains, assert_stdout_contains};
-use tempfile::tempdir;
+use std::{fs::File, io::Write};
+use tempfile::{TempDir, tempdir};
 
+use crate::helpers::constants::{LEDGER_PUBLIC_KEY, TEST_LEDGER_PATH_STORED};
 use crate::{e2e::account::helpers::create_tempdir_with_accounts_file, helpers::runner::runner};
+
+fn create_tempdir_with_signer_display_cases(file_name: &str) -> TempDir {
+    let dir = tempdir().expect("Unable to create a temporary directory");
+    let location = dir.path().join(file_name);
+    let mut file = File::create(location).expect("Unable to create a temporary accounts file");
+
+    let data = formatdoc! {r#"
+        {{
+            "alpha-sepolia": {{
+                "ledger_user": {{
+                    "public_key": "{LEDGER_PUBLIC_KEY}",
+                    "address": "0x123",
+                    "type": "open_zeppelin",
+                    "ledger_path": "{TEST_LEDGER_PATH_STORED}"
+                }},
+                "ambiguous_multiple": {{
+                    "public_key": "0x1",
+                    "address": "0x2",
+                    "private_key": "0x3",
+                    "ledger_path": "{TEST_LEDGER_PATH_STORED}"
+                }},
+                "ambiguous_missing": {{
+                    "public_key": "0x4",
+                    "address": "0x5"
+                }}
+            }}
+        }}
+    "#};
+
+    file.write_all(data.as_bytes())
+        .expect("Unable to write test data to a temporary file");
+    file.flush().expect("Unable to flush a temporary file");
+    dir
+}
 
 #[test]
 fn test_happy_case() {
@@ -30,12 +66,14 @@ fn test_happy_case() {
         - user0:
           network: alpha-sepolia
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+          signer type: private_key
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
           type: OpenZeppelin
 
         - user1:
           network: alpha-sepolia
           public key: 0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd
+          signer type: private_key
           address: 0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e
           salt: 0xe2b200bbdf76c31b
           type: Ready
@@ -44,6 +82,7 @@ fn test_happy_case() {
         - user2:
           network: alpha-sepolia
           public key: 0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd
+          signer type: private_key
           address: 0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e
           salt: 0xe2b200bbdf76c31b
           type: Ready
@@ -52,11 +91,13 @@ fn test_happy_case() {
         - user3:
           network: custom-network
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+          signer type: private_key
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
 
         - user4:
           network: custom-network
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+          signer type: private_key
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
           salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
           deployed: true
@@ -98,37 +139,42 @@ fn test_happy_case_with_private_keys() {
         Available accounts (at {}):
         - user0:
           network: alpha-sepolia
-          private key: 0x1e9038bdc68ce1d27d54205256988e85
           public key: 0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39
+          signer type: private_key
+          private key: 0x1e9038bdc68ce1d27d54205256988e85
           address: 0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a
           type: OpenZeppelin
 
         - user1:
           network: alpha-sepolia
-          private key: 0x1c3495fce931c0b3ed244f55c54226441a8254deafbc7fab2e46926b4d2fdae
           public key: 0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd
+          signer type: private_key
+          private key: 0x1c3495fce931c0b3ed244f55c54226441a8254deafbc7fab2e46926b4d2fdae
           address: 0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e
           salt: 0xe2b200bbdf76c31b
           type: Ready
 
         - user2:
           network: alpha-sepolia
-          private key: 0x1c3495fce931c0b3ed244f55c54226441a8254deafbc7fab2e46926b4d2fdae
           public key: 0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd
+          signer type: private_key
+          private key: 0x1c3495fce931c0b3ed244f55c54226441a8254deafbc7fab2e46926b4d2fdae
           address: 0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e
           salt: 0xe2b200bbdf76c31b
           type: Ready
 
         - user3:
           network: custom-network
-          private key: 0xe3e70682c2094cac629f6fbed82c07cd
           public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
+          signer type: private_key
+          private key: 0xe3e70682c2094cac629f6fbed82c07cd
           address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
 
         - user4:
           network: custom-network
-          private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
           public key: 0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182
+          signer type: private_key
+          private key: 0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f
           address: 0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91
           salt: 0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064
           deployed: true
@@ -164,25 +210,28 @@ fn test_happy_case_json() {
 
     let expected = json!(
         {
-            "command": "account delete",
+            "command": "account list",
             "type": "response",
             "user3": {
               "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
               "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
-              "network": "custom-network"
+              "network": "custom-network",
+              "signer_type": "private_key"
             },
             "user4": {
               "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
               "address": "0x7ccdf182d27c7aaa2e733b94db4a3f7b28ff56336b34abf43c15e3a9edfbe91",
               "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
               "deployed": true,
-              "network": "custom-network"
+              "network": "custom-network",
+              "signer_type": "private_key"
             },
             "user0": {
               "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
               "address": "0x4f5f24ceaae64434fa2bc2befd08976b51cf8f6a5d8257f7ec3616f61de263a",
               "type": "open_zeppelin",
-              "network": "alpha-sepolia"
+              "network": "alpha-sepolia",
+              "signer_type": "private_key"
             },
             "user1": {
               "address": "0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e",
@@ -190,7 +239,8 @@ fn test_happy_case_json() {
               "public_key": "0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd",
               "salt": "0xe2b200bbdf76c31b",
               "type": "ready",
-              "network": "alpha-sepolia"
+              "network": "alpha-sepolia",
+              "signer_type": "private_key"
             },
             "user2": {
               "address": "0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e",
@@ -198,7 +248,8 @@ fn test_happy_case_json() {
               "public_key": "0x63b3a3ac141e4c007b167b27450f110c729cc0d0238541ca705b0de5144edbd",
               "salt": "0xe2b200bbdf76c31b",
               "type": "ready",
-              "network": "alpha-sepolia"
+              "network": "alpha-sepolia",
+              "signer_type": "private_key"
             },
         }
     );
@@ -232,13 +283,14 @@ fn test_happy_case_with_private_keys_json() {
 
     let expected = json!(
         {
-          "command": "account delete",
+          "command": "account list",
           "type": "response",
           "user3": {
               "address": "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
               "private_key": "0xe3e70682c2094cac629f6fbed82c07cd",
               "public_key": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
-              "network": "custom-network"
+              "network": "custom-network",
+              "signer_type": "private_key"
           },
           "user4": {
             "public_key": "0x43a74f86b7e204f1ba081636c9d4015e1f54f5bb03a4ae8741602a15ffbb182",
@@ -246,7 +298,8 @@ fn test_happy_case_with_private_keys_json() {
             "salt": "0x54aa715a5cff30ccf7845ad4659eb1dac5b730c2541263c358c7e3a4c4a8064",
             "private_key": "0x73fbb3c1eff11167598455d0408f3932e42c678bd8f7fbc6028c716867cc01f",
             "deployed": true,
-            "network": "custom-network"
+            "network": "custom-network",
+            "signer_type": "private_key"
           },
           "user0": {
             "public_key": "0x2f91ed13f8f0f7d39b942c80bfcd3d0967809d99e0cc083606cbe59033d2b39",
@@ -254,6 +307,7 @@ fn test_happy_case_with_private_keys_json() {
             "type": "open_zeppelin",
             "network": "alpha-sepolia",
             "private_key": "0x1e9038bdc68ce1d27d54205256988e85",
+            "signer_type": "private_key"
           },
           "user1": {
             "address": "0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e",
@@ -263,6 +317,7 @@ fn test_happy_case_with_private_keys_json() {
             "salt": "0xe2b200bbdf76c31b",
             "type": "ready",
             "network": "alpha-sepolia",
+            "signer_type": "private_key"
           },
           "user2": {
             "address": "0x9613a934141dd6625748a7e066a380b3f9787f079f35ecc2f3ba934d507d4e",
@@ -272,9 +327,110 @@ fn test_happy_case_with_private_keys_json() {
             "salt": "0xe2b200bbdf76c31b",
             "type": "ready",
             "network": "alpha-sepolia",
+            "signer_type": "private_key"
           },
         }
     );
+
+    assert_eq!(output_parsed, expected);
+}
+
+#[test]
+fn test_ledger_and_ambiguous_signers() {
+    let accounts_file_name = "signer_display_accounts.json";
+    let temp_dir = create_tempdir_with_signer_display_cases(accounts_file_name);
+
+    let accounts_file_path = temp_dir
+        .path()
+        .canonicalize()
+        .expect("Unable to resolve a temporary directory path")
+        .join(accounts_file_name);
+
+    let args = vec!["--accounts-file", accounts_file_name, "account", "list"];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let expected = formatdoc!(
+        "
+        Available accounts (at {}):
+        - ambiguous_multiple:
+          network: alpha-sepolia
+          public key: 0x1
+          signer type: ambiguous (only one of `private_key`, `ledger_path` may be specified)
+          address: 0x2
+
+        - ambiguous_missing:
+          network: alpha-sepolia
+          public key: 0x4
+          signer type: ambiguous (only one of `private_key`, `ledger_path` may be specified)
+          address: 0x5
+
+        - ledger_user:
+          network: alpha-sepolia
+          public key: {LEDGER_PUBLIC_KEY}
+          signer type: ledger
+          ledger path: {TEST_LEDGER_PATH_STORED}
+          address: 0x123
+          type: OpenZeppelin
+
+        To show private keys too, run with --display-private-keys or -p
+        ",
+        accounts_file_path.to_str().unwrap()
+    );
+
+    assert_stdout_contains(output, expected);
+}
+
+#[test]
+fn test_ledger_and_ambiguous_signers_json() {
+    let accounts_file_name = "signer_display_accounts.json";
+    let temp_dir = create_tempdir_with_signer_display_cases(accounts_file_name);
+
+    let args = vec![
+        "--json",
+        "--accounts-file",
+        accounts_file_name,
+        "account",
+        "list",
+    ];
+
+    let snapbox = runner(&args).current_dir(temp_dir.path());
+    let output = snapbox.assert().success();
+
+    assert!(output.as_stderr().is_empty());
+
+    let output_plain = output.as_stdout().to_string();
+    let output_parsed: Value = serde_json::from_str(&output_plain)
+        .context("Failed to parse command's output to JSON")
+        .unwrap();
+
+    let expected = json!({
+        "command": "account list",
+        "type": "response",
+        "ledger_user": {
+            "public_key": LEDGER_PUBLIC_KEY,
+            "address": "0x123",
+            "type": "open_zeppelin",
+            "network": "alpha-sepolia",
+            "signer_type": "ledger",
+            "ledger_path": TEST_LEDGER_PATH_STORED,
+        },
+        "ambiguous_multiple": {
+            "public_key": "0x1",
+            "address": "0x2",
+            "network": "alpha-sepolia",
+            "signer_type": "ambiguous",
+        },
+        "ambiguous_missing": {
+            "public_key": "0x4",
+            "address": "0x5",
+            "network": "alpha-sepolia",
+            "signer_type": "ambiguous",
+        },
+    });
 
     assert_eq!(output_parsed, expected);
 }

--- a/crates/sncast/tests/e2e/ledger/mod.rs
+++ b/crates/sncast/tests/e2e/ledger/mod.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crate::helpers::constants::URL;
+pub(crate) use crate::helpers::constants::{LEDGER_PUBLIC_KEY, TEST_LEDGER_PATH_STORED};
 use crate::helpers::fixtures::mint_token;
 use clap::Command;
 use clap::builder::TypedValueParser;
@@ -35,12 +36,7 @@ pub(crate) const READY_LEDGER_PATH: &str = "m//starknet'/sncast'/0'/1'/0";
 pub(crate) const BRAAVOS_LEDGER_PATH: &str = "m//starknet'/sncast'/0'/2'/0";
 pub(crate) const TEST_LEDGER_PATH: &str = OZ_LEDGER_PATH;
 
-pub(crate) const TEST_LEDGER_PATH_STORED: &str = "m/2645'/1195502025'/355113700'/0'/0'/0";
-
 const APP_PATH: &str = "tests/data/ledger-app/nanox.elf";
-
-pub(crate) const LEDGER_PUBLIC_KEY: &str =
-    "0x51f3e99d539868d8f45ca705ad6f75e68229a6037a919b15216b4e92a4d6d8";
 
 pub(crate) const LEDGER_ACCOUNT_NAME: &str = "my_ledger";
 

--- a/crates/sncast/tests/helpers/constants.rs
+++ b/crates/sncast/tests/helpers/constants.rs
@@ -48,3 +48,9 @@ pub const DATA_TRANSFORMER_CONTRACT_ABI_PATH: &str =
     "tests/data/files/data_transformer_contract_abi.json";
 pub const DATA_TRANSFORMER_CONTRACT_DIR: &str =
     "../../crates/data-transformer/tests/data/data_transformer";
+
+/// Canonical numeric form of `m//starknet'/sncast'/0'/0'/0`.
+pub const TEST_LEDGER_PATH_STORED: &str = "m/2645'/1195502025'/355113700'/0'/0'/0";
+
+pub const LEDGER_PUBLIC_KEY: &str =
+    "0x51f3e99d539868d8f45ca705ad6f75e68229a6037a919b15216b4e92a4d6d8";

--- a/crates/sncast/tests/integration/lib_tests.rs
+++ b/crates/sncast/tests/integration/lib_tests.rs
@@ -137,7 +137,7 @@ async fn test_get_account_failed_to_convert_field_elements() {
     let err = account1.unwrap_err();
 
     assert!(err.to_string().contains(
-        "Failed to parse field `alpha-sepolia.with_invalid_private_key` in file 'tests/data/accounts/faulty_accounts_invalid_felt.json': data did not match any variant of untagged enum SignerType at line 9 column 9"
+        "Failed to parse field `alpha-sepolia.with_invalid_private_key` in file 'tests/data/accounts/faulty_accounts_invalid_felt.json': expected hex string to be prefixed by '0x' at line 9 column 9"
     ));
 }
 


### PR DESCRIPTION

<!-- Reference any GitHub issues resolved by this PR -->

Towards #3994 

## Stack
- #4502
- #4510 

## Introduced changes

<!-- A brief description of the changes -->

#### Primary:
1. Replace untagged `SignerType` deserialize with:
   - i `SignerTypeParams` - file representation, with flat `Option<>` fields for signer locators (`private_key`, `ledger_path` + upcoming `keystore` and `keyring` variants)
   - ii.  `SignerType` - internal repr with `Ambiguous` variant for clear handling (soft-parsing) of 0 or ≥2 locator fields.
2. Capture `unknown_fields` on `AccountData`
   - TBD: warn/error once accounts-file JSON shape is stabilized
3. Keep on-disk accounts-file JSON shape unchanged
4. `account list`: always show `signer_type` (`private_key` | `ledger` | `ambiguous`) in text + JSON
5. Fix `command` field in `account list --json`: `account delete` → `account list`

#### Context:
- Hard-fail `Ambiguous` on use (`build_signer`) and on `serialize` (avoid wiping locator keys on write)
- Centralize accounts-file signing through `build_signer` → `SignerBackend` (resolve / deploy / address compute / devnet); drop duplicated local/ledger builders

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
