### PR TITLE
refactor(sncast): Introduce schema-agnostic models of accounts and signers

### DIFF
--- a/crates/sncast/src/accounts/error.rs
+++ b/crates/sncast/src/accounts/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Errors raised while validating and resolving native account data.
+#[derive(Debug, Error)]
+pub enum AccountsError {
+    #[error("{kind} cannot be empty")]
+    EmptyIdentifier { kind: &'static str },
+
+    #[error("invalid account type `{account_type}`")]
+    InvalidAccountType { account_type: String },
+
+    #[error("account is missing required field `{field}` for {operation}")]
+    MissingField {
+        field: &'static str,
+        operation: &'static str,
+    },
+}

--- a/crates/sncast/src/accounts/mod.rs
+++ b/crates/sncast/src/accounts/mod.rs
@@ -1,0 +1,9 @@
+//! Account model and persistence boundaries.
+
+pub mod error;
+pub mod model;
+
+pub use error::AccountsError;
+pub use model::{
+    AccountName, AccountRecord, AccountRegistry, AccountType, DeployableAccountRecord, NetworkName,
+};

--- a/crates/sncast/src/accounts/model.rs
+++ b/crates/sncast/src/accounts/model.rs
@@ -1,0 +1,248 @@
+use std::borrow::Borrow;
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+use crate::accounts::AccountsError;
+use crate::signers::SignerSpec;
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum AccountType {
+    #[serde(rename = "open_zeppelin")]
+    OpenZeppelin,
+    // Backwards compatibility with pre-rebranding account files.
+    #[serde(alias = "argent")]
+    Ready,
+    Braavos,
+}
+
+impl FromStr for AccountType {
+    type Err = AccountsError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "open_zeppelin" | "open-zeppelin" | "oz" => Ok(Self::OpenZeppelin),
+            "ready" => Ok(Self::Ready),
+            "braavos" => Ok(Self::Braavos),
+            account_type => Err(AccountsError::InvalidAccountType {
+                account_type: account_type.to_owned(),
+            }),
+        }
+    }
+}
+
+impl Display for AccountType {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+macro_rules! identifier {
+    ($name:ident, $kind:literal) => {
+        #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, AccountsError> {
+                let value = value.into();
+                if value.trim().is_empty() {
+                    return Err(AccountsError::EmptyIdentifier { kind: $kind });
+                }
+                Ok(Self(value))
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl Borrow<str> for $name {
+            fn borrow(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl Display for $name {
+            fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str(self.as_str())
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = AccountsError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = AccountsError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+identifier!(AccountName, "account name");
+identifier!(NetworkName, "network name");
+
+#[derive(Clone, Debug, Default)]
+pub struct AccountRegistry {
+    networks: BTreeMap<NetworkName, BTreeMap<AccountName, AccountRecord>>,
+}
+
+impl AccountRegistry {
+    #[must_use]
+    pub fn new(networks: BTreeMap<NetworkName, BTreeMap<AccountName, AccountRecord>>) -> Self {
+        Self { networks }
+    }
+
+    #[must_use]
+    pub fn networks(&self) -> &BTreeMap<NetworkName, BTreeMap<AccountName, AccountRecord>> {
+        &self.networks
+    }
+
+    pub fn networks_mut(
+        &mut self,
+    ) -> &mut BTreeMap<NetworkName, BTreeMap<AccountName, AccountRecord>> {
+        &mut self.networks
+    }
+
+    #[must_use]
+    pub fn account(&self, network: &str, name: &str) -> Option<&AccountRecord> {
+        self.networks
+            .get(network)
+            .and_then(|accounts| accounts.get(name))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AccountRecord {
+    pub public_key: Felt,
+    pub address: Felt,
+    pub salt: Option<Felt>,
+    pub deployed: Option<bool>,
+    pub class_hash: Option<Felt>,
+    pub legacy: Option<bool>,
+    pub account_type: Option<AccountType>,
+    pub signer: SignerSpec,
+}
+
+impl AccountRecord {
+    pub fn as_deployable(&self) -> Result<DeployableAccountRecord<'_>, AccountsError> {
+        Ok(DeployableAccountRecord {
+            account: self,
+            salt: required(self.salt, "salt", "account deployment")?,
+            class_hash: required(self.class_hash, "class_hash", "account deployment")?,
+            account_type: required(self.account_type, "type", "account deployment")?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DeployableAccountRecord<'a> {
+    account: &'a AccountRecord,
+    salt: Felt,
+    class_hash: Felt,
+    account_type: AccountType,
+}
+
+impl<'a> DeployableAccountRecord<'a> {
+    #[must_use]
+    pub fn account(self) -> &'a AccountRecord {
+        self.account
+    }
+
+    #[must_use]
+    pub fn salt(self) -> Felt {
+        self.salt
+    }
+
+    #[must_use]
+    pub fn class_hash(self) -> Felt {
+        self.class_hash
+    }
+
+    #[must_use]
+    pub fn account_type(self) -> AccountType {
+        self.account_type
+    }
+}
+
+fn required<T>(
+    value: Option<T>,
+    field: &'static str,
+    operation: &'static str,
+) -> Result<T, AccountsError> {
+    value.ok_or(AccountsError::MissingField { field, operation })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signers::PrivateKeySpec;
+
+    fn account() -> AccountRecord {
+        AccountRecord {
+            public_key: Felt::ONE,
+            address: Felt::TWO,
+            salt: Some(Felt::THREE),
+            deployed: Some(false),
+            class_hash: Some(Felt::from(4_u8)),
+            legacy: Some(false),
+            account_type: Some(AccountType::OpenZeppelin),
+            signer: SignerSpec::PrivateKey(PrivateKeySpec::new(Felt::from(5_u8))),
+        }
+    }
+
+    #[test]
+    fn identifiers_reject_empty_values() {
+        assert!(AccountName::new("").is_err());
+        assert!(NetworkName::new("").is_err());
+        assert!(AccountName::new("  \t").is_err());
+        assert!(NetworkName::new("\n").is_err());
+    }
+
+    #[test]
+    fn registry_looks_up_accounts_by_strings() {
+        let mut networks = BTreeMap::new();
+        networks.insert(
+            NetworkName::new("alpha-sepolia").unwrap(),
+            BTreeMap::from([(AccountName::new("alice").unwrap(), account())]),
+        );
+
+        let registry = AccountRegistry::new(networks);
+        assert!(registry.account("alpha-sepolia", "alice").is_some());
+        assert!(registry.account("alpha-sepolia", "bob").is_none());
+    }
+
+    #[test]
+    fn deployable_view_validates_required_fields() {
+        let account = account();
+        assert_eq!(account.as_deployable().unwrap().salt(), Felt::THREE);
+
+        let incomplete = AccountRecord {
+            salt: None,
+            ..account
+        };
+        assert!(matches!(
+            incomplete.as_deployable(),
+            Err(AccountsError::MissingField { field: "salt", .. })
+        ));
+    }
+}

--- a/crates/sncast/src/helpers/ledger/hd_path.rs
+++ b/crates/sncast/src/helpers/ledger/hd_path.rs
@@ -1,13 +1,13 @@
 use std::str::FromStr;
 
 use crate::response::ui::UI;
-use anyhow::{Result, anyhow, bail};
-use clap::{Arg, Command, Error, builder::TypedValueParser, error::ErrorKind};
+use clap::{self, Arg, Command, builder::TypedValueParser};
 use foundry_ui::components::warning::WarningMessage;
 use sha2::{Digest, Sha256};
 use starknet_rust::signers::DerivationPath;
+use thiserror::Error;
 
-const EIP2645_LENGTH: usize = 6;
+const EIP_2645_LENGTH: usize = 6;
 
 /// BIP-32 encoding of `2645'`
 const EIP_2645_PURPOSE: u32 = 0x8000_0a55;
@@ -17,6 +17,66 @@ const HARDENED_BIT: u32 = 1 << 31;
 
 /// Mask to extract the non-hardened index from a BIP-32 path component.
 const NON_HARDENED_MASK: u32 = 0x7fff_ffff;
+
+#[derive(Debug, Error)]
+pub enum DerivationPathError {
+    #[error("invalid BIP-32 derivation path: {0}")]
+    InvalidBip32(String),
+
+    #[error("EIP-2645 paths must have {EIP_2645_LENGTH} levels")]
+    InvalidLength,
+
+    #[error("HD wallet paths must start with \"m/\"")]
+    InvalidPrefix,
+
+    #[error("EIP-2645 paths must start with \"m/2645'/\"")]
+    InvalidPurpose,
+
+    #[error("the \"{level}\" level of an EIP-2645 path must be hardened")]
+    Unhardened { level: &'static str },
+
+    #[error("the \"index\" level must be a number")]
+    InvalidIndex,
+
+    #[error("path must not contain whitespaces")]
+    Whitespace,
+
+    #[error("invalid path level \"{body}\": {message}")]
+    InvalidLevel { body: String, message: String },
+
+    #[error("`'` appended to an already-hardened value of {raw_node}")]
+    UnnecessaryHardening { raw_node: u32 },
+}
+
+/// Parses the canonical numeric EIP-2645 representation stored in an accounts file.
+pub fn parse_derivation_path(value: &str) -> Result<DerivationPath, DerivationPathError> {
+    let path = DerivationPath::from_str(value)
+        .map_err(|error| DerivationPathError::InvalidBip32(error.to_string()))?;
+    validate_derivation_path(&path)?;
+    Ok(path)
+}
+
+pub fn validate_derivation_path(path: &DerivationPath) -> Result<(), DerivationPathError> {
+    if path.len() != EIP_2645_LENGTH {
+        return Err(DerivationPathError::InvalidLength);
+    }
+
+    let levels = path.iter().copied().collect::<Vec<_>>();
+    if levels[0] != EIP_2645_PURPOSE {
+        return Err(DerivationPathError::InvalidPurpose);
+    }
+
+    for (index, level) in ["layer", "application", "eth_address_1", "eth_address_2"]
+        .into_iter()
+        .enumerate()
+    {
+        if levels[index + 1] & HARDENED_BIT == 0 {
+            return Err(DerivationPathError::Unhardened { level });
+        }
+    }
+
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct DerivationPathParser;
@@ -74,11 +134,12 @@ impl TypedValueParser for DerivationPathParser {
         cmd: &Command,
         _arg: Option<&Arg>,
         value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, Error> {
+    ) -> Result<Self::Value, clap::Error> {
         if value.is_empty() {
-            return Err(cmd
-                .clone()
-                .error(ErrorKind::InvalidValue, "empty Ledger derivation path"));
+            return Err(cmd.clone().error(
+                clap::error::ErrorKind::InvalidValue,
+                "empty Ledger derivation path",
+            ));
         }
         match value.to_str() {
             Some(value) => match Eip2645Path::from_str_with_warnings(value) {
@@ -87,12 +148,12 @@ impl TypedValueParser for DerivationPathParser {
                     warnings,
                 }),
                 Err(err) => Err(cmd.clone().error(
-                    ErrorKind::InvalidValue,
+                    clap::error::ErrorKind::InvalidValue,
                     format!("invalid Ledger derivation path: {err}"),
                 )),
             },
             None => Err(cmd.clone().error(
-                ErrorKind::InvalidValue,
+                clap::error::ErrorKind::InvalidValue,
                 "invalid Ledger derivation path: not UTF-8",
             )),
         }
@@ -100,7 +161,7 @@ impl TypedValueParser for DerivationPathParser {
 }
 
 impl Eip2645Path {
-    fn from_str_with_warnings(s: &str) -> Result<(Self, Vec<String>)> {
+    fn from_str_with_warnings(s: &str) -> anyhow::Result<(Self, Vec<String>)> {
         let path = s.parse::<Self>()?;
         let mut warnings = Vec::new();
 
@@ -324,6 +385,16 @@ mod tests {
             hardened: false,
         });
         u32::from(&level)
+    }
+
+    #[test]
+    fn accepts_canonical_eip_2645_path() {
+        assert!(parse_derivation_path("m/2645'/1195502025'/355113700'/0'/0'/0").is_ok());
+    }
+
+    #[test]
+    fn rejects_general_bip_32_path() {
+        assert!(parse_derivation_path("m/44'/60'/0'/0/0").is_err());
     }
 
     #[test]

--- a/crates/sncast/src/helpers/ledger/hd_path.rs
+++ b/crates/sncast/src/helpers/ledger/hd_path.rs
@@ -229,7 +229,7 @@ impl Eip2645Path {
 }
 
 impl FromStr for Eip2645Path {
-    type Err = anyhow::Error;
+    type Err = DerivationPathError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Handle m// prefix (omitted 2645')
@@ -240,16 +240,16 @@ impl FromStr for Eip2645Path {
         };
 
         let segments: Vec<&str> = s.split('/').collect();
-        if segments.len() != EIP2645_LENGTH + 1 {
-            bail!("EIP-2645 paths must have {EIP2645_LENGTH} levels");
+        if segments.len() != EIP_2645_LENGTH + 1 {
+            Err(DerivationPathError::InvalidLength)?;
         }
         if segments[0] != "m" {
-            bail!("HD wallet paths must start with \"m/\"");
+            Err(DerivationPathError::InvalidPrefix)?;
         }
 
         let prefix = segments[1].parse()?;
         if u32::from(&prefix) != EIP_2645_PURPOSE {
-            bail!("EIP-2645 paths must start with \"m/2645'/\"");
+            Err(DerivationPathError::InvalidPurpose)?;
         }
 
         let path = Self {
@@ -262,22 +262,28 @@ impl FromStr for Eip2645Path {
 
         // These are not enforced by Ledger (for now) but are nice to have security properties
         if !path.layer.is_hardened() {
-            bail!("the \"layer\" level of an EIP-2645 path must be hardened");
+            Err(DerivationPathError::Unhardened { level: "layer" })?;
         }
         if !path.application.is_hardened() {
-            bail!("the \"application\" level of an EIP-2645 path must be hardened");
+            Err(DerivationPathError::Unhardened {
+                level: "application",
+            })?;
         }
         if !path.eth_address_1.is_hardened() {
-            bail!("the \"eth_address_1\" level of an EIP-2645 path must be hardened");
+            Err(DerivationPathError::Unhardened {
+                level: "eth_address_1",
+            })?;
         }
         if !path.eth_address_2.is_hardened() {
-            bail!("the \"eth_address_2\" level of an EIP-2645 path must be hardened");
+            Err(DerivationPathError::Unhardened {
+                level: "eth_address_2",
+            })?;
         }
 
         // In the future, certain wallets might utilize sequential `index` values for key discovery,
         // so it might be a good idea for us to disallow using hash-based values for `index` here.
         if matches!(path.index, Eip2645Level::Hash(_)) {
-            bail!("the \"index\" level must be a number");
+            Err(DerivationPathError::InvalidIndex)?;
         }
 
         Ok(path)
@@ -294,11 +300,11 @@ impl Eip2645Level {
 }
 
 impl FromStr for Eip2645Level {
-    type Err = anyhow::Error;
+    type Err = DerivationPathError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.trim() != s || s.split_whitespace().count() != 1 {
-            bail!("path must not contain whitespaces");
+            Err(DerivationPathError::Whitespace)?;
         }
 
         let (body, harden_notation) = if s.ends_with('\'') {
@@ -308,13 +314,16 @@ impl FromStr for Eip2645Level {
         };
 
         if body.chars().all(|char| char.is_ascii_digit()) {
-            let raw_node = body
-                .parse::<u32>()
-                .map_err(|err| anyhow!("invalid path level \"{body}\": {err}"))?;
+            let raw_node =
+                body.parse::<u32>()
+                    .map_err(|err| DerivationPathError::InvalidLevel {
+                        body: body.to_string(),
+                        message: err.to_string(),
+                    })?;
 
             if harden_notation {
                 if raw_node & HARDENED_BIT > 0 {
-                    bail!("`'` appended to an already-hardened value of {raw_node}");
+                    Err(DerivationPathError::UnnecessaryHardening { raw_node })?;
                 }
                 Ok(Self::Raw(raw_node | HARDENED_BIT))
             } else {

--- a/crates/sncast/src/helpers/ledger/mod.rs
+++ b/crates/sncast/src/helpers/ledger/mod.rs
@@ -8,7 +8,9 @@ mod emulator_transport;
 pub use account::{
     create_ledger_signer, get_ledger_public_key, ledger_account, verify_ledger_public_key,
 };
-pub use hd_path::{DerivationPathParser, ParsedDerivationPath};
+pub use hd_path::{
+    DerivationPathParser, ParsedDerivationPath, parse_derivation_path, validate_derivation_path,
+};
 pub use key_locator::{LedgerKeyLocator, LedgerKeyLocatorAccount};
 
 use starknet_rust::signers::ledger::LedgerStarknetApp;

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -39,52 +39,25 @@ use starknet_rust::{
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{env, fs};
 use thiserror::Error;
 use url::Url;
 
+pub mod accounts;
 pub mod helpers;
 pub mod response;
+pub mod signers;
 
 use crate::helpers::ledger;
 use crate::response::ui::UI;
+pub use accounts::AccountType;
 use conversions::byte_array::ByteArray;
 use foundry_ui::components::warning::WarningMessage;
 pub use helpers::signer::{AccountVariant, SignerSource, SignerType};
 
 pub type NestedMap<T> = HashMap<String, HashMap<String, T>>;
-
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
-#[serde(rename_all = "lowercase")]
-pub enum AccountType {
-    #[serde(rename = "open_zeppelin")]
-    OpenZeppelin,
-    #[serde(alias = "argent")] // backward compatibility with pre-rebranding account files
-    Ready,
-    Braavos,
-}
-
-impl FromStr for AccountType {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "open_zeppelin" | "open-zeppelin" | "oz" => Ok(AccountType::OpenZeppelin),
-            "ready" => Ok(AccountType::Ready),
-            "braavos" => Ok(AccountType::Braavos),
-            account_type => Err(anyhow!("Invalid account type = {account_type}")),
-        }
-    }
-}
-
-impl Display for AccountType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
 
 pub const MAINNET: Felt =
     Felt::from_hex_unchecked(const_hex::const_encode::<7, true>(b"SN_MAIN").as_str());

--- a/crates/sncast/src/signers/mod.rs
+++ b/crates/sncast/src/signers/mod.rs
@@ -1,0 +1,5 @@
+//! Persistent signer specifications and runtime signer implementations.
+
+pub mod spec;
+
+pub use spec::{KeystoreSpec, LedgerSpec, PrivateKeySpec, SignerKind, SignerSpec};

--- a/crates/sncast/src/signers/spec.rs
+++ b/crates/sncast/src/signers/spec.rs
@@ -22,16 +22,16 @@ impl Display for SignerKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum LocalWalletKind {
+pub enum PrivateKeySource {
     PrivateKey,
     Keystore,
 }
 
-impl From<LocalWalletKind> for SignerKind {
-    fn from(kind: LocalWalletKind) -> Self {
+impl From<PrivateKeySource> for SignerKind {
+    fn from(kind: PrivateKeySource) -> Self {
         match kind {
-            LocalWalletKind::PrivateKey => SignerKind::PrivateKey,
-            LocalWalletKind::Keystore => SignerKind::Keystore,
+            PrivateKeySource::PrivateKey => SignerKind::PrivateKey,
+            PrivateKeySource::Keystore => SignerKind::Keystore,
         }
     }
 }

--- a/crates/sncast/src/signers/spec.rs
+++ b/crates/sncast/src/signers/spec.rs
@@ -1,0 +1,112 @@
+use std::fmt::{Display, Formatter};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use starknet_rust::signers::DerivationPath;
+use starknet_types_core::felt::Felt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SignerKind {
+    PrivateKey,
+    Keystore,
+    Ledger,
+}
+
+impl Display for SignerKind {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PrivateKey => formatter.write_str("private_key"),
+            Self::Keystore => formatter.write_str("keystore"),
+            Self::Ledger => formatter.write_str("ledger"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LocalWalletKind {
+    PrivateKey,
+    Keystore,
+}
+
+impl From<LocalWalletKind> for SignerKind {
+    fn from(kind: LocalWalletKind) -> Self {
+        match kind {
+            LocalWalletKind::PrivateKey => SignerKind::PrivateKey,
+            LocalWalletKind::Keystore => SignerKind::Keystore,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum SignerSpec {
+    PrivateKey(PrivateKeySpec),
+    Keystore(KeystoreSpec),
+    Ledger(LedgerSpec),
+}
+
+impl SignerSpec {
+    #[must_use]
+    pub fn kind(&self) -> SignerKind {
+        match self {
+            Self::PrivateKey(_) => SignerKind::PrivateKey,
+            Self::Keystore(_) => SignerKind::Keystore,
+            Self::Ledger(_) => SignerKind::Ledger,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PrivateKeySpec {
+    private_key: Felt,
+}
+
+impl PrivateKeySpec {
+    #[must_use]
+    pub fn new(private_key: Felt) -> Self {
+        Self { private_key }
+    }
+
+    #[must_use]
+    pub fn private_key(self) -> Felt {
+        self.private_key
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct KeystoreSpec {
+    path: Utf8PathBuf,
+    password_env: Option<String>,
+}
+
+impl KeystoreSpec {
+    #[must_use]
+    pub fn new(path: Utf8PathBuf, password_env: Option<String>) -> Self {
+        Self { path, password_env }
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Utf8Path {
+        self.path.as_path()
+    }
+
+    #[must_use]
+    pub fn password_env(&self) -> Option<&str> {
+        self.password_env.as_deref()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LedgerSpec {
+    derivation_path: DerivationPath,
+}
+
+impl LedgerSpec {
+    #[must_use]
+    pub fn new(derivation_path: DerivationPath) -> Self {
+        Self { derivation_path }
+    }
+
+    #[must_use]
+    pub fn derivation_path(&self) -> &DerivationPath {
+        &self.derivation_path
+    }
+}


### PR DESCRIPTION
## Introduced changes

This PR introduces schema-agnostic models of accounts and signers. They are used later in the stack to represent accounts abstracted from their physical storage.

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`