### PR TITLE
refactor(sncast) Extract account helpers as clean services

### DIFF
--- a/crates/sncast/src/accounts/deployment.rs
+++ b/crates/sncast/src/accounts/deployment.rs
@@ -1,0 +1,290 @@
+use anyhow::{Result, anyhow};
+use conversions::IntoConv;
+use starknet_rust::accounts::{
+    AccountDeploymentV3, AccountFactory, AccountFactoryError, ArgentAccountFactory,
+    OpenZeppelinAccountFactory,
+};
+use starknet_rust::core::types::{
+    ContractExecutionError, FeeEstimate, StarknetError::ClassHashNotFound,
+    StarknetError::TransactionExecutionError, TransactionExecutionErrorData,
+};
+use starknet_rust::providers::ProviderError::StarknetError;
+use starknet_rust::providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use starknet_rust::signers::Signer;
+use starknet_types_core::felt::Felt;
+
+use crate::accounts::AccountType;
+use crate::apply_optional_fields;
+use crate::helpers::braavos::BraavosAccountFactory;
+use crate::helpers::constants::BRAAVOS_BASE_ACCOUNT_CLASS_HASH;
+use crate::helpers::dry_run::DryRunArgs;
+use crate::helpers::fee::{FeeArgs, FeeSettings};
+use crate::response::errors::{SNCastProviderError, SNCastStarknetError};
+use crate::response::invoke::{InvokeResponse, InvokeTransactionResponse};
+use crate::response::ui::UI;
+use crate::{WaitForTx, handle_account_factory_error, handle_rpc_error, handle_wait_for_tx};
+
+pub struct AccountDeploymentService;
+
+impl AccountDeploymentService {
+    pub async fn compute_address<S>(
+        provider: &JsonRpcClient<HttpTransport>,
+        account_type: AccountType,
+        class_hash: Felt,
+        signer: S,
+        salt: Felt,
+        chain_id: Felt,
+    ) -> Result<Felt>
+    where
+        S: Signer + Send + Sync,
+        S::GetPublicKeyError: 'static,
+    {
+        match account_type {
+            AccountType::OpenZeppelin => {
+                let factory =
+                    OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
+                Ok(factory.deploy_v3(salt).address())
+            }
+            AccountType::Ready => {
+                let factory =
+                    ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
+                Ok(factory.deploy_v3(salt).address())
+            }
+            AccountType::Braavos => {
+                let factory = BraavosAccountFactory::new(
+                    class_hash,
+                    BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
+                    chain_id,
+                    signer,
+                    provider,
+                )
+                .await?;
+                Ok(factory.deploy_v3(salt).address())
+            }
+        }
+    }
+
+    pub async fn estimate_fee<S>(
+        provider: &JsonRpcClient<HttpTransport>,
+        account_type: AccountType,
+        class_hash: Felt,
+        signer: S,
+        salt: Felt,
+        chain_id: Felt,
+    ) -> Result<(Felt, FeeEstimate)>
+    where
+        S: Signer + Send + Sync,
+        S::GetPublicKeyError: 'static,
+    {
+        match account_type {
+            AccountType::OpenZeppelin => {
+                let factory =
+                    OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
+                estimate_factory(factory, salt).await
+            }
+            AccountType::Ready => {
+                let factory =
+                    ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
+                estimate_factory(factory, salt).await
+            }
+            AccountType::Braavos => {
+                let factory = BraavosAccountFactory::new(
+                    class_hash,
+                    BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
+                    chain_id,
+                    signer,
+                    provider,
+                )
+                .await?;
+                estimate_factory(factory, salt).await
+            }
+        }
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub async fn deploy<S>(
+        provider: &JsonRpcClient<HttpTransport>,
+        account_type: AccountType,
+        class_hash: Felt,
+        signer: S,
+        salt: Felt,
+        chain_id: Felt,
+        fee_args: FeeArgs,
+        dry_run_args: DryRunArgs,
+        wait_config: WaitForTx,
+        ui: &UI,
+    ) -> Result<(Felt, InvokeResponse)>
+    where
+        S: Signer + Send + Sync,
+        S::GetPublicKeyError: 'static,
+        S::SignError: 'static,
+    {
+        match account_type {
+            AccountType::Ready => {
+                let factory =
+                    ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
+                deploy_factory(
+                    factory,
+                    provider,
+                    salt,
+                    fee_args,
+                    dry_run_args,
+                    wait_config,
+                    class_hash,
+                    ui,
+                )
+                .await
+            }
+            AccountType::OpenZeppelin => {
+                let factory =
+                    OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
+                deploy_factory(
+                    factory,
+                    provider,
+                    salt,
+                    fee_args,
+                    dry_run_args,
+                    wait_config,
+                    class_hash,
+                    ui,
+                )
+                .await
+            }
+            AccountType::Braavos => {
+                let factory = BraavosAccountFactory::new(
+                    class_hash,
+                    BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
+                    chain_id,
+                    signer,
+                    provider,
+                )
+                .await?;
+                deploy_factory(
+                    factory,
+                    provider,
+                    salt,
+                    fee_args,
+                    dry_run_args,
+                    wait_config,
+                    class_hash,
+                    ui,
+                )
+                .await
+            }
+        }
+    }
+}
+
+async fn estimate_factory<T>(factory: T, salt: Felt) -> Result<(Felt, FeeEstimate)>
+where
+    T: AccountFactory + Sync,
+{
+    let deployment = factory.deploy_v3(salt);
+    let address = deployment.address();
+    let fee = deployment.estimate_fee().await.map_err(|error| {
+        anyhow!(
+            "Failed to estimate account deployment fee. Reason: {}",
+            handle_account_factory_error::<T>(error)
+        )
+    })?;
+    Ok((address, fee))
+}
+
+fn execution_error_message(error: &ContractExecutionError) -> &str {
+    match error {
+        ContractExecutionError::Message(message) => message,
+        ContractExecutionError::Nested(inner) => execution_error_message(&inner.error),
+    }
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn deploy_factory<T>(
+    account_factory: T,
+    provider: &JsonRpcClient<HttpTransport>,
+    salt: Felt,
+    fee_args: FeeArgs,
+    dry_run_args: DryRunArgs,
+    wait_config: WaitForTx,
+    class_hash: Felt,
+    ui: &UI,
+) -> Result<(Felt, InvokeResponse)>
+where
+    T: AccountFactory + Sync,
+{
+    let deployment = account_factory.deploy_v3(salt);
+    let address = deployment.address();
+
+    if dry_run_args.dry_run {
+        return dry_run_args
+            .estimate(|| deployment.estimate_fee())
+            .await
+            .map(|response| (address, InvokeResponse::DryRun(response)))
+            .map_err(|error| anyhow!("Failed to estimate fee for dry run: {error}"));
+    }
+
+    let fee_settings = if fee_args.max_fee.is_some() {
+        let fee_estimate = deployment
+            .estimate_fee()
+            .await
+            .expect("Failed to estimate fee");
+        fee_args.try_into_fee_settings(Some(&fee_estimate))
+    } else {
+        fee_args.try_into_fee_settings(None)
+    };
+
+    let FeeSettings {
+        l1_gas,
+        l1_gas_price,
+        l2_gas,
+        l2_gas_price,
+        l1_data_gas,
+        l1_data_gas_price,
+        tip,
+    } = fee_settings.expect("Failed to convert to fee settings");
+
+    let deployment = apply_optional_fields!(
+        deployment,
+        l1_gas => AccountDeploymentV3::l1_gas,
+        l1_gas_price => AccountDeploymentV3::l1_gas_price,
+        l2_gas => AccountDeploymentV3::l2_gas,
+        l2_gas_price => AccountDeploymentV3::l2_gas_price,
+        l1_data_gas => AccountDeploymentV3::l1_data_gas,
+        l1_data_gas_price => AccountDeploymentV3::l1_data_gas_price,
+        tip => AccountDeploymentV3::tip
+    );
+
+    match deployment.send().await {
+        Err(AccountFactoryError::Provider(error)) => match error {
+            StarknetError(ClassHashNotFound) => Err(anyhow!(
+                "Provided class hash {class_hash:#x} does not exist"
+            )),
+            StarknetError(TransactionExecutionError(TransactionExecutionErrorData {
+                ref execution_error,
+                ..
+            })) => Err(anyhow!(execution_error_message(execution_error).to_owned())),
+            StarknetError(error) => Err(SNCastProviderError::StarknetError(
+                SNCastStarknetError::from_starknet_error_with_account(error, address.into_()),
+            )
+            .into()),
+            _ => Err(handle_rpc_error(error)),
+        },
+        Err(_) => Err(anyhow!("Unknown AccountFactoryError")),
+        Ok(result) => {
+            let response = InvokeResponse::Transaction(InvokeTransactionResponse {
+                transaction_hash: result.transaction_hash.into_(),
+            });
+            if let Err(message) = handle_wait_for_tx(
+                provider,
+                result.transaction_hash,
+                response.clone(),
+                wait_config,
+                ui,
+            )
+            .await
+            {
+                return Err(anyhow!(message));
+            }
+            Ok((address, response))
+        }
+    }
+}

--- a/crates/sncast/src/accounts/error.rs
+++ b/crates/sncast/src/accounts/error.rs
@@ -35,6 +35,9 @@ pub enum AccountsError {
         message: String,
     },
 
+    #[error("invalid account: {message}")]
+    InvalidAccount { message: String },
+
     #[error("failed to {operation} the {file_type} `{path}`")]
     Storage {
         operation: StorageOperation,

--- a/crates/sncast/src/accounts/mod.rs
+++ b/crates/sncast/src/accounts/mod.rs
@@ -1,12 +1,18 @@
 //! Account model and persistence boundaries.
 
+pub mod deployment;
 pub mod error;
 pub mod model;
 pub mod repository;
 pub mod schema;
+pub mod selector;
+pub mod service;
 
+pub use deployment::AccountDeploymentService;
 pub use error::{AccountsError, AccountsFileError};
 pub use model::{
     AccountName, AccountRecord, AccountRegistry, AccountType, DeployableAccountRecord, NetworkName,
 };
 pub use repository::{AccountRepository, MigrationOutcome, MutationResult};
+pub use selector::AccountSelector;
+pub use service::AccountService;

--- a/crates/sncast/src/accounts/selector.rs
+++ b/crates/sncast/src/accounts/selector.rs
@@ -1,0 +1,61 @@
+use std::num::NonZeroU8;
+
+use camino::Utf8PathBuf;
+
+use crate::accounts::{AccountName, AccountsError};
+
+#[derive(Clone, Debug)]
+pub enum AccountSelector {
+    Named {
+        name: AccountName,
+    },
+    Devnet {
+        index: NonZeroU8,
+    },
+    LegacyStarkli {
+        account_file: Utf8PathBuf,
+        keystore_file: Utf8PathBuf,
+    },
+}
+
+impl AccountSelector {
+    pub fn named(name: impl Into<String>) -> Result<Self, AccountsError> {
+        Ok(Self::Named {
+            name: AccountName::new(name)?,
+        })
+    }
+
+    pub fn devnet(value: &str) -> Result<Self, AccountsError> {
+        let index = value
+            .strip_prefix("devnet-")
+            .and_then(|value| value.parse::<u8>().ok())
+            .and_then(NonZeroU8::new)
+            .ok_or_else(|| AccountsError::InvalidAccount {
+                message: format!("invalid devnet account selector `{value}`"),
+            })?;
+        Ok(Self::Devnet { index })
+    }
+
+    #[must_use]
+    pub fn legacy_starkli(account_file: Utf8PathBuf, keystore_file: Utf8PathBuf) -> Self {
+        Self::LegacyStarkli {
+            account_file,
+            keystore_file,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_only_nonzero_devnet_indices() {
+        assert!(matches!(
+            AccountSelector::devnet("devnet-1").unwrap(),
+            AccountSelector::Devnet { .. }
+        ));
+        assert!(AccountSelector::devnet("devnet-0").is_err());
+        assert!(AccountSelector::devnet("devnet-invalid").is_err());
+    }
+}

--- a/crates/sncast/src/accounts/service.rs
+++ b/crates/sncast/src/accounts/service.rs
@@ -1,0 +1,100 @@
+use anyhow::Context;
+use starknet_rust::accounts::SingleOwnerAccount;
+use starknet_rust::core::types::{BlockId, BlockTag};
+use starknet_rust::providers::jsonrpc::{HttpTransport, JsonRpcClient};
+use starknet_rust::signers::Signer;
+use starknet_types_core::felt::Felt;
+use url::Url;
+
+use crate::accounts::{AccountRecord, AccountRepository, AccountSelector};
+use crate::helpers::account::get_account_from_devnet;
+use crate::response::ui::UI;
+use crate::signers::spec::PrivateKeySource;
+use crate::signers::{RuntimeSigner, SignerError};
+use crate::{RuntimeAccount, get_chain_id};
+
+pub struct AccountService {
+    repository: AccountRepository,
+}
+
+impl AccountService {
+    #[must_use]
+    pub fn new(repository: AccountRepository) -> Self {
+        Self { repository }
+    }
+
+    pub async fn connected_account<'a>(
+        &self,
+        selector: &AccountSelector,
+        provider: &'a JsonRpcClient<HttpTransport>,
+        devnet_url: Option<&Url>,
+        ui: &UI,
+    ) -> anyhow::Result<RuntimeAccount<'a>> {
+        match selector {
+            AccountSelector::Named { name } => {
+                let chain_id = get_chain_id(provider).await?;
+                let account = crate::get_account_record_from_repository(
+                    name.as_str(),
+                    chain_id,
+                    &self.repository,
+                )?;
+                let signer = RuntimeSigner::from_spec(account.signer.clone(), ui).await?;
+                Self::build_runtime_account(account, chain_id, provider, signer).await
+            }
+            AccountSelector::LegacyStarkli {
+                account_file,
+                keystore_file,
+            } => {
+                let chain_id = get_chain_id(provider).await?;
+                let account: AccountRecord =
+                    crate::get_account_data_from_keystore(account_file.as_str(), keystore_file)?
+                        .try_into()?;
+                let private_key = account
+                    .signer
+                    .private_key()
+                    .context("Private key not found in starkli account")?;
+                let signer =
+                    RuntimeSigner::from_private_key(private_key, PrivateKeySource::Keystore);
+                verify_public_key(&account, &signer).await?;
+                Self::build_runtime_account(account, chain_id, provider, signer).await
+            }
+            AccountSelector::Devnet { index } => {
+                let url = devnet_url.context("Devnet account requires a devnet URL")?;
+                get_account_from_devnet(*index, provider, url).await
+            }
+        }
+    }
+
+    pub(crate) async fn build_runtime_account(
+        account: AccountRecord,
+        chain_id: Felt,
+        provider: &JsonRpcClient<HttpTransport>,
+        signer: RuntimeSigner,
+    ) -> anyhow::Result<RuntimeAccount<'_>> {
+        let address = account.address;
+        crate::verify_account_address(address, chain_id, provider).await?;
+        let encoding =
+            crate::get_account_encoding(account.legacy, account.class_hash, address, provider)
+                .await?;
+
+        let mut runtime = SingleOwnerAccount::new(provider, signer, address, chain_id, encoding);
+        runtime.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
+        Ok(runtime)
+    }
+}
+
+async fn verify_public_key(
+    account: &AccountRecord,
+    signer: &RuntimeSigner,
+) -> Result<(), SignerError> {
+    let expected = account.public_key;
+    let actual = signer.get_public_key().await?.scalar();
+    if expected != actual {
+        Err(SignerError::PublicKeyMismatch {
+            kind: signer.kind(),
+            expected,
+            actual,
+        })?;
+    }
+    Ok(())
+}

--- a/crates/sncast/src/helpers/account.rs
+++ b/crates/sncast/src/helpers/account.rs
@@ -1,13 +1,14 @@
-use crate::check_account_file_exists;
-use crate::{RuntimeAccount, build_account, helpers::devnet::provider::DevnetProvider};
+use crate::helpers::devnet::provider::DevnetProvider;
 use anyhow::{Result, ensure};
 use camino::Utf8PathBuf;
 use starknet_rust::providers::{JsonRpcClient, Provider, jsonrpc::HttpTransport};
 use std::fs;
+use std::num::NonZeroU8;
 use url::Url;
 
-use crate::accounts::{AccountRecord, AccountRepository};
+use crate::accounts::{AccountRecord, AccountRepository, AccountService};
 use crate::signers::{RuntimeSigner, spec::PrivateKeySource};
+use crate::{RuntimeAccount, check_account_file_exists};
 use anyhow::Context;
 use serde_json::{Value, json};
 
@@ -55,16 +56,11 @@ pub fn is_devnet_account(account: &str) -> bool {
     account.starts_with("devnet-")
 }
 
-pub async fn get_account_from_devnet<'a>(
-    account: &str,
+pub(crate) async fn get_account_from_devnet<'a>(
+    account_number: NonZeroU8,
     provider: &'a JsonRpcClient<HttpTransport>,
     url: &Url,
 ) -> Result<RuntimeAccount<'a>> {
-    let account_number: u8 = account
-        .strip_prefix("devnet-")
-        .map(|s| s.parse::<u8>().expect("Invalid devnet account number"))
-        .context("Failed to parse devnet account number")?;
-
     let devnet_provider = DevnetProvider::new(url.as_ref());
     devnet_provider.ensure_alive().await?;
 
@@ -77,14 +73,14 @@ pub async fn get_account_from_devnet<'a>(
     };
 
     ensure!(
-        account_number <= devnet_config.total_accounts && account_number != 0,
+        account_number.get() <= devnet_config.total_accounts,
         "Devnet account number must be between 1 and {}",
         devnet_config.total_accounts
     );
 
     let devnet_accounts = devnet_provider.get_predeployed_accounts().await?;
     let predeployed_account = devnet_accounts
