### PR TITLE
refactor(sncast) Introduce runtime signers

### DIFF
--- a/crates/sncast/src/helpers/account.rs
+++ b/crates/sncast/src/helpers/account.rs
@@ -1,17 +1,15 @@
 use crate::{
-    NestedMap, build_account, check_account_file_exists, helpers::devnet::provider::DevnetProvider,
+    NestedMap, RuntimeAccount, build_account, check_account_file_exists,
+    helpers::devnet::provider::DevnetProvider, signers::spec::PrivateKeySource,
 };
 use anyhow::{Result, ensure};
 use camino::Utf8PathBuf;
-use starknet_rust::{
-    accounts::SingleOwnerAccount,
-    providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport},
-    signers::LocalWallet,
-};
+use starknet_rust::providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use url::Url;
 
+use crate::signers::RuntimeSigner;
 use crate::{AccountData, read_and_parse_json_file};
 use anyhow::Context;
 use serde_json::{Value, json};
@@ -93,7 +91,7 @@ pub async fn get_account_from_devnet<'a>(
     account: &str,
     provider: &'a JsonRpcClient<HttpTransport>,
     url: &Url,
-) -> Result<SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>> {
+) -> Result<RuntimeAccount<'a>> {
     let account_number: u8 = account
         .strip_prefix("devnet-")
         .map(|s| s.parse::<u8>().expect("Invalid devnet account number"))
@@ -124,5 +122,10 @@ pub async fn get_account_from_devnet<'a>(
 
     let account_data = AccountData::from(predeployed_account);
     let chain_id = provider.chain_id().await?;
-    build_account(account_data, chain_id, provider).await
+    let private_key = account_data
+        .signer_type
+        .private_key()
+        .context("Private key not found for devnet account")?;
+    let signer = RuntimeSigner::from_private_key(private_key, PrivateKeySource::PrivateKey);
+    build_account(account_data, chain_id, provider, signer).await
 }

--- a/crates/sncast/src/helpers/constants.rs
+++ b/crates/sncast/src/helpers/constants.rs
@@ -44,6 +44,3 @@ pub const WAIT_TIMEOUT: NonZeroU16 = NonZeroU16::new(300).unwrap();
 pub const WAIT_RETRY_INTERVAL: NonZeroU8 = NonZeroU8::new(5).unwrap();
 
 pub const DEFAULT_ACCOUNTS_FILE: &str = "~/.starknet_accounts/starknet_open_zeppelin_accounts.json";
-
-pub const KEYSTORE_PASSWORD_ENV_VAR: &str = "KEYSTORE_PASSWORD";
-pub const CREATE_KEYSTORE_PASSWORD_ENV_VAR: &str = "CREATE_KEYSTORE_PASSWORD";

--- a/crates/sncast/src/helpers/ledger/account.rs
+++ b/crates/sncast/src/helpers/ledger/account.rs
@@ -1,22 +1,47 @@
 use super::{SncastLedgerTransport, create_ledger_app};
 use crate::response::ui::UI;
-use anyhow::{Context, Result, bail};
-use starknet_rust::{
-    accounts::{ExecutionEncoding, SingleOwnerAccount},
-    core::types::{BlockId, BlockTag},
-    providers::jsonrpc::{HttpTransport, JsonRpcClient},
-    signers::{DerivationPath, LedgerSigner},
-};
+use starknet_rust::signers::{DerivationPath, LedgerError as StarknetLedgerError, LedgerSigner};
 use starknet_types_core::felt::Felt;
+use thiserror::Error;
 
