### PR TITLE
Fix warnings of Clippy v1.98.0

### DIFF
--- a/crates/conversions/src/byte_array.rs
+++ b/crates/conversions/src/byte_array.rs
@@ -15,11 +15,14 @@ pub struct ByteArray {
 
 impl From<&str> for ByteArray {
     fn from(value: &str) -> Self {
-        let chunks = value.as_bytes().chunks_exact(BYTES_IN_WORD);
-        let remainder = chunks.remainder();
+        let (chunks, remainder) = value.as_bytes().as_chunks::<BYTES_IN_WORD>();
         let pending_word_len = remainder.len();
 
-        let words = chunks.map(Felt::from_bytes_be_slice).collect();
+        let words = chunks
+            .iter()
+            .map(|chunk| Felt::from_bytes_be_slice(&chunk[..]))
+            .collect();
+
         let pending_word = Felt::from_bytes_be_slice(remainder);
 
         Self {

--- a/crates/forge/src/compatibility_check.rs
+++ b/crates/forge/src/compatibility_check.rs
@@ -157,6 +157,7 @@ pub fn create_version_parser<'a>(name: &'a str, pattern: &'a str) -> Box<Version
 mod tests {
     use super::*;
     use crate::MINIMAL_SCARB_VERSION;
+    #[cfg(feature = "no_scarb_installed")]
     use assert_fs::{
         TempDir,
         fixture::{FileWriteStr, PathChild},

--- a/crates/forge/src/main.rs
+++ b/crates/forge/src/main.rs
@@ -46,7 +46,7 @@ fn init_logging() -> Option<impl Drop> {
                 .from_env_lossy(),
         );
 
-    let tracing_profile = env::var("SNFORGE_TRACING_PROFILE").ok().is_some_and(|var| {
+    let tracing_profile = env::var("SNFORGE_TRACING_PROFILE").is_ok_and(|var| {
         let s = var.as_str();
         s == "true" || s == "1"
     });

--- a/crates/sncast/src/starknet_commands/call.rs
+++ b/crates/sncast/src/starknet_commands/call.rs
@@ -34,6 +34,7 @@ pub struct Call {
     pub rpc: RpcArgs,
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn call(
     contract_address: Felt,
     entry_point_selector: Felt,

--- a/crates/sncast/src/starknet_commands/declare.rs
+++ b/crates/sncast/src/starknet_commands/declare.rs
@@ -66,6 +66,7 @@ pub struct Declare {
 
 // TODO(#3785)
 #[expect(clippy::too_many_arguments)]
+#[expect(clippy::result_large_err)]
 pub async fn declare<S>(
     contract_name: String,
     fee_args: FeeArgs,
@@ -123,6 +124,7 @@ pub fn compile_sierra_to_casm(
 
 #[expect(clippy::too_many_lines)]
 #[expect(clippy::too_many_arguments)]
+#[expect(clippy::result_large_err)]
 pub async fn declare_with_artifacts<S>(
     mut sierra_class: SierraClass,
     compiled_casm: CompiledClass,

--- a/crates/sncast/src/starknet_commands/declare_from.rs
+++ b/crates/sncast/src/starknet_commands/declare_from.rs
@@ -106,6 +106,7 @@ pub enum ContractSource {
     },
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn declare_from<S>(
     contract_source: ContractSource,
     no_abi: bool,

--- a/crates/sncast/src/starknet_commands/deploy.rs
+++ b/crates/sncast/src/starknet_commands/deploy.rs
@@ -90,6 +90,7 @@ pub struct DeployArguments {
 }
 
 #[expect(clippy::ptr_arg, clippy::too_many_arguments)]
+#[expect(clippy::result_large_err)]
 pub async fn deploy<S>(
     class_hash: Felt,
     calldata: &Vec<Felt>,

--- a/crates/sncast/src/starknet_commands/get/balance.rs
+++ b/crates/sncast/src/starknet_commands/get/balance.rs
@@ -114,6 +114,7 @@ async fn get_account_address(
         .context("Failed to get account address")
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn get_balance(
     account_address: Felt,
     provider: &JsonRpcClient<HttpTransport>,

--- a/crates/sncast/src/starknet_commands/get/block.rs
+++ b/crates/sncast/src/starknet_commands/get/block.rs
@@ -42,6 +42,7 @@ pub async fn block(block: Block, config: CastConfig, ui: &UI) -> Result<ExitCode
     Ok(process_command_result("get block", result, ui, None))
 }
 
+#[expect(clippy::result_large_err)]
 async fn get_block(
     provider: &JsonRpcClient<HttpTransport>,
     block_id: &str,

--- a/crates/sncast/src/starknet_commands/get/class_hash_at.rs
+++ b/crates/sncast/src/starknet_commands/get/class_hash_at.rs
@@ -56,6 +56,7 @@ pub async fn class_hash_at(
     ))
 }
 
+#[expect(clippy::result_large_err)]
 async fn get_class_hash_at(
     provider: &JsonRpcClient<HttpTransport>,
     contract_address: Felt,

--- a/crates/sncast/src/starknet_commands/get/nonce.rs
+++ b/crates/sncast/src/starknet_commands/get/nonce.rs
@@ -43,6 +43,7 @@ pub async fn nonce(nonce: Nonce, config: CastConfig, ui: &UI) -> Result<ExitCode
     Ok(process_command_result("get nonce", result, ui, None))
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn get_nonce(
     provider: &JsonRpcClient<HttpTransport>,
     contract_address: Felt,

--- a/crates/sncast/src/starknet_commands/get/state_update.rs
+++ b/crates/sncast/src/starknet_commands/get/state_update.rs
@@ -38,6 +38,7 @@ pub async fn state_update(
     Ok(process_command_result("get state-update", result, ui, None))
 }
 
+#[expect(clippy::result_large_err)]
 async fn get_state_update(
     provider: &JsonRpcClient<HttpTransport>,
     block_id: &str,

--- a/crates/sncast/src/starknet_commands/get/transaction.rs
+++ b/crates/sncast/src/starknet_commands/get/transaction.rs
@@ -46,6 +46,7 @@ pub async fn transaction(tx: Transaction, config: CastConfig, ui: &UI) -> Result
     ))
 }
 
+#[expect(clippy::result_large_err)]
 async fn get_transaction(
     provider: &JsonRpcClient<HttpTransport>,
     transaction_hash: Felt,

--- a/crates/sncast/src/starknet_commands/get/tx_receipt.rs
+++ b/crates/sncast/src/starknet_commands/get/tx_receipt.rs
@@ -32,6 +32,7 @@ pub async fn tx_receipt(tx: TxReceipt, config: CastConfig, ui: &UI) -> Result<Ex
     Ok(process_command_result("get tx-receipt", result, ui, None))
 }
 
+#[expect(clippy::result_large_err)]
 async fn get_tx_receipt(
     provider: &JsonRpcClient<HttpTransport>,
     transaction_hash: Felt,

--- a/crates/sncast/src/starknet_commands/get/tx_status.rs
+++ b/crates/sncast/src/starknet_commands/get/tx_status.rs
@@ -38,6 +38,7 @@ pub async fn tx_status(
     Ok(process_command_result("get tx-status", result, ui, None))
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn get_tx_status(
     provider: &JsonRpcClient<HttpTransport>,
     transaction_hash: Felt,

--- a/crates/sncast/src/starknet_commands/invoke.rs
+++ b/crates/sncast/src/starknet_commands/invoke.rs
@@ -58,6 +58,7 @@ pub struct Invoke {
 }
 
 #[expect(clippy::too_many_arguments)]
+#[expect(clippy::result_large_err)]
 pub async fn invoke<S>(
     contract_address: Felt,
     calldata: Vec<Felt>,
@@ -107,6 +108,7 @@ where
     })
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn execute_calls<S>(
     account: &SingleOwnerAccount<&JsonRpcClient<HttpTransport>, S>,
     calls: Vec<Call>,

--- a/crates/sncast/src/starknet_commands/utils/contract_address.rs
+++ b/crates/sncast/src/starknet_commands/utils/contract_address.rs
@@ -35,6 +35,7 @@ pub struct ContractAddressArgs {
     pub rpc: Option<RpcArgs>,
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn get_contract_address(
     args: ContractAddressArgs,
     artifacts: Option<ContractArtifactsMap>,

--- a/crates/sncast/src/starknet_commands/utils/serialize.rs
+++ b/crates/sncast/src/starknet_commands/utils/serialize.rs
@@ -69,6 +69,7 @@ pub struct Serialize {
     pub rpc_args: Option<RpcArgs>,
 }
 
+#[expect(clippy::result_large_err)]
 pub async fn serialize(
     Serialize {
         function,


### PR DESCRIPTION
Our CI fails since `dtolnay/rust-toolchain@stable` bumped the version of the toolchain to v1.98.0.
