### PR TITLE
feat(sncast) Add `import-starkli` command

### DIFF
--- a/crates/sncast/src/compat/mod.rs
+++ b/crates/sncast/src/compat/mod.rs
@@ -1,0 +1,3 @@
+//! Adapters used to import external account formats.
+
+pub mod starkli;

--- a/crates/sncast/src/compat/starkli.rs
+++ b/crates/sncast/src/compat/starkli.rs
@@ -1,0 +1,122 @@
+use anyhow::{Context, Result, anyhow, bail};
+use camino::Utf8PathBuf;
+use serde::de::DeserializeOwned;
+use serde_json::{Deserializer, Value};
+use starknet_rust::signers::{SigningKey, VerifyingKey};
+use starknet_types_core::felt::Felt;
+
+use crate::accounts::{AccountRecord, AccountType};
+use crate::signers::{PrivateKeySpec, SignerSpec};
+
+pub fn load_account_with_password(
+    account_path: &Utf8PathBuf,
+    keystore_path: &Utf8PathBuf,
+    password: &str,
+) -> Result<AccountRecord> {
+    check_files_exist(keystore_path, account_path)?;
+
+    let private_key = SigningKey::from_keystore(keystore_path, password)?.secret_scalar();
+    let account_info: Value = read_json_file(account_path)?;
+
+    let parse_to_felt = |pointer: &str| -> Option<Felt> {
+        string_value(&account_info, pointer).and_then(|value| value.parse().ok())
+    };
+
+    let address = parse_to_felt("/deployment/address")
+        .context("Failed to get account address from account JSON file")?;
+    let class_hash = parse_to_felt("/deployment/class_hash");
+    let salt = parse_to_felt("/deployment/salt");
+    let deployed =
+        string_value(&account_info, "/deployment/status").map(|status| status == "deployed");
+    let legacy = account_info
+        .pointer("/variant/legacy")
+        .and_then(Value::as_bool);
+    let account_type = string_value(&account_info, "/variant/type")
+        .map(|account_type| match account_type.as_str() {
+            "argent" => "ready".to_owned(),
+            _ => account_type,
+        })
+        .and_then(|account_type| account_type.parse().ok());
+
+    let public_key = match account_type.context("Failed to get type key")? {
+        AccountType::Ready => parse_to_felt("/variant/owner"),
+        AccountType::OpenZeppelin => parse_to_felt("/variant/public_key"),
+        AccountType::Braavos => braavos_public_key(&account_info)?,
+    }
+    .context("Failed to get public key from account JSON file")?;
+
+    Ok(AccountRecord {
+        public_key,
+        address,
+        salt,
+        deployed,
+        class_hash,
+        legacy,
+        account_type,
+        signer: SignerSpec::PrivateKey(PrivateKeySpec::new(private_key)),
+    })
+}
+
+pub fn verify_private_key(account: &AccountRecord) -> Result<VerifyingKey> {
+    let private_key = account
+        .signer
+        .private_key()
+        .context("Private key not found in starkli account")?;
+    let signing_key = SigningKey::from_secret_scalar(private_key);
+    let verifying_key = signing_key.verifying_key();
+    if verifying_key.scalar() != account.public_key {
+        bail!("Public key and private key from keystore do not match");
+    }
+    Ok(verifying_key)
+}
+
+fn braavos_public_key(account_info: &Value) -> Result<Option<Felt>> {
+    string_value(account_info, "/variant/multisig/status")
+        .filter(|status| status == "off")
+        .context("Braavos accounts cannot be deployed with multisig on")?;
+
+    account_info
+        .pointer("/variant/signers")
+        .and_then(Value::as_array)
+        .filter(|signers| signers.len() == 1)
+        .context("Braavos accounts can only be deployed with one seed signer")?;
+
+    Ok(string_value(account_info, "/variant/signers/0/public_key")
+        .and_then(|value| value.parse().ok()))
+}
+
+fn string_value(json: &Value, pointer: &str) -> Option<String> {
+    json.pointer(pointer)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+fn read_json_file<T>(path: &Utf8PathBuf) -> Result<T>
+where
+    T: DeserializeOwned + Default,
+{
+    let contents =
+        std::fs::read_to_string(path).with_context(|| format!("Failed to read a file = {path}"))?;
+    if contents.trim().is_empty() {
+        return Ok(T::default());
+    }
+
+    let deserializer = &mut Deserializer::from_str(&contents);
+    serde_path_to_error::deserialize(deserializer).map_err(|error| {
+        let field = error.path().to_string();
+        anyhow!(
+            "Failed to parse field `{field}` in file '{path}': {}",
+            error.into_inner()
+        )
+    })
+}
+
+fn check_files_exist(keystore_path: &Utf8PathBuf, account_path: &Utf8PathBuf) -> Result<()> {
+    if !keystore_path.exists() {
+        bail!("Keystore file = {keystore_path} does not exist");
+    }
+    if !account_path.exists() {
+        bail!("Account file = {account_path} does not exist");
+    }
+    Ok(())
+}

--- a/crates/sncast/src/lib.rs
+++ b/crates/sncast/src/lib.rs
@@ -42,6 +42,7 @@ use thiserror::Error;
 use url::Url;
 
 pub mod accounts;
+pub mod compat;
 pub mod helpers;
 pub mod response;
 pub mod signers;

--- a/crates/sncast/src/main.rs
+++ b/crates/sncast/src/main.rs
@@ -341,7 +341,8 @@ fn resolve_fee_args(command: &mut Commands, config: &FeeParams) {
             | account::Commands::Create(_)
             | account::Commands::Delete(_)
             | account::Commands::List(_)
-            | account::Commands::Migrate(_) => return,
+            | account::Commands::Migrate(_)
+            | account::Commands::ImportStarkli(_) => return,
         },
         Commands::Get(_)
         | Commands::Call(_)

--- a/crates/sncast/src/starknet_commands/account/import_starkli.rs
+++ b/crates/sncast/src/starknet_commands/account/import_starkli.rs
@@ -1,0 +1,145 @@
+use crate::starknet_commands::account::{
+    generate_add_profile_message, notify_if_migrated, save_account,
+};
+use anyhow::{Context, Result, anyhow};
+use camino::Utf8PathBuf;
+use clap::Args;
+use sncast::accounts::{AccountRecord, AccountRepository};
+use sncast::compat::starkli;
+use sncast::get_chain_id;
+use sncast::helpers::configuration::CastConfig;
+use sncast::helpers::rpc::RpcArgs;
+use sncast::response::account::import::AccountImportResponse;
+use sncast::response::ui::UI;
+use sncast::signers::{KeystoreSpec, SignerSpec, keystore_password};
+use starknet_rust::providers::jsonrpc::{HttpTransport, JsonRpcClient};
+
+/// Convert a starkli account/keystore pair into a native sncast account.
+#[derive(Args, Debug)]
+pub struct ImportStarkli {
+    /// Name of the native account to create
+    #[arg(short, long)]
+    pub name: Option<String>,
+
+    /// Path to the starkli JSON account file
+    #[arg(long)]
+    pub account_file: Utf8PathBuf,
+
+    /// Path to the starkli encrypted keystore
+    #[arg(long)]
+    pub keystore: Utf8PathBuf,
+
+    /// Environment variable containing the keystore password
+    #[arg(long)]
+    pub keystore_password_env: Option<String>,
+
+    /// Add a profile with this name to snfoundry.toml
+    #[arg(long)]
+    pub add_profile: Option<String>,
+
+    #[command(flatten)]
+    pub rpc: RpcArgs,
+
+    /// Do not prompt to make the imported account the default
+    #[arg(long)]
+    pub silent: bool,
+}
+
+pub async fn import_starkli(
+    repository: &AccountRepository,
+    provider: &JsonRpcClient<HttpTransport>,
+    import: &ImportStarkli,
+    config: &CastConfig,
+    ui: &UI,
+) -> Result<AccountImportResponse> {
+    let credential_spec = KeystoreSpec::new(
+        import.keystore.clone(),
+        import.keystore_password_env.clone(),
+    );
+    let password = keystore_password(&credential_spec)?;
+    let account = native_account_from_starkli(
+        &import.account_file,
+        &import.keystore,
+        &password,
+        import.keystore_password_env.clone(),
+    )?;
+
+    let account_name = match &import.name {
+        Some(name) => name.clone(),
+        None => repository.generate_account_name()?,
+    };
+    let chain_id = get_chain_id(provider).await?;
+    let migrated = save_account(&account_name, repository, chain_id, account)?;
+    notify_if_migrated(migrated, ui);
+
+    let add_profile = generate_add_profile_message(
+        import.add_profile.as_ref(),
+        &import.rpc,
+        &account_name,
+        repository.path(),
+        config,
+    )?;
+
+    Ok(AccountImportResponse {
+        add_profile,
+        account_name,
+    })
+}
+
+fn canonical_utf8_path(path: &Utf8PathBuf) -> Result<Utf8PathBuf> {
+    let canonical = std::fs::canonicalize(path)
+        .with_context(|| format!("Failed to canonicalize keystore `{path}`"))?;
+    Utf8PathBuf::from_path_buf(canonical)
+        .map_err(|path| anyhow!("Keystore path is not valid UTF-8: {}", path.display()))
+}
+
+fn native_account_from_starkli(
+    account_file: &Utf8PathBuf,
+    keystore: &Utf8PathBuf,
+    password: &str,
+    password_env: Option<String>,
+) -> Result<AccountRecord> {
+    let mut account = starkli::load_account_with_password(account_file, keystore, password)?;
+    starkli::verify_private_key(&account)?;
+    let persisted_keystore =
+        canonical_utf8_path(keystore).context("Failed to resolve the imported keystore path")?;
+    account.signer = SignerSpec::Keystore(KeystoreSpec::new(persisted_keystore, password_env));
+    Ok(account)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_relative_keystore_path_for_native_storage() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("key.json");
+        std::fs::write(&path, "{}").unwrap();
+        let path = Utf8PathBuf::from_path_buf(path).unwrap();
+
+        let canonical = canonical_utf8_path(&path).unwrap();
+
+        assert!(canonical.is_absolute());
+        assert!(canonical.ends_with("key.json"));
+    }
+
+    #[test]
+    fn converts_starkli_pair_to_native_keystore_signer() {
+        let fixtures = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data/keystore");
+
+        let account = native_account_from_starkli(
+            &fixtures.join("my_account.json"),
+            &fixtures.join("my_key.json"),
+            "123",
+            Some("ALICE_KEYSTORE_PASSWORD".to_owned()),
+        )
+        .unwrap();
+
+        let SignerSpec::Keystore(spec) = account.signer else {
+            panic!("expected a native keystore signer");
+        };
+        assert!(spec.path().is_absolute());
+        assert_eq!(spec.password_env(), Some("ALICE_KEYSTORE_PASSWORD"));
+    }
+}