-const LEDGER_SIGNER_ERROR: &str = "Failed to create Ledger signer. Ensure the derivation path is correct and the Ledger app is ready.";
+#[derive(Debug, Error)]
+pub enum LedgerError {
+    #[error(
+        "Failed to create Ledger signer. Ensure the derivation path is correct and the Ledger app is ready"
+    )]
+    Create {
+        #[source]
+        source: StarknetLedgerError,
+    },
+
+    #[error(
+        "Public key mismatch!\n\
+        Ledger public key: {ledger_public_key:#x}\n\
+        Stored public key: {stored_public_key:#x}\n\
+        \n\
+        This account was created with a different Ledger derivation path or public key.\n\
+        Make sure you're using the same derivation path that was used during account creation."
+    )]
+    PublicKeyMismatch {
+        ledger_public_key: Felt,
+        stored_public_key: Felt,
+    },
+
+    #[error("Failed to get public key from Ledger")]
+    PublicKeyFetch {
+        #[source]
+        source: StarknetLedgerError,
+    },
+}
 
 pub async fn create_ledger_signer(
     ledger_path: &DerivationPath,
     ui: &UI,
     print_message: bool,
-) -> Result<LedgerSigner<SncastLedgerTransport>> {
-    let ledger_app = create_ledger_app().await?;
+) -> Result<LedgerSigner<SncastLedgerTransport>, LedgerError> {
+    let ledger_app = create_ledger_app()
+        .await
+        .map_err(|source| LedgerError::Create { source })?;
 
     if print_message {
         ui.print_notification(
@@ -24,49 +49,34 @@ pub async fn create_ledger_signer(
         );
     }
 
-    LedgerSigner::new_with_app(ledger_path.clone(), ledger_app).context(LEDGER_SIGNER_ERROR)
+    LedgerSigner::new_with_app(ledger_path.clone(), ledger_app)
+        .map_err(|source| LedgerError::Create { source })
 }
 
-pub fn verify_ledger_public_key(ledger_public_key: Felt, stored_public_key: Felt) -> Result<()> {
-    if ledger_public_key != stored_public_key {
-        bail!(
-            "Public key mismatch!\n\
-            Ledger public key: {ledger_public_key:#x}\n\
-            Stored public key: {stored_public_key:#x}\n\
-            \n\
-            This account was created with a different Ledger derivation path or public key.\n\
-            Make sure you're using the same derivation path that was used during account creation."
-        );
-    }
-    Ok(())
+pub fn verify_ledger_public_key(
+    ledger_public_key: Felt,
+    stored_public_key: Felt,
+) -> Result<(), LedgerError> {
+    (ledger_public_key == stored_public_key).ok_or_else(|| LedgerError::PublicKeyMismatch {
+        ledger_public_key,
+        stored_public_key,
+    })
 }
 
-pub async fn ledger_account<'a>(
+pub async fn get_ledger_public_key(
     ledger_path: &DerivationPath,
-    address: Felt,
-    chain_id: Felt,
-    encoding: ExecutionEncoding,
-    provider: &'a JsonRpcClient<HttpTransport>,
     ui: &UI,
-) -> Result<SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LedgerSigner<SncastLedgerTransport>>>
-{
-    let signer = create_ledger_signer(ledger_path, ui, true).await?;
-
-    let mut account = SingleOwnerAccount::new(provider, signer, address, chain_id, encoding);
-    account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
-
-    Ok(account)
-}
-
-pub async fn get_ledger_public_key(ledger_path: &DerivationPath, ui: &UI) -> Result<Felt> {
-    let ledger_app = create_ledger_app().await?;
+) -> Result<Felt, LedgerError> {
+    let ledger_app = create_ledger_app()
+        .await
+        .map_err(|source| LedgerError::Create { source })?;
 
     ui.print_notification("Please confirm the public key on your Ledger device...\n");
 
     let public_key = ledger_app
         .get_public_key(ledger_path.clone(), true)
         .await
-        .context("Failed to get public key from Ledger")?;
+        .map_err(|source| LedgerError::PublicKeyFetch { source })?;
 
     Ok(public_key.scalar())
 }

--- a/crates/sncast/src/helpers/ledger/mod.rs
+++ b/crates/sncast/src/helpers/ledger/mod.rs
@@ -6,14 +6,14 @@ mod key_locator;
 mod emulator_transport;
 
 pub use account::{
-    create_ledger_signer, get_ledger_public_key, ledger_account, verify_ledger_public_key,
+    LedgerError, create_ledger_signer, get_ledger_public_key, verify_ledger_public_key,
 };
 pub use hd_path::{
     DerivationPathParser, ParsedDerivationPath, parse_derivation_path, validate_derivation_path,
 };
 pub use key_locator::{LedgerKeyLocator, LedgerKeyLocatorAccount};
 
-use starknet_rust::signers::ledger::LedgerStarknetApp;
+use starknet_rust::signers::ledger::{LedgerError as StarknetLedgerError, LedgerStarknetApp};
 
 #[cfg(feature = "ledger-emulator")]
 pub type SncastLedgerTransport = emulator_transport::SpeculosHttpTransport;
@@ -21,7 +21,8 @@ pub type SncastLedgerTransport = emulator_transport::SpeculosHttpTransport;
 #[cfg(not(feature = "ledger-emulator"))]
 pub type SncastLedgerTransport = coins_ledger::transports::Ledger;
 
-pub async fn create_ledger_app() -> anyhow::Result<LedgerStarknetApp<SncastLedgerTransport>> {
+pub async fn create_ledger_app()
+-> Result<LedgerStarknetApp<SncastLedgerTransport>, StarknetLedgerError> {
     #[cfg(feature = "ledger-emulator")]
     let app = emulator_transport::emulator_ledger_app().await?;
     #[cfg(not(feature = "ledger-emulator"))]

--- a/crates/sncast/src/helpers/signer.rs
+++ b/crates/sncast/src/helpers/signer.rs
@@ -1,12 +1,7 @@
-use crate::helpers::ledger;
 use anyhow::{Result, bail};
 use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
-use starknet_rust::{
-    accounts::SingleOwnerAccount,
-    providers::jsonrpc::{HttpTransport, JsonRpcClient},
-    signers::{DerivationPath, LedgerSigner, LocalWallet},
-};
+use starknet_rust::signers::DerivationPath;
 use starknet_types_core::felt::Felt;
 
 /// Represents the type of signer stored in the accounts file
@@ -36,48 +31,6 @@ impl SignerType {
             SignerType::Local { .. } => None,
         }
     }
-}
-
-#[derive(Debug)]
-/// Represents the `SingleOwnerAccount` variant with either `LocalWallet` or `LedgerSigner` as signer
-pub enum AccountVariant<'a> {
-    LocalWallet(SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, LocalWallet>),
-    Ledger(
-        SingleOwnerAccount<
-            &'a JsonRpcClient<HttpTransport>,
-            LedgerSigner<ledger::SncastLedgerTransport>,
-        >,
-    ),
-}
-
-impl AccountVariant<'_> {
-    #[must_use]
-    pub fn address(&self) -> Felt {
-        use starknet_rust::accounts::Account;
-        match self {
-            AccountVariant::LocalWallet(account) => account.address(),
-            AccountVariant::Ledger(account) => account.address(),
-        }
-    }
-
-    #[must_use]
-    pub fn chain_id(&self) -> Felt {
-        use starknet_rust::accounts::Account;
-        match self {
-            AccountVariant::LocalWallet(account) => account.chain_id(),
-            AccountVariant::Ledger(account) => account.chain_id(),
-        }
-    }
-}
-
-#[macro_export]
-macro_rules! with_account {
-    ($variant:expr, |$account:ident| $body:expr) => {
-        match $variant {
-            &$crate::AccountVariant::LocalWallet(ref $account) => $body,
-            &$crate::AccountVariant::Ledger(ref $account) => $body,
-        }
-    };
 }
 
 /// Represents the source of the signer for account operations

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -5,11 +5,13 @@ use crate::helpers::configuration::CastConfig;
 use crate::helpers::constants::{DEFAULT_ACCOUNTS_FILE, WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
 use crate::helpers::rpc::RpcArgs;
 use crate::response::errors::SNCastProviderError;
+use crate::signers::LEGACY_KEYSTORE_PASSWORD_ENV;
+use crate::signers::spec::PrivateKeySource;
 use anyhow::{Context, Error, Result, anyhow, bail, ensure};
 use camino::Utf8PathBuf;
 use clap::ValueEnum;
 use configuration::Override;
-use helpers::constants::{KEYSTORE_PASSWORD_ENV_VAR, UDC_ADDRESS};
+use helpers::constants::UDC_ADDRESS;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use response::errors::SNCastStarknetError;
@@ -34,7 +36,7 @@ use starknet_rust::{
         ProviderError::StarknetError,
         jsonrpc::{HttpTransport, JsonRpcClient},
     },
-    signers::{DerivationPath, LocalWallet, SigningKey},
+    signers::{Signer, SigningKey},
 };
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
@@ -55,9 +57,11 @@ use crate::response::ui::UI;
 pub use accounts::AccountType;
 use conversions::byte_array::ByteArray;
 use foundry_ui::components::warning::WarningMessage;