-        .get((account_number - 1) as usize)
+        .get((account_number.get() - 1) as usize)
         .expect("Failed to get devnet account");
 
     let account_data = AccountRecord::from(predeployed_account);
@@ -94,5 +90,5 @@ pub async fn get_account_from_devnet<'a>(
         .private_key()
         .context("Private key not found for devnet account")?;
     let signer = RuntimeSigner::from_private_key(private_key, PrivateKeySource::PrivateKey);
-    build_account(account_data, chain_id, provider, signer).await
+    AccountService::build_runtime_account(account_data, chain_id, provider, signer).await
 }

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -1,12 +1,11 @@
 use std::num::{NonZeroU8, NonZeroU16};
 
-use crate::helpers::account::{check_account_exists, get_account_from_devnet, is_devnet_account};
+use crate::helpers::account::{check_account_exists, is_devnet_account};
 use crate::helpers::configuration::CastConfig;
 use crate::helpers::constants::{DEFAULT_ACCOUNTS_FILE, WAIT_RETRY_INTERVAL, WAIT_TIMEOUT};
 use crate::helpers::rpc::RpcArgs;
 use crate::response::errors::SNCastProviderError;
 use crate::signers::LEGACY_KEYSTORE_PASSWORD_ENV;
-use crate::signers::spec::PrivateKeySource;
 use anyhow::{Context, Error, Result, anyhow, bail, ensure};
 use camino::Utf8PathBuf;
 use clap::ValueEnum;