--- a/crates/sncast/src/starknet_commands/account/list.rs
+++ b/crates/sncast/src/starknet_commands/account/list.rs
@@ -27,7 +27,7 @@ pub struct List {
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub struct AccountDataRepresentationMessage {
+pub struct AccountRecordRepresentation {
     pub public_key: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signer: Option<v2::Signer>,
@@ -48,7 +48,7 @@ pub struct AccountDataRepresentationMessage {
     pub account_type: Option<AccountType>,
 }
 
-impl AccountDataRepresentationMessage {
+impl AccountRecordRepresentation {
     fn new(account: &AccountRecord, display_private_key: bool) -> Self {
         Self {
             signer: match &account.signer {
@@ -83,13 +83,13 @@ impl AccountDataRepresentationMessage {
 fn read_and_flatten(
     repository: &AccountRepository,
     display_private_keys: bool,
-) -> anyhow::Result<BTreeMap<String, AccountDataRepresentationMessage>> {
+) -> anyhow::Result<BTreeMap<String, AccountRecordRepresentation>> {
     let registry = repository.load()?.registry;
     let mut result = BTreeMap::new();
 
     for (network, accounts) in registry.networks() {
         for (name, data) in accounts.iter().sorted_by_key(|(name, _)| *name) {
-            let mut data_repr = AccountDataRepresentationMessage::new(data, display_private_keys);
+            let mut data_repr = AccountRecordRepresentation::new(data, display_private_keys);
 
             data_repr.set_network(network.as_str());
             result.insert(name.to_string(), data_repr);
@@ -99,7 +99,7 @@ fn read_and_flatten(
     Ok(result)
 }
 
-impl Message for AccountDataRepresentationMessage {
+impl Message for AccountRecordRepresentation {
     fn text(&self) -> String {
         let mut result = String::new();
 
@@ -154,7 +154,7 @@ impl Message for AccountDataRepresentationMessage {
 pub struct AccountsListMessage {
     accounts_file_path: String,
     display_private_keys: bool,
-    accounts: BTreeMap<String, AccountDataRepresentationMessage>,
+    accounts: BTreeMap<String, AccountRecordRepresentation>,
 }
 
 impl AccountsListMessage {

--- a/crates/sncast/src/starknet_commands/account/mod.rs
+++ b/crates/sncast/src/starknet_commands/account/mod.rs
@@ -2,6 +2,7 @@ use crate::starknet_commands::account::create::Create;
 use crate::starknet_commands::account::delete::Delete;
 use crate::starknet_commands::account::deploy::Deploy;
 use crate::starknet_commands::account::import::Import;
+use crate::starknet_commands::account::import_starkli::ImportStarkli;
 use crate::starknet_commands::account::list::{AccountsListMessage, List};
 use crate::starknet_commands::account::migrate::Migrate;
 use crate::{process_command_result, starknet_commands};
@@ -40,6 +41,7 @@ pub mod create;
 pub mod delete;
 pub mod deploy;
 pub mod import;
+pub mod import_starkli;
 pub mod list;
 pub mod migrate;
 
@@ -53,6 +55,7 @@ pub struct Account {
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     Import(Import),
+    ImportStarkli(ImportStarkli),
     Create(Create),
     Deploy(Deploy),
     Delete(Delete),
@@ -292,6 +295,36 @@ pub async fn account(
             }
 
             Ok(process_command_result("account import", result, ui, None))
+        }
+        Commands::ImportStarkli(import) => {
+            let provider = import.rpc.get_provider(&config, ui).await?;
+            let result = starknet_commands::account::import_starkli::import_starkli(
+                &repository,
+                &provider,
+                &import,
+                &config,
+                ui,
+            )
+            .await;
+
+            let run_interactive_prompt =
+                !import.silent && result.is_ok() && io::stdout().is_terminal();
+            if run_interactive_prompt
+                && let Some(account_name) = result.as_ref().ok().map(|r| r.account_name.clone())
+                && let Err(err) = prompt_to_add_account_as_default(account_name.as_str(), ui)
+            {
+                ui.print_error(
+                    "account import-starkli",
+                    format!("Error: Failed to launch interactive prompt: {err}"),
+                );
+            }
+
+            Ok(process_command_result(
+                "account import-starkli",
+                result,
+                ui,
+                None,
+            ))
         }
         Commands::Create(create) => {
             let ledger_path = create.ledger_key_locator.resolve(ui);

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -144,6 +144,7 @@
     * [common flags](appendix/sncast/common.md)
     * [account](appendix/sncast/account/account.md)
         * [import](appendix/sncast/account/import.md)
+        * [import-starkli](appendix/sncast/account/import-starkli.md)
         * [create](appendix/sncast/account/create.md)
         * [deploy](appendix/sncast/account/deploy.md)
         * [delete](appendix/sncast/account/delete.md)

--- a/docs/src/appendix/sncast.md
+++ b/docs/src/appendix/sncast.md
@@ -3,6 +3,7 @@
 * [common flags](./sncast/common.md)
 * [account](./sncast/account/account.md)
     * [import](./sncast/account/import.md)
+    * [import-starkli](./sncast/account/import-starkli.md)
     * [create](./sncast/account/create.md)
     * [deploy](./sncast/account/deploy.md)
     * [delete](./sncast/account/delete.md)

--- a/docs/src/appendix/sncast/account/account.md
+++ b/docs/src/appendix/sncast/account/account.md
@@ -3,6 +3,7 @@ Provides a set of account management commands.
 
 It has the following subcommands:
 * [`import`](./import.md)
+* [`import-starkli`](./import-starkli.md)
 * [`create`](./create.md)
 * [`deploy`](./deploy.md)
 * [`delete`](./delete.md)

--- a/docs/src/appendix/sncast/account/import-starkli.md
+++ b/docs/src/appendix/sncast/account/import-starkli.md
@@ -1,0 +1,26 @@
+# `import-starkli`
+
+Convert a starkli account JSON file and encrypted keystore into a native sncast account.
+
+The account metadata is stored in the V2 accounts file and the existing encrypted keystore becomes its tagged signer. Subsequent commands select the account by name and do not need the global `--keystore` flag.
+
+## `--account-file <PATH>`
+Required. Path to the starkli JSON account file.
+
+## `--keystore <PATH>`
+Required. Path to the existing starkli encrypted keystore.
+
+## `--name, -n <NAME>`
+Optional. Name of the native account. A name is generated when omitted.
+
+## `--keystore-password-env <ENVIRONMENT_VARIABLE>`
+Optional. Environment variable containing the password and recorded as the account's future password source.
+
+## `--url, -u <RPC_URL>` / `--network <NETWORK>`
+Select the network under which the account is stored.
+
+## `--add-profile <NAME>`
+Optional. Add a native account profile to `snfoundry.toml`.
+
+## `--silent`
+Optional. Do not prompt to make the imported account the default.

--- a/docs/src/starknet/account.md
+++ b/docs/src/starknet/account.md
@@ -302,3 +302,20 @@ $ sncast \
 An existing encrypted key can be attached during `account import` with the same two keystore options. All later commands select `alice` like any private-key or Ledger account; no global `--keystore` flag is needed.
 
 Passwords are looked up from the signer's `password_env` first and then `SNCAST_KEYSTORE_PASSWORD`; an interactive terminal prompts only if neither is set. Password values are never written to the accounts file.
+
+#### Importing a Starkli Account
+
+Convert an existing [starkli](https://book.starkli.rs/accounts#accounts) account/keystore pair into a native account:
+
+<!-- { "ignored": true } -->
+```shell
+$ sncast \
+    account import-starkli \
+    --network sepolia \
+    --name alice \
+    --account-file account.json \
+    --keystore keystore.json \
+    --keystore-password-env ALICE_KEYSTORE_PASSWORD
+```
+
+The conversion preserves the starkli account metadata and references the existing encrypted keystore from a V2 signer. The native account is then used with `--account alice`.


### PR DESCRIPTION
## Introduced changes
`import-starkli` allows to migrate from legacy starkli account to native sncast account, preserving the keystore.

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`