### PR TITLE
[WIP] Cache CASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `declare!` macro for declaring contracts using Cairo paths. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge-library/declare_macro.html).
 - Debugging traces now display the class hash for forked contracts.
 - `declare_from_file` function for declaring contracts from Sierra contract class JSON files. Read more [here](https://foundry-rs.github.io/starknet-foundry/appendix/snforge-library/declare_from_file.html).
+- Caching mechanism for CASM artifacts compiled from Sierra. Artifacts are stored in `.snfoundry_cache/casm` directory and reused on subsequent runs if the Sierra input has not changed.
 
 #### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9032,7 +9032,7 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-sierra-compiler-api"
-version = "0.62.1"
+version = "0.63.0"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9032,13 +9032,16 @@ checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-sierra-compiler-api"
-version = "1.0.0"
+version = "0.62.1"
 dependencies = [
  "cairo-lang-casm",
+ "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "num-bigint",
+ "regex",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "shared",
  "strum_macros 0.28.0",
  "tempfile",

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -95,6 +95,7 @@ pub fn get_contracts() -> ContractsData {
         &ui,
         CompilationOpts {
             use_test_target_contracts: false,
+            casm_cache_dir: None,
             #[cfg(feature = "cairo-native")]
             run_native: true,
         },

--- a/crates/forge-runner/src/package_tests/raw.rs
+++ b/crates/forge-runner/src/package_tests/raw.rs
@@ -1,11 +1,13 @@
 use super::TestTargetLocation;
 use cairo_lang_sierra::program::ProgramArtifact;
 use camino::Utf8PathBuf;
+use universal_sierra_compiler_api::SierraProgramHash;
 
 /// these structs are representation of scarb output for `scarb build --test`
 /// produced by scarb
 pub struct TestTargetRaw {
     pub sierra_program: ProgramArtifact,
     pub sierra_program_path: Utf8PathBuf,
+    pub sierra_program_hash: SierraProgramHash,
     pub tests_location: TestTargetLocation,
 }

--- a/crates/forge-runner/src/running/target.rs
+++ b/crates/forge-runner/src/running/target.rs
@@ -15,10 +15,11 @@ use cairo_lang_sierra::{
     ids::{ConcreteTypeId, FunctionId},
     program::{GenFunction, StatementIdx, TypeDeclaration},
 };
+use camino::Utf8Path;
 use rayon::iter::IntoParallelIterator;
 use rayon::iter::ParallelIterator;
 use std::{collections::HashMap, sync::Arc};
-use universal_sierra_compiler_api::compile_raw_sierra_at_path;
+use universal_sierra_compiler_api::compile_raw_sierra_at_path_with_cache_key;
 use universal_sierra_compiler_api::representation::RawCasmProgram;
 
 pub struct PrepareTestTargetResult {
@@ -40,6 +41,7 @@ pub fn prepare_test_target(
     tracked_resource: &ForgeTrackedResource,
     name_filter: &NameFilter,
     partition_config: &PartitionConfig,
+    cache_dir: &Utf8Path,
 ) -> Result<PrepareTestTargetResult> {
     let tests_location = test_target_raw.tests_location;
     let default_executables = vec![];
@@ -77,8 +79,10 @@ pub fn prepare_test_target(
     let funcs = by_id!(funcs);
     let type_declarations = by_id!(type_declarations);
 
-    let casm_program = Arc::new(compile_raw_sierra_at_path(
+    let casm_program = Arc::new(compile_raw_sierra_at_path_with_cache_key(
         test_target_raw.sierra_program_path.as_std_path(),
+        cache_dir.as_std_path(),
+        &test_target_raw.sierra_program_hash,
     )?);
 
     let test_cases = matched_cases

--- a/crates/forge-runner/src/scarb.rs
+++ b/crates/forge-runner/src/scarb.rs
@@ -3,6 +3,7 @@ use cairo_lang_sierra::program::VersionedProgram;
 use camino::Utf8Path;
 use scarb_api::{metadata::PackageMetadata, test_targets_by_name};
 use std::{fs, io::ErrorKind};
+use universal_sierra_compiler_api::raw_sierra_program_content_hash;
 
 use crate::package_tests::{TestTargetLocation, raw::TestTargetRaw};
 
@@ -33,10 +34,12 @@ pub fn load_test_artifacts(
                 let sierra_program = match versioned_program {
                     VersionedProgram::V1 { program, .. } => program,
                 };
+                let sierra_program_hash = raw_sierra_program_content_hash(&sierra_program.program);
 
                 let test_target = TestTargetRaw {
                     sierra_program,
                     sierra_program_path,
+                    sierra_program_hash,
                     tests_location,
                 };
 

--- a/crates/forge-runner/src/scarb.rs
+++ b/crates/forge-runner/src/scarb.rs
@@ -3,7 +3,7 @@ use cairo_lang_sierra::program::VersionedProgram;
 use camino::Utf8Path;
 use scarb_api::{metadata::PackageMetadata, test_targets_by_name};
 use std::{fs, io::ErrorKind};
-use universal_sierra_compiler_api::raw_sierra_program_content_hash;
+use universal_sierra_compiler_api::raw_sierra_program_hash;
 
 use crate::package_tests::{TestTargetLocation, raw::TestTargetRaw};
 
@@ -34,7 +34,7 @@ pub fn load_test_artifacts(
                 let sierra_program = match versioned_program {
                     VersionedProgram::V1 { program, .. } => program,
                 };
-                let sierra_program_hash = raw_sierra_program_content_hash(&sierra_program.program);
+                let sierra_program_hash = raw_sierra_program_hash(&sierra_program.program);
 
                 let test_target = TestTargetRaw {
                     sierra_program,

--- a/crates/forge/src/clean.rs
+++ b/crates/forge/src/clean.rs
@@ -10,6 +10,7 @@ use semver::Version;
 use shared::cache::CACHEDIR_TAG_FILENAME;
 use std::fs;
 use std::sync::OnceLock;
+use universal_sierra_compiler_api::CASM_CACHE_DIR;
 
 const COVERAGE_DIR: &str = "coverage";
 const PROFILE_DIR: &str = "profile";
@@ -88,7 +89,11 @@ pub fn clean_cache_dir(path: &Utf8Path, ui: &UI) -> Result<()> {
         let entry = entry.with_context(|| format!("Failed to read cache directory: {path}"))?;
         let entry_path = entry.path();
 
-        if is_snfoundry_cache_file(entry_path) {
+        if entry_path.is_dir() && entry_path.file_name() == Some(CASM_CACHE_DIR) {
+            fs::remove_dir_all(entry_path)
+                .with_context(|| format!("Failed to remove cache directory: {entry_path}"))?;
+            ui.println(&format!("Removed directory: {entry_path}"));
+        } else if is_snfoundry_cache_file(entry_path) {
             fs::remove_file(entry_path)
                 .with_context(|| format!("Failed to remove cache file: {entry_path}"))?;
             ui.println(&format!("Removed file: {entry_path}"));

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -99,6 +99,7 @@ impl RunForPackageArgs {
             ui,
             CompilationOpts {
                 use_test_target_contracts: !args.no_optimization,
+                casm_cache_dir: Some(cache_dir.clone()),
                 #[cfg(feature = "cairo-native")]
                 run_native: args.run_native,
             },
@@ -143,6 +144,7 @@ impl RunForPackageArgs {
                     tracked_resource,
                     tests_filter.name_filter.clone(),
                     tests_filter.partitioning_config.clone(),
+                    cache_dir.clone(),
                 )
             })
             .collect();
@@ -163,6 +165,7 @@ fn spawn_prepare_test_target(
     tracked_resource: ForgeTrackedResource,
     name_filter: NameFilter,
     partitioning_config: PartitionConfig,
+    cache_dir: Utf8PathBuf,
 ) -> PrepareTargetHandle {
     tokio::task::spawn_blocking(move || {
         prepare_test_target(
@@ -170,6 +173,7 @@ fn spawn_prepare_test_target(
             &tracked_resource,
             &name_filter,
             &partitioning_config,
+            &cache_dir,
         )
     })
 }

--- a/crates/forge/src/run_tests/workspace.rs
+++ b/crates/forge/src/run_tests/workspace.rs
@@ -25,6 +25,7 @@ use scarb_api::{
     packages_from_filter, target_dir_for_workspace,
 };
 use scarb_ui::args::PackagesFilter;
+use shared::cache::prepare_cache_dir;
 use shared::consts::SNFORGE_TEST_FILTER;
 use std::env;
 use std::sync::Arc;
@@ -106,6 +107,8 @@ pub async fn execute_workspace(
     let mut exit_first_channel = ExitFirstChannel::new();
 
     let cache_dir = resolve_cache_dir(&scarb_metadata.workspace.root)?;
+    prepare_cache_dir(&cache_dir)?;
+
     let packages_len = packages.len();
 
     let partitioning_config = get_partitioning_config(args, &ui, &packages, &artifacts_dir_path)?;

--- a/crates/forge/tests/e2e/casm_cache.rs
+++ b/crates/forge/tests/e2e/casm_cache.rs
@@ -1,0 +1,182 @@
+use crate::e2e::common::runner::{setup_package, test_runner};
+use forge_runner::DEFAULT_CACHE_DIR;
+use std::fs;
+use std::path::{Path, PathBuf};
+use universal_sierra_compiler_api::CASM_CACHE_DIR;
+use universal_sierra_compiler_api::version_command;
+
+#[test]
+fn creates_raw_and_contract_casm_cache_entries() {
+    let temp = setup_package("targets/unit_and_integration");
+
+    test_runner(&temp).assert().success();
+
+    let casm_cache_dir = casm_cache_dir(temp.path());
+
+    assert_cache_entries_created(&json_files(&casm_cache_dir.join("raw")), "raw");
+    assert_cache_entries_created(&json_files(&casm_cache_dir.join("contract")), "contract");
+}
+
+#[test]
+fn reuses_cached_casm_without_invoking_compiler() {
+    let temp = setup_package("targets/unit_and_integration");
+
+    test_runner(&temp).assert().success();
+
+    let casm_cache_dir = casm_cache_dir(temp.path());
+    let raw_cache_dir = casm_cache_dir.join("raw");
+    let contract_cache_dir = casm_cache_dir.join("contract");
+    let raw_cache_entries = json_files(&raw_cache_dir);
+    let contract_cache_entries = json_files(&contract_cache_dir);
+    assert_cache_entries_created(&raw_cache_entries, "raw");
+    assert_cache_entries_created(&contract_cache_entries, "contract");
+
+    let fake_compiler = fake_compiler_that_fails_on_compile(temp.path());
+    test_runner(&temp)
+        .env("UNIVERSAL_SIERRA_COMPILER", fake_compiler)
+        .assert()
+        .success();
+
+    assert_eq!(
+        json_files(&raw_cache_dir),
+        raw_cache_entries,
+        "raw cache entries should be reused without creating new files",
+    );
+    assert_eq!(
+        json_files(&contract_cache_dir),
+        contract_cache_entries,
+        "contract cache entries should be reused without creating new files",
+    );
+}
+
+#[test]
+fn creates_new_cache_entries_after_sierra_changes() {
+    let temp = setup_package("targets/unit_and_integration");
+
+    test_runner(&temp).assert().success();
+
+    let casm_cache_dir = casm_cache_dir(temp.path());
+    let raw_cache_dir = casm_cache_dir.join("raw");
+    let contract_cache_dir = casm_cache_dir.join("contract");
+    let raw_cache_entries = json_files(&raw_cache_dir);
+    let contract_cache_entries = json_files(&contract_cache_dir);
+    assert_cache_entries_created(&raw_cache_entries, "raw");
+    assert_cache_entries_created(&contract_cache_entries, "contract");
+
+    replace_file_contents(
+        &temp.path().join("tests/tests.cairo"),
+        "'balance != 100'",
+        "'balance still 100'",
+    );
+    replace_file_contents(
+        &temp.path().join("src/lib.cairo"),
+        "arr.append('DAYTAH');",
+        "arr.append('CACHE');",
+    );
+
+    test_runner(&temp).assert().success();
+
+    assert_new_cache_entries_created(&raw_cache_entries, &json_files(&raw_cache_dir), "raw");
+    assert_new_cache_entries_created(
+        &contract_cache_entries,
+        &json_files(&contract_cache_dir),
+        "contract",
+    );
+}
+
+fn casm_cache_dir(temp_dir: &Path) -> PathBuf {
+    temp_dir.join(DEFAULT_CACHE_DIR).join(CASM_CACHE_DIR)
+}
+
+fn assert_cache_entries_created(cache_entries: &[PathBuf], cache_kind: &str) {
+    assert!(
+        !cache_entries.is_empty(),
+        "{cache_kind} cache should contain at least one json file",
+    );
+}
+
+fn assert_new_cache_entries_created(
+    old_cache_entries: &[PathBuf],
+    new_cache_entries: &[PathBuf],
+    cache_kind: &str,
+) {
+    assert!(
+        new_cache_entries.len() > old_cache_entries.len(),
+        "{cache_kind} cache should contain new entries after sierra changes: old={old_cache_entries:?}, new={new_cache_entries:?}",
+    );
+    assert!(
+        old_cache_entries
+            .iter()
+            .all(|cache_entry| new_cache_entries.contains(cache_entry)),
+        "{cache_kind} cache should preserve existing entries after sierra changes",
+    );
+}
+
+fn replace_file_contents(path: &Path, from: &str, to: &str) {
+    let contents = fs::read_to_string(path).unwrap();
+    assert_eq!(
+        contents.matches(from).count(),
+        1,
+        "{from} should occur exactly once in {}",
+        path.display()
+    );
+    let updated_contents = contents.replace(from, to);
+    fs::write(path, updated_contents).unwrap();
+}
+
+fn json_files(path: &Path) -> Vec<PathBuf> {
+    let mut files = vec![];
+    collect_json_files(path, &mut files);
+    files.sort();
+    files
+}
+
+fn collect_json_files(path: &Path, files: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+
+    for entry in entries {
+        let entry = entry
+            .unwrap_or_else(|error| panic!("failed to read entry in {}: {error}", path.display()));
+        let path = entry.path();
+        if path.is_dir() {
+            collect_json_files(&path, files);
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            files.push(path);
+        }
+    }
+}
+
+fn fake_compiler_that_fails_on_compile(temp_dir: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let compiler = temp_dir.join("fake-universal-sierra-compiler");
+    fs::write(compiler.with_extension("version"), compiler_version()).unwrap();
+    fs::write(
+        &compiler,
+        r#"#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  cat "$0.version"
+  exit 0
+fi
+echo "unexpected universal-sierra-compiler invocation: $*" >&2
+exit 99
+"#,
+    )
+    .unwrap();
+
+    let mut permissions = fs::metadata(&compiler).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&compiler, permissions).unwrap();
+
+    compiler
+}
+
+fn compiler_version() -> Vec<u8> {
+    let output = version_command().unwrap().output().unwrap();
+    assert!(output.status.success());
+    output.stdout
+}

--- a/crates/forge/tests/e2e/clean.rs
+++ b/crates/forge/tests/e2e/clean.rs
@@ -7,6 +7,7 @@ use shared::cache::CACHEDIR_TAG_FILENAME;
 use shared::test_utils::output_assert::assert_stdout_contains;
 use std::fs;
 use std::path::Path;
+use universal_sierra_compiler_api::representation::{AssembledCairoProgram, RawCasmProgram};
 
 const COVERAGE_DIR: &str = "coverage";
 const PROFILE_DIR: &str = "profile";
@@ -176,6 +177,9 @@ fn test_clean_cache_with_custom_cache_dir_preserves_unrelated_files() {
         "{}",
     )
     .unwrap();
+    write_raw_casm_cache_entry(
+        &custom_cache_dir.join("casm/raw/universal-sierra-compiler-2.9.1/cache-entry.json"),
+    );
     fs::write(custom_cache_dir.join("keep.txt"), "keep").unwrap();
 
     runner(&temp_dir)
@@ -193,7 +197,23 @@ fn test_clean_cache_with_custom_cache_dir_preserves_unrelated_files() {
             .join("http___rpc_example_54060_v0_60_0.json")
             .exists()
     );
+    assert!(!custom_cache_dir.join("casm").exists());
     assert!(custom_cache_dir.join("keep.txt").exists());
+}
+
+fn write_raw_casm_cache_entry(path: &Path) {
+    let parent = path.parent().unwrap();
+    fs::create_dir_all(parent).unwrap();
+
+    let casm = RawCasmProgram {
+        assembled_cairo_program: AssembledCairoProgram {
+            bytecode: vec![],
+            hints: vec![],
+        },
+        debug_info: vec![(0, 0)],
+    };
+
+    fs::write(path, serde_json::to_string(&casm).unwrap()).unwrap();
 }
 
 #[test]

--- a/crates/forge/tests/e2e/mod.rs
+++ b/crates/forge/tests/e2e/mod.rs
@@ -4,6 +4,7 @@ mod backtrace;
 mod build_profile;
 #[cfg(not(feature = "cairo-native"))]
 mod build_trace_data;
+mod casm_cache;
 mod clean;
 mod code_quality;
 mod collection;

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -134,17 +134,22 @@ fn fork_aliased_decorator() {
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
 
     let ui = Arc::new(UI::default());
+    let cache_dir = Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+        .unwrap()
+        .join(DEFAULT_CACHE_DIR);
     let result = rt
         .block_on(async {
             let target_handles = raw_test_targets
                 .into_iter()
                 .map(|t| {
+                    let cache_dir = cache_dir.clone();
                     tokio::task::spawn_blocking(move || {
                         prepare_test_target(
                             t,
                             &ForgeTrackedResource::CairoSteps,
                             &NameFilter::All,
                             &PartitionConfig::default(),
+                            &cache_dir,
                         )
                     })
                 })
@@ -172,9 +177,7 @@ fn fork_aliased_decorator() {
                             fuzzer_seed: 12345,
                             max_n_steps: None,
                             is_vm_trace_needed: false,
-                            cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                                .unwrap()
-                                .join(DEFAULT_CACHE_DIR),
+                            cache_dir: cache_dir.clone(),
                             contracts_data: ContractsData::try_from(
                                 test.contracts(&ui).unwrap(),
                                 cfg!(feature = "cairo-native"),
@@ -249,17 +252,22 @@ fn fork_aliased_decorator_overriding() {
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
 
     let ui = Arc::new(UI::default());
+    let cache_dir = Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+        .unwrap()
+        .join(DEFAULT_CACHE_DIR);
     let result = rt
         .block_on(async {
             let target_handles = raw_test_targets
                 .into_iter()
                 .map(|t| {
+                    let cache_dir = cache_dir.clone();
                     tokio::task::spawn_blocking(move || {
                         prepare_test_target(
                             t,
                             &ForgeTrackedResource::CairoSteps,
                             &NameFilter::All,
                             &PartitionConfig::default(),
+                            &cache_dir,
                         )
                     })
                 })
@@ -287,9 +295,7 @@ fn fork_aliased_decorator_overriding() {
                             fuzzer_seed: 12345,
                             max_n_steps: None,
                             is_vm_trace_needed: false,
-                            cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                                .unwrap()
-                                .join(DEFAULT_CACHE_DIR),
+                            cache_dir: cache_dir.clone(),
                             contracts_data: ContractsData::try_from(
                                 test.contracts(&ui).unwrap(),
                                 cfg!(feature = "cairo-native"),

--- a/crates/forge/tests/utils/runner.rs
+++ b/crates/forge/tests/utils/runner.rs
@@ -111,6 +111,7 @@ impl Contract {
             ui,
             CompilationOpts {
                 use_test_target_contracts: false,
+                casm_cache_dir: None,
                 #[cfg(feature = "cairo-native")]
                 run_native: true,
             },

--- a/crates/forge/tests/utils/running_tests.rs
+++ b/crates/forge/tests/utils/running_tests.rs
@@ -51,16 +51,21 @@ pub fn run_test_case(
         load_test_artifacts(&test.path().unwrap().join("target/dev"), package).unwrap();
 
     let ui = Arc::new(UI::default());
+    let cache_dir = Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
+        .unwrap()
+        .join(DEFAULT_CACHE_DIR);
     rt.block_on(async {
         let target_handles = raw_test_targets
             .into_iter()
             .map(|t| {
+                let cache_dir = cache_dir.clone();
                 tokio::task::spawn_blocking(move || {
                     prepare_test_target(
                         t,
                         &tracked_resource,
                         &NameFilter::All,
                         &PartitionConfig::default(),
+                        &cache_dir,
                     )
                 })
             })
@@ -88,9 +93,7 @@ pub fn run_test_case(
                         fuzzer_seed: 12345,
                         max_n_steps: None,
                         is_vm_trace_needed: false,
-                        cache_dir: Utf8PathBuf::from_path_buf(tempdir().unwrap().keep())
-                            .unwrap()
-                            .join(DEFAULT_CACHE_DIR),
+                        cache_dir: cache_dir.clone(),
                         contracts_data: ContractsData::try_from(
                             test.contracts(&ui).unwrap(),
                             cfg!(feature = "cairo-native"),

--- a/crates/scarb-api/src/artifacts.rs
+++ b/crates/scarb-api/src/artifacts.rs
@@ -8,7 +8,10 @@ use camino::{Utf8Path, Utf8PathBuf};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::fs;
-use universal_sierra_compiler_api::compile_contract_sierra_at_path;
+use universal_sierra_compiler_api::{
+    compile_contract_sierra_at_path, compile_contract_sierra_bytes_with_cache_key,
+    contract_sierra_content_hash,
+};
 
 pub mod deserialized;
 mod representation;
@@ -51,6 +54,7 @@ pub type ContractsData = HashMap<String, ContractData>;
 pub(crate) struct StarknetArtifactsFiles {
     base: Utf8PathBuf,
     other: Vec<Utf8PathBuf>,
+    casm_cache_dir: Option<Utf8PathBuf>,
     #[cfg(feature = "cairo-native")]
     compile_native: bool,
 }
@@ -60,9 +64,15 @@ impl StarknetArtifactsFiles {
         Self {
             base: base_file,
             other: other_files,
+            casm_cache_dir: None,
             #[cfg(feature = "cairo-native")]
             compile_native: false,
         }
+    }
+
+    pub(crate) fn casm_cache_dir(mut self, casm_cache_dir: Option<Utf8PathBuf>) -> Self {
+        self.casm_cache_dir = casm_cache_dir;
+        self
     }
 
     #[cfg(feature = "cairo-native")]
@@ -117,7 +127,16 @@ impl StarknetArtifactsFiles {
     fn compile_artifact_at_path(&self, path: &Utf8Path) -> Result<StarknetContractArtifacts> {
         let sierra = fs::read_to_string(path)?;
 
-        let casm = compile_contract_sierra_at_path(path.as_std_path())?;
+        let casm = if let Some(cache_dir) = &self.casm_cache_dir {
+            let sierra_content_hash = contract_sierra_content_hash(sierra.as_bytes());
+            compile_contract_sierra_bytes_with_cache_key(
+                sierra.as_bytes(),
+                cache_dir.as_std_path(),
+                &sierra_content_hash,
+            )?
+        } else {
+            compile_contract_sierra_at_path(path.as_std_path())?
+        };
 
         #[cfg(feature = "cairo-native")]
         let executor = self.compile_to_native(&sierra)?;

--- a/crates/scarb-api/src/lib.rs
+++ b/crates/scarb-api/src/lib.rs
@@ -100,11 +100,15 @@ fn get_starknet_artifacts_path(
 #[derive(Default)]
 pub struct CompilationOpts {
     pub use_test_target_contracts: bool,
+    pub casm_cache_dir: Option<Utf8PathBuf>,
     #[cfg(feature = "cairo-native")]
     pub run_native: bool,
 }
 
-/// Get the map with `StarknetContractArtifacts` for the given package
+/// Get the map with `StarknetContractArtifacts` for the given package.
+///
+/// When [`CompilationOpts::casm_cache_dir`] is set, compiled CASM is read from and written to that
+/// cache, so unchanged contracts are not recompiled on subsequent runs.
 #[tracing::instrument(skip_all, level = "debug")]
 pub fn get_contracts_artifacts_and_source_sierra_paths(
     artifacts_dir: &Utf8Path,
@@ -112,6 +116,7 @@ pub fn get_contracts_artifacts_and_source_sierra_paths(
     ui: &UI,
     CompilationOpts {
         use_test_target_contracts,
+        casm_cache_dir,
         #[cfg(feature = "cairo-native")]
         run_native,
     }: CompilationOpts,
@@ -131,6 +136,7 @@ pub fn get_contracts_artifacts_and_source_sierra_paths(
     };
 
     if let Some(starknet_artifact_files) = starknet_artifact_files {
+        let starknet_artifact_files = starknet_artifact_files.casm_cache_dir(casm_cache_dir);
         #[cfg(feature = "cairo-native")]
         let starknet_artifact_files = starknet_artifact_files.compile_native(run_native);
         starknet_artifact_files.load_contracts_artifacts()
@@ -591,6 +597,7 @@ mod tests {
             &ui,
             CompilationOpts {
                 use_test_target_contracts: false,
+                casm_cache_dir: None,
                 #[cfg(feature = "cairo-native")]
                 run_native: true,
             },

--- a/crates/universal-sierra-compiler-api/Cargo.toml
+++ b/crates/universal-sierra-compiler-api/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "universal-sierra-compiler-api"
-version = "1.0.0"
+# Versioned with the workspace so `CARGO_PKG_VERSION` is the snforge release version, which the CASM
+# cache uses as a key input (see `cache.rs`). Keep this workspace-versioned.
+version.workspace = true
 edition.workspace = true
 
 [dependencies]
 shared.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+regex.workspace = true
 which.workspace = true
 tempfile.workspace = true
 num-bigint.workspace = true
 cairo-lang-casm.workspace = true
+cairo-lang-sierra.workspace = true
 cairo-lang-starknet-classes.workspace = true
 tracing.workspace = true
 strum_macros.workspace = true

--- a/crates/universal-sierra-compiler-api/src/cache.rs
+++ b/crates/universal-sierra-compiler-api/src/cache.rs
@@ -34,12 +34,14 @@ pub struct SierraProgramHash(String);
 // `debug_info` is not an input to Sierra -> CASM codegen, so it must not invalidate the raw CASM
 // cache. See the Cairo Sierra -> CASM compiler API:
 // https://github.com/starkware-libs/cairo/blob/eea264fa54fac04a1a5745ad533a0c0ab3106ab3/crates/cairo-lang-sierra-to-casm/src/compiler.rs#L441
+#[must_use]
 pub fn raw_sierra_program_content_hash(sierra_program: &Program) -> SierraProgramHash {
     let mut hasher = Sha256::new();
     write_serializable_to_hash(&mut hasher, sierra_program);
     SierraProgramHash(hex_encode(hasher.finalize()))
 }
 
+#[must_use]
 pub fn contract_sierra_content_hash(sierra_bytes: &[u8]) -> SierraProgramHash {
     let mut hasher = Sha256::new();
     hasher.update(sierra_bytes);
@@ -101,10 +103,10 @@ where
         sierra_content_hash,
     );
 
-    if let Some(cache_file_path) = &cache_file_path {
-        if let Some(casm) = read_cache_entry(cache_file_path) {
-            return Ok(casm);
-        }
+    if let Some(cache_file_path) = &cache_file_path
+        && let Some(casm) = read_cache_entry(cache_file_path)
+    {
+        return Ok(casm);
     }
 
     let json = compile()?;
@@ -458,9 +460,13 @@ mod tests {
         let raw =
             cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash)
                 .unwrap();
-        let contract =
-            cache_file_path_for_content_hash(&cache_dir, SierraType::Contract, version, &content_hash)
-                .unwrap();
+        let contract = cache_file_path_for_content_hash(
+            &cache_dir,
+            SierraType::Contract,
+            version,
+            &content_hash,
+        )
+        .unwrap();
 
         assert_ne!(raw, contract);
     }

--- a/crates/universal-sierra-compiler-api/src/cache.rs
+++ b/crates/universal-sierra-compiler-api/src/cache.rs
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_content_hash_ignores_sierra_json_field_order() {
+    fn raw_hash_ignores_json_field_order() {
         let program_a: Program = serde_json::from_str(
             r#"{"type_declarations":[],"libfunc_declarations":[],"statements":[],"funcs":[]}"#,
         )
@@ -344,7 +344,7 @@ mod tests {
     // Raw hashing is computed over the typed `Program`, which carries no debug info, so builds that
     // differ only in debug info hash the same and reuse this entry.
     #[test]
-    fn reuses_raw_cache_on_matching_content_hash() {
+    fn reuses_raw_cache_on_same_hash() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let content_hash = raw_sierra_program_hash(&empty_sierra_program());
@@ -370,7 +370,7 @@ mod tests {
     }
 
     #[test]
-    fn reuses_contract_cache_with_precomputed_content_hash() {
+    fn reuses_contract_cache_on_same_hash() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let sierra_bytes = br#"{"contract":"same"}"#;
@@ -426,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn separates_cache_entries_for_versions_with_same_sanitized_path_segment() {
+    fn versions_with_same_dir_name_get_distinct_files() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let version_a = "universal-sierra-compiler 1.2.3";
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn skips_cache_when_compiler_version_has_no_valid_path_segment() {
+    fn skips_cache_for_unsanitizable_version() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let content_hash = raw_sierra_program_hash(&empty_sierra_program());
@@ -531,7 +531,7 @@ mod tests {
     }
 
     #[test]
-    fn returns_compiled_result_when_cache_entry_cannot_be_written() {
+    fn still_compiles_when_cache_not_writable() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         fs::create_dir(&cache_dir).unwrap();
@@ -551,7 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn sanitizes_compiler_version_for_directory_name() {
+    fn sanitizes_version_for_dir_name() {
         assert_eq!(
             sanitize_path_segment("universal-sierra-compiler 2.9.0").as_deref(),
             Some("universal-sierra-compiler-2_9_0")
@@ -561,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_program_content_hash_is_stable_and_content_sensitive() {
+    fn raw_hash_is_stable_and_sensitive() {
         // Same program -> same hash, so an unchanged program reuses its entry across runs.
         assert_eq!(
             raw_sierra_program_hash(&empty_sierra_program()),
@@ -575,7 +575,7 @@ mod tests {
     }
 
     #[test]
-    fn different_raw_programs_do_not_share_cache_entry() {
+    fn different_programs_dont_share_cache() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let version = "universal-sierra-compiler 1.2.3";
@@ -606,7 +606,7 @@ mod tests {
     // Same for the production contract cache key, which comes from `contract_sierra_content_hash`
     // (called in `scarb-api`).
     #[test]
-    fn contract_content_hash_is_stable_and_byte_sensitive() {
+    fn contract_hash_is_stable_and_sensitive() {
         let bytes = br#"{"sierra_program":["0x1"],"abi":"a"}"#;
         // Same bytes -> same hash.
         assert_eq!(
@@ -621,12 +621,11 @@ mod tests {
     }
 
     #[test]
-    fn contract_content_hash_covers_debug_info_unlike_raw() {
+    fn contract_hash_includes_debug_info() {
         // Contracts are hashed over the whole artifact bytes (not the typed program), so even a
         // difference confined to debug info - which does not affect codegen - yields a different key.
         // This is intentionally conservative: it can only cause an extra recompile, never a stale
-        // hit. Raw programs strip debug info instead (see
-        // `reuses_raw_cache_for_same_program_with_different_debug_info`).
+        // hit. Raw programs strip debug info instead (see `reuses_raw_cache_on_same_hash`).
         assert_ne!(
             contract_sierra_content_hash(br#"{"sierra_program":["0x1"],"debug_info":{"a":1}}"#),
             contract_sierra_content_hash(br#"{"sierra_program":["0x1"],"debug_info":{"a":2}}"#),

--- a/crates/universal-sierra-compiler-api/src/cache.rs
+++ b/crates/universal-sierra-compiler-api/src/cache.rs
@@ -1,0 +1,564 @@
+use crate::command::{USCError, USCInternalCommand};
+use crate::compile::{CompilationError, SierraType, compile_sierra_at_path, compile_sierra_bytes};
+use cairo_lang_sierra::program::Program;
+use regex::Regex;
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::fs;
+use std::io::{self, BufReader, BufWriter, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex, OnceLock};
+use tempfile::Builder;
+
+pub const CASM_CACHE_DIR: &str = "casm";
+
+// snforge's release version, keyed into every cache entry so upgrading snforge starts from a fresh
+// cache namespace (the same approach as the fork cache's `cache_version`). This crate is
+// workspace-versioned, so `CARGO_PKG_VERSION` bumps on every release; any change that could alter the
+// cached CASM ships in a release and therefore moves this version: a `cairo-lang-*` bump that changes
+// the serialized representation (`CasmContractClass` / the `cairo-lang-casm` types in
+// `RawCasmProgram`), or an in-repo change to `RawCasmProgram` itself. Sierra -> CASM codegen changes
+// come from the separately installed USC binary and are covered by its version in `cache_key`.
+const SNFORGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+static USC_VERSION: OnceLock<String> = OnceLock::new();
+static USC_VERSION_LOCK: Mutex<()> = Mutex::new(());
+static PATH_SEGMENT_WHITESPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwrap());
+static PATH_SEGMENT_UNSAFE_CHARS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[^A-Za-z0-9-]+").unwrap());
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SierraProgramHash(String);
+
+// `debug_info` is not an input to Sierra -> CASM codegen, so it must not invalidate the raw CASM
+// cache. See the Cairo Sierra -> CASM compiler API:
+// https://github.com/starkware-libs/cairo/blob/eea264fa54fac04a1a5745ad533a0c0ab3106ab3/crates/cairo-lang-sierra-to-casm/src/compiler.rs#L441
+#[tracing::instrument(skip_all, level = "debug")]
+pub fn raw_sierra_program_content_hash(sierra_program: &Program) -> SierraProgramHash {
+    let mut hasher = Sha256::new();
+    write_serializable_to_hash(&mut hasher, sierra_program);
+    SierraProgramHash(hex_encode(hasher.finalize()))
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+pub fn contract_sierra_content_hash(sierra_bytes: &[u8]) -> SierraProgramHash {
+    let mut hasher = Sha256::new();
+    hasher.update(sierra_bytes);
+    SierraProgramHash(hex_encode(hasher.finalize()))
+}
+
+pub(crate) fn compile_sierra_at_path_with_content_hash<T>(
+    sierra_file_path: &Path,
+    sierra_type: SierraType,
+    cache_dir: &Path,
+    sierra_content_hash: &SierraProgramHash,
+) -> Result<T, CompilationError>
+where
+    T: DeserializeOwned + Serialize,
+{
+    compile_sierra_with_content_hash_using_version(
+        sierra_type,
+        cache_dir,
+        compiler_version()?,
+        sierra_content_hash,
+        || compile_sierra_at_path(sierra_file_path, sierra_type),
+    )
+}
+
+pub(crate) fn compile_sierra_bytes_with_content_hash<T>(
+    sierra_bytes: &[u8],
+    sierra_type: SierraType,
+    cache_dir: &Path,
+    sierra_content_hash: &SierraProgramHash,
+) -> Result<T, CompilationError>
+where
+    T: DeserializeOwned + Serialize,
+{
+    let compiler_version = compiler_version()?;
+
+    compile_sierra_with_content_hash_using_version(
+        sierra_type,
+        cache_dir,
+        compiler_version,
+        sierra_content_hash,
+        || compile_sierra_bytes(sierra_bytes, sierra_type),
+    )
+}
+
+fn compile_sierra_with_content_hash_using_version<T>(
+    sierra_type: SierraType,
+    cache_dir: &Path,
+    compiler_version: &str,
+    sierra_content_hash: &SierraProgramHash,
+    compile: impl FnOnce() -> Result<String, CompilationError>,
+) -> Result<T, CompilationError>
+where
+    T: DeserializeOwned + Serialize,
+{
+    let cache_file_path = cache_file_path_for_content_hash(
+        cache_dir,
+        sierra_type,
+        compiler_version,
+        sierra_content_hash,
+    );
+
+    if let Some(casm) = read_cache_entry(&cache_file_path) {
+        return Ok(casm);
+    }
+
+    let json = compile()?;
+    let casm = serde_json::from_str(&json).map_err(CompilationError::Deserialization)?;
+
+    if let Err(error) = write_cache_entry(&cache_file_path, &casm) {
+        tracing::debug!(
+            path = %cache_file_path.display(),
+            %error,
+            "failed to write CASM cache entry"
+        );
+    }
+
+    Ok(casm)
+}
+
+fn compiler_version() -> Result<&'static str, USCError> {
+    if let Some(version) = USC_VERSION.get() {
+        return Ok(version);
+    }
+
+    let _guard = USC_VERSION_LOCK
+        .lock()
+        .expect("USC version lock should not be poisoned");
+    if let Some(version) = USC_VERSION.get() {
+        return Ok(version);
+    }
+
+    let output = USCInternalCommand::new()?.arg("--version").run()?;
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    Ok(USC_VERSION.get_or_init(|| version))
+}
+
+fn cache_file_path_for_content_hash(
+    cache_dir: &Path,
+    sierra_type: SierraType,
+    compiler_version: &str,
+    sierra_content_hash: &SierraProgramHash,
+) -> PathBuf {
+    cache_dir
+        .join(CASM_CACHE_DIR)
+        .join(sierra_type.to_string())
+        .join(sanitize_path_segment(SNFORGE_VERSION))
+        .join(sanitize_path_segment(compiler_version))
+        .join(format!(
+            "{}.json",
+            cache_key(sierra_type, compiler_version, sierra_content_hash)
+        ))
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+fn cache_key(
+    sierra_type: SierraType,
+    compiler_version: &str,
+    sierra_content_hash: &SierraProgramHash,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(SNFORGE_VERSION.as_bytes());
+    hasher.update([0]);
+    hasher.update(sierra_type.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(compiler_version.as_bytes());
+    hasher.update([0]);
+    hasher.update(sierra_content_hash.0.as_bytes());
+
+    hex_encode(hasher.finalize())
+}
+
+fn write_serializable_to_hash(hasher: &mut Sha256, value: &impl Serialize) {
+    serde_json::to_writer(HashWriter(hasher), value)
+        .expect("writing JSON to a hasher should not fail");
+}
+
+struct HashWriter<'a>(&'a mut Sha256);
+
+impl io::Write for HashWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+fn read_cache_entry<T>(path: &Path) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    let file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            tracing::debug!(
+                path = %path.display(),
+                %error,
+                "failed to read CASM cache entry"
+            );
+            return None;
+        }
+    };
+
+    match serde_json::from_reader(BufReader::new(file)) {
+        Ok(casm) => Some(casm),
+        Err(error) => {
+            tracing::debug!(
+                path = %path.display(),
+                %error,
+                "failed to deserialize CASM cache entry"
+            );
+            None
+        }
+    }
+}
+
+#[tracing::instrument(skip_all, level = "debug")]
+fn write_cache_entry<T>(path: &Path, casm: &T) -> io::Result<()>
+where
+    T: Serialize,
+{
+    let parent = path
+        .parent()
+        .expect("CASM cache path should always have a parent directory");
+    fs::create_dir_all(parent)?;
+
+    let mut temp_file = Builder::new()
+        .prefix(".casm-cache-")
+        .suffix(".json")
+        .tempfile_in(parent)?;
+
+    {
+        let mut writer = BufWriter::new(&mut temp_file);
+        serde_json::to_writer(&mut writer, casm).map_err(io::Error::other)?;
+        writer.flush()?;
+    }
+
+    temp_file.flush()?;
+    temp_file.persist(path).map_err(|error| error.error)?;
+
+    Ok(())
+}
+
+fn sanitize_path_segment(value: &str) -> String {
+    let sanitized = PATH_SEGMENT_WHITESPACE.replace_all(value, "-");
+    let sanitized = PATH_SEGMENT_UNSAFE_CHARS.replace_all(&sanitized, "_");
+    let sanitized = sanitized.trim_matches(['_', '-']).to_string();
+
+    if sanitized.is_empty() {
+        fallback_path_segment(value)
+    } else {
+        sanitized
+    }
+}
+
+fn fallback_path_segment(value: &str) -> String {
+    let digest = hex_encode(Sha256::digest(value.as_bytes()));
+    format!("hash-{}", &digest[..12])
+}
+
+fn hex_encode(bytes: impl AsRef<[u8]>) -> String {
+    bytes
+        .as_ref()
+        .iter()
+        .fold(String::new(), |mut output, byte| {
+            write!(&mut output, "{byte:02x}").expect("writing to String should not fail");
+            output
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::representation::{AssembledCairoProgram, RawCasmProgram};
+
+    fn raw_casm(debug_info: Vec<(usize, usize)>) -> RawCasmProgram {
+        RawCasmProgram {
+            assembled_cairo_program: AssembledCairoProgram {
+                bytecode: vec![],
+                hints: vec![],
+            },
+            debug_info,
+        }
+    }
+
+    fn raw_casm_json(debug_info: Vec<(usize, usize)>) -> String {
+        serde_json::to_string(&raw_casm(debug_info)).unwrap()
+    }
+
+    fn empty_sierra_program() -> Program {
+        Program {
+            type_declarations: vec![],
+            libfunc_declarations: vec![],
+            statements: vec![],
+            funcs: vec![],
+        }
+    }
+
+    fn sierra_program_with_return() -> Program {
+        Program {
+            statements: vec![cairo_lang_sierra::program::Statement::Return(vec![])],
+            ..empty_sierra_program()
+        }
+    }
+
+    #[test]
+    fn raw_content_hash_ignores_sierra_json_field_order() {
+        let program_a: Program = serde_json::from_str(
+            r#"{"type_declarations":[],"libfunc_declarations":[],"statements":[],"funcs":[]}"#,
+        )
+        .unwrap();
+        let program_b: Program = serde_json::from_str(
+            r#"{"funcs":[],"statements":[],"libfunc_declarations":[],"type_declarations":[]}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            raw_sierra_program_content_hash(&program_a),
+            raw_sierra_program_content_hash(&program_b),
+        );
+    }
+
+    #[test]
+    fn reuses_raw_cache_for_same_program_with_different_debug_info() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let first = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(1, 2)])),
+        )
+        .unwrap();
+        let second = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &content_hash,
+            || panic!("debug info differences should not invalidate raw CASM cache"),
+        )
+        .unwrap();
+
+        assert_eq!(first, raw_casm(vec![(1, 2)]));
+        assert_eq!(second, raw_casm(vec![(1, 2)]));
+    }
+
+    #[test]
+    fn reuses_contract_cache_with_precomputed_content_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let sierra_bytes = br#"{"contract":"same"}"#;
+        let content_hash = contract_sierra_content_hash(sierra_bytes);
+
+        let first = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Contract,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(1, 2)])),
+        )
+        .unwrap();
+
+        let second = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Contract,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &content_hash,
+            || panic!("same contract Sierra content hash should reuse cache"),
+        )
+        .unwrap();
+
+        assert_eq!(first, raw_casm(vec![(1, 2)]));
+        assert_eq!(second, raw_casm(vec![(1, 2)]));
+    }
+
+    #[test]
+    fn separates_cache_entries_by_compiler_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+
+        compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(1, 2)])),
+        )
+        .unwrap();
+        // Same program, newer USC => different key => must compile again.
+        let result = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.4",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(3, 4)])),
+        )
+        .unwrap();
+
+        assert_eq!(result, raw_casm(vec![(3, 4)]));
+    }
+
+    #[test]
+    fn separates_cache_entries_for_versions_with_same_sanitized_path_segment() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let version_a = "universal-sierra-compiler 1.2.3";
+        let version_b = "universal-sierra-compiler-1/2/3";
+
+        assert_eq!(
+            sanitize_path_segment(version_a),
+            sanitize_path_segment(version_b)
+        );
+
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let cache_file_a =
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_a, &content_hash);
+        let cache_file_b =
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_b, &content_hash);
+
+        assert_eq!(cache_file_a.parent(), cache_file_b.parent());
+        assert_ne!(cache_file_a.file_name(), cache_file_b.file_name());
+    }
+
+    #[test]
+    fn recompiles_and_overwrites_corrupt_cache_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let version = "universal-sierra-compiler 1.2.3";
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+
+        let cache_file =
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash);
+        fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
+        fs::write(&cache_file, "not valid json").unwrap();
+
+        let result = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            version,
+            &content_hash,
+            || Ok(raw_casm_json(vec![(5, 6)])),
+        )
+        .unwrap();
+        let cached: RawCasmProgram =
+            serde_json::from_str(&fs::read_to_string(cache_file).unwrap()).unwrap();
+
+        assert_eq!(result, raw_casm(vec![(5, 6)]));
+        assert_eq!(cached, raw_casm(vec![(5, 6)]));
+    }
+
+    #[test]
+    fn returns_compiled_result_when_cache_entry_cannot_be_written() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        fs::create_dir(&cache_dir).unwrap();
+        fs::write(cache_dir.join(CASM_CACHE_DIR), "not a directory").unwrap();
+
+        let result = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "universal-sierra-compiler 1.2.3",
+            &raw_sierra_program_content_hash(&empty_sierra_program()),
+            || Ok(raw_casm_json(vec![(9, 10)])),
+        )
+        .unwrap();
+
+        assert_eq!(result, raw_casm(vec![(9, 10)]));
+        assert!(cache_dir.join(CASM_CACHE_DIR).is_file());
+    }
+
+    #[test]
+    fn sanitizes_compiler_version_for_directory_name() {
+        assert_eq!(
+            sanitize_path_segment("universal-sierra-compiler 2.9.0"),
+            "universal-sierra-compiler-2_9_0"
+        );
+        assert_eq!(sanitize_path_segment("../"), "hash-fa08499e14d0");
+    }
+
+    #[test]
+    fn raw_program_content_hash_is_stable_and_content_sensitive() {
+        // Same program -> same hash, so an unchanged program reuses its entry across runs.
+        assert_eq!(
+            raw_sierra_program_content_hash(&empty_sierra_program()),
+            raw_sierra_program_content_hash(&empty_sierra_program()),
+        );
+        // Different program -> different hash, so a real code change gets a fresh entry.
+        assert_ne!(
+            raw_sierra_program_content_hash(&empty_sierra_program()),
+            raw_sierra_program_content_hash(&sierra_program_with_return()),
+        );
+    }
+
+    #[test]
+    fn different_raw_programs_do_not_share_cache_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let version = "universal-sierra-compiler 1.2.3";
+
+        let first = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            version,
+            &raw_sierra_program_content_hash(&empty_sierra_program()),
+            || Ok(raw_casm_json(vec![(1, 2)])),
+        )
+        .unwrap();
+        // A different program hashes differently, so this must compile instead of hitting the entry
+        // written above.
+        let second = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            version,
+            &raw_sierra_program_content_hash(&sierra_program_with_return()),
+            || Ok(raw_casm_json(vec![(3, 4)])),
+        )
+        .unwrap();
+
+        assert_eq!(first, raw_casm(vec![(1, 2)]));
+        assert_eq!(second, raw_casm(vec![(3, 4)]));
+    }
+
+    // Same for the production contract cache key, which comes from `contract_sierra_content_hash`
+    // (called in `scarb-api`).
+    #[test]
+    fn contract_content_hash_is_stable_and_byte_sensitive() {
+        let bytes = br#"{"sierra_program":["0x1"],"abi":"a"}"#;
+        // Same bytes -> same hash.
+        assert_eq!(
+            contract_sierra_content_hash(bytes),
+            contract_sierra_content_hash(bytes),
+        );
+        // Any change to the contract artifact -> different hash.
+        assert_ne!(
+            contract_sierra_content_hash(br#"{"sierra_program":["0x1"]}"#),
+            contract_sierra_content_hash(br#"{"sierra_program":["0x2"]}"#),
+        );
+    }
+
+    #[test]
+    fn contract_content_hash_covers_debug_info_unlike_raw() {
+        // Contracts are hashed over the whole artifact bytes (not the typed program), so even a
+        // difference confined to debug info - which does not affect codegen - yields a different key.
+        // This is intentionally conservative: it can only cause an extra recompile, never a stale
+        // hit. Raw programs strip debug info instead (see
+        // `reuses_raw_cache_for_same_program_with_different_debug_info`).
+        assert_ne!(
+            contract_sierra_content_hash(br#"{"sierra_program":["0x1"],"debug_info":{"a":1}}"#),
+            contract_sierra_content_hash(br#"{"sierra_program":["0x1"],"debug_info":{"a":2}}"#),
+        );
+    }
+}

--- a/crates/universal-sierra-compiler-api/src/cache.rs
+++ b/crates/universal-sierra-compiler-api/src/cache.rs
@@ -34,14 +34,12 @@ pub struct SierraProgramHash(String);
 // `debug_info` is not an input to Sierra -> CASM codegen, so it must not invalidate the raw CASM
 // cache. See the Cairo Sierra -> CASM compiler API:
 // https://github.com/starkware-libs/cairo/blob/eea264fa54fac04a1a5745ad533a0c0ab3106ab3/crates/cairo-lang-sierra-to-casm/src/compiler.rs#L441
-#[tracing::instrument(skip_all, level = "debug")]
 pub fn raw_sierra_program_content_hash(sierra_program: &Program) -> SierraProgramHash {
     let mut hasher = Sha256::new();
     write_serializable_to_hash(&mut hasher, sierra_program);
     SierraProgramHash(hex_encode(hasher.finalize()))
 }
 
-#[tracing::instrument(skip_all, level = "debug")]
 pub fn contract_sierra_content_hash(sierra_bytes: &[u8]) -> SierraProgramHash {
     let mut hasher = Sha256::new();
     hasher.update(sierra_bytes);
@@ -103,19 +101,31 @@ where
         sierra_content_hash,
     );
 
-    if let Some(casm) = read_cache_entry(&cache_file_path) {
-        return Ok(casm);
+    if let Some(cache_file_path) = &cache_file_path {
+        if let Some(casm) = read_cache_entry(cache_file_path) {
+            return Ok(casm);
+        }
     }
 
     let json = compile()?;
     let casm = serde_json::from_str(&json).map_err(CompilationError::Deserialization)?;
 
-    if let Err(error) = write_cache_entry(&cache_file_path, &casm) {
-        tracing::debug!(
-            path = %cache_file_path.display(),
-            %error,
-            "failed to write CASM cache entry"
-        );
+    match &cache_file_path {
+        Some(cache_file_path) => {
+            if let Err(error) = write_cache_entry(cache_file_path, &casm) {
+                tracing::debug!(
+                    path = %cache_file_path.display(),
+                    %error,
+                    "failed to write CASM cache entry"
+                );
+            }
+        }
+        None => {
+            tracing::debug!(
+                compiler_version,
+                "skipping CASM cache: compiler version has no valid path segment"
+            );
+        }
     }
 
     Ok(casm)
@@ -144,19 +154,20 @@ fn cache_file_path_for_content_hash(
     sierra_type: SierraType,
     compiler_version: &str,
     sierra_content_hash: &SierraProgramHash,
-) -> PathBuf {
-    cache_dir
-        .join(CASM_CACHE_DIR)
-        .join(sierra_type.to_string())
-        .join(sanitize_path_segment(SNFORGE_VERSION))
-        .join(sanitize_path_segment(compiler_version))
-        .join(format!(
-            "{}.json",
-            cache_key(sierra_type, compiler_version, sierra_content_hash)
-        ))
+) -> Option<PathBuf> {
+    Some(
+        cache_dir
+            .join(CASM_CACHE_DIR)
+            .join(sierra_type.to_string())
+            .join(sanitize_path_segment(SNFORGE_VERSION)?)
+            .join(sanitize_path_segment(compiler_version)?)
+            .join(format!(
+                "{}.json",
+                cache_key(sierra_type, compiler_version, sierra_content_hash)
+            )),
+    )
 }
 
-#[tracing::instrument(skip_all, level = "debug")]
 fn cache_key(
     sierra_type: SierraType,
     compiler_version: &str,
@@ -250,21 +261,20 @@ where
     Ok(())
 }
 
-fn sanitize_path_segment(value: &str) -> String {
+/// Turns a version string into a human-readable, filesystem-safe directory segment.
+///
+/// Returns `None` when the value sanitizes to an empty string (e.g. it consists only of
+/// separators or whitespace). The caller then skips caching instead of inventing a name.
+fn sanitize_path_segment(value: &str) -> Option<String> {
     let sanitized = PATH_SEGMENT_WHITESPACE.replace_all(value, "-");
     let sanitized = PATH_SEGMENT_UNSAFE_CHARS.replace_all(&sanitized, "_");
     let sanitized = sanitized.trim_matches(['_', '-']).to_string();
 
     if sanitized.is_empty() {
-        fallback_path_segment(value)
+        None
     } else {
-        sanitized
+        Some(sanitized)
     }
-}
-
-fn fallback_path_segment(value: &str) -> String {
-    let digest = hex_encode(Sha256::digest(value.as_bytes()));
-    format!("hash-{}", &digest[..12])
 }
 
 fn hex_encode(bytes: impl AsRef<[u8]>) -> String {
@@ -329,8 +339,10 @@ mod tests {
         );
     }
 
+    // Raw hashing is computed over the typed `Program`, which carries no debug info, so builds that
+    // differ only in debug info hash the same and reuse this entry.
     #[test]
-    fn reuses_raw_cache_for_same_program_with_different_debug_info() {
+    fn reuses_raw_cache_on_matching_content_hash() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
@@ -347,7 +359,7 @@ mod tests {
             &cache_dir,
             "universal-sierra-compiler 1.2.3",
             &content_hash,
-            || panic!("debug info differences should not invalidate raw CASM cache"),
+            || panic!("a matching content hash should reuse the cached CASM entry"),
         )
         .unwrap();
 
@@ -425,12 +437,63 @@ mod tests {
 
         let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
         let cache_file_a =
-            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_a, &content_hash);
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_a, &content_hash)
+                .unwrap();
         let cache_file_b =
-            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_b, &content_hash);
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_b, &content_hash)
+                .unwrap();
 
         assert_eq!(cache_file_a.parent(), cache_file_b.parent());
         assert_ne!(cache_file_a.file_name(), cache_file_b.file_name());
+    }
+
+    #[test]
+    fn separates_cache_entries_by_sierra_type() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let version = "universal-sierra-compiler 1.2.3";
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+
+        // The same content hash under different Sierra types must never collide onto one entry.
+        let raw =
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash)
+                .unwrap();
+        let contract =
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Contract, version, &content_hash)
+                .unwrap();
+
+        assert_ne!(raw, contract);
+    }
+
+    #[test]
+    fn skips_cache_when_compiler_version_has_no_valid_path_segment() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache_dir = temp.path().join("cache");
+        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+
+        // A version string that sanitizes to empty cannot form a cache path, so the compiler runs
+        // and nothing is cached...
+        let first = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "../",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(1, 2)])),
+        )
+        .unwrap();
+        // ...so a second call must compile again instead of reusing an entry.
+        let second = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
+            SierraType::Raw,
+            &cache_dir,
+            "../",
+            &content_hash,
+            || Ok(raw_casm_json(vec![(3, 4)])),
+        )
+        .unwrap();
+
+        assert_eq!(first, raw_casm(vec![(1, 2)]));
+        assert_eq!(second, raw_casm(vec![(3, 4)]));
+        assert!(!cache_dir.join(CASM_CACHE_DIR).exists());
     }
 
     #[test]
@@ -441,7 +504,8 @@ mod tests {
         let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
 
         let cache_file =
-            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash);
+            cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash)
+                .unwrap();
         fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
         fs::write(&cache_file, "not valid json").unwrap();
 
@@ -483,10 +547,11 @@ mod tests {
     #[test]
     fn sanitizes_compiler_version_for_directory_name() {
         assert_eq!(
-            sanitize_path_segment("universal-sierra-compiler 2.9.0"),
-            "universal-sierra-compiler-2_9_0"
+            sanitize_path_segment("universal-sierra-compiler 2.9.0").as_deref(),
+            Some("universal-sierra-compiler-2_9_0")
         );
-        assert_eq!(sanitize_path_segment("../"), "hash-fa08499e14d0");
+        // A version made only of separators sanitizes to nothing, so it has no valid path segment.
+        assert_eq!(sanitize_path_segment("../"), None);
     }
 
     #[test]

--- a/crates/universal-sierra-compiler-api/src/cache.rs
+++ b/crates/universal-sierra-compiler-api/src/cache.rs
@@ -35,7 +35,7 @@ pub struct SierraProgramHash(String);
 // cache. See the Cairo Sierra -> CASM compiler API:
 // https://github.com/starkware-libs/cairo/blob/eea264fa54fac04a1a5745ad533a0c0ab3106ab3/crates/cairo-lang-sierra-to-casm/src/compiler.rs#L441
 #[must_use]
-pub fn raw_sierra_program_content_hash(sierra_program: &Program) -> SierraProgramHash {
+pub fn raw_sierra_program_hash(sierra_program: &Program) -> SierraProgramHash {
     let mut hasher = Sha256::new();
     write_serializable_to_hash(&mut hasher, sierra_program);
     SierraProgramHash(hex_encode(hasher.finalize()))
@@ -336,8 +336,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            raw_sierra_program_content_hash(&program_a),
-            raw_sierra_program_content_hash(&program_b),
+            raw_sierra_program_hash(&program_a),
+            raw_sierra_program_hash(&program_b),
         );
     }
 
@@ -347,7 +347,7 @@ mod tests {
     fn reuses_raw_cache_on_matching_content_hash() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
         let first = compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
             SierraType::Raw,
             &cache_dir,
@@ -402,7 +402,7 @@ mod tests {
     fn separates_cache_entries_by_compiler_version() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
 
         compile_sierra_with_content_hash_using_version::<RawCasmProgram>(
             SierraType::Raw,
@@ -437,7 +437,7 @@ mod tests {
             sanitize_path_segment(version_b)
         );
 
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
         let cache_file_a =
             cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version_a, &content_hash)
                 .unwrap();
@@ -454,7 +454,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let version = "universal-sierra-compiler 1.2.3";
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
 
         // The same content hash under different Sierra types must never collide onto one entry.
         let raw =
@@ -475,7 +475,7 @@ mod tests {
     fn skips_cache_when_compiler_version_has_no_valid_path_segment() {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
 
         // A version string that sanitizes to empty cannot form a cache path, so the compiler runs
         // and nothing is cached...
@@ -507,7 +507,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let cache_dir = temp.path().join("cache");
         let version = "universal-sierra-compiler 1.2.3";
-        let content_hash = raw_sierra_program_content_hash(&empty_sierra_program());
+        let content_hash = raw_sierra_program_hash(&empty_sierra_program());
 
         let cache_file =
             cache_file_path_for_content_hash(&cache_dir, SierraType::Raw, version, &content_hash)
@@ -541,7 +541,7 @@ mod tests {
             SierraType::Raw,
             &cache_dir,
             "universal-sierra-compiler 1.2.3",
-            &raw_sierra_program_content_hash(&empty_sierra_program()),
+            &raw_sierra_program_hash(&empty_sierra_program()),
             || Ok(raw_casm_json(vec![(9, 10)])),
         )
         .unwrap();
@@ -564,13 +564,13 @@ mod tests {
     fn raw_program_content_hash_is_stable_and_content_sensitive() {
         // Same program -> same hash, so an unchanged program reuses its entry across runs.
         assert_eq!(
-            raw_sierra_program_content_hash(&empty_sierra_program()),
-            raw_sierra_program_content_hash(&empty_sierra_program()),
+            raw_sierra_program_hash(&empty_sierra_program()),
+            raw_sierra_program_hash(&empty_sierra_program()),
         );
         // Different program -> different hash, so a real code change gets a fresh entry.
         assert_ne!(
-            raw_sierra_program_content_hash(&empty_sierra_program()),
-            raw_sierra_program_content_hash(&sierra_program_with_return()),
+            raw_sierra_program_hash(&empty_sierra_program()),
+            raw_sierra_program_hash(&sierra_program_with_return()),
         );
     }
 
@@ -584,7 +584,7 @@ mod tests {
             SierraType::Raw,
             &cache_dir,
             version,
-            &raw_sierra_program_content_hash(&empty_sierra_program()),
+            &raw_sierra_program_hash(&empty_sierra_program()),
             || Ok(raw_casm_json(vec![(1, 2)])),
         )
         .unwrap();
@@ -594,7 +594,7 @@ mod tests {
             SierraType::Raw,
             &cache_dir,
             version,
-            &raw_sierra_program_content_hash(&sierra_program_with_return()),
+            &raw_sierra_program_hash(&sierra_program_with_return()),
             || Ok(raw_casm_json(vec![(3, 4)])),
         )
         .unwrap();

--- a/crates/universal-sierra-compiler-api/src/compile.rs
+++ b/crates/universal-sierra-compiler-api/src/compile.rs
@@ -2,7 +2,7 @@ use crate::command::{USCError, USCInternalCommand};
 use serde_json::Value;
 use std::io;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use strum_macros::Display;
 use tempfile::Builder;
 use thiserror::Error;
@@ -12,6 +12,13 @@ use thiserror::Error;
 pub enum CompilationError {
     #[error("Failed to write Sierra JSON to temp file: {0}")]
     TempFileWrite(#[from] io::Error),
+
+    #[error("Failed to read Sierra JSON file at {path}: {source}")]
+    SierraFileRead {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
 
     #[error("Could not serialize Sierra JSON: {0}")]
     Serialization(serde_json::Error),
@@ -23,7 +30,7 @@ pub enum CompilationError {
     Deserialization(serde_json::Error),
 }
 
-#[derive(Debug, Display, Copy, Clone)]
+#[derive(Debug, Display, Copy, Clone, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 pub enum SierraType {
     Contract,
@@ -35,10 +42,19 @@ pub fn compile_sierra(
     sierra_json: &Value,
     sierra_type: SierraType,
 ) -> Result<String, CompilationError> {
+    let json_bytes = serde_json::to_vec(sierra_json).map_err(CompilationError::Serialization)?;
+    compile_sierra_bytes(&json_bytes, sierra_type)
+}
+
+/// Compiles the given Sierra JSON bytes into the specified type using the `universal-sierra-compiler`.
+pub(crate) fn compile_sierra_bytes(
+    sierra_bytes: &[u8],
+    sierra_type: SierraType,
+) -> Result<String, CompilationError> {
     let mut temp_sierra_file = Builder::new().tempfile()?;
 
-    let json_bytes = serde_json::to_vec(sierra_json).map_err(CompilationError::Serialization)?;
-    temp_sierra_file.write_all(&json_bytes)?;
+    temp_sierra_file.write_all(sierra_bytes)?;
+    temp_sierra_file.flush()?;
 
     compile_sierra_at_path(temp_sierra_file.path(), sierra_type)
 }

--- a/crates/universal-sierra-compiler-api/src/compile.rs
+++ b/crates/universal-sierra-compiler-api/src/compile.rs
@@ -2,7 +2,7 @@ use crate::command::{USCError, USCInternalCommand};
 use serde_json::Value;
 use std::io;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use strum_macros::Display;
 use tempfile::Builder;
 use thiserror::Error;
@@ -12,13 +12,6 @@ use thiserror::Error;
 pub enum CompilationError {
     #[error("Failed to write Sierra JSON to temp file: {0}")]
     TempFileWrite(#[from] io::Error),
-
-    #[error("Failed to read Sierra JSON file at {path}: {source}")]
-    SierraFileRead {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
 
     #[error("Could not serialize Sierra JSON: {0}")]
     Serialization(serde_json::Error),
@@ -30,7 +23,7 @@ pub enum CompilationError {
     Deserialization(serde_json::Error),
 }
 
-#[derive(Debug, Display, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Display, Copy, Clone)]
 #[strum(serialize_all = "lowercase")]
 pub enum SierraType {
     Contract,

--- a/crates/universal-sierra-compiler-api/src/lib.rs
+++ b/crates/universal-sierra-compiler-api/src/lib.rs
@@ -6,8 +6,7 @@
 //! To allow more flexibility when changing internals, please make public as few items as possible.
 
 pub use crate::cache::{
-    CASM_CACHE_DIR, SierraProgramHash, contract_sierra_content_hash,
-    raw_sierra_program_content_hash,
+    CASM_CACHE_DIR, SierraProgramHash, contract_sierra_content_hash, raw_sierra_program_hash,
 };
 use crate::cache::{
     compile_sierra_at_path_with_content_hash, compile_sierra_bytes_with_content_hash,

--- a/crates/universal-sierra-compiler-api/src/lib.rs
+++ b/crates/universal-sierra-compiler-api/src/lib.rs
@@ -5,6 +5,13 @@
 //! # Note:
 //! To allow more flexibility when changing internals, please make public as few items as possible.
 
+pub use crate::cache::{
+    CASM_CACHE_DIR, SierraProgramHash, contract_sierra_content_hash,
+    raw_sierra_program_content_hash,
+};
+use crate::cache::{
+    compile_sierra_at_path_with_content_hash, compile_sierra_bytes_with_content_hash,
+};
 use crate::command::{USCError, USCInternalCommand};
 use crate::compile::{CompilationError, SierraType, compile_sierra, compile_sierra_at_path};
 use crate::representation::RawCasmProgram;
@@ -13,6 +20,7 @@ use serde_json::Value;
 use std::path::Path;
 use std::process::Command;
 
+mod cache;
 mod command;
 mod compile;
 pub mod representation;
@@ -31,6 +39,21 @@ pub fn compile_contract_sierra_at_path(
     serde_json::from_str(&json).map_err(CompilationError::Deserialization)
 }
 
+/// Compiles Sierra JSON bytes of a contract into [`CasmContractClass`],
+/// reusing cached CASM under a precomputed Sierra content hash.
+pub fn compile_contract_sierra_bytes_with_cache_key(
+    sierra_bytes: &[u8],
+    cache_dir: &Path,
+    sierra_content_hash: &SierraProgramHash,
+) -> Result<CasmContractClass, CompilationError> {
+    compile_sierra_bytes_with_content_hash(
+        sierra_bytes,
+        SierraType::Contract,
+        cache_dir,
+        sierra_content_hash,
+    )
+}
+
 /// Compiles Sierra JSON of a raw program into [`RawCasmProgram`].
 pub fn compile_raw_sierra(sierra_json: &Value) -> Result<RawCasmProgram, CompilationError> {
     let json = compile_sierra(sierra_json, SierraType::Raw)?;
@@ -43,6 +66,21 @@ pub fn compile_raw_sierra_at_path(
 ) -> Result<RawCasmProgram, CompilationError> {
     let json = compile_sierra_at_path(sierra_file_path, SierraType::Raw)?;
     serde_json::from_str(&json).map_err(CompilationError::Deserialization)
+}
+
+/// Compiles Sierra JSON file at the given path of a raw program into [`RawCasmProgram`],
+/// reusing cached CASM under a precomputed Sierra content hash.
+pub fn compile_raw_sierra_at_path_with_cache_key(
+    sierra_file_path: &Path,
+    cache_dir: &Path,
+    sierra_content_hash: &SierraProgramHash,
+) -> Result<RawCasmProgram, CompilationError> {
+    compile_sierra_at_path_with_content_hash(
+        sierra_file_path,
+        SierraType::Raw,
+        cache_dir,
+        sierra_content_hash,
+    )
 }
 
 /// Creates a `universal-sierra-compiler --version` command.


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3832 

## Introduced changes

Add CASM caching for `snforge` so repeated test runs can reuse previously compiled CASM instead of invoking `universal-sierra-compiler` for identical Sierra inputs. The cache covers both contracts and test targets.

## How It Works

Once Sierra is available, the cache layer reads the Sierra bytes and resolves the current `universal-sierra-compiler --version`. It then builds a cache key from:

- snforge version,
- Sierra type: `raw` or `contract`,
- USC version,
- Sierra itself.

Cache entries are stored under `<cache_dir>/casm/<raw|contract>/<sanitized-usc-version>/<sha256>.json`

## Benchmarks

```
➜  cairo-contracts git:(main) ✗ hyperfine --runs=5 --warmup=1 'SNFORGE_TRACING_PROFILE=1 /Users/franciszekjob/Projects/SWM/starknet-foundry/franciszekjob/3832-cache-compiled-casm/target/release/snforge test --workspace'
Benchmark 1: SNFORGE_TRACING_PROFILE=1 /Users/franciszekjob/Projects/SWM/starknet-foundry/franciszekjob/3832-cache-compiled-casm/target/release/snforge test --workspace
  Time (mean ± σ):     47.764 s ±  1.297 s    [User: 255.691 s, System: 22.181 s]
  Range (min … max):   45.881 s … 49.170 s    5 runs
 
➜  cairo-contracts git:(main) ✗ hyperfine --runs=5 --warmup=1 'SNFORGE_TRACING_PROFILE=1 snforge test --workspace' 
Benchmark 1: SNFORGE_TRACING_PROFILE=1 snforge test --workspac
  Time (mean ± σ):     51.813 s ±  0.903 s    [User: 268.379 s, System: 26.833 s]
  Range (min … max):   50.283 s … 52.475 s    5 runs
```

Example profiles:
[snforge-profile-0-62-1.json](https://github.com/user-attachments/files/30751605/snforge-profile-0-62-1.json)
[snforge-profile-with-casm-caching.json](https://github.com/user-attachments/files/30751613/snforge-profile-with-casm-caching.json)


## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