@@ -36,7 +35,7 @@ use starknet_rust::{
         ProviderError::StarknetError,
         jsonrpc::{HttpTransport, JsonRpcClient},
     },
-    signers::{Signer, SigningKey},
+    signers::SigningKey,
 };
 use starknet_types_core::felt::Felt;
 use std::collections::HashMap;
@@ -318,6 +317,9 @@ pub async fn get_account<'a>(
 
     let network_name = chain_id_to_network_name(chain_id);
     let account = &config.account;
+    if account.is_empty() {
+        bail!("Account name not passed nor found in snfoundry.toml");
+    }
     let is_devnet_account = is_devnet_account(account);
 
     if is_devnet_account
@@ -341,78 +343,35 @@ pub async fn get_account<'a>(
     let exists_in_accounts_file =
         check_account_exists(account, &network_name, &repository, accounts_file_required)?;
 
-    match (is_devnet_account, exists_in_accounts_file) {
-        (true, true) => {
-            ui.print_warning(WarningMessage::new(format!(
-                "Using account {account} from accounts file {accounts_file}. \
-                To use an inbuilt devnet account, please rename your existing account or use an account with a different number."
-            )));
-            ui.print_blank_line();
-            get_account_from_repository(
-                account,
-                &repository,
-                provider,
-                config.keystore.as_ref(),
-                ui,
-            )
-            .await
-        }
-        (true, false) => {
-            let url = rpc_args
-                .get_url(config)
-                .await
-                .context("Failed to get url")?;
-            let local_account = get_account_from_devnet(account, provider, &url).await?;
-            Ok(local_account)
-        }
-        _ => {
-            get_account_from_repository(
-                account,
-                &repository,
-                provider,
-                config.keystore.as_ref(),
-                ui,
-            )
-            .await
-        }
-    }
-}
-
-pub async fn get_account_from_repository<'a>(
-    account: &str,
-    repository: &accounts::AccountRepository,
-    provider: &'a JsonRpcClient<HttpTransport>,
-    keystore: Option<&Utf8PathBuf>,
-    ui: &UI,
-) -> Result<RuntimeAccount<'a>> {
-    let chain_id = get_chain_id(provider).await?;
-    let (account_data, signer) = if let Some(keystore) = keystore {
-        let account_data: accounts::AccountRecord =
-            get_account_data_from_keystore(account, keystore)?.try_into()?;
-        let private_key = account_data
-            .signer
-            .private_key()
-            .context("Private key not found")?;
+    let (selector, devnet_url) = if let Some(keystore) = &config.keystore {
         (
-            account_data,
-            RuntimeSigner::from_private_key(private_key, PrivateKeySource::Keystore),
+            accounts::AccountSelector::legacy_starkli(Utf8PathBuf::from(account), keystore.clone()),
+            None,
         )
     } else {
-        let account_data = get_account_record_from_repository(account, chain_id, repository)?;
-        let signer = RuntimeSigner::from_spec(account_data.signer.clone(), ui).await?;
-        (account_data, signer)
+        match (is_devnet_account, exists_in_accounts_file) {
+            (true, true) => {
+                ui.print_warning(WarningMessage::new(format!(
+                    "Using account {account} from accounts file {accounts_file}. \
+                    To use an inbuilt devnet account, please rename your existing account or use an account with a different number."
+                )));
+                ui.print_blank_line();
+                (accounts::AccountSelector::named(account.clone())?, None)
+            }
+            (true, false) => {
+                let url = rpc_args
+                    .get_url(config)
+                    .await
+                    .context("Failed to get url")?;
+                (accounts::AccountSelector::devnet(account)?, Some(url))
+            }
+            _ => (accounts::AccountSelector::named(account.clone())?, None),
+        }
     };
 
-    let actual_public_key = signer.get_public_key().await?.scalar();
-    let signer_kind = signer.kind();
-
-    ensure!(
-        actual_public_key == account_data.public_key,
-        "{signer_kind} signer public key does not match the account: expected {:#x}, got {actual_public_key:#x}",
-        account_data.public_key
-    );
-
-    build_account(account_data, chain_id, provider, signer).await
+    accounts::AccountService::new(repository)
+        .connected_account(&selector, provider, devnet_url.as_ref(), ui)
+        .await
 }
 
 pub async fn get_contract_class(
@@ -439,30 +398,7 @@ pub async fn get_contract_class(
     result.map_err(handle_rpc_error)
 }
 
-pub(crate) async fn build_account(
-    account_data: accounts::AccountRecord,
-    chain_id: Felt,
-    provider: &JsonRpcClient<HttpTransport>,
-    signer: RuntimeSigner,
-) -> Result<RuntimeAccount<'_>> {
-    let address = account_data.address;
-
-    verify_account_address(address, chain_id, provider).await?;
-
-    let class_hash = account_data.class_hash;
-
-    let account_encoding =
-        get_account_encoding(account_data.legacy, class_hash, address, provider).await?;
-
-    let mut account =
-        SingleOwnerAccount::new(provider, signer, address, chain_id, account_encoding);
-
-    account.set_block_id(BlockId::Tag(PreConfirmed));
-
-    Ok(account)
-}
-
-async fn verify_account_address(
+pub(crate) async fn verify_account_address(
     address: Felt,
     chain_id: Felt,
     provider: &JsonRpcClient<HttpTransport>,
@@ -658,7 +594,7 @@ where
     })
 }
 
