### PR TITLE
Disambiguate ABI entry point lookup

### DIFF
--- a/crates/data-transformer/src/lib.rs
+++ b/crates/data-transformer/src/lib.rs
@@ -8,5 +8,5 @@ pub use reverse_transformer::{
     reverse_transform_entry_point_output, reverse_transform_event, reverse_transform_input,
     reverse_transform_output,
 };
-pub use shared::extraction::extract_entry_point_from_selector;
+pub use shared::extraction::find_entry_point_by_selector;
 pub use transformer::transform;

--- a/crates/data-transformer/src/lib.rs
+++ b/crates/data-transformer/src/lib.rs
@@ -4,8 +4,9 @@ mod shared;
 mod transformer;
 
 pub use reverse_transformer::{
-    ReverseTransformError, ReverseTransformEventError, reverse_transform_event,
-    reverse_transform_input, reverse_transform_output,
+    ReverseTransformError, ReverseTransformEventError, reverse_transform_entry_point_input,
+    reverse_transform_entry_point_output, reverse_transform_event, reverse_transform_input,
+    reverse_transform_output,
 };
-pub use shared::extraction::extract_function_from_selector;
+pub use shared::extraction::extract_entry_point_from_selector;
 pub use transformer::transform;

--- a/crates/data-transformer/src/reverse_transformer/mod.rs
+++ b/crates/data-transformer/src/reverse_transformer/mod.rs
@@ -4,8 +4,11 @@ mod types;
 
 pub use self::event::{ReverseTransformEventError, reverse_transform_event};
 use crate::reverse_transformer::transform::{ReverseTransformer, TransformationError};
-use crate::shared::extraction::extract_function_from_selector;
+use crate::shared::extraction::{
+    extract_entry_point_from_selector, extract_function_from_selector,
+};
 use cairo_lang_parser::utils::SimpleParserDatabase;
+use starknet_rust::core::types::EntryPointType;
 use starknet_rust::core::types::contract::AbiEntry;
 use starknet_types_core::felt::Felt;
 
