### PR TITLE
Support `CACHEDIR.TAG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 - Possibility to set an L2 gas limit via unnamed argument `#[available_gas(...)]`, equivalent to `#[available_gas(l2_gas: ...)]`.
+- `CACHEDIR.TAG` file is now created in the cache directory.
 
 ## [0.63.0] - 2026-08-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7560,7 +7560,7 @@ dependencies = [
  "starknet-types-core 0.2.4",
  "starknet_api",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,7 +7559,8 @@ dependencies = [
  "starknet-rust",
  "starknet-types-core 0.2.4",
  "starknet_api",
- "thiserror 2.0.19",
+ "tempfile",
+ "thiserror 2.0.18",
  "url",
 ]
 

--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -4,13 +4,13 @@ use fs2::FileExt;
 use regex::Regex;
 use runtime::starknet::context::SerializableBlockInfo;
 use serde::{Deserialize, Serialize};
+use shared::cache::prepare_cache_dir;
 use starknet_api::block::{BlockInfo, BlockNumber};
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::state::StorageKey;
 use starknet_rust::core::types::ContractClass;
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
-use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, Write};
 use std::string::ToString;
@@ -279,7 +279,7 @@ fn cache_file_path_from_fork_config(
         cache_version()
     ));
 
-    fs::create_dir_all(cache_file_path.parent().unwrap())
+    prepare_cache_dir(cache_file_path.parent().unwrap())
         .context("Fork cache directory could not be created")?;
 
     Ok(cache_file_path)

--- a/crates/cheatnet/src/forking/cache.rs
+++ b/crates/cheatnet/src/forking/cache.rs
@@ -280,7 +280,7 @@ fn cache_file_path_from_fork_config(
     ));
 
     prepare_cache_dir(cache_file_path.parent().unwrap())
-        .context("Fork cache directory could not be created")?;
+        .context("Cache directory could not be created")?;
 
     Ok(cache_file_path)
 }

--- a/crates/forge/src/clean.rs
+++ b/crates/forge/src/clean.rs
@@ -7,7 +7,7 @@ use foundry_ui::UI;
 use regex::Regex;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
 use semver::Version;
-use shared::cache::CACHEDIR_TAG_FILENAME;
+use shared::cache::{CACHEDIR_TAG_FILENAME, SNFOUNDRY_CACHE_TAG_MARKER};
 use std::fs;
 use std::sync::OnceLock;
 