-async fn get_account_encoding(
+pub(crate) async fn get_account_encoding(
     legacy: Option<bool>,
     class_hash: Option<Felt>,
     address: Felt,
@@ -941,7 +877,7 @@ macro_rules! apply_optional_fields {
         {
             let mut value = $initial;
             $(
-                value = ::sncast::apply_optional(value, $option, $setter);
+                value = $crate::apply_optional(value, $option, $setter);
             )*
             value
         }

--- a/crates/sncast/src/starknet_commands/account/create.rs
+++ b/crates/sncast/src/starknet_commands/account/create.rs
@@ -3,15 +3,14 @@ use crate::starknet_commands::account::{
     validate_private_key,
 };
 use crate::starknet_commands::utils::felt_or_id::ClassHash;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use bigdecimal::BigDecimal;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
 use console::style;
 use conversions::IntoConv;
 use serde_json::json;
-use sncast::accounts::{AccountRecord, AccountRepository};
-use sncast::helpers::braavos::BraavosAccountFactory;
+use sncast::accounts::{AccountDeploymentService, AccountRecord, AccountRepository};
 use sncast::helpers::configuration::CastConfig;
 use sncast::helpers::constants::{
     BRAAVOS_BASE_ACCOUNT_CLASS_HASH, BRAAVOS_CLASS_HASH, OZ_CLASS_HASH, READY_CLASS_HASH,
@@ -25,12 +24,8 @@ use sncast::signers::credentials::LEGACY_CREATE_KEYSTORE_PASSWORD_ENV;
 use sncast::signers::{LedgerSpec, PrivateKeySpec, SignerSpec};
 use sncast::{
     AccountType, SignerSource, check_class_hash_exists, check_if_legacy_contract,
-    extract_or_generate_salt, get_keystore_password, handle_account_factory_error,
+    extract_or_generate_salt, get_keystore_password,
 };
-use starknet_rust::accounts::{
-    AccountDeploymentV3, AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory,
-};
-use starknet_rust::core::types::FeeEstimate;
 use starknet_rust::providers::JsonRpcClient;
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::signers::{LocalWallet, Signer, SigningKey};
@@ -245,29 +240,15 @@ where
 {
     let public_key = signer.get_public_key().await?.scalar();
 
-    let (address, estimated_fee) = match account_type {
-        AccountType::OpenZeppelin => {
-            let factory =
-                OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
-            get_address_and_deployment_fee(factory, salt).await
-        }
-        AccountType::Ready => {
-            let factory =
-                ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
-            get_address_and_deployment_fee(factory, salt).await
-        }
-        AccountType::Braavos => {
-            let factory = BraavosAccountFactory::new(
-                class_hash,
-                BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
-                chain_id,
-                signer,
-                provider,
-            )
-            .await?;
-            get_address_and_deployment_fee(factory, salt).await
-        }
-    }?;
+    let (address, estimated_fee) = AccountDeploymentService::estimate_fee(
+        provider,
+        account_type,
+        class_hash,
+        signer,
+        salt,
+        chain_id,
+    )
+    .await?;
 
     let legacy = check_if_legacy_contract(Some(class_hash), address, provider).await?;
 
@@ -283,34 +264,6 @@ where
     );
 
     Ok((account, estimated_fee.overall_fee))
-}
-
-async fn get_address_and_deployment_fee<T>(
-    account_factory: T,
-    salt: Felt,
-) -> Result<(Felt, FeeEstimate)>
-where
-    T: AccountFactory + Sync,
-{
-    let deployment = account_factory.deploy_v3(salt);
-    Ok((deployment.address(), get_deployment_fee(&deployment).await?))
-}
-
-async fn get_deployment_fee<T>(
-    account_deployment: &AccountDeploymentV3<'_, T>,
-) -> Result<FeeEstimate>
-where
-    T: AccountFactory + Sync,
-{
-    let fee_estimate = account_deployment.estimate_fee().await;
-
-    match fee_estimate {
-        Ok(fee_estimate) => Ok(fee_estimate),
-        Err(err) => Err(anyhow!(
-            "Failed to estimate account deployment fee. Reason: {}",
-            handle_account_factory_error::<T>(err)
-        )),
-    }
 }
 
 fn create_to_keystore(

--- a/crates/sncast/src/starknet_commands/account/deploy.rs
+++ b/crates/sncast/src/starknet_commands/account/deploy.rs
@@ -1,33 +1,22 @@
 use anyhow::{Context, Result, anyhow, bail};
 use camino::Utf8PathBuf;
 use clap::Args;
-use conversions::IntoConv;
 use serde_json::Map;
-use sncast::accounts::{AccountRecord, AccountRepository, AccountsError};
-use sncast::helpers::braavos::BraavosAccountFactory;
-use sncast::helpers::constants::BRAAVOS_BASE_ACCOUNT_CLASS_HASH;
+use sncast::accounts::{AccountDeploymentService, AccountRecord, AccountRepository, AccountsError};
 use sncast::helpers::dry_run::DryRunArgs;
-use sncast::helpers::fee::{FeeArgs, FeeSettings};
+use sncast::helpers::fee::FeeArgs;
 use sncast::helpers::rpc::RpcArgs;
 use sncast::response::account::deploy::AccountDeployResponse;
-use sncast::response::errors::{SNCastProviderError, SNCastStarknetError};
-use sncast::response::invoke::{InvokeResponse, InvokeTransactionResponse};
+use sncast::response::invoke::InvokeResponse;
 use sncast::response::ui::UI;
 use sncast::signers::RuntimeSigner;
 use sncast::{
-    AccountType, WaitForTx, apply_optional_fields, chain_id_to_network_name,
-    check_account_file_exists, get_account_data_from_keystore, get_account_record_from_repository,
-    handle_rpc_error, handle_wait_for_tx,
+    AccountType, WaitForTx, chain_id_to_network_name, check_account_file_exists,
+    get_account_data_from_keystore, get_account_record_from_repository,
 };
-use starknet_rust::accounts::{AccountDeploymentV3, AccountFactory, OpenZeppelinAccountFactory};
-use starknet_rust::accounts::{AccountFactoryError, ArgentAccountFactory};
-use starknet_rust::core::types::{
-    ContractExecutionError, StarknetError::ClassHashNotFound,
-    StarknetError::TransactionExecutionError, TransactionExecutionErrorData,
-};
+use starknet_rust::providers::JsonRpcClient;
 use starknet_rust::providers::jsonrpc::HttpTransport;
-use starknet_rust::providers::{JsonRpcClient, ProviderError::StarknetError};
-use starknet_rust::signers::{LocalWallet, Signer, SigningKey};
+use starknet_rust::signers::{LocalWallet, SigningKey};
 use starknet_types_core::felt::Felt;
 
 #[derive(Args, Debug)]
@@ -145,7 +134,7 @@ async fn deploy_from_keystore(
     })?;
 
     let signer = LocalWallet::from_signing_key(private_key);
-    let (address, result) = create_factory_and_deploy(
+    let (address, result) = AccountDeploymentService::deploy(
         provider,
         account_type,
         class_hash,
@@ -180,7 +169,7 @@ async fn deploy_from_accounts_file(
     let account_data = get_account_record_from_repository(&name, chain_id, repository)?;
     let (account_type, class_hash, salt) = extract_deployment_fields(&account_data)?;
     let signer = RuntimeSigner::from_spec(account_data.signer.clone(), ui).await?;
-    let (_, result) = create_factory_and_deploy(
+    let (_, result) = AccountDeploymentService::deploy(
         provider,
         account_type,
         class_hash,
@@ -201,79 +190,6 @@ async fn deploy_from_accounts_file(
     Ok(result)
 }
 
-#[expect(clippy::too_many_arguments)]
-async fn create_factory_and_deploy<S>(
-    provider: &JsonRpcClient<HttpTransport>,
-    account_type: AccountType,
-    class_hash: Felt,
-    signer: S,
-    salt: Felt,
-    chain_id: Felt,
-    fee_args: FeeArgs,
-    dry_run_args: DryRunArgs,
-    wait_config: WaitForTx,
-    ui: &UI,
-) -> Result<(Felt, InvokeResponse)>
-where
-    S: Signer + Send + Sync,
-    S::GetPublicKeyError: 'static,
-    S::SignError: 'static,
-{
-    match account_type {
-        AccountType::Ready => {
-            let factory =
-                ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
-            deploy_account(
-                factory,
-                provider,
-                salt,
-                fee_args,
-                dry_run_args,
-                wait_config,
-                class_hash,
-                ui,
-            )
-            .await
-        }
-        AccountType::OpenZeppelin => {
-            let factory =
-                OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
-            deploy_account(
-                factory,
-                provider,
-                salt,
-                fee_args,
-                dry_run_args,
-                wait_config,
-                class_hash,
-                ui,
-            )
-            .await
-        }
-        AccountType::Braavos => {
-            let factory = BraavosAccountFactory::new(
-                class_hash,
-                BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
-                chain_id,
-                signer,
-                provider,
-            )
-            .await?;
-            deploy_account(
-                factory,
-                provider,
-                salt,
-                fee_args,
-                dry_run_args,
-                wait_config,
-                class_hash,
-                ui,
-            )
-            .await
-        }
-    }
-}
-
 fn extract_deployment_fields(account: &AccountRecord) -> Result<(AccountType, Felt, Felt)> {
     let deployable = account.as_deployable()?;
     Ok((
@@ -281,108 +197,6 @@ fn extract_deployment_fields(account: &AccountRecord) -> Result<(AccountType, Fe
         deployable.class_hash(),
         deployable.salt(),
     ))
-}
-
-fn execution_error_message(error: &ContractExecutionError) -> &str {
-    match error {
-        ContractExecutionError::Message(msg) => msg,
-        ContractExecutionError::Nested(inner) => execution_error_message(&inner.error),
-    }
-}
-
-#[expect(clippy::too_many_arguments)]
-async fn deploy_account<T>(
-    account_factory: T,
-    provider: &JsonRpcClient<HttpTransport>,
-    salt: Felt,
-    fee_args: FeeArgs,
-    dry_run_args: DryRunArgs,
-    wait_config: WaitForTx,
-    class_hash: Felt,
-    ui: &UI,
-) -> Result<(Felt, InvokeResponse)>
-where
-    T: AccountFactory + Sync,
-{
-    let deployment = account_factory.deploy_v3(salt);
-    let address = deployment.address();
-
-    if dry_run_args.dry_run {
-        return dry_run_args
-            .estimate(|| deployment.estimate_fee())
-            .await
-            .map(|response| (address, InvokeResponse::DryRun(response)))
-            .map_err(|error| anyhow!("Failed to estimate fee for dry run: {error}"));
-    }
-
-    let fee_settings = if fee_args.max_fee.is_some() {
-        let fee_estimate = deployment
-            .estimate_fee()
-            .await
-            .map_err(|error| anyhow!("Failed to estimate fee: {error}"))?;
-        fee_args.try_into_fee_settings(Some(&fee_estimate))
-    } else {
-        fee_args.try_into_fee_settings(None)
-    };
-
-    let FeeSettings {
-        l1_gas,
-        l1_gas_price,
-        l2_gas,
-        l2_gas_price,
-        l1_data_gas,
-        l1_data_gas_price,
-        tip,
-    } = fee_settings?;
-
-    let deployment = apply_optional_fields!(
-        deployment,
-        l1_gas => AccountDeploymentV3::l1_gas,
-        l1_gas_price => AccountDeploymentV3::l1_gas_price,
-        l2_gas => AccountDeploymentV3::l2_gas,
-        l2_gas_price => AccountDeploymentV3::l2_gas_price,
-        l1_data_gas => AccountDeploymentV3::l1_data_gas,
-        l1_data_gas_price => AccountDeploymentV3::l1_data_gas_price,
-        tip => AccountDeploymentV3::tip
-    );
-
-    let result = deployment.send().await;
-
-    match result {
-        Err(AccountFactoryError::Provider(error)) => match error {
-            StarknetError(ClassHashNotFound) => Err(anyhow!(
-                "Provided class hash {class_hash:#x} does not exist",
-            )),
-            StarknetError(TransactionExecutionError(TransactionExecutionErrorData {
-                ref execution_error,
-                ..
-            })) => Err(anyhow!(execution_error_message(execution_error).to_owned())),
-            StarknetError(error) => Err(SNCastProviderError::StarknetError(
-                SNCastStarknetError::from_starknet_error_with_account(error, address.into_()),
-            )
-            .into()),
-            _ => Err(handle_rpc_error(error)),
-        },
-        Err(_) => Err(anyhow!("Unknown AccountFactoryError")),
-        Ok(result) => {
-            let return_value = InvokeResponse::Transaction(InvokeTransactionResponse {
-                transaction_hash: result.transaction_hash.into_(),
-            });
-            if let Err(message) = handle_wait_for_tx(
-                provider,
-                result.transaction_hash,
-                return_value.clone(),
-                wait_config,
-                ui,
-            )
-            .await
-            {
-                return Err(anyhow!(message));
-            }
-
-            Ok((address, return_value))
-        }
-    }
 }
 
 fn update_account_in_accounts_file(

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -12,11 +12,9 @@ use configuration::resolve_config_file;
 use configuration::{load_config, search_config_upwards_relative_to};
 use conversions::string::{TryFromDecStr, TryFromHexStr};
 use sncast::accounts::{AccountName, AccountRecord, AccountRepository, NetworkName};
-use sncast::helpers::braavos::BraavosAccountFactory;
 use sncast::helpers::configuration::{
     CastConfig, NetworkParams, PartialCastConfig, SncastProfileAppend,
 };
-use sncast::helpers::constants::BRAAVOS_BASE_ACCOUNT_CLASS_HASH;
 use sncast::helpers::interactive::prompt_to_add_account_as_default;
 use sncast::helpers::ledger;
 use sncast::helpers::rpc::RpcArgs;
@@ -26,7 +24,6 @@ use sncast::signers::SignerSpec;
 use sncast::{AccountType, chain_id_to_network_name};
 use sncast::{SignerSource, WaitForTx, get_chain_id};
 use starknet_curve::curve_params::EC_ORDER;
-use starknet_rust::accounts::{AccountFactory, ArgentAccountFactory, OpenZeppelinAccountFactory};
 use starknet_rust::providers::jsonrpc::HttpTransport;
 use starknet_rust::providers::{JsonRpcClient, Provider};
 use starknet_rust::signers::{LocalWallet, SigningKey};
@@ -416,54 +413,30 @@ pub async fn compute_account_address(
         SignerSpec::PrivateKey(spec) => {
             let signer =
                 LocalWallet::from_signing_key(SigningKey::from_secret_scalar(spec.private_key()));
-            compute_address_with_signer(salt, class_hash, account_type, chain_id, signer, provider)
-                .await?
+            sncast::accounts::AccountDeploymentService::compute_address(
+                provider,
+                account_type,
+                class_hash,
+                signer,
+                salt,
+                chain_id,
+            )
+            .await?
         }
         SignerSpec::Ledger(spec) => {
             let signer = ledger::create_ledger_signer(spec.derivation_path(), ui, false).await?;
-            compute_address_with_signer(salt, class_hash, account_type, chain_id, signer, provider)
-                .await?
+            sncast::accounts::AccountDeploymentService::compute_address(
+                provider,
+                account_type,
+                class_hash,
+                signer,
+                salt,
+                chain_id,
+            )
+            .await?
         }
         SignerSpec::Keystore(_) => {
             bail!("keystore signer must be resolved before computing an account address")
-        }
-    };
-    Ok(address)
-}
-
-async fn compute_address_with_signer<S>(
-    salt: Felt,
-    class_hash: Felt,
-    account_type: AccountType,
-    chain_id: Felt,
-    signer: S,
-    provider: &JsonRpcClient<HttpTransport>,
-) -> Result<Felt>
-where
-    S: starknet_rust::signers::Signer + Send + Sync,
-    <S as starknet_rust::signers::Signer>::GetPublicKeyError: 'static,
-{
-    let address = match account_type {
-        AccountType::OpenZeppelin => {
-            let factory =
-                OpenZeppelinAccountFactory::new(class_hash, chain_id, signer, provider).await?;
-            factory.deploy_v3(salt).address()
-        }
-        AccountType::Ready => {
-            let factory =
-                ArgentAccountFactory::new(class_hash, chain_id, None, signer, provider).await?;
-            factory.deploy_v3(salt).address()
-        }
-        AccountType::Braavos => {
-            let factory = BraavosAccountFactory::new(
-                class_hash,
-                BRAAVOS_BASE_ACCOUNT_CLASS_HASH,
-                chain_id,
-                signer,
-                provider,
-            )
-            .await?;
-            factory.deploy_v3(salt).address()
         }
     };
     Ok(address)


### PR DESCRIPTION
## Introduced changes
This PR introduces:
1. `AccountSelector` that differentiates the account variants (named, devnet and legacy starkli) and owns each one's data
2. `AccountDeploymentService` that owns the logic related to account deployment (address computation, fee estimation, deployment itself)
3. `AccountService` that builds runtime accounts based on `AccountSelector` and wraps the dispatch logic between a transparent API

Those new structures are used in place of old, messy code.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`