### PR TITLE
feat(sncast): Add versioned accounts schema

### DIFF
--- a/crates/sncast/src/accounts/error.rs
+++ b/crates/sncast/src/accounts/error.rs
@@ -14,4 +14,39 @@ pub enum AccountsError {
         field: &'static str,
         operation: &'static str,
     },
+
+    #[error(transparent)]
+    AccountsFile(#[from] AccountsFileError),
+
+    #[error("invalid account `{account}` on network `{network}`: {message}")]
+    InvalidAccountEntry {
+        network: String,
+        account: String,
+        message: String,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum AccountsFileError {
+    #[error("failed to serialize accounts file to JSON")]
+    Serialize {
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("failed to deserialize accounts file from JSON")]
+    Deserialize {
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("invalid schema of field {field_path} in the accounts file")]
+    Schema {
+        field_path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("accounts file schema version {version} is not supported")]
+    Version { version: String },
 }

--- a/crates/sncast/src/accounts/mod.rs
+++ b/crates/sncast/src/accounts/mod.rs
@@ -2,8 +2,9 @@
 
 pub mod error;
 pub mod model;
+pub mod schema;
 
-pub use error::AccountsError;
+pub use error::{AccountsError, AccountsFileError};
 pub use model::{
     AccountName, AccountRecord, AccountRegistry, AccountType, DeployableAccountRecord, NetworkName,
 };

--- a/crates/sncast/src/accounts/model.rs
+++ b/crates/sncast/src/accounts/model.rs
@@ -7,7 +7,7 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use starknet_types_core::felt::Felt;
 
-use crate::accounts::AccountsError;
+use crate::accounts::{AccountsError, AccountsFileError, schema};
 use crate::signers::SignerSpec;
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -128,6 +128,14 @@ impl AccountRegistry {
         self.networks
             .get(network)
             .and_then(|accounts| accounts.get(name))
+    }
+
+    pub fn encode_v2(&self) -> Result<Vec<u8>, AccountsError> {
+        let file_content = schema::v2::AccountsFile::from(self);
+        let mut output = serde_json::to_vec_pretty(&file_content)
+            .map_err(|source| AccountsFileError::Serialize { source })?;
+        output.push(b'\n');
+        Ok(output)
     }
 }
 

--- a/crates/sncast/src/accounts/schema/conversion.rs
+++ b/crates/sncast/src/accounts/schema/conversion.rs
@@ -1,0 +1,155 @@
+use std::collections::BTreeMap;
+
+use crate::accounts::schema::{v1, v2};
+use crate::accounts::{
+    AccountName, AccountRecord, AccountRegistry, AccountsError, AccountsFileError, NetworkName,
+};
+use crate::helpers::ledger::{parse_derivation_path, validate_derivation_path};
+use crate::signers::{KeystoreSpec, LedgerSpec, PrivateKeySpec, SignerSpec};
+
+impl TryFrom<v1::AccountsFile> for AccountRegistry {
+    type Error = AccountsError;
+
+    fn try_from(accounts_data: v1::AccountsFile) -> Result<Self, Self::Error> {
+        convert_accounts_data(accounts_data.0, |network, account_name, account| {
+            let signer = match account.signer {
+                v1::Signer::PrivateKey { private_key } => {
+                    SignerSpec::PrivateKey(PrivateKeySpec::new(private_key))
+                }
+                v1::Signer::Ledger { ledger_path } => {
+                    validate_derivation_path(&ledger_path).map_err(|error| {
+                        AccountsError::InvalidAccountEntry {
+                            network: network.to_owned(),
+                            account: account_name.to_owned(),
+                            message: error.to_string(),
+                        }
+                    })?;
+                    SignerSpec::Ledger(LedgerSpec::new(ledger_path))
+                }
+            };
+
+            Ok(AccountRecord {
+                public_key: account.public_key,
+                address: account.address,
+                salt: account.salt,
+                deployed: account.deployed,
+                class_hash: account.class_hash,
+                legacy: account.legacy,
+                account_type: account.account_type,
+                signer,
+            })
+        })
+    }
+}
+
+impl TryFrom<v2::AccountsFile> for AccountRegistry {
+    type Error = AccountsError;
+
+    fn try_from(file: v2::AccountsFile) -> Result<Self, Self::Error> {
+        if file.version != 2 {
+            return Err(AccountsFileError::Version {
+                version: file.version.to_string(),
+            }
+            .into());
+        }
+
+        convert_accounts_data(file.accounts, |network, account_name, account| {
+            let signer = match account.signer {
+                v2::Signer::PrivateKey { private_key } => {
+                    SignerSpec::PrivateKey(PrivateKeySpec::new(private_key))
+                }
+                v2::Signer::Keystore { path, password_env } => {
+                    SignerSpec::Keystore(KeystoreSpec::new(path, password_env))
+                }
+                v2::Signer::Ledger { derivation_path } => {
+                    let derivation_path =
+                        parse_derivation_path(&derivation_path).map_err(|error| {
+                            AccountsError::InvalidAccountEntry {
+                                network: network.to_owned(),
+                                account: account_name.to_owned(),
+                                message: error.to_string(),
+                            }
+                        })?;
+                    SignerSpec::Ledger(LedgerSpec::new(derivation_path))
+                }
+            };
+
+            Ok(AccountRecord {
+                public_key: account.public_key,
+                address: account.address,
+                salt: account.salt,
+                deployed: account.deployed,
+                class_hash: account.class_hash,
+                legacy: account.legacy,
+                account_type: account.account_type,
+                signer,
+            })
+        })
+    }
+}
+
+impl From<&AccountRegistry> for v2::AccountsFile {
+    fn from(registry: &AccountRegistry) -> Self {
+        let accounts = registry
+            .networks()
+            .iter()
+            .map(|(network, accounts)| {
+                let accounts = accounts
+                    .iter()
+                    .map(|(name, account)| {
+                        let signer = match &account.signer {
+                            SignerSpec::PrivateKey(spec) => v2::Signer::PrivateKey {
+                                private_key: spec.private_key(),
+                            },
+                            SignerSpec::Keystore(spec) => v2::Signer::Keystore {
+                                path: spec.path().to_owned(),
+                                password_env: spec.password_env().map(ToOwned::to_owned),
+                            },
+                            SignerSpec::Ledger(spec) => v2::Signer::Ledger {
+                                derivation_path: spec.derivation_path().derivation_string(),
+                            },
+                        };
+
+                        let account = v2::Account {
+                            public_key: account.public_key,
+                            address: account.address,
+                            salt: account.salt,
+                            deployed: account.deployed,
+                            class_hash: account.class_hash,
+                            legacy: account.legacy,
+                            account_type: account.account_type,
+                            signer,
+                        };
+
+                        (name.to_string(), account)
+                    })
+                    .collect::<BTreeMap<_, _>>();
+                (network.to_string(), accounts)
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        v2::AccountsFile {
+            version: v2::VERSION,
+            accounts,
+        }
+    }
+}
+
+fn convert_accounts_data<T, F>(
+    accounts_data: BTreeMap<String, BTreeMap<String, T>>,
+    convert: F,
+) -> Result<AccountRegistry, AccountsError>
+where
+    F: Fn(&str, &str, T) -> Result<AccountRecord, AccountsError>,
+{
+    let mut converted = BTreeMap::new();
+    for (network, accounts) in accounts_data {
+        let mut converted_accounts = BTreeMap::new();
+        for (name, account) in accounts {
+            let account = convert(&network, &name, account)?;
+            converted_accounts.insert(AccountName::new(name)?, account);
+        }
+        converted.insert(NetworkName::new(network)?, converted_accounts);
+    }
+    Ok(AccountRegistry::new(converted))
+}

--- a/crates/sncast/src/accounts/schema/mod.rs
+++ b/crates/sncast/src/accounts/schema/mod.rs
@@ -1,0 +1,349 @@
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
+
+use crate::accounts::{AccountRegistry, AccountsError, AccountsFileError};
+
+pub mod conversion;
+pub mod v1;
+pub mod v2;
+
+#[derive(Clone, Copy, Debug, strum_macros::Display, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SourceVersion {
+    #[strum(to_string = "v1")]
+    V1,
+
+    #[strum(to_string = "v2")]
+    V2,
+}
+
+impl SourceVersion {
+    pub const LATEST: Self = Self::V2;
+
+    #[must_use]
+    pub fn is_latest(&self) -> bool {
+        self == &Self::LATEST
+    }
+}
+
+#[derive(Debug)]
+enum VersionedAccountsFile {
+    V1(v1::AccountsFile),
+    V2(v2::AccountsFile),
+}
+
+impl VersionedAccountsFile {
+    fn parse_json(input: &[u8]) -> Result<Self, AccountsFileError> {
+        if input.iter().all(u8::is_ascii_whitespace) {
+            // Empty files are valid legacy inputs and predate the versioned envelope.
+            return Ok(Self::V1(v1::AccountsFile::default()));
+        }
+
+        let envelope: Value = deserialize(input)?;
+        match envelope.get("version") {
+            None | Some(Value::Object(_)) => deserialize(input).map(Self::V1),
+            Some(version) if version.as_u64() == Some(u64::from(v2::VERSION)) => {
+                let file_content: v2::AccountsFile = deserialize(input)?;
+                Ok(Self::V2(file_content))
+            }
+            Some(version) => Err(AccountsFileError::Version {
+                version: version.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DecodedAccountRegistry {
+    pub registry: AccountRegistry,
+    pub source_version: SourceVersion,
+}
+
+impl DecodedAccountRegistry {
+    pub fn parse_json(input: &[u8]) -> Result<Self, AccountsError> {
+        match VersionedAccountsFile::parse_json(input)? {
+            VersionedAccountsFile::V1(file_content) => Ok(Self {
+                registry: file_content.try_into()?,
+                source_version: SourceVersion::V1,
+            }),
+            VersionedAccountsFile::V2(file) => Ok(Self {
+                registry: file.try_into()?,
+                source_version: SourceVersion::V2,
+            }),
+        }
+    }
+}
+
+fn deserialize<T: DeserializeOwned>(input: &[u8]) -> Result<T, AccountsFileError> {
+    let mut deserializer = serde_json::Deserializer::from_slice(input);
+    let value = serde_path_to_error::deserialize(&mut deserializer).map_err(|source| {
+        AccountsFileError::Schema {
+            field_path: source.path().to_string(),
+            source: source.into_inner(),
+        }
+    })?;
+    deserializer
+        .end()
+        .map_err(|source| AccountsFileError::Deserialize { source })?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use camino::Utf8PathBuf;
+    use serde_json::json;
+    use starknet_types_core::felt::Felt;
+
+    use super::*;
+    use crate::accounts::{AccountName, AccountRecord, AccountType, NetworkName};
+    use crate::signers::{KeystoreSpec, SignerSpec};
+
+    #[test]
+    fn decodes_empty_file_as_empty_v1() {
+        let decoded = DecodedAccountRegistry::parse_json(b" \n\t").unwrap();
+
+        assert_eq!(decoded.source_version, SourceVersion::V1);
+        assert!(decoded.registry.networks().is_empty());
+    }
+
+    #[test]
+    fn decodes_object_valued_version_key_as_v1_network() {
+        let input = br#"{
+            "version": {
+                "alice": {
+                    "public_key": "0x1",
+                    "address": "0x3",
+                    "private_key": "0x2"
+                }
+            }
+        }"#;
+
+        let decoded = DecodedAccountRegistry::parse_json(input).unwrap();
+
+        assert_eq!(decoded.source_version, SourceVersion::V1);
+        assert!(decoded.registry.account("version", "alice").is_some());
+    }
+
+    #[test]
+    fn preserves_v1_untagged_precedence_only_in_v1() {
+        let input = br#"{
+            "alpha-sepolia": {
+                "alice": {
+                    "public_key": "0x1",
+                    "address": "0x3",
+                    "private_key": "0x2",
+                    "ledger_path": "m/44'/60'/0'/0/0"
+                }
+            }
+        }"#;
+
+        let decoded = DecodedAccountRegistry::parse_json(input).unwrap();
+        assert!(matches!(
+            &decoded
+                .registry
+                .account("alpha-sepolia", "alice")
+                .unwrap()
+                .signer,
+            SignerSpec::PrivateKey(_)
+        ));
+    }
+
+    #[test]
+    fn decodes_tagged_v2_keystore() {
+        let input = br#"{
+            "version": 2,
+            "accounts": {
+                "alpha-sepolia": {
+                    "alice": {
+                        "public_key": "0x1",
+                        "address": "0x3",
+                        "signer": {
+                            "type": "keystore",
+                            "path": "keys/alice.json",
+                            "password_env": "ALICE_PASSWORD"
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let decoded = DecodedAccountRegistry::parse_json(input).unwrap();
+        assert_eq!(decoded.source_version, SourceVersion::V2);
+        assert!(matches!(
+            &decoded
+                .registry
+                .account("alpha-sepolia", "alice")
+                .unwrap()
+                .signer,
+            SignerSpec::Keystore(_)
+        ));
+    }
+
+    #[test]
+    fn decodes_tagged_v2_private_key() {
+        let input = br#"{
+            "version": 2,
+            "accounts": {
+                "alpha-sepolia": {
+                    "alice": {
+                        "public_key": "0x1",
+                        "address": "0x3",
+                        "signer": {
+                            "type": "private_key",
+                            "private_key": "0x2"
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let decoded = DecodedAccountRegistry::parse_json(input).unwrap();
+
+        assert_eq!(decoded.source_version, SourceVersion::V2);
+        assert!(matches!(
+            &decoded
+                .registry
+                .account("alpha-sepolia", "alice")
+                .unwrap()
+                .signer,
+            SignerSpec::PrivateKey(_)
+        ));
+    }
+
+    #[test]
+    fn decodes_tagged_v2_ledger() {
+        let input = br#"{
+            "version": 2,
+            "accounts": {
+                "alpha-sepolia": {
+                    "alice": {
+                        "public_key": "0x1",
+                        "address": "0x3",
+                        "signer": {
+                            "type": "ledger",
+                            "derivation_path": "m/2645'/1195502025'/355113700'/0'/0'/0"
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let decoded = DecodedAccountRegistry::parse_json(input).unwrap();
+
+        assert_eq!(decoded.source_version, SourceVersion::V2);
+        assert!(matches!(
+            &decoded
+                .registry
+                .account("alpha-sepolia", "alice")
+                .unwrap()
+                .signer,
+            SignerSpec::Ledger(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_unknown_version() {
+        let unknown_version = serde_json::to_vec(&json!({"version": 3, "accounts": {}})).unwrap();
+        assert!(matches!(
+            DecodedAccountRegistry::parse_json(&unknown_version),
+            Err(AccountsError::AccountsFile(
+                AccountsFileError::Version { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_untagged_signer() {
+        let untagged = br#"{
+            "version": 2,
+            "accounts": {
+                "alpha-sepolia": {
+                    "alice": {
+                        "public_key": "0x1",
+                        "address": "0x3",
+                        "private_key": "0x2"
+                    }
+                }
+            }
+        }"#;
+        assert!(matches!(
+            DecodedAccountRegistry::parse_json(untagged),
+            Err(AccountsError::AccountsFile(
+                AccountsFileError::Schema { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_trailing_json_content() {
+        let input = br#"{"version": 2, "accounts": {}} {"trailing": true}"#;
+
+        assert!(matches!(
+            DecodedAccountRegistry::parse_json(input),
+            Err(AccountsError::AccountsFile(
+                AccountsFileError::Deserialize { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_address_in_both_schemas() {
+        let v1 = br#"{
+            "alpha-sepolia": {
+                "alice": {"public_key": "0x1", "private_key": "0x2"}
+            }
+        }"#;
+        let v2 = br#"{
+            "version": 2,
+            "accounts": {
+                "alpha-sepolia": {
+                    "alice": {
+                        "public_key": "0x1",
+                        "signer": {"type": "private_key", "private_key": "0x2"}
+                    }
+                }
+            }
+        }"#;
+
+        for input in [v1.as_slice(), v2.as_slice()] {
+            assert!(matches!(
+                DecodedAccountRegistry::parse_json(input),
+                Err(AccountsError::AccountsFile(
+                    AccountsFileError::Schema { .. }
+                ))
+            ));
+        }
+    }
+
+    #[test]
+    fn encodes_only_deterministic_v2() {
+        let account = AccountRecord {
+            public_key: Felt::ONE,
+            address: Felt::TWO,
+            salt: None,
+            deployed: None,
+            class_hash: None,
+            legacy: Some(false),
+            account_type: Some(AccountType::OpenZeppelin),
+            signer: SignerSpec::Keystore(KeystoreSpec::new(
+                Utf8PathBuf::from("keys/alice.json"),
+                Some("ALICE_PASSWORD".to_owned()),
+            )),
+        };
+        let registry = AccountRegistry::new(BTreeMap::from([(
+            NetworkName::new("alpha-sepolia").unwrap(),
+            BTreeMap::from([(AccountName::new("alice").unwrap(), account)]),
+        )]));
+
+        let encoded = registry.encode_v2().unwrap();
+        let value: Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(value["version"], 2);
+        assert_eq!(
+            value["accounts"]["alpha-sepolia"]["alice"]["signer"]["type"],
+            "keystore"
+        );
+        assert_eq!(encoded, registry.encode_v2().unwrap());
+    }
+}

--- a/crates/sncast/src/accounts/schema/v1.rs
+++ b/crates/sncast/src/accounts/schema/v1.rs
@@ -1,0 +1,36 @@
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+use starknet_rust::signers::DerivationPath;
+use starknet_types_core::felt::Felt;
+
+use crate::accounts::AccountType;
+
+/// The legacy, unversioned accounts file. Its permissive signer model is intentionally
+/// isolated in this module and must not be reused for new writes.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(transparent)]
+pub struct AccountsFile(pub BTreeMap<String, BTreeMap<String, Account>>);
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Account {
+    pub public_key: Felt,
+    pub address: Felt,
+    pub salt: Option<Felt>,
+    pub deployed: Option<bool>,
+    pub class_hash: Option<Felt>,
+    pub legacy: Option<bool>,
+
+    #[serde(default, rename = "type")]
+    pub account_type: Option<AccountType>,
+
+    #[serde(flatten)]
+    pub signer: Signer,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Signer {
+    PrivateKey { private_key: Felt },
+    Ledger { ledger_path: DerivationPath },
+}

--- a/crates/sncast/src/accounts/schema/v2.rs
+++ b/crates/sncast/src/accounts/schema/v2.rs
@@ -1,0 +1,58 @@
+use std::collections::BTreeMap;
+
+use camino::Utf8PathBuf;
+use serde::{Deserialize, Serialize};
+use starknet_types_core::felt::Felt;
+
+use crate::accounts::AccountType;
+
+pub const VERSION: u32 = 2;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccountsFile {
+    pub version: u32,
+    pub accounts: BTreeMap<String, BTreeMap<String, Account>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Account {
+    pub public_key: Felt,
+
+    pub address: Felt,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub salt: Option<Felt>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployed: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub class_hash: Option<Felt>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub legacy: Option<bool>,
+
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub account_type: Option<AccountType>,
+
+    pub signer: Signer,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Signer {
+    PrivateKey {
+        private_key: Felt,
+    },
+    Keystore {
+        path: Utf8PathBuf,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        password_env: Option<String>,
+    },
+    Ledger {
+        derivation_path: String,
+    },
+}


### PR DESCRIPTION
## Introduced changes
This PR introduces a versioned schema of the accounts file:
1. The previous model with `private_key` and `ledger_path` fields becomes the legacy `v1` variant. Its behaviour remains exactly the same.
2. The new model with explicit `signer` field, deserialized as a tagged enum, is the latest `v2` variant.

Both variants converge to the common `AccountsRegistry` structure that holds the accounts' data expressed using domain models from https://github.com/foundry-rs/starknet-foundry/pull/4547.

Utility functions in `sncast::accounts::schema::migrations` allow upgrading `v1` to `v2`.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`