-pub use helpers::signer::{AccountVariant, SignerSource, SignerType};
+pub use helpers::signer::{SignerSource, SignerType};
+use signers::RuntimeSigner;
 
 pub type NestedMap<T> = HashMap<String, HashMap<String, T>>;
+pub type RuntimeAccount<'a> = SingleOwnerAccount<&'a JsonRpcClient<HttpTransport>, RuntimeSigner>;
 
 pub const MAINNET: Felt =
     Felt::from_hex_unchecked(const_hex::const_encode::<7, true>(b"SN_MAIN").as_str());
@@ -282,7 +286,7 @@ pub async fn get_account<'a>(
     provider: &'a JsonRpcClient<HttpTransport>,
     rpc_args: &RpcArgs,
     ui: &UI,
-) -> Result<AccountVariant<'a>> {
+) -> Result<RuntimeAccount<'a>> {
     let chain_id = get_chain_id(provider).await?;
 
     let network_name = chain_id_to_network_name(chain_id);
@@ -335,7 +339,7 @@ pub async fn get_account<'a>(
                 .await
                 .context("Failed to get url")?;
             let local_account = get_account_from_devnet(account, provider, &url).await?;
-            Ok(AccountVariant::LocalWallet(local_account))
+            Ok(local_account)
         }
         _ => {
             get_account_from_accounts_file(
@@ -356,7 +360,7 @@ pub async fn get_account_from_accounts_file<'a>(
     provider: &'a JsonRpcClient<HttpTransport>,
     keystore: Option<&Utf8PathBuf>,
     ui: &UI,
-) -> Result<AccountVariant<'a>> {
+) -> Result<RuntimeAccount<'a>> {
     let chain_id = get_chain_id(provider).await?;
     let account_data = if let Some(keystore) = keystore {
         get_account_data_from_keystore(account, keystore)?
@@ -364,14 +368,36 @@ pub async fn get_account_from_accounts_file<'a>(
         get_account_data_from_accounts_file(account, chain_id, accounts_file)?
     };
 
-    if let SignerSource::Ledger(ledger_path) =
-        SignerSource::new(keystore.cloned(), Some(&account_data.signer_type))?
-    {
-        return build_ledger_account(ledger_path, account_data, chain_id, provider, ui).await;
-    }
+    let signer_source = SignerSource::new(keystore.cloned(), Some(&account_data.signer_type))?;
+    let signer = match signer_source {
+        SignerSource::Keystore(_) | SignerSource::AccountsFile => {
+            let private_key = account_data
+                .signer_type
+                .private_key()
+                .context("Private key not found")?;
+            let kind = if keystore.is_some() {
+                PrivateKeySource::Keystore
+            } else {
+                PrivateKeySource::PrivateKey
+            };
+            RuntimeSigner::from_private_key(private_key, kind)
+        }
+        SignerSource::Ledger(ledger_path) => {
+            let signer = ledger::create_ledger_signer(&ledger_path, ui, true).await?;
+            signer.into()
+        }
+    };
 
