### PR TITLE
Replace `cargo lint` alias with proper configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[alias]
-lint = "clippy --all-targets --all-features -- --no-deps -W clippy::pedantic -W clippy::undocumented_unsafe_blocks  -A clippy::module_name_repetitions -A clippy::missing_errors_doc -A clippy::missing_panics_doc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,10 +456,10 @@ jobs:
         working-directory: crates/snforge-scarb-plugin
 
       - name: Lint
-        run: cargo lint
+        run: cargo clippy --all-targets --all-features --no-deps
 
       - name: Lint snforge-scarb-plugin
-        run: cargo lint
+        run: cargo clippy --all-targets --all-features --no-deps
         working-directory: crates/snforge-scarb-plugin
 
       - name: Check cairo files format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,13 @@ repository = "https://github.com/foundry-rs/starknet-foundry"
 license = "MIT"
 license-file = "LICENSE"
 
+[workspace.lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+undocumented_unsafe_blocks = "warn"
+module_name_repetitions = "allow"
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+
 [workspace.dependencies]
 blockifier = { version = "0.19.0-rc.2", features = ["testing", "tracing", "node_api"] }
 starknet_api = "0.19.0-rc.2"

--- a/crates/cheatnet/Cargo.toml
+++ b/crates/cheatnet/Cargo.toml
@@ -12,6 +12,9 @@ cairo-native = [
     "scarb-api/cairo-native",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 blockifier.workspace = true

--- a/crates/configuration/Cargo.toml
+++ b/crates/configuration/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [features]
 testing = []
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 serde_json.workspace = true

--- a/crates/conversions/Cargo.toml
+++ b/crates/conversions/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [features]
 testing = []
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 blockifier.workspace = true

--- a/crates/data-transformer/Cargo.toml
+++ b/crates/data-transformer/Cargo.toml
@@ -3,6 +3,9 @@ name = "data-transformer"
 version = "1.0.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 serde_json.workspace = true

--- a/crates/debugging/Cargo.toml
+++ b/crates/debugging/Cargo.toml
@@ -3,6 +3,9 @@ name = "debugging"
 version = "1.0.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 blockifier.workspace = true
 cairo-annotations.workspace = true

--- a/crates/docs/Cargo.toml
+++ b/crates/docs/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 repository.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 regex.workspace = true
 shell-words.workspace = true

--- a/crates/forge-runner/Cargo.toml
+++ b/crates/forge-runner/Cargo.toml
@@ -3,7 +3,8 @@ name = "forge_runner"
 version.workspace = true
 edition.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -3,8 +3,6 @@ name = "forge"
 version.workspace = true
 edition.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 # This should match `MINIMAL_SCARB_VERSION`
 scarb_2_13_1 = []
@@ -13,6 +11,9 @@ no_scarb_installed = []
 non_exact_gas_assertions = []
 scheduled_latest_scarb_only = []
 cairo-native = ["cheatnet/cairo-native", "scarb-api/cairo-native"]
+
+[lints]
+workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/foundry-ui/Cargo.toml
+++ b/crates/foundry-ui/Cargo.toml
@@ -3,6 +3,9 @@ name = "foundry-ui"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/native-api/Cargo.toml
+++ b/crates/native-api/Cargo.toml
@@ -3,6 +3,9 @@ name = "native-api"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 starknet_api.workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [features]
 testing = []
 
+[lints]
+workspace = true
+
 [dependencies]
 indoc.workspace = true
 anyhow.workspace = true

--- a/crates/scarb-api/Cargo.toml
+++ b/crates/scarb-api/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 [features]
 cairo-native = ["dep:cairo-native", "dep:native-api"]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 shared.workspace = true

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -3,6 +3,9 @@ name = "shared"
 version = "0.1.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 starknet_api.workspace = true
 anyhow.workspace = true

--- a/crates/sncast/Cargo.toml
+++ b/crates/sncast/Cargo.toml
@@ -4,6 +4,9 @@ description = "sncast - a Starknet Foundry CLI client"
 version.workspace = true
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true

--- a/crates/snforge-scarb-plugin/Cargo.toml
+++ b/crates/snforge-scarb-plugin/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["rlib", "cdylib"]
 inherits = "release"
 debug-assertions = true
 
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+missing_errors_doc = "allow"
+
 [dependencies]
 cairo-lang-macro = "0.2.1"
 cairo-lang-parser = "=2.12.3"

--- a/crates/testing/packages_validation/Cargo.toml
+++ b/crates/testing/packages_validation/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 
 [lib]
 
+[lints]
+workspace = true
+
 [dependencies]
 camino.workspace = true
 scarb-api = { path = "../../scarb-api" }

--- a/crates/universal-sierra-compiler-api/Cargo.toml
+++ b/crates/universal-sierra-compiler-api/Cargo.toml
@@ -3,6 +3,9 @@ name = "universal-sierra-compiler-api"
 version = "1.0.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 shared.workspace = true
 serde.workspace = true

--- a/docs/src/development/environment-setup.md
+++ b/docs/src/development/environment-setup.md
@@ -178,13 +178,7 @@ $ cargo fmt
 For linting, it uses [clippy](https://github.com/rust-lang/rust-clippy). You can run it with this command:
 
 ```shell
-$ cargo clippy --all-targets --all-features -- --no-deps -W clippy::pedantic -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::default_trait_access
-```
-
-Or using our defined alias
-
-```shell
-$ cargo lint
+$ cargo clippy --all-targets --all-features --no-deps
 ```
 
 ## Spelling


### PR DESCRIPTION
`cargo lint` alias was non-idiomatic and confusing for developers and agents. The new configuration allows using `cargo clippy` while retaining the same behaviour.
Additionally, lints from `pedantic` group now result in **errors** instead of **warnings**.
