### PR TITLE
Display decoded event and contract's full path in `assert_emitted`/`assert_not_emitted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - Raw Sierra tests now use compiler-inferred function costs as their initial gas budget, allowing correct gas refunds beyond the contract entry-point precharge.
+- `assert_emitted` and `assert_not_emitted` now display decoded expected events and their emitting contract in failure messages.
 
 ### Cast
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/event_formatter.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/event_formatter.rs
@@ -1,0 +1,64 @@
+use std::str::FromStr;
+
+use crate::runtime_extensions::forge_runtime_extension::contracts_data::ContractsData;
+use conversions::FromConv;
+use data_transformer::reverse_transform_event;
+use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_rust::core::types::contract::AbiEntry;
+use starknet_types_core::felt::Felt;
+
+pub struct FormattedEvent {
+    pub event: String,
+    pub contract_address: String,
+    pub contract_full_module_path: Option<String>,
+}
+
+impl FormattedEvent {
+    pub fn new(
+        contracts_data: &ContractsData,
+        contract_address: ContractAddress,
+        class_hash: Option<ClassHash>,
+        keys: &[Felt],
+        data: &[Felt],
+    ) -> Self {
+        let contract_address = format!("{:#x}", Felt::from_(contract_address));
+
+        let contract_full_module_path = class_hash
+            .and_then(|class_hash| contracts_data.get_contract_module_path(&class_hash))
+            .map(String::from);
+
+        let event = class_hash
+            .and_then(|class_hash| {
+                let contract = contracts_data.get_contract_by_class_hash(&class_hash)?;
+                let sierra = serde_json::Value::from_str(&contract.artifacts.sierra).ok()?;
+                let abi = sierra.get("abi").cloned()?;
+                let abi = serde_json::from_value::<Vec<AbiEntry>>(abi).ok()?;
+                reverse_transform_event(keys, data, &abi).ok()
+            })
+            .unwrap_or_else(|| format_raw_event(keys, data));
+
+        Self {
+            event,
+            contract_address,
+            contract_full_module_path,
+        }
+    }
+}
+
+fn format_raw_event(keys: &[Felt], data: &[Felt]) -> String {
+    format!(
+        "{{ keys: {}, data: {} }}",
+        format_felt_slice(keys),
+        format_felt_slice(data)
+    )
+}
+
+fn format_felt_slice(felts: &[Felt]) -> String {
+    let felts = felts
+        .iter()
+        .map(|felt| format!("{felt:#x}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!("[{felts}]")
+}

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/mod.rs
@@ -9,6 +9,7 @@ pub mod cheat_caller_address;
 pub mod cheat_execution_info;
 pub mod cheat_sequencer_address;
 pub mod declare;
+pub mod event_formatter;
 pub mod generate_random_felt;
 pub mod get_class_hash;
 pub mod l1_handler_execute;

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/contracts_data.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/contracts_data.rs
@@ -138,6 +138,14 @@ impl ContractsData {
         self.contracts.get(module_path)
     }
 
+    /// Returns the full module path for a contract class.
+    #[must_use]
+    pub fn get_contract_module_path(&self, class_hash: &ClassHash) -> Option<&str> {
+        self.class_hashes
+            .get_by_right(class_hash)
+            .map(String::as_str)
+    }
+
     #[must_use]
     pub fn get_contract_name(&self, class_hash: &ClassHash) -> Option<ContractName> {
         let module_path = self.class_hashes.get_by_right(class_hash)?;

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -1,5 +1,6 @@
 use self::contracts_data::ContractsData;
 use crate::runtime_extensions::common::sum_syscall_usage;
+use crate::runtime_extensions::forge_runtime_extension::cheatcodes::event_formatter::FormattedEvent;
 use crate::runtime_extensions::forge_runtime_extension::cheatcodes::replace_bytecode::ReplaceBytecodeError;
 use crate::runtime_extensions::outer_call_runtime_extension::rpc::UsedResources;
 use crate::runtime_extensions::{
@@ -327,6 +328,46 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .get_events(events_offset);
 
                 Ok(CheatcodeHandlingResult::from_serializable(events))
+            }
+            "format_event" => {
+                let contract_address = input_reader.read()?;
+                let keys: Vec<Felt> = input_reader.read()?;
+                let data: Vec<Felt> = input_reader.read()?;
+
+                let state = &extended_runtime
+                    .extended_runtime
+                    .extended_runtime
+                    .hint_handler
+                    .base
+                    .state;
+
+                let replacement_class_hash = extended_runtime
+                    .extended_runtime
+                    .extension
+                    .cheatnet_state
+                    .replaced_bytecode_contracts
+                    .get(&contract_address)
+                    .copied();
+
+                let class_hash = replacement_class_hash
+                    .or_else(|| state.get_class_hash_at(contract_address).ok());
+
+                let formatted_event = FormattedEvent::new(
+                    self.contracts_data,
+                    contract_address,
+                    class_hash,
+                    &keys,
+                    &data,
+                );
+
+                Ok(CheatcodeHandlingResult::from_serializable((
+                    ByteArray::from(formatted_event.event.as_str()),
+                    ByteArray::from(formatted_event.contract_address.as_str()),
+                    formatted_event
+                        .contract_full_module_path
+                        .as_deref()
+                        .map(ByteArray::from),
+                )))
             }
             "spy_messages_to_l1" => {
                 let messages_offset = extended_runtime

--- a/crates/forge/tests/data/contracts/two_implementations.cairo
+++ b/crates/forge/tests/data/contracts/two_implementations.cairo
@@ -1,6 +1,7 @@
 #[starknet::interface]
 trait IReplaceBytecode<TContractState> {
     fn get(self: @TContractState) -> felt252;
+    fn emit_event(ref self: TContractState);
     fn libcall(self: @TContractState, class_hash: starknet::ClassHash) -> felt252;
 }
 
@@ -28,10 +29,24 @@ mod ReplaceBytecodeA {
     #[storage]
     struct Storage {}
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        value: felt252,
+    }
+
     #[abi(embed_v0)]
     impl IReplaceBytecodeA of super::IReplaceBytecode<ContractState> {
         fn get(self: @ContractState) -> felt252 {
             2137
+        }
+        fn emit_event(ref self: ContractState) {
+            self.emit(Event::ValueChanged(ValueChanged { value: 2137 }));
         }
         fn libcall(self: @ContractState, class_hash: starknet::ClassHash) -> felt252 {
             let dispatcher = ILibLibraryDispatcher { class_hash };
@@ -46,10 +61,24 @@ mod ReplaceBytecodeB {
     #[storage]
     struct Storage {}
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        ValueChanged: ValueChanged,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ValueChanged {
+        value: felt252,
+    }
+
     #[abi(embed_v0)]
     impl IReplaceBytecodeB of super::IReplaceBytecode<ContractState> {
         fn get(self: @ContractState) -> felt252 {
             420
+        }
+        fn emit_event(ref self: ContractState) {
+            self.emit(Event::ValueChanged(ValueChanged { value: 420 }));
         }
         fn libcall(self: @ContractState, class_hash: starknet::ClassHash) -> felt252 {
             let dispatcher = ILibLibraryDispatcher { class_hash };

--- a/crates/forge/tests/integration/spy_events.rs
+++ b/crates/forge/tests/integration/spy_events.rs
@@ -78,6 +78,145 @@ fn spy_events_simple() {
 }
 
 #[test]
+fn spy_events_emitted_by_library_call() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use array::ArrayTrait;
+            use result::ResultTrait;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait, spy_events, test_address, Event,
+                EventSpy, EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait ISpyEventsChecker<TContractState> {
+                fn emit_one_event(ref self: TContractState, some_data: felt252);
+            }
+
+            #[starknet::contract]
+            mod SpyEventsChecker {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    FirstEvent: FirstEvent
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct FirstEvent {
+                    some_data: felt252
+                }
+            }
+
+            #[test]
+            fn spy_events_emitted_by_library_call() {
+                let contract = declare("SpyEventsChecker").unwrap().contract_class();
+                let dispatcher = ISpyEventsCheckerLibraryDispatcher {
+                    class_hash: contract.class_hash.clone()
+                };
+
+                let mut spy = spy_events();
+                dispatcher.emit_one_event(123);
+
+                spy.assert_emitted(@array![
+                    (
+                        test_address(),
+                        SpyEventsChecker::Event::FirstEvent(
+                            SpyEventsChecker::FirstEvent { some_data: 123 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::SpyEventsChecker".to_string(),
+            Path::new("tests/data/contracts/spy_events_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_passed(&result);
+}
+
+#[test]
+fn spy_events_emitted_by_library_call_fails() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use array::ArrayTrait;
+            use result::ResultTrait;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait, spy_events, test_address, Event,
+                EventSpy, EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait ISpyEventsChecker<TContractState> {
+                fn emit_one_event(ref self: TContractState, some_data: felt252);
+            }
+
+            #[starknet::contract]
+            mod SpyEventsChecker {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    FirstEvent: FirstEvent
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct FirstEvent {
+                    some_data: felt252
+                }
+            }
+
+            #[test]
+            fn spy_events_emitted_by_library_call_fails() {
+                let contract = declare("SpyEventsChecker").unwrap().contract_class();
+                let dispatcher = ISpyEventsCheckerLibraryDispatcher {
+                    class_hash: contract.class_hash.clone()
+                };
+
+                let mut spy = spy_events();
+                dispatcher.emit_one_event(123);
+
+                spy.assert_emitted(@array![
+                    (
+                        test_address(),
+                        SpyEventsChecker::Event::FirstEvent(
+                            SpyEventsChecker::FirstEvent { some_data: 456 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::SpyEventsChecker".to_string(),
+            Path::new("tests/data/contracts/spy_events_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_failed(&result);
+    assert_case_output_contains(
+        &result,
+        "spy_events_emitted_by_library_call_fails",
+        "Event { keys: [0xa7f959d3eee3641c46990c878d8b5c3072bd06e41c69736b51b45017c5dad6], data: [0x1c8] } was not emitted from contract at",
+    );
+}
+
+#[test]
 fn assert_emitted_fails() {
     let test = test_case!(
         indoc!(
@@ -147,9 +286,8 @@ fn assert_emitted_fails() {
     assert_case_output_contains(
         &result,
         "assert_emitted_fails",
-        "Event with matching data and",
+        "Event FirstEvent { some_data: 0x7b } was not emitted from contract::SpyEventsChecker at",
     );
-    assert_case_output_contains(&result, "assert_emitted_fails", "keys was not emitted");
 }
 
 #[test]
@@ -256,12 +394,12 @@ fn expect_three_events_while_two_emitted() {
     assert_case_output_contains(
         &result,
         "expect_three_events_while_two_emitted",
-        "Event with matching data and",
+        "contract::SpyEventsChecker",
     );
     assert_case_output_contains(
         &result,
         "expect_three_events_while_two_emitted",
-        "keys was not emitted",
+        "Event ThirdEvent {",
     );
 }
 
@@ -429,12 +567,7 @@ fn event_emitted_wrong_data_asserted() {
     assert_case_output_contains(
         &result,
         "event_emitted_wrong_data_asserted",
-        "Event with matching data and",
-    );
-    assert_case_output_contains(
-        &result,
-        "event_emitted_wrong_data_asserted",
-        "keys was not emitted from",
+        "Event FirstEvent { some_data: 0x7c } was not emitted from contract::SpyEventsChecker at",
     );
 }
 
@@ -486,6 +619,56 @@ fn emit_unnamed_event() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
+}
+
+#[test]
+fn emit_unnamed_event_fails() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use array::ArrayTrait;
+            use result::ResultTrait;
+            use starknet::ContractAddress;
+            use snforge_std::{
+                declare, ContractClassTrait, DeclareResultTrait, spy_events, Event,
+                EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait ISpyEventsChecker<TContractState> {
+                fn emit_event_syscall(ref self: TContractState, some_key: felt252, some_data: felt252);
+            }
+
+            #[test]
+            fn emit_unnamed_event_fails() {
+                let contract = declare("SpyEventsChecker").unwrap().contract_class();
+                let (contract_address, _) = contract.deploy(@array![]).unwrap();
+                let dispatcher = ISpyEventsCheckerDispatcher { contract_address };
+
+                let mut spy = spy_events();
+                dispatcher.emit_event_syscall(123, 456);
+
+                spy.assert_emitted(@array![
+                    (contract_address, Event { keys: array![123], data: array![457] })
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::SpyEventsChecker".to_string(),
+            Path::new("tests/data/contracts/spy_events_checker.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_failed(&result);
+    assert_case_output_contains(
+        &result,
+        "emit_unnamed_event_fails",
+        "Event { keys: [0x7b], data: [0x1c9] } was not emitted from contract::SpyEventsChecker at",
+    );
 }
 
 #[test]
@@ -627,9 +810,8 @@ fn assert_not_emitted_fails() {
     assert_case_output_contains(
         &result,
         "assert_not_emitted_fails",
-        "Event with matching data and",
+        "Event FirstEvent { some_data: 0x7b } was emitted from contract::SpyEventsChecker at",
     );
-    assert_case_output_contains(&result, "assert_not_emitted_fails", "keys was emitted");
 }
 
 #[test]
@@ -810,4 +992,306 @@ fn test_filtering() {
     let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
 
     assert_passed(&result);
+}
+
+#[test]
+fn assert_emitted_with_replaced_bytecode() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use core::clone::Clone;
+            use snforge_std::{
+                declare, replace_bytecode, spy_events, ContractClassTrait, DeclareResultTrait,
+                EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait IReplaceBytecode<TContractState> {
+                fn emit_event(ref self: TContractState);
+            }
+
+            #[starknet::contract]
+            mod ReplaceBytecodeB {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    ValueChanged: ValueChanged,
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct ValueChanged {
+                    value: felt252,
+                }
+            }
+
+            #[test]
+            fn assert_emitted_with_replaced_bytecode() {
+                let contract = declare("ReplaceBytecodeA").unwrap().contract_class();
+                let replacement = declare("ReplaceBytecodeB").unwrap().contract_class().class_hash.clone();
+                let (contract_address, _) = contract.deploy(@array![]).unwrap();
+                let dispatcher = IReplaceBytecodeDispatcher { contract_address };
+
+                replace_bytecode(contract_address, replacement);
+
+                let mut spy = spy_events();
+                dispatcher.emit_event();
+
+                spy.assert_emitted(@array![
+                    (
+                        contract_address,
+                        ReplaceBytecodeB::Event::ValueChanged(
+                            ReplaceBytecodeB::ValueChanged { value: 420 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeA",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeB",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_passed(&result);
+}
+
+#[test]
+fn assert_not_emitted_with_replaced_bytecode() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use core::clone::Clone;
+            use snforge_std::{
+                declare, replace_bytecode, spy_events, ContractClassTrait, DeclareResultTrait,
+                EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait IReplaceBytecode<TContractState> {
+                fn emit_event(ref self: TContractState);
+            }
+
+            #[starknet::contract]
+            mod ReplaceBytecodeB {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    ValueChanged: ValueChanged,
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct ValueChanged {
+                    value: felt252,
+                }
+            }
+
+            #[test]
+            fn assert_not_emitted_with_replaced_bytecode() {
+                let contract = declare("ReplaceBytecodeA").unwrap().contract_class();
+                let replacement = declare("ReplaceBytecodeB").unwrap().contract_class().class_hash.clone();
+                let (contract_address, _) = contract.deploy(@array![]).unwrap();
+                let dispatcher = IReplaceBytecodeDispatcher { contract_address };
+
+                replace_bytecode(contract_address, replacement);
+
+                let mut spy = spy_events();
+                dispatcher.emit_event();
+
+                spy.assert_not_emitted(@array![
+                    (
+                        contract_address,
+                        ReplaceBytecodeB::Event::ValueChanged(
+                            ReplaceBytecodeB::ValueChanged { value: 2137 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeA",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeB",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_passed(&result);
+}
+
+#[test]
+fn assert_emitted_with_replaced_bytecode_fails() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use core::clone::Clone;
+            use snforge_std::{
+                declare, replace_bytecode, spy_events, ContractClassTrait, DeclareResultTrait,
+                EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait IReplaceBytecode<TContractState> {
+                fn emit_event(ref self: TContractState);
+            }
+
+            #[starknet::contract]
+            mod ReplaceBytecodeB {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    ValueChanged: ValueChanged,
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct ValueChanged {
+                    value: felt252,
+                }
+            }
+
+            #[test]
+            fn assert_emitted_with_replaced_bytecode_fails() {
+                let contract = declare("ReplaceBytecodeA").unwrap().contract_class();
+                let replacement = declare("ReplaceBytecodeB").unwrap().contract_class().class_hash.clone();
+                let (contract_address, _) = contract.deploy(@array![]).unwrap();
+                let dispatcher = IReplaceBytecodeDispatcher { contract_address };
+
+                replace_bytecode(contract_address, replacement);
+
+                let mut spy = spy_events();
+                dispatcher.emit_event();
+
+                spy.assert_emitted(@array![
+                    (
+                        contract_address,
+                        ReplaceBytecodeB::Event::ValueChanged(
+                            ReplaceBytecodeB::ValueChanged { value: 2137 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeA",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeB",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_failed(&result);
+    assert_case_output_contains(
+        &result,
+        "assert_emitted_with_replaced_bytecode_fails",
+        "Event ValueChanged { value: 0x859 } was not emitted from contract::ReplaceBytecodeB at",
+    );
+}
+
+#[test]
+fn assert_not_emitted_with_replaced_bytecode_fails() {
+    let test = test_case!(
+        indoc!(
+            r#"
+            use core::clone::Clone;
+            use snforge_std::{
+                declare, replace_bytecode, spy_events, ContractClassTrait, DeclareResultTrait,
+                EventSpyAssertionsTrait
+            };
+
+            #[starknet::interface]
+            trait IReplaceBytecode<TContractState> {
+                fn emit_event(ref self: TContractState);
+            }
+
+            #[starknet::contract]
+            mod ReplaceBytecodeB {
+                #[storage]
+                struct Storage {}
+
+                #[event]
+                #[derive(Drop, starknet::Event)]
+                enum Event {
+                    ValueChanged: ValueChanged,
+                }
+
+                #[derive(Drop, starknet::Event)]
+                struct ValueChanged {
+                    value: felt252,
+                }
+            }
+
+            #[test]
+            fn assert_not_emitted_with_replaced_bytecode_fails() {
+                let contract = declare("ReplaceBytecodeA").unwrap().contract_class();
+                let replacement = declare("ReplaceBytecodeB").unwrap().contract_class().class_hash.clone();
+                let (contract_address, _) = contract.deploy(@array![]).unwrap();
+                let dispatcher = IReplaceBytecodeDispatcher { contract_address };
+
+                replace_bytecode(contract_address, replacement);
+
+                let mut spy = spy_events();
+                dispatcher.emit_event();
+
+                spy.assert_not_emitted(@array![
+                    (
+                        contract_address,
+                        ReplaceBytecodeB::Event::ValueChanged(
+                            ReplaceBytecodeB::ValueChanged { value: 420 }
+                        )
+                    )
+                ]);
+            }
+        "#
+        ),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeA",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap(),
+        Contract::from_code_path(
+            "contract::ReplaceBytecodeB",
+            Path::new("tests/data/contracts/two_implementations.cairo"),
+        )
+        .unwrap()
+    );
+
+    let result = run_test_case(&test, ForgeTrackedResource::CairoSteps);
+
+    assert_failed(&result);
+    assert_case_output_contains(
+        &result,
+        "assert_not_emitted_with_replaced_bytecode_fails",
+        "Event ValueChanged { value: 0x1a4 } was emitted from contract::ReplaceBytecodeB at",
+    );
 }

--- a/crates/snforge-scarb-plugin/Cargo.toml
+++ b/crates/snforge-scarb-plugin/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "snforge_scarb_plugin"
 version = "0.63.0"

--- a/docs/src/testing/testing-events.md
+++ b/docs/src/testing/testing-events.md
@@ -24,6 +24,11 @@ tuples we expect that were emitted.
 > 📝 **Note**
 > We can pass events defined in the contract and construct them like in the `self.emit` method!
 
+If an assertion fails, Forge displays the expected event decoded with the emitting contract's ABI,
+along with the contract's full module path and address. For events that cannot be decoded, such as
+custom events emitted with `emit_event_syscall`, the error instead identifies a raw event with
+matching keys and data.
+
 
 ## Asserting lack of event emission with `assert_not_emitted`
 

--- a/snforge_std/src/cheatcodes/events.cairo
+++ b/snforge_std/src/cheatcodes/events.cairo
@@ -68,8 +68,14 @@ impl EventSpyAssertionsTraitImpl<T, +starknet::Event<T>, +Drop<T>> of EventSpyAs
 
         for (from, event) in events.span() {
             if !received_events.is_emitted(*from, event) {
-                let from: felt252 = (*from).into();
-                panic!("Event with matching data and keys was not emitted from {}", from);
+                let (event, contract_address, contract_full_path) = format_event(*from, event);
+                let contract_full_path = contract_full_path.unwrap_or("contract");
+                panic!(
+                    "Event {} was not emitted from {} at {}",
+                    event,
+                    contract_full_path,
+                    contract_address,
+                );
             }
         };
     }
@@ -79,11 +85,27 @@ impl EventSpyAssertionsTraitImpl<T, +starknet::Event<T>, +Drop<T>> of EventSpyAs
 
         for (from, event) in events.span() {
             if received_events.is_emitted(*from, event) {
-                let from: felt252 = (*from).into();
-                panic!("Event with matching data and keys was emitted from {}", from);
+                let (event, contract_address, contract_full_path) = format_event(*from, event);
+                let contract_full_path = contract_full_path.unwrap_or("contract");
+                panic!(
+                    "Event {} was emitted from {} at {}",
+                    event,
+                    contract_full_path,
+                    contract_address,
+                );
             }
         };
     }
+}
+
+fn format_event<T, +starknet::Event<T>, +Drop<T>>(
+    from: ContractAddress, event: @T,
+) -> (ByteArray, ByteArray, Option<ByteArray>) {
+    let event: Event = event.into();
+    let mut input = array![];
+    from.serialize(ref input);
+    event.serialize(ref input);
+    execute_cheatcode_and_deserialize::<'format_event'>(input.span())
 }
 
 pub trait IsEmitted<T, +starknet::Event<T>, +Drop<T>> {


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2989

## Introduced changes
- New cheatcode `format_event`, wrapped by `format_event` in `snforge_std`, allows reverse-transformation of the event at runtime
- Now, the error message from `assert_emitted` has a form:
```
Event <event> was not emitted from <contract-full-path> at <contract-address>
```
- `assert_not_emitted` has analogical behaviour

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