-    let account = build_account(account_data, chain_id, provider).await?;
-    Ok(AccountVariant::LocalWallet(account))
+    let actual_public_key = signer.get_public_key().await?.scalar();
+    let signer_kind = signer.kind();
+
+    ensure!(
+        actual_public_key == account_data.public_key,
+        "{signer_kind} signer public key does not match the account: expected {:#x}, got {actual_public_key:#x}",
+        account_data.public_key
+    );
+
+    build_account(account_data, chain_id, provider, signer).await
 }
 
 pub async fn get_contract_class(
@@ -398,18 +424,12 @@ pub async fn get_contract_class(
     result.map_err(handle_rpc_error)
 }
 
-async fn build_account(
+pub(crate) async fn build_account(
     account_data: AccountData,
     chain_id: Felt,
     provider: &JsonRpcClient<HttpTransport>,
-) -> Result<SingleOwnerAccount<&JsonRpcClient<HttpTransport>, LocalWallet>> {
-    let private_key = account_data
-        .signer_type
-        .private_key()
-        .context("Private key not found")?;
-
-    let signer = LocalWallet::from(SigningKey::from_secret_scalar(private_key));
-
+    signer: RuntimeSigner,
+) -> Result<RuntimeAccount<'_>> {
     let address = account_data
         .address
         .context("Failed to get account address")?;
@@ -427,33 +447,6 @@ async fn build_account(
     account.set_block_id(BlockId::Tag(PreConfirmed));
 
     Ok(account)
-}
-
-async fn build_ledger_account<'a>(
-    ledger_path: DerivationPath,
-    account_data: AccountData,
-    chain_id: Felt,
-    provider: &'a JsonRpcClient<HttpTransport>,
-    ui: &UI,
-) -> Result<AccountVariant<'a>> {
-    let address = account_data
-        .address
-        .context("Failed to get account address")?;
-
-    verify_account_address(address, chain_id, provider).await?;
-
-    let encoding = get_account_encoding(
-        account_data.legacy,
-        account_data.class_hash,
-        address,
-        provider,
-    )
-    .await?;
-
-    let account =
-        ledger::ledger_account(&ledger_path, address, chain_id, encoding, provider, ui).await?;
-
-    Ok(AccountVariant::Ledger(account))
 }
 
 async fn verify_account_address(
@@ -506,7 +499,7 @@ pub fn get_account_data_from_keystore(
 
     let private_key = SigningKey::from_keystore(
         keystore_path,
-        get_keystore_password(KEYSTORE_PASSWORD_ENV_VAR)?.as_str(),
+        get_keystore_password(LEGACY_KEYSTORE_PASSWORD_ENV)?.as_str(),
     )?
     .secret_scalar();
 
@@ -914,11 +907,10 @@ macro_rules! apply_optional_fields {
 mod tests {
     use std::num::{NonZeroU8, NonZeroU16};
 
-    use crate::helpers::constants::KEYSTORE_PASSWORD_ENV_VAR;
     use crate::{
         AccountType, PartialWaitParams, chain_id_to_network_name, extract_or_generate_salt,
         get_account_data_from_accounts_file, get_account_data_from_keystore, get_block_id,
-        udc_uniqueness,
+        signers::LEGACY_KEYSTORE_PASSWORD_ENV, udc_uniqueness,
     };
     use camino::Utf8PathBuf;
     use configuration::{Override, override_optional};
@@ -1198,7 +1190,7 @@ mod tests {
         // The only potential issue would be if a test explicitly required this variable to be unset,
         // but to the best of our knowledge, no such test exists.
         unsafe {
-            env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
+            env::set_var(LEGACY_KEYSTORE_PASSWORD_ENV, "123");
         };
     }
 }

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -43,7 +43,7 @@ use sncast::response::transformed_call::transform_response;
 use sncast::response::ui::UI;
 use sncast::{
     PartialWaitParams, WaitForTx, get_account, get_block_id, get_class_hash_by_address,
-    get_contract_class, with_account,
+    get_contract_class,
 };
 use starknet_commands::ledger::{self, Ledger};
 use starknet_commands::verify::Verify;
@@ -393,21 +393,19 @@ async fn run_async_command(mut cli: Cli, config: CastConfig, ui: &UI) -> Result<
             )
             .context("Failed to build contract")?;
 
-            let result = with_account!(&account, |account| {
-                starknet_commands::declare::declare(
-                    declare.contract_name.clone(),
-                    declare.common.fee_args,
-                    declare.common.dry_run_args,
-                    declare.common.nonce,
-                    declare.no_abi,
-                    account,
-                    &artifacts,
-                    wait_config,
-                    false,
-                    ui,
-                )
-                .await
-            });
+            let result = starknet_commands::declare::declare(
+                declare.contract_name.clone(),
+                declare.common.fee_args,
+                declare.common.dry_run_args,
+                declare.common.nonce,
+                declare.no_abi,
+                &account,
+                &artifacts,
+                wait_config,
+                false,
+                ui,
+            )
+            .await;
 
             let result = match result {
                 Ok(DeclareResponse::DryRun(response)) => {
@@ -479,18 +477,16 @@ async fn run_async_command(mut cli: Cli, config: CastConfig, ui: &UI) -> Result<
             let provider = declare_from.common.rpc.get_provider(&config, ui).await?;
             let account = get_account(&config, &provider, &declare_from.common.rpc, ui).await?;
 
-            let result = with_account!(&account, |account| {
-                starknet_commands::declare_from::declare_from(
-                    contract_source,
-                    declare_from.no_abi,
-                    &declare_from.common,
-                    account,
-                    wait_config,
-                    false,
-                    ui,
-                )
-                .await
-            });
+            let result = starknet_commands::declare_from::declare_from(
+                contract_source,
+                declare_from.no_abi,
+                &declare_from.common,
+                &account,
+                wait_config,
+                false,
+                ui,
+            )
+            .await;
 
             let result = match result {
                 Ok(DeclareResponse::DryRun(response)) => {
@@ -569,25 +565,23 @@ async fn run_async_command(mut cli: Cli, config: CastConfig, ui: &UI) -> Result<
                         .context("Failed to parse casm artifact")?;
                 let local_abi = contract_definition.abi.clone();
 
-                let declare_result = with_account!(&account, |account| {
-                    declare_with_artifacts(
-                        contract_definition,
-                        casm_contract_definition,
-                        &fee_args,
-                        &dry_run_args,
-                        nonce,
-                        no_abi,
-                        account,
-                        WaitForTx {
-                            wait: true,
-                            wait_params: wait_config.wait_params,
-                            show_ui_outputs: wait_config.wait,
-                        },
-                        true,
-                        ui,
-                    )
-                    .await
-                })
+                let declare_result = declare_with_artifacts(
+                    contract_definition,
+                    casm_contract_definition,
+                    &fee_args,
+                    &dry_run_args,
+                    nonce,
+                    no_abi,
+                    &account,
+                    WaitForTx {
+                        wait: true,
+                        wait_params: wait_config.wait_params,
+                        show_ui_outputs: wait_config.wait,
+                    },
+                    true,
+                    ui,
+                )
+                .await
                 .map_err(handle_starknet_command_error);
 
                 // Increment nonce after successful declare if it was explicitly provided
@@ -634,21 +628,19 @@ async fn run_async_command(mut cli: Cli, config: CastConfig, ui: &UI) -> Result<
             };
             let calldata = arguments.try_into_calldata(&abi, &selector, &config)?;
 
-            let result = with_account!(&account, |account| {
-                starknet_commands::deploy::deploy(
-                    class_hash,
-                    &calldata,
-                    deploy.common.salt,
-                    deploy.common.unique,
-                    fee_args,
-                    dry_run_args,
-                    nonce,
-                    account,
-                    wait_config,
-                    ui,
-                )
-                .await
-            })
+            let result = starknet_commands::deploy::deploy(
+                class_hash,
+                &calldata,
+                deploy.common.salt,
+                deploy.common.unique,
+                fee_args,
+                dry_run_args,
+                nonce,
+                &account,
+                wait_config,
+                ui,
+            )
+            .await
             .map_err(handle_starknet_command_error);
 
             let result = if let Some(declare_response) = declare_response {
@@ -773,21 +765,19 @@ async fn run_async_command(mut cli: Cli, config: CastConfig, ui: &UI) -> Result<
                 )?
             };
 
-            let result = with_account!(&account, |account| {
-                starknet_commands::invoke::invoke(
-                    contract_address,
-                    calldata,
-                    nonce,
-                    fee_args,
-                    dry_run_args,
-                    proof_args,
-                    selector,
-                    account,
-                    wait_config,
-                    ui,
-                )
-                .await
-            })
+            let result = starknet_commands::invoke::invoke(
+                contract_address,
+                calldata,
+                nonce,
+                fee_args,
+                dry_run_args,
+                proof_args,
+                selector,
+                &account,
+                wait_config,
+                ui,
+            )
+            .await
             .map_err(handle_starknet_command_error);
 
             let block_explorer_link =

--- a/crates/sncast/src/signers/credentials.rs
+++ b/crates/sncast/src/signers/credentials.rs
@@ -1,0 +1,28 @@
+use std::env;
+use std::io::{self, IsTerminal};
+
+use crate::signers::KeystoreSpec;
+use crate::signers::error::KeystoreError;
+
+pub const SNCAST_KEYSTORE_PASSWORD_ENV: &str = "SNCAST_KEYSTORE_PASSWORD";
+pub const LEGACY_KEYSTORE_PASSWORD_ENV: &str = "KEYSTORE_PASSWORD";
+pub const LEGACY_CREATE_KEYSTORE_PASSWORD_ENV: &str = "CREATE_KEYSTORE_PASSWORD";
+
+pub fn keystore_password(spec: &KeystoreSpec) -> Result<String, KeystoreError> {
+    let from_env = spec
+        .password_env()
+        .into_iter()
+        .chain([SNCAST_KEYSTORE_PASSWORD_ENV, LEGACY_KEYSTORE_PASSWORD_ENV])
+        .find_map(|variable| env::var(variable).ok());
+
+    if let Some(password) = from_env {
+        return Ok(password);
+    }
+
+    if io::stdin().is_terminal() {
+        return rpassword::prompt_password("Enter keystore password: ")
+            .map_err(|source| KeystoreError::InteractivePassword { source });
+    }
+
+    Err(KeystoreError::PasswordUnavailable)
+}

--- a/crates/sncast/src/signers/error.rs
+++ b/crates/sncast/src/signers/error.rs
@@ -1,0 +1,65 @@
+use std::io;
+
+use crate::{helpers::ledger::LedgerError, signers::SignerKind};
+use camino::Utf8PathBuf;
+use starknet_rust::signers::KeystoreError as StarknetKeystoreError;
+use starknet_types_core::felt::Felt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SignerError {
+    #[error(transparent)]
+    Keystore(#[from] KeystoreError),
+
+    #[error(transparent)]
+    Ledger(#[from] LedgerError),
+
+    #[error(transparent)]
+    Operation(#[from] SignerOperationError),
+
+    #[error(
+        "{kind} signer public key does not match the account: expected {expected:#x}, got {actual:#x}"
+    )]
+    PublicKeyMismatch {
+        kind: SignerKind,
+        expected: Felt,
+        actual: Felt,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum KeystoreError {
+    #[error(
+        "no keystore password is available; configure the signer's `password_env`, set SNCAST_KEYSTORE_PASSWORD, or use an interactive terminal"
+    )]
+    PasswordUnavailable,
+
+    #[error("failed to read keystore password from the terminal")]
+    InteractivePassword {
+        #[source]
+        source: io::Error,
+    },
+
+    #[error("failed to decrypt keystore `{path}`")]
+    Decrypt {
+        path: Utf8PathBuf,
+        #[source]
+        source: StarknetKeystoreError,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum SignerOperationError {
+    #[error("{kind} signer failed to obtain its public key")]
+    GetPublicKey {
+        kind: SignerKind,
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("{kind} signer failed to sign hash")]
+    SignHash {
+        kind: SignerKind,
+        #[source]
+        source: anyhow::Error,
+    },
+}

--- a/crates/sncast/src/signers/mod.rs
+++ b/crates/sncast/src/signers/mod.rs
@@ -1,5 +1,13 @@
 //! Persistent signer specifications and runtime signer implementations.
 
+pub mod credentials;
+pub mod error;
+pub mod runtime;
 pub mod spec;
 
+pub use credentials::{
+    LEGACY_KEYSTORE_PASSWORD_ENV, SNCAST_KEYSTORE_PASSWORD_ENV, keystore_password,
+};
+pub use error::{KeystoreError, SignerError, SignerOperationError};
+pub use runtime::RuntimeSigner;
 pub use spec::{KeystoreSpec, LedgerSpec, PrivateKeySpec, SignerKind, SignerSpec};

--- a/crates/sncast/src/signers/runtime.rs
+++ b/crates/sncast/src/signers/runtime.rs
@@ -1,0 +1,228 @@
+use std::fmt::{Debug, Formatter};
+
+use async_trait::async_trait;
+use starknet_rust::core::crypto::Signature;
+use starknet_rust::signers::{
+    LedgerSigner, LocalWallet, Signer, SignerInteractivityContext, SigningKey, VerifyingKey,
+};
+use starknet_types_core::felt::Felt;
+
+use crate::helpers::ledger::{self, SncastLedgerTransport};
+use crate::response::ui::UI;
+use crate::signers::error::KeystoreError;
+use crate::signers::spec::PrivateKeySource;
+use crate::signers::{
+    KeystoreSpec, PrivateKeySpec, SignerError, SignerKind, SignerOperationError, SignerSpec,
+    keystore_password,
+};
+
+pub enum RuntimeSigner {
+    LocalWallet {
+        signer: LocalWallet,
+        source: PrivateKeySource,
+    },
+    Ledger(LedgerSigner<SncastLedgerTransport>),
+}
+
+impl RuntimeSigner {
+    pub async fn from_spec(spec: SignerSpec, ui: &UI) -> Result<Self, SignerError> {
+        match spec {
+            SignerSpec::PrivateKey(spec) => Ok(Self::from(spec)),
+            SignerSpec::Keystore(spec) => Self::try_from(spec),
+            SignerSpec::Ledger(spec) => {
+                ledger::create_ledger_signer(spec.derivation_path(), ui, false)
+                    .await
+                    .map(Self::from)
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn from_private_key(private_key: Felt, source: PrivateKeySource) -> Self {
+        let key = SigningKey::from_secret_scalar(private_key);
+        let signer = LocalWallet::from_signing_key(key);
+        Self::LocalWallet { signer, source }
+    }
+
+    #[must_use]
+    pub fn kind(&self) -> SignerKind {
+        match self {
+            Self::LocalWallet { source, .. } => SignerKind::from(*source),
+            Self::Ledger { .. } => SignerKind::Ledger,
+        }
+    }
+}
+
+impl From<PrivateKeySpec> for RuntimeSigner {
+    fn from(spec: PrivateKeySpec) -> Self {
+        Self::from_private_key(spec.private_key(), PrivateKeySource::PrivateKey)
+    }
+}
+
+impl TryFrom<KeystoreSpec> for RuntimeSigner {
+    type Error = SignerError;
+
+    fn try_from(spec: KeystoreSpec) -> Result<Self, Self::Error> {
+        let password = keystore_password(&spec)?;
+        let key = SigningKey::from_keystore(spec.path(), &password).map_err(|source| {
+            KeystoreError::Decrypt {
+                path: spec.path().to_owned(),
+                source,
+            }
+        })?;
+        let wallet = LocalWallet::from_signing_key(key);
+        Ok(RuntimeSigner::LocalWallet {
+            signer: wallet,
+            source: PrivateKeySource::Keystore,
+        })
+    }
+}
+
+impl From<LedgerSigner<SncastLedgerTransport>> for RuntimeSigner {
+    fn from(signer: LedgerSigner<SncastLedgerTransport>) -> Self {
+        Self::Ledger(signer)
+    }
+}
+
+impl Debug for RuntimeSigner {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimeSigner")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl Signer for RuntimeSigner {
+    type GetPublicKeyError = SignerError;
+    type SignError = SignerError;
+
+    async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError> {
+        match self {
+            Self::LocalWallet { signer, source } => get_public_key(signer, (*source).into()).await,
+            Self::Ledger(signer) => get_public_key(signer, SignerKind::Ledger).await,
+        }
+    }
+
+    async fn sign_hash(&self, hash: &Felt) -> Result<Signature, Self::SignError> {
+        match self {
+            Self::LocalWallet { signer, source } => sign_hash(signer, hash, (*source).into()).await,
+            Self::Ledger(signer) => sign_hash(signer, hash, SignerKind::Ledger).await,
+        }
+    }
+
+    fn is_interactive(&self, context: SignerInteractivityContext<'_>) -> bool {
+        match self {
+            Self::LocalWallet { signer, .. } => signer.is_interactive(context),
+            Self::Ledger(signer) => signer.is_interactive(context),
+        }
+    }
+}
+
+async fn get_public_key<S>(signer: &S, kind: SignerKind) -> Result<VerifyingKey, SignerError>
+where
+    S: Signer,
+    S::GetPublicKeyError: 'static,
+{
+    signer.get_public_key().await.map_err(|source| {
+        SignerOperationError::GetPublicKey {
+            kind,
+            source: anyhow::Error::from(source),
+        }
+        .into()
+    })
+}
+
+async fn sign_hash<S>(signer: &S, hash: &Felt, kind: SignerKind) -> Result<Signature, SignerError>
+where
+    S: Signer,
+    S::SignError: 'static,
+{
+    signer.sign_hash(hash).await.map_err(|source| {
+        SignerOperationError::SignHash {
+            kind,
+            source: anyhow::Error::from(source),
+        }
+        .into()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use starknet_rust::signers::SigningKey;
+    use thiserror::Error;
+
+    use super::*;
+
+    #[derive(Debug, Error)]
+    #[error("signer failure")]
+    struct TestSignerError;
+
+    struct FailingSigner;
+
+    #[async_trait]
+    impl Signer for FailingSigner {
+        type GetPublicKeyError = TestSignerError;
+        type SignError = TestSignerError;
+
+        async fn get_public_key(&self) -> Result<VerifyingKey, Self::GetPublicKeyError> {
+            Err(TestSignerError)
+        }
+
+        async fn sign_hash(&self, _hash: &Felt) -> Result<Signature, Self::SignError> {
+            Err(TestSignerError)
+        }
+
+        fn is_interactive(&self, _context: SignerInteractivityContext<'_>) -> bool {
+            false
+        }
+    }
+
+    #[tokio::test]
+    async fn delegates_successful_operations_to_local_wallet() {
+        let key = SigningKey::from_secret_scalar(Felt::ONE);
+        let expected_public_key = key.verifying_key();
+        let signer =
+            RuntimeSigner::from_private_key(key.secret_scalar(), PrivateKeySource::PrivateKey);
+
+        assert_eq!(
+            signer.get_public_key().await.unwrap().scalar(),
+            expected_public_key.scalar()
+        );
+        assert!(signer.sign_hash(&Felt::TWO).await.is_ok());
+        assert_eq!(signer.kind(), SignerKind::PrivateKey);
+    }
+
+    #[tokio::test]
+    async fn wraps_public_key_errors_with_signer_kind_and_operation() {
+        let error = get_public_key(&FailingSigner, SignerKind::Keystore)
+            .await
+            .unwrap_err();
+
+        match error {
+            SignerError::Operation(SignerOperationError::GetPublicKey { kind, source }) => {
+                assert_eq!(kind, SignerKind::Keystore);
+                assert_eq!(source.to_string(), "signer failure");
+            }
+            error => panic!("expected public-key operation error, got {error:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn wraps_signing_errors_with_signer_kind_and_operation() {
+        let error = sign_hash(&FailingSigner, &Felt::TWO, SignerKind::Ledger)
+            .await
+            .unwrap_err();
+
+        match error {
+            SignerError::Operation(SignerOperationError::SignHash { kind, source }) => {
+                assert_eq!(kind, SignerKind::Ledger);
+                assert_eq!(source.to_string(), "signer failure");
+            }
+            error => panic!("expected signing operation error, got {error:?}"),
+        }
+    }
+}

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -13,14 +13,14 @@ use serde_json::json;
 use sncast::helpers::braavos::BraavosAccountFactory;
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::{
-    BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH, CREATE_KEYSTORE_PASSWORD_ENV_VAR,
-    OZ_CLASS_HASH, READY_CLASS_HASH,
+    BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH, OZ_CLASS_HASH, READY_CLASS_HASH,
 };
 use sncast::helpers::ledger;
 use sncast::helpers::ledger::LedgerKeyLocatorAccount;
 use sncast::helpers::rpc::{RpcArgs, generate_network_flag};
 use sncast::response::account::create::AccountCreateResponse;
 use sncast::response::ui::UI;
+use sncast::signers::credentials::LEGACY_CREATE_KEYSTORE_PASSWORD_ENV;
 use sncast::{
     AccountType, SignerSource, SignerType, check_class_hash_exists, check_if_legacy_contract,
     extract_or_generate_salt, get_keystore_password, handle_account_factory_error,
@@ -335,7 +335,7 @@ fn create_to_keystore(
     if account_path.exists() {
         bail!("Account file {account_path} already exists");
     }
-    let password = get_keystore_password(CREATE_KEYSTORE_PASSWORD_ENV_VAR)?;
+    let password = get_keystore_password(LEGACY_CREATE_KEYSTORE_PASSWORD_ENV)?;
     let private_key = SigningKey::from_secret_scalar(private_key);
     private_key.save_as_keystore(keystore_path, &password)?;
     let account_json = match account_type {

--- a/crates/sncast/src/starknet_commands/get/balance.rs
+++ b/crates/sncast/src/starknet_commands/get/balance.rs
@@ -11,6 +11,7 @@ use sncast::response::get::balance::BalanceResponse;
 use sncast::response::ui::UI;
 use sncast::{get_account, get_account_data_from_accounts_file, get_block_id, get_chain_id};
 use starknet_rust::{
+    accounts::Account,
     core::{types::FunctionCall, utils::get_selector_from_name},
     providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport},
 };

--- a/crates/sncast/src/starknet_commands/multicall/mod.rs
+++ b/crates/sncast/src/starknet_commands/multicall/mod.rs
@@ -17,7 +17,6 @@ use foundry_ui::Message;
 use new::New;
 use run::Run;
 use sncast::response::ui::UI;
-use sncast::with_account;
 use sncast::{
     WaitForTx, get_account,
     helpers::{configuration::CastConfig, constants::DEFAULT_MULTICALL_CONTENTS},
@@ -82,17 +81,15 @@ pub async fn multicall(
             let provider = run.rpc.get_provider(&config, ui).await?;
 
             let account = get_account(&config, &provider, &run.rpc, ui).await?;
-            let result = with_account!(&account, |account| {
-                starknet_commands::multicall::run::run(
-                    run,
-                    account,
-                    &provider,
-                    &config,
-                    wait_config,
-                    ui,
-                )
-                .await
-            });
+            let result = starknet_commands::multicall::run::run(
+                run,
+                &account,
+                &provider,
+                &config,
+                wait_config,
+                ui,
+            )
+            .await;
 
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
@@ -108,17 +105,15 @@ pub async fn multicall(
 
             let account = get_account(&config, &provider, &execute.rpc, ui).await?;
 
-            let result = with_account!(&account, |account| {
-                starknet_commands::multicall::execute::execute(
-                    *execute,
-                    account,
-                    &provider,
-                    &config,
-                    wait_config,
-                    ui,
-                )
-                .await
-            });
+            let result = starknet_commands::multicall::execute::execute(
+                *execute,
+                &account,
+                &provider,
+                &config,
+                wait_config,
+                ui,
+            )
+            .await;
             let block_explorer_link =
                 block_explorer_link_if_allowed(&result, provider.chain_id().await?, &config).await;
             Ok(process_command_result(

--- a/crates/sncast/tests/e2e/account/deploy.rs
+++ b/crates/sncast/tests/e2e/account/deploy.rs
@@ -12,9 +12,8 @@ use indoc::indoc;
 use shared::test_utils::output_assert::{AsOutput, assert_stderr_contains, assert_stdout_contains};
 use sncast::AccountType;
 use sncast::helpers::account::load_accounts;
-use sncast::helpers::constants::{
-    BRAAVOS_CLASS_HASH, KEYSTORE_PASSWORD_ENV_VAR, OZ_CLASS_HASH, READY_CLASS_HASH,
-};
+use sncast::helpers::constants::{BRAAVOS_CLASS_HASH, OZ_CLASS_HASH, READY_CLASS_HASH};
+use sncast::signers::LEGACY_KEYSTORE_PASSWORD_ENV;
 use starknet_rust::core::types::TransactionReceipt::DeployAccount;
 use std::fs;
 use tempfile::{TempDir, tempdir};
@@ -279,7 +278,7 @@ pub async fn test_happy_case_keystore(account_type: &str) {
     let address = get_address_from_keystore(
         tempdir.path().join(keystore_file).to_str().unwrap(),
         tempdir.path().join(&account_file).to_str().unwrap(),
-        KEYSTORE_PASSWORD_ENV_VAR,
+        LEGACY_KEYSTORE_PASSWORD_ENV,
         &account_type.parse().unwrap(),
     );
 
@@ -609,7 +608,7 @@ pub async fn test_deploy_keystore_other_args() {
     let address = get_address_from_keystore(
         tempdir.path().join(keystore_file),
         tempdir.path().join(account_file),
-        KEYSTORE_PASSWORD_ENV_VAR,
+        LEGACY_KEYSTORE_PASSWORD_ENV,
         &AccountType::OpenZeppelin,
     );
 

--- a/crates/sncast/tests/helpers/env.rs
+++ b/crates/sncast/tests/helpers/env.rs
@@ -1,5 +1,8 @@
-use sncast::helpers::constants::{CREATE_KEYSTORE_PASSWORD_ENV_VAR, KEYSTORE_PASSWORD_ENV_VAR};
 use std::env;
+
+use sncast::signers::{
+    LEGACY_KEYSTORE_PASSWORD_ENV, credentials::LEGACY_CREATE_KEYSTORE_PASSWORD_ENV,
+};
 
 pub fn set_keystore_password_env() {
     // SAFETY: Tests run in parallel and share the same environment variables.
@@ -7,7 +10,7 @@ pub fn set_keystore_password_env() {
     // The only potential issue would be if a test explicitly required this variable to be unset,
     // but to the best of our knowledge, no such test exists.
     unsafe {
-        env::set_var(KEYSTORE_PASSWORD_ENV_VAR, "123");
+        env::set_var(LEGACY_KEYSTORE_PASSWORD_ENV, "123");
     };
 }
 
@@ -17,6 +20,6 @@ pub fn set_create_keystore_password_env() {
     // The only potential issue would be if a test explicitly required this variable to be unset,
     // but to the best of our knowledge, no such test exists.
     unsafe {
-        env::set_var(CREATE_KEYSTORE_PASSWORD_ENV_VAR, "123");
+        env::set_var(LEGACY_CREATE_KEYSTORE_PASSWORD_ENV, "123");
     };
 }

--- a/crates/sncast/tests/helpers/fixtures.rs
+++ b/crates/sncast/tests/helpers/fixtures.rs
@@ -219,11 +219,6 @@ pub async fn invoke_contract(
         calldata,
     };
 
-    let account = match account {
-        sncast::AccountVariant::LocalWallet(acc) => acc,
-        sncast::AccountVariant::Ledger(_) => panic!("Ledger account not supported in test"),
-    };
-
     let execution = account.execute_v3(vec![call]);
     let execution = apply_optional_fields!(
         execution,

--- a/crates/sncast/tests/integration/lib_tests.rs
+++ b/crates/sncast/tests/integration/lib_tests.rs
@@ -9,6 +9,7 @@ use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::rpc::RpcArgs;
 use sncast::response::ui::UI;
 use sncast::{check_if_legacy_contract, get_account, get_provider};
+use starknet_rust::accounts::Account;
 use starknet_rust::macros::felt;
 use url::Url;
 

--- a/crates/sncast/tests/integration/wait_for_tx.rs
+++ b/crates/sncast/tests/integration/wait_for_tx.rs
@@ -53,11 +53,6 @@ async fn test_rejected_transaction() {
         .await
         .expect("Could not get the account");
 
-    let account = match account {
-        sncast::AccountVariant::LocalWallet(acc) => acc,
-        sncast::AccountVariant::Ledger(_) => panic!("Ledger account not supported in tests"),
-    };
-
     let factory = ContractFactory::new_with_udc(
         MAP_CONTRACT_CLASS_HASH_SEPOLIA.parse().unwrap(),
         account,


### PR DESCRIPTION
## Introduced changes
This PR introduces a transparent, polymorphic signer that abstracts the concrete signing technology (in-memory private key, Ledger, keyring in the future) from code that actually uses signing.

`RuntimeSigner` wraps all possible types of signers and dispatches them internally under a transparent API. `SignerProvider` **constructs** the runtime signer from `SignerSpec` that forwards the private key, Ledger locator path, etc. from the CLI.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`