@@ -23,14 +26,31 @@ pub fn reverse_transform_input(
     abi: &[AbiEntry],
     function_selector: &Felt,
 ) -> Result<String, ReverseTransformError> {
-    let input_types: Vec<_> = extract_function_from_selector(abi, *function_selector)
-        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?
-        .inputs
-        .into_iter()
-        .map(|input| input.r#type)
-        .collect();
+    let function = extract_function_from_selector(abi, *function_selector)
+        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
 
-    reverse_transform(input, abi, &input_types)
+    reverse_transform(
+        input,
+        abi,
+        function.inputs.iter().map(|input| input.r#type.as_str()),
+    )
+}
+
+/// Transforms entry point calldata into a Cairo-like representation of its arguments.
+pub fn reverse_transform_entry_point_input(
+    input: &[Felt],
+    abi: &[AbiEntry],
+    function_selector: &Felt,
+    entry_point_type: EntryPointType,
+) -> Result<String, ReverseTransformError> {
+    let function = extract_entry_point_from_selector(abi, *function_selector, entry_point_type)
+        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
+
+    reverse_transform(
+        input,
+        abi,
+        function.inputs.iter().map(|input| input.r#type.as_str()),
+    )
 }
 
 /// Transforms a call output into a Cairo-like string representation of the return values
@@ -39,26 +59,43 @@ pub fn reverse_transform_output(
     abi: &[AbiEntry],
     function_selector: &Felt,
 ) -> Result<String, ReverseTransformError> {
-    let output_types: Vec<_> = extract_function_from_selector(abi, *function_selector)
-        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?
-        .outputs
-        .into_iter()
-        .map(|input| input.r#type)
-        .collect();
+    let function = extract_function_from_selector(abi, *function_selector)
+        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
 
-    reverse_transform(output, abi, &output_types)
+    reverse_transform(
+        output,
+        abi,
+        function.outputs.iter().map(|output| output.r#type.as_str()),
+    )
 }
 
-fn reverse_transform(
+/// Transforms entry point output into a Cairo-like representation of its return values.
+pub fn reverse_transform_entry_point_output(
+    output: &[Felt],
+    abi: &[AbiEntry],
+    function_selector: &Felt,
+    entry_point_type: EntryPointType,
+) -> Result<String, ReverseTransformError> {
+    let function = extract_entry_point_from_selector(abi, *function_selector, entry_point_type)
+        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
+
+    reverse_transform(
+        output,
+        abi,
+        function.outputs.iter().map(|output| output.r#type.as_str()),
+    )
+}
+
+fn reverse_transform<'a>(
     felts: &[Felt],
     abi: &[AbiEntry],
-    types: &[String],
+    parameter_types: impl IntoIterator<Item = &'a str>,
 ) -> Result<String, ReverseTransformError> {
     let db = SimpleParserDatabase::default();
     let mut reverse_transformer = ReverseTransformer::new(felts, abi);
 
-    Ok(types
-        .iter()
+    Ok(parameter_types
+        .into_iter()
         .map(|parameter_type| {
             Ok(reverse_transformer
                 .parse_and_transform(parameter_type, &db)?

--- a/crates/data-transformer/src/reverse_transformer/mod.rs
+++ b/crates/data-transformer/src/reverse_transformer/mod.rs
@@ -4,7 +4,7 @@ mod types;
 
 pub use self::event::{ReverseTransformEventError, reverse_transform_event};
 use crate::reverse_transformer::transform::{ReverseTransformer, TransformationError};
-use crate::shared::extraction::extract_entry_point_from_selector;
+use crate::shared::extraction::find_entry_point_by_selector;
 use cairo_lang_parser::utils::SimpleParserDatabase;
 use starknet_rust::core::types::EntryPointType;
 use starknet_rust::core::types::contract::AbiEntry;
@@ -34,7 +34,7 @@ pub fn reverse_transform_entry_point_input(
     function_selector: &Felt,
     entry_point_type: EntryPointType,
 ) -> Result<String, ReverseTransformError> {
-    let function = extract_entry_point_from_selector(abi, *function_selector, entry_point_type)
+    let function = find_entry_point_by_selector(abi, *function_selector, entry_point_type)
         .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
 
     reverse_transform(
@@ -60,7 +60,7 @@ pub fn reverse_transform_entry_point_output(
     function_selector: &Felt,
     entry_point_type: EntryPointType,
 ) -> Result<String, ReverseTransformError> {
-    let function = extract_entry_point_from_selector(abi, *function_selector, entry_point_type)
+    let function = find_entry_point_by_selector(abi, *function_selector, entry_point_type)
         .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
 
     reverse_transform(

--- a/crates/data-transformer/src/reverse_transformer/mod.rs
+++ b/crates/data-transformer/src/reverse_transformer/mod.rs
@@ -4,9 +4,7 @@ mod types;
 
 pub use self::event::{ReverseTransformEventError, reverse_transform_event};
 use crate::reverse_transformer::transform::{ReverseTransformer, TransformationError};
-use crate::shared::extraction::{
-    extract_entry_point_from_selector, extract_function_from_selector,
-};
+use crate::shared::extraction::extract_entry_point_from_selector;
 use cairo_lang_parser::utils::SimpleParserDatabase;
 use starknet_rust::core::types::EntryPointType;
 use starknet_rust::core::types::contract::AbiEntry;
@@ -26,14 +24,7 @@ pub fn reverse_transform_input(
     abi: &[AbiEntry],
     function_selector: &Felt,
 ) -> Result<String, ReverseTransformError> {
-    let function = extract_function_from_selector(abi, *function_selector)
-        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
-
-    reverse_transform(
-        input,
-        abi,
-        function.inputs.iter().map(|input| input.r#type.as_str()),
-    )
+    reverse_transform_entry_point_input(input, abi, function_selector, EntryPointType::External)
 }
 
 /// Transforms entry point calldata into a Cairo-like representation of its arguments.
@@ -59,14 +50,7 @@ pub fn reverse_transform_output(
     abi: &[AbiEntry],
     function_selector: &Felt,
 ) -> Result<String, ReverseTransformError> {
-    let function = extract_function_from_selector(abi, *function_selector)
-        .ok_or(ReverseTransformError::FunctionNotFound(*function_selector))?;
-
-    reverse_transform(
-        output,
-        abi,
-        function.outputs.iter().map(|output| output.r#type.as_str()),
-    )
+    reverse_transform_entry_point_output(output, abi, function_selector, EntryPointType::External)
 }
 
 /// Transforms entry point output into a Cairo-like representation of its return values.

--- a/crates/data-transformer/src/shared/extraction.rs
+++ b/crates/data-transformer/src/shared/extraction.rs
@@ -7,19 +7,17 @@ const CONSTRUCTOR_AS_SELECTOR: Felt =
     Felt::from_hex_unchecked("0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194");
 
 #[must_use]
-pub fn extract_function_from_selector(
+pub(crate) fn find_function_or_constructor_by_selector(
     abi: &[AbiEntry],
     searched_selector: Felt,
 ) -> Option<AbiFunction> {
-    search_for_function(abi, searched_selector)
-        // If the user doesn't explicitly define a constructor in the contract,
-        // it won't be present in the ABI. In such cases, an implicit constructor
-        // with no arguments is assumed.
-        .or_else(|| (searched_selector == CONSTRUCTOR_AS_SELECTOR).then(default_constructor))
+    find_entry_point_by_selector(abi, searched_selector, EntryPointType::External).or_else(|| {
+        find_entry_point_by_selector(abi, searched_selector, EntryPointType::Constructor)
+    })
 }
 
 #[must_use]
-pub fn extract_entry_point_from_selector(
+pub fn find_entry_point_by_selector(
     abi: &[AbiEntry],
     searched_selector: Felt,
     entry_point_type: EntryPointType,
@@ -38,29 +36,6 @@ fn default_constructor() -> AbiFunction {
         outputs: vec![],
         state_mutability: StateMutability::View,
     }
-}
-
-fn search_for_function(abi: &[AbiEntry], searched_selector: Felt) -> Option<AbiFunction> {
-    abi.iter().find_map(|entry| match entry {
-        AbiEntry::Function(func) => {
-            let selector = get_selector_from_name(&func.name).ok()?;
-            (selector == searched_selector).then(|| func.clone())
-        }
-        // We treat constructor like a regular function
-        // because it's searched for using Felt entrypoint selector, identically as functions.
-        // Also, we don't need any constructor-specific properties, just argument types.
-        AbiEntry::Constructor(constructor) => {
-            let selector = get_selector_from_name(&constructor.name).ok()?;
-            (selector == searched_selector).then(|| AbiFunction {
-                name: constructor.name.clone(),
-                inputs: constructor.inputs.clone(),
-                outputs: vec![],
-                state_mutability: StateMutability::View,
-            })
-        }
-        AbiEntry::Interface(interface) => search_for_function(&interface.items, searched_selector),
-        _ => None,
-    })
 }
 
 fn search_for_entry_point(
@@ -93,7 +68,7 @@ fn search_for_entry_point(
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_entry_point_from_selector, extract_function_from_selector};
+    use super::{find_entry_point_by_selector, find_function_or_constructor_by_selector};
     use starknet_rust::core::types::EntryPointType;
     use starknet_rust::core::types::contract::{
         AbiEntry, AbiFunction, AbiNamedMember, StateMutability,
@@ -129,21 +104,19 @@ mod tests {
                 AbiEntry::L1Handler(l1_handler.clone()),
             ],
         ] {
-            let regular_lookup = extract_function_from_selector(&abi, selector).unwrap();
+            let regular_lookup = find_function_or_constructor_by_selector(&abi, selector).unwrap();
             assert_eq!(regular_lookup.inputs[0].r#type, "core::integer::u8");
 
             let external =
-                extract_entry_point_from_selector(&abi, selector, EntryPointType::External)
-                    .unwrap();
+                find_entry_point_by_selector(&abi, selector, EntryPointType::External).unwrap();
             assert_eq!(external.inputs[0].r#type, "core::integer::u8");
 
             let l1_handler =
-                extract_entry_point_from_selector(&abi, selector, EntryPointType::L1Handler)
-                    .unwrap();
+                find_entry_point_by_selector(&abi, selector, EntryPointType::L1Handler).unwrap();
             assert_eq!(l1_handler.inputs[0].r#type, "core::integer::u16");
         }
 
         let l1_handler_only = [AbiEntry::L1Handler(l1_handler)];
-        assert!(extract_function_from_selector(&l1_handler_only, selector).is_none());
+        assert!(find_function_or_constructor_by_selector(&l1_handler_only, selector).is_none());
     }
 }

--- a/crates/data-transformer/src/shared/extraction.rs
+++ b/crates/data-transformer/src/shared/extraction.rs
@@ -1,21 +1,34 @@
+use starknet_rust::core::types::EntryPointType;
 use starknet_rust::core::types::contract::{AbiEntry, AbiFunction, StateMutability};
 use starknet_rust::core::utils::get_selector_from_name;
 use starknet_types_core::felt::Felt;
+
+const CONSTRUCTOR_AS_SELECTOR: Felt =
+    Felt::from_hex_unchecked("0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194");
 
 #[must_use]
 pub fn extract_function_from_selector(
     abi: &[AbiEntry],
     searched_selector: Felt,
 ) -> Option<AbiFunction> {
-    const CONSTRUCTOR_AS_SELECTOR: Felt = Felt::from_hex_unchecked(
-        "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
-    );
-
     search_for_function(abi, searched_selector)
         // If the user doesn't explicitly define a constructor in the contract,
         // it won't be present in the ABI. In such cases, an implicit constructor
         // with no arguments is assumed.
         .or_else(|| (searched_selector == CONSTRUCTOR_AS_SELECTOR).then(default_constructor))
+}
+
+#[must_use]
+pub fn extract_entry_point_from_selector(
+    abi: &[AbiEntry],
+    searched_selector: Felt,
+    entry_point_type: EntryPointType,
+) -> Option<AbiFunction> {
+    search_for_entry_point(abi, searched_selector, entry_point_type).or_else(|| {
+        (entry_point_type == EntryPointType::Constructor
+            && searched_selector == CONSTRUCTOR_AS_SELECTOR)
+            .then(default_constructor)
+    })
 }
 
 fn default_constructor() -> AbiFunction {
@@ -29,7 +42,7 @@ fn default_constructor() -> AbiFunction {
 
 fn search_for_function(abi: &[AbiEntry], searched_selector: Felt) -> Option<AbiFunction> {
     abi.iter().find_map(|entry| match entry {
-        AbiEntry::Function(func) | AbiEntry::L1Handler(func) => {
+        AbiEntry::Function(func) => {
             let selector = get_selector_from_name(&func.name).ok()?;
             (selector == searched_selector).then(|| func.clone())
         }
@@ -48,4 +61,89 @@ fn search_for_function(abi: &[AbiEntry], searched_selector: Felt) -> Option<AbiF
         AbiEntry::Interface(interface) => search_for_function(&interface.items, searched_selector),
         _ => None,
     })
+}
+
+fn search_for_entry_point(
+    abi: &[AbiEntry],
+    searched_selector: Felt,
+    entry_point_type: EntryPointType,
+) -> Option<AbiFunction> {
+    abi.iter()
+        .find_map(|entry| match (entry_point_type, entry) {
+            (EntryPointType::External, AbiEntry::Function(function))
+            | (EntryPointType::L1Handler, AbiEntry::L1Handler(function)) => {
+                let selector = get_selector_from_name(&function.name).ok()?;
+                (selector == searched_selector).then(|| function.clone())
+            }
+            (EntryPointType::Constructor, AbiEntry::Constructor(constructor)) => {
+                let selector = get_selector_from_name(&constructor.name).ok()?;
+                (selector == searched_selector).then(|| AbiFunction {
+                    name: constructor.name.clone(),
+                    inputs: constructor.inputs.clone(),
+                    outputs: vec![],
+                    state_mutability: StateMutability::View,
+                })
+            }
+            (_, AbiEntry::Interface(interface)) => {
+                search_for_entry_point(&interface.items, searched_selector, entry_point_type)
+            }
+            _ => None,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_entry_point_from_selector, extract_function_from_selector};
+    use starknet_rust::core::types::EntryPointType;
+    use starknet_rust::core::types::contract::{
+        AbiEntry, AbiFunction, AbiNamedMember, StateMutability,
+    };
+    use starknet_rust::core::utils::get_selector_from_name;
+
+    fn entry(name: &str, input_type: &str) -> AbiFunction {
+        AbiFunction {
+            name: name.to_string(),
+            inputs: vec![AbiNamedMember {
+                name: "value".to_string(),
+                r#type: input_type.to_string(),
+            }],
+            outputs: vec![],
+            state_mutability: StateMutability::External,
+        }
+    }
+
+    #[test]
+    fn entry_point_lookup_distinguishes_function_from_l1_handler() {
+        let name = "shared_name";
+        let selector = get_selector_from_name(name).unwrap();
+        let function = entry(name, "core::integer::u8");
+        let l1_handler = entry(name, "core::integer::u16");
+
+        for abi in [
+            vec![
+                AbiEntry::L1Handler(l1_handler.clone()),
+                AbiEntry::Function(function.clone()),
+            ],
+            vec![
+                AbiEntry::Function(function.clone()),
+                AbiEntry::L1Handler(l1_handler.clone()),
+            ],
+        ] {
+            let regular_lookup = extract_function_from_selector(&abi, selector).unwrap();
+            assert_eq!(regular_lookup.inputs[0].r#type, "core::integer::u8");
+
+            let external =
+                extract_entry_point_from_selector(&abi, selector, EntryPointType::External)
+                    .unwrap();
+            assert_eq!(external.inputs[0].r#type, "core::integer::u8");
+
+            let l1_handler =
+                extract_entry_point_from_selector(&abi, selector, EntryPointType::L1Handler)
+                    .unwrap();
+            assert_eq!(l1_handler.inputs[0].r#type, "core::integer::u16");
+        }
+
+        let l1_handler_only = [AbiEntry::L1Handler(l1_handler)];
+        assert!(extract_function_from_selector(&l1_handler_only, selector).is_none());
+    }
 }

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -1,6 +1,6 @@
 mod sierra_abi;
 
-use crate::shared::extraction::extract_function_from_selector;
+use crate::shared::extraction::find_function_or_constructor_by_selector;
 use crate::shared::parsing::parse_expression;
 use crate::transformer::sierra_abi::build_representation;
 use anyhow::{Context, Result, bail, ensure};
@@ -13,7 +13,7 @@ use starknet_types_core::felt::Felt;
 
 /// Interpret `calldata` as a comma-separated series of expressions in Cairo syntax and serialize it
 pub fn transform(calldata: &str, abi: &[AbiEntry], function_selector: &Felt) -> Result<Vec<Felt>> {
-    let function = extract_function_from_selector(abi, *function_selector).with_context(|| {
+    let function = find_function_or_constructor_by_selector(abi, *function_selector).with_context(|| {
         format!(
             r#"Function with selector "{function_selector:#x}" not found in ABI of the contract"#
         )

--- a/crates/data-transformer/tests/integration/reverse_transformer.rs
+++ b/crates/data-transformer/tests/integration/reverse_transformer.rs
@@ -1,9 +1,13 @@
 use crate::integration::{NO_CONSTRUCTOR_CLASS_HASH, get_abi, init_class};
-use data_transformer::{reverse_transform_input, reverse_transform_output};
+use data_transformer::{
+    reverse_transform_entry_point_input, reverse_transform_input, reverse_transform_output,
+};
 use itertools::Itertools;
 use primitive_types::U256;
-use starknet_rust::core::types::ContractClass;
-use starknet_rust::core::types::contract::AbiEntry;
+use starknet_rust::core::types::contract::{
+    AbiEntry, AbiFunction, AbiNamedMember, StateMutability,
+};
+use starknet_rust::core::types::{ContractClass, EntryPointType};
 use starknet_rust::core::utils::get_selector_from_name;
 use starknet_types_core::felt::Felt;
 
@@ -363,4 +367,41 @@ async fn test_implicit_contract_constructor() {
     let expected_output = "";
 
     assert_eq!(result, expected_output);
+}
+
+#[test]
+fn test_reverse_transformation_uses_entry_point_type() {
+    let name = "shared_name";
+    let selector = get_selector_from_name(name).unwrap();
+    let entry = |input_type: &str| AbiFunction {
+        name: name.to_string(),
+        inputs: vec![AbiNamedMember {
+            name: "value".to_string(),
+            r#type: input_type.to_string(),
+        }],
+        outputs: vec![],
+        state_mutability: StateMutability::External,
+    };
+    let abi = vec![
+        AbiEntry::L1Handler(entry("core::integer::u16")),
+        AbiEntry::Function(entry("core::integer::u8")),
+    ];
+
+    let external = reverse_transform_entry_point_input(
+        &[Felt::ONE],
+        &abi,
+        &selector,
+        EntryPointType::External,
+    )
+    .unwrap();
+    assert_eq!(external, "1_u8");
+
+    let l1_handler = reverse_transform_entry_point_input(
+        &[Felt::ONE],
+        &abi,
+        &selector,
+        EntryPointType::L1Handler,
+    )
+    .unwrap();
+    assert_eq!(l1_handler, "1_u16");
 }

--- a/crates/data-transformer/tests/integration/reverse_transformer.rs
+++ b/crates/data-transformer/tests/integration/reverse_transformer.rs
@@ -1,6 +1,7 @@
 use crate::integration::{NO_CONSTRUCTOR_CLASS_HASH, get_abi, init_class};
 use data_transformer::{
-    reverse_transform_entry_point_input, reverse_transform_input, reverse_transform_output,
+    reverse_transform_entry_point_input, reverse_transform_entry_point_output,
+    reverse_transform_input, reverse_transform_output,
 };
 use itertools::Itertools;
 use primitive_types::U256;
@@ -304,13 +305,21 @@ async fn test_external_type() {
 
 #[tokio::test]
 async fn test_constructor() {
-    assert_reverse_transformation(
+    let abi = get_abi().await;
+    let selector = get_selector_from_name("constructor").unwrap();
+    let input = reverse_transform_entry_point_input(
         &[Felt::from_hex_unchecked("0x123")],
-        "constructor",
-        "ContractAddress(0x123)",
-        Some(""),
+        &abi,
+        &selector,
+        EntryPointType::Constructor,
     )
-    .await;
+    .unwrap();
+    let output =
+        reverse_transform_entry_point_output(&[], &abi, &selector, EntryPointType::Constructor)
+            .unwrap();
+
+    assert_eq!(input, "ContractAddress(0x123)");
+    assert_eq!(output, "");
 }
 
 #[tokio::test]
@@ -360,9 +369,13 @@ async fn test_implicit_contract_constructor() {
 
     let abi: Vec<AbiEntry> = serde_json::from_str(sierra_class.abi.as_str()).unwrap();
 
-    let result =
-        reverse_transform_input(&[], &abi, &get_selector_from_name("constructor").unwrap())
-            .unwrap();
+    let result = reverse_transform_entry_point_input(
+        &[],
+        &abi,
+        &get_selector_from_name("constructor").unwrap(),
+        EntryPointType::Constructor,
+    )
+    .unwrap();
 
     let expected_output = "";
 

--- a/crates/sncast/src/response/get/tx_trace.rs
+++ b/crates/sncast/src/response/get/tx_trace.rs
@@ -2,7 +2,7 @@ use crate::response::cast_message::SncastCommandMessage;
 use crate::response::get::transaction::TransactionOutputBuilder;
 use conversions::IntoConv;
 use data_transformer::{
-    extract_entry_point_from_selector, reverse_transform_entry_point_input,
+    find_entry_point_by_selector, reverse_transform_entry_point_input,
     reverse_transform_entry_point_output,
 };
 use foundry_ui::{Message, components::warning::WarningMessage, styling::OutputBuilder};
@@ -281,7 +281,7 @@ impl TraceDecoder {
 
     fn selector(&self, invocation: &FunctionInvocation) -> String {
         if let Some(abi) = self.sierra_abis.get(&invocation.class_hash.into_())
-            && let Some(function) = extract_entry_point_from_selector(
+            && let Some(function) = find_entry_point_by_selector(
                 abi,
                 invocation.entry_point_selector,
                 invocation.entry_point_type,

--- a/crates/sncast/src/response/get/tx_trace.rs
+++ b/crates/sncast/src/response/get/tx_trace.rs
@@ -2,7 +2,8 @@ use crate::response::cast_message::SncastCommandMessage;
 use crate::response::get::transaction::TransactionOutputBuilder;
 use conversions::IntoConv;
 use data_transformer::{
-    extract_function_from_selector, reverse_transform_input, reverse_transform_output,
+    extract_entry_point_from_selector, reverse_transform_entry_point_input,
+    reverse_transform_entry_point_output,
 };
 use foundry_ui::{Message, components::warning::WarningMessage, styling::OutputBuilder};
 use itertools::Itertools;
@@ -15,8 +16,9 @@ use starknet_rust::core::types::{
     CallType, ContractClass, ContractStorageDiffItem, DeclareTransactionTrace, DeclaredClassItem,
     DeployAccountTransactionTrace, DeployedContractItem, EntryPointType, ExecuteInvocation,
     ExecutionResources, FunctionInvocation, InnerCallExecutionResources, InvokeTransactionTrace,
-    L1HandlerTransactionTrace, LegacyContractAbiEntry, MigratedCompiledClassItem, NonceUpdate,
-    OrderedEvent, OrderedMessage, ReplacedClassItem, StateDiff, TransactionTrace,
+    L1HandlerTransactionTrace, LegacyContractAbiEntry, LegacyFunctionAbiType,
+    MigratedCompiledClassItem, NonceUpdate, OrderedEvent, OrderedMessage, ReplacedClassItem,
+    StateDiff, TransactionTrace,
 };
 use starknet_rust::core::utils::get_selector_from_name;
 use starknet_types_core::felt::Felt;
@@ -264,9 +266,10 @@ impl TraceDecoder {
                         if let LegacyContractAbiEntry::Function(function) = entry
                             && let Ok(selector) = get_selector_from_name(&function.name)
                         {
-                            decoder
-                                .legacy_selectors
-                                .insert((class_hash, selector), function.name);
+                            decoder.legacy_selectors.insert(
+                                (class_hash, selector, function.r#type.into()),
+                                function.name,
+                            );
                         }
                     }
                 }
@@ -387,6 +390,33 @@ fn invocation_result(invocation: &FunctionInvocation, decoder: Option<&TraceDeco
         },
         |decoder| decoder.result(invocation),
     )
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+enum EntryPointKind {
+    External,
+    L1Handler,
+    Constructor,
+}
+
+impl From<EntryPointType> for EntryPointKind {
+    fn from(value: EntryPointType) -> Self {
+        match value {
+            EntryPointType::External => Self::External,
+            EntryPointType::L1Handler => Self::L1Handler,
+            EntryPointType::Constructor => Self::Constructor,
+        }
+    }
+}
+
+impl From<LegacyFunctionAbiType> for EntryPointKind {
+    fn from(value: LegacyFunctionAbiType) -> Self {
+        match value {
+            LegacyFunctionAbiType::Function => Self::External,
+            LegacyFunctionAbiType::L1Handler => Self::L1Handler,
+            LegacyFunctionAbiType::Constructor => Self::Constructor,
+        }
+    }
 }
 
 #[must_use]

--- a/crates/sncast/src/response/get/tx_trace.rs
+++ b/crates/sncast/src/response/get/tx_trace.rs
@@ -236,7 +236,7 @@ impl TraceDecodingWarning {
 pub struct TraceDecoder {
     sierra_abis: HashMap<ClassHash, Vec<AbiEntry>>,
     legacy_class_hashes: HashSet<ClassHash>,
-    legacy_selectors: HashMap<(ClassHash, Felt), String>,
+    legacy_selectors: HashMap<(ClassHash, Felt, EntryPointKind), String>,
     decoding_warnings: RefCell<BTreeSet<TraceDecodingWarning>>,
 }
 
@@ -281,8 +281,11 @@ impl TraceDecoder {
 
     fn selector(&self, invocation: &FunctionInvocation) -> String {
         if let Some(abi) = self.sierra_abis.get(&invocation.class_hash.into_())
-            && let Some(function) =
-                extract_function_from_selector(abi, invocation.entry_point_selector)
+            && let Some(function) = extract_entry_point_from_selector(
+                abi,
+                invocation.entry_point_selector,
+                invocation.entry_point_type,
+            )
         {
             return function.name;
         }
@@ -292,6 +295,7 @@ impl TraceDecoder {
             .get(&(
                 invocation.class_hash.into_(),
                 invocation.entry_point_selector,
+                invocation.entry_point_type.into(),
             ))
             .cloned();
         if selector.is_none()
@@ -314,13 +318,18 @@ impl TraceDecoder {
             return format_raw_felts(&invocation.calldata);
         };
 
-        reverse_transform_input(&invocation.calldata, abi, &invocation.entry_point_selector)
-            .unwrap_or_else(|_| {
-                self.add_warning(TraceDecodingWarning::CalldataDecodingFailed {
-                    class_hash: invocation.class_hash.into_(),
-                });
-                format_raw_felts(&invocation.calldata)
-            })
+        reverse_transform_entry_point_input(
+            &invocation.calldata,
+            abi,
+            &invocation.entry_point_selector,
+            invocation.entry_point_type,
+        )
+        .unwrap_or_else(|_| {
+            self.add_warning(TraceDecodingWarning::CalldataDecodingFailed {
+                class_hash: invocation.class_hash.into_(),
+            });
+            format_raw_felts(&invocation.calldata)
+        })
     }
 
     fn result(&self, invocation: &FunctionInvocation) -> String {
@@ -329,13 +338,18 @@ impl TraceDecoder {
         }
 
         let result = if let Some(abi) = self.sierra_abis.get(&invocation.class_hash.into_()) {
-            reverse_transform_output(&invocation.result, abi, &invocation.entry_point_selector)
-                .unwrap_or_else(|_| {
-                    self.add_warning(TraceDecodingWarning::ResultDecodingFailed {
-                        class_hash: invocation.class_hash.into_(),
-                    });
-                    format_raw_felts(&invocation.result)
-                })
+            reverse_transform_entry_point_output(
+                &invocation.result,
+                abi,
+                &invocation.entry_point_selector,
+                invocation.entry_point_type,
+            )
+            .unwrap_or_else(|_| {
+                self.add_warning(TraceDecodingWarning::ResultDecodingFailed {
+                    class_hash: invocation.class_hash.into_(),
+                });
+                format_raw_felts(&invocation.result)
+            })
         } else {
             format_raw_felts(&invocation.result)
         };


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3557

## Introduced changes

This PR makes transaction trace ABI decoding aware of the entry point type. Previously, functions and L1 handlers sharing the same selector could be decoded using the wrong signature, depending on their order in the ABI.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>