@@ -115,7 +115,8 @@ fn is_snfoundry_cache_file(path: &Utf8Path) -> bool {
     }
 
     if file_name == CACHEDIR_TAG_FILENAME {
-        return true;
+        return fs::read_to_string(path)
+            .is_ok_and(|contents| contents.contains(SNFOUNDRY_CACHE_TAG_MARKER));
     }
 
     let Some(captures) = fork_cache_file_regex().captures(file_name) else {
@@ -130,7 +131,8 @@ fn is_snfoundry_cache_file(path: &Utf8Path) -> bool {
 mod tests {
     use super::is_snfoundry_cache_file;
     use camino::Utf8Path;
-    use shared::cache::CACHEDIR_TAG_FILENAME;
+    use shared::cache::{CACHEDIR_TAG_CONTENTS, CACHEDIR_TAG_FILENAME};
+    use std::fs;
 
     #[test]
     fn recognizes_prev_failed_tests_file() {
@@ -139,9 +141,28 @@ mod tests {
 
     #[test]
     fn recognizes_cachedir_tag() {
-        assert!(is_snfoundry_cache_file(Utf8Path::new(
-            CACHEDIR_TAG_FILENAME
-        )));
+        let temp = tempfile::tempdir().unwrap();
+        let tag_path = temp.path().join(CACHEDIR_TAG_FILENAME);
+        fs::write(&tag_path, CACHEDIR_TAG_CONTENTS).unwrap();
+
+        assert!(is_snfoundry_cache_file(
+            Utf8Path::from_path(&tag_path).unwrap()
+        ));
+    }
+
+    #[test]
+    fn rejects_cachedir_tag_not_created_by_snfoundry() {
+        let temp = tempfile::tempdir().unwrap();
+        let tag_path = temp.path().join(CACHEDIR_TAG_FILENAME);
+        fs::write(
+            &tag_path,
+            "Signature: 8a477f597d28d172789f06886806bc55\n# Created by another tool.\n",
+        )
+        .unwrap();
+
+        assert!(!is_snfoundry_cache_file(
+            Utf8Path::from_path(&tag_path).unwrap()
+        ));
     }
 
     #[test]

--- a/crates/forge/src/clean.rs
+++ b/crates/forge/src/clean.rs
@@ -7,6 +7,7 @@ use foundry_ui::UI;
 use regex::Regex;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
 use semver::Version;
+use shared::cache::CACHEDIR_TAG_FILENAME;
 use std::fs;
 use std::sync::OnceLock;
 
@@ -14,7 +15,7 @@ const COVERAGE_DIR: &str = "coverage";
 const PROFILE_DIR: &str = "profile";
 const TRACE_DIR: &str = "snfoundry_trace";
 
-fn snfoundry_cache_file_regex() -> &'static Regex {
+fn fork_cache_file_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
     REGEX.get_or_init(|| {
         Regex::new(r"^[a-zA-Z0-9_]+_\d+_v(?<version>[A-Za-z0-9_.+-]+)\.json$").unwrap()
@@ -113,7 +114,11 @@ fn is_snfoundry_cache_file(path: &Utf8Path) -> bool {
         return true;
     }
 
-    let Some(captures) = snfoundry_cache_file_regex().captures(file_name) else {
+    if file_name == CACHEDIR_TAG_FILENAME {
+        return true;
+    }
+
+    let Some(captures) = fork_cache_file_regex().captures(file_name) else {
         return false;
     };
 
@@ -125,10 +130,18 @@ fn is_snfoundry_cache_file(path: &Utf8Path) -> bool {
 mod tests {
     use super::is_snfoundry_cache_file;
     use camino::Utf8Path;
+    use shared::cache::CACHEDIR_TAG_FILENAME;
 
     #[test]
     fn recognizes_prev_failed_tests_file() {
         assert!(is_snfoundry_cache_file(Utf8Path::new(".prev_tests_failed")));
+    }
+
+    #[test]
+    fn recognizes_cachedir_tag() {
+        assert!(is_snfoundry_cache_file(Utf8Path::new(
+            CACHEDIR_TAG_FILENAME
+        )));
     }
 
     #[test]

--- a/crates/forge/src/clean.rs
+++ b/crates/forge/src/clean.rs
@@ -7,7 +7,7 @@ use foundry_ui::UI;
 use regex::Regex;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
 use semver::Version;
-use shared::cache::{CACHEDIR_TAG_FILENAME, SNFOUNDRY_CACHE_TAG_MARKER};
+use shared::cache::{CACHEDIR_TAG_CONTENTS, CACHEDIR_TAG_FILENAME};
 use std::fs;
 use std::sync::OnceLock;
 
@@ -116,7 +116,7 @@ fn is_snfoundry_cache_file(path: &Utf8Path) -> bool {
 
     if file_name == CACHEDIR_TAG_FILENAME {
         return fs::read_to_string(path)
-            .is_ok_and(|contents| contents.contains(SNFOUNDRY_CACHE_TAG_MARKER));
+            .is_ok_and(|contents| contents.contains(CACHEDIR_TAG_CONTENTS));
     }
 
     let Some(captures) = fork_cache_file_regex().captures(file_name) else {

--- a/crates/forge/src/shared_cache.rs
+++ b/crates/forge/src/shared_cache.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use camino::Utf8PathBuf;
 use forge_runner::test_case_summary::AnyTestCaseSummary;
+use shared::cache::prepare_cache_dir;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
 
@@ -33,7 +34,7 @@ impl FailedTestsCache {
     }
 
     pub fn save_failed_tests(&self, all_failed_tests: &[&AnyTestCaseSummary]) -> Result<()> {
-        std::fs::create_dir_all(self.cache_file.parent().unwrap())?;
+        prepare_cache_dir(self.cache_file.parent().unwrap())?;
 
         let file = File::create(&self.cache_file)?;
 

--- a/crates/forge/tests/e2e/clean.rs
+++ b/crates/forge/tests/e2e/clean.rs
@@ -3,6 +3,7 @@ use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use forge_runner::DEFAULT_CACHE_DIR;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
+use shared::cache::CACHEDIR_TAG_FILENAME;
 use shared::test_utils::output_assert::assert_stdout_contains;
 use std::fs;
 use std::path::Path;
@@ -168,6 +169,7 @@ fn test_clean_cache_with_custom_cache_dir_preserves_unrelated_files() {
 
     let custom_cache_dir = temp_dir.path().join("custom_cache");
     fs::create_dir(&custom_cache_dir).unwrap();
+    fs::write(custom_cache_dir.join(CACHEDIR_TAG_FILENAME), "invalid").unwrap();
     fs::write(custom_cache_dir.join(".prev_tests_failed"), "failed_test").unwrap();
     fs::write(
         custom_cache_dir.join("http___rpc_example_54060_v0_60_0.json"),
@@ -184,6 +186,7 @@ fn test_clean_cache_with_custom_cache_dir_preserves_unrelated_files() {
         .success();
 
     assert!(custom_cache_dir.exists());
+    assert!(!custom_cache_dir.join(CACHEDIR_TAG_FILENAME).exists());
     assert!(!custom_cache_dir.join(".prev_tests_failed").exists());
     assert!(
         !custom_cache_dir

--- a/crates/forge/tests/e2e/clean.rs
+++ b/crates/forge/tests/e2e/clean.rs
@@ -3,7 +3,7 @@ use assert_fs::TempDir;
 use camino::Utf8PathBuf;
 use forge_runner::DEFAULT_CACHE_DIR;
 use scarb_api::metadata::{MetadataOpts, metadata_with_opts};
-use shared::cache::CACHEDIR_TAG_FILENAME;
+use shared::cache::{CACHEDIR_TAG_CONTENTS, CACHEDIR_TAG_FILENAME};
 use shared::test_utils::output_assert::assert_stdout_contains;
 use std::fs;
 use std::path::Path;
@@ -169,7 +169,11 @@ fn test_clean_cache_with_custom_cache_dir_preserves_unrelated_files() {
 
     let custom_cache_dir = temp_dir.path().join("custom_cache");
     fs::create_dir(&custom_cache_dir).unwrap();
-    fs::write(custom_cache_dir.join(CACHEDIR_TAG_FILENAME), "invalid").unwrap();
+    fs::write(
+        custom_cache_dir.join(CACHEDIR_TAG_FILENAME),
+        CACHEDIR_TAG_CONTENTS,
+    )
+    .unwrap();
     fs::write(custom_cache_dir.join(".prev_tests_failed"), "failed_test").unwrap();
     fs::write(
         custom_cache_dir.join("http___rpc_example_54060_v0_60_0.json"),

--- a/crates/forge/tests/e2e/running.rs
+++ b/crates/forge/tests/e2e/running.rs
@@ -4,7 +4,9 @@ use super::common::runner::{
 };
 use crate::utils::get_snforge_std_entry;
 use assert_fs::fixture::{FileWriteStr, PathChild};
+use forge_runner::DEFAULT_CACHE_DIR;
 use indoc::{formatdoc, indoc};
+use shared::cache::{CACHEDIR_TAG_CONTENTS, CACHEDIR_TAG_FILENAME};
 use shared::test_utils::output_assert::{AsOutput, assert_stdout, assert_stdout_contains};
 use std::fs;
 use toml_edit::{DocumentMut, value};
@@ -763,6 +765,20 @@ fn with_rerun_failed_flag_and_name_filter() {
             simple_package_integrationtest::test_simple::test_another_failing
 
         "},
+    );
+}
+
+#[test]
+fn creates_default_cache_files() {
+    let temp = setup_package("simple_package");
+
+    test_runner(&temp).assert().code(1);
+
+    let cache_dir = temp.path().join(DEFAULT_CACHE_DIR);
+    assert!(cache_dir.join(".prev_tests_failed").is_file());
+    assert_eq!(
+        fs::read_to_string(cache_dir.join(CACHEDIR_TAG_FILENAME)).unwrap(),
+        CACHEDIR_TAG_CONTENTS
     );
 }
 

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -21,5 +21,8 @@ num-traits.workspace = true
 foundry-ui ={ path = "../foundry-ui" }
 thiserror = "2.0.17"
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [features]
 testing = []

--- a/crates/shared/src/cache.rs
+++ b/crates/shared/src/cache.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -20,16 +20,7 @@ pub fn prepare_cache_dir(cache_dir: impl AsRef<Path>) -> Result<()> {
     let tag_path = cache_dir.join(CACHEDIR_TAG_FILENAME);
 
     match fs::symlink_metadata(&tag_path) {
-        Ok(metadata) => {
-            if !metadata.file_type().is_file() {
-                bail!(
-                    "Cache directory tag path is not a regular file: {}",
-                    tag_path.display()
-                );
-            }
-
-            return Ok(());
-        }
+        Ok(_) => return Ok(()),
         Err(err) if err.kind() == ErrorKind::NotFound => {}
         Err(err) => {
             return Err(err).with_context(|| {

--- a/crates/shared/src/cache.rs
+++ b/crates/shared/src/cache.rs
@@ -1,0 +1,100 @@
+use anyhow::{Context, Result, bail};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub const CACHEDIR_TAG_FILENAME: &str = "CACHEDIR.TAG";
+
+const CACHEDIR_TAG_CONTENTS: &str = "\
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by Starknet Foundry.
+# For information about cache directory tags, see:
+# https://bford.info/cachedir/
+";
+
+pub fn prepare_cache_dir(cache_dir: impl AsRef<Path>) -> Result<()> {
+    let cache_dir = cache_dir.as_ref();
+    fs::create_dir_all(cache_dir)
+        .with_context(|| format!("Failed to create cache directory: {}", cache_dir.display()))?;
+
+    let tag_path = cache_dir.join(CACHEDIR_TAG_FILENAME);
+
+    match fs::symlink_metadata(&tag_path) {
+        Ok(metadata) => {
+            if !metadata.file_type().is_file() {
+                bail!(
+                    "Cache directory tag path is not a regular file: {}",
+                    tag_path.display()
+                );
+            }
+
+            return Ok(());
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "Failed to read cache directory tag metadata: {}",
+                    tag_path.display()
+                )
+            });
+        }
+    }
+
+    fs::write(&tag_path, CACHEDIR_TAG_CONTENTS).with_context(|| {
+        format!(
+            "Failed to write cache directory tag: {}",
+            tag_path.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CACHEDIR_TAG_CONTENTS, CACHEDIR_TAG_FILENAME, prepare_cache_dir};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn creates_cache_dir_with_tag() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join(".snfoundry_cache");
+
+        prepare_cache_dir(&cache_dir).unwrap();
+
+        let tag = fs::read_to_string(cache_dir.join(CACHEDIR_TAG_FILENAME)).unwrap();
+        assert_eq!(tag, CACHEDIR_TAG_CONTENTS);
+    }
+
+    #[test]
+    fn creates_cache_dir_tag_when_missing() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join(".snfoundry_cache");
+        fs::create_dir(&cache_dir).unwrap();
+
+        prepare_cache_dir(&cache_dir).unwrap();
+
+        let tag = fs::read_to_string(cache_dir.join(CACHEDIR_TAG_FILENAME)).unwrap();
+        assert_eq!(tag, CACHEDIR_TAG_CONTENTS);
+    }
+
+    #[test]
+    fn leaves_existing_cache_dir_tag_unchanged() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join(".snfoundry_cache");
+        fs::create_dir(&cache_dir).unwrap();
+        let tag_path = cache_dir.join(CACHEDIR_TAG_FILENAME);
+        let existing_tag = "\
+Signature: 8a477f597d28d172789f06886806bc55
+# Existing cache tag.
+";
+        fs::write(&tag_path, existing_tag).unwrap();
+
+        prepare_cache_dir(&cache_dir).unwrap();
+
+        let tag = fs::read_to_string(tag_path).unwrap();
+        assert_eq!(tag, existing_tag);
+    }
+}

--- a/crates/shared/src/cache.rs
+++ b/crates/shared/src/cache.rs
@@ -4,7 +4,8 @@ use std::io::{ErrorKind, Write};
 use std::path::Path;
 
 pub const CACHEDIR_TAG_FILENAME: &str = "CACHEDIR.TAG";
-
+pub const SNFOUNDRY_CACHE_TAG_MARKER: &str =
+    "This file is a cache directory tag created by Starknet Foundry";
 pub const CACHEDIR_TAG_CONTENTS: &str = "\
 Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by Starknet Foundry.

--- a/crates/shared/src/cache.rs
+++ b/crates/shared/src/cache.rs
@@ -1,11 +1,11 @@
 use anyhow::{Context, Result};
-use std::fs;
-use std::io::ErrorKind;
+use std::fs::{self, File};
+use std::io::{ErrorKind, Write};
 use std::path::Path;
 
 pub const CACHEDIR_TAG_FILENAME: &str = "CACHEDIR.TAG";
 
-const CACHEDIR_TAG_CONTENTS: &str = "\
+pub const CACHEDIR_TAG_CONTENTS: &str = "\
 Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by Starknet Foundry.
 # For information about cache directory tags, see:
@@ -19,25 +19,23 @@ pub fn prepare_cache_dir(cache_dir: impl AsRef<Path>) -> Result<()> {
 
     let tag_path = cache_dir.join(CACHEDIR_TAG_FILENAME);
 
-    match fs::symlink_metadata(&tag_path) {
-        Ok(_) => return Ok(()),
-        Err(err) if err.kind() == ErrorKind::NotFound => {}
-        Err(err) => {
-            return Err(err).with_context(|| {
+    match File::create_new(&tag_path) {
+        Ok(mut file) => file
+            .write_all(CACHEDIR_TAG_CONTENTS.as_bytes())
+            .with_context(|| {
                 format!(
-                    "Failed to read cache directory tag metadata: {}",
+                    "Failed to write cache directory tag: {}",
                     tag_path.display()
                 )
-            });
-        }
-    }
-
-    fs::write(&tag_path, CACHEDIR_TAG_CONTENTS).with_context(|| {
-        format!(
-            "Failed to write cache directory tag: {}",
-            tag_path.display()
-        )
-    })?;
+            }),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => Ok(()),
+        Err(err) => Err(err).with_context(|| {
+            format!(
+                "Failed to create cache directory tag: {}",
+                tag_path.display()
+            )
+        }),
+    }?;
 
     Ok(())
 }

--- a/crates/shared/src/cache.rs
+++ b/crates/shared/src/cache.rs
@@ -4,8 +4,6 @@ use std::io::{ErrorKind, Write};
 use std::path::Path;
 
 pub const CACHEDIR_TAG_FILENAME: &str = "CACHEDIR.TAG";
-pub const SNFOUNDRY_CACHE_TAG_MARKER: &str =
-    "This file is a cache directory tag created by Starknet Foundry";
 pub const CACHEDIR_TAG_CONTENTS: &str = "\
 Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by Starknet Foundry.

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -9,6 +9,7 @@ use starknet_rust::providers::jsonrpc::HttpTransport;
 use std::fmt::Display;
 
 pub mod auto_completions;
+pub mod cache;
 pub mod command;
 pub mod consts;
 pub mod rpc;


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #

## Introduced changes

Add a `CACHEDIR.TAG` at the root of `.snfoundry_cache/`. Backup/archival tools that honor the Cache Directory Tagging Spec automatically skip the regenerable cache. It's a standard convention (`scarb` / `cargo` add it under `target/`), but we don't have it in our cache dir. See https://bford.info/cachedir/

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`