### PR TITLE
Fix tuple length validation in data transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--json` flag is now global, and can be passed to any subcommand.
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 
+#### Fixed
+
+- Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
+
 ## [0.63.0] - 2026-08-05
 
 ### Forge

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -478,9 +478,16 @@ impl SupportedCalldataKind for ExprListParenthesized<'_> {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let parsed_exprs = self
-            .expressions(db)
-            .elements(db)
+        let tuple_expressions = self.expressions(db).elements(db);
+
+        ensure!(
+            tuple_expressions.len() == tuple_types.len(),
+            r#"Invalid tuple length for type "{expected_type}": expected {} elements, got {}"#,
+            tuple_types.len(),
+            tuple_expressions.len()
+        );
+
+        let parsed_exprs = tuple_expressions
             .zip(tuple_types)
             .map(|(expr, single_param)| build_representation(expr, single_param, abi, db))
             .collect::<Result<Vec<_>>>()?;

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -179,6 +179,21 @@ async fn test_happy_case_tuple_function_cairo_expression_input() {
     assert_eq!(result, expected_output);
 }
 
+#[test_case("()", 0; "empty tuple")]
+#[test_case("(1234_felt252, 1_u8)", 2; "too few elements")]
+#[test_case("(1234_felt252, 1_u8, Enum::One, 0x420)", 4; "too many elements")]
+#[tokio::test]
+async fn test_tuple_function_invalid_number_of_elements(input: &str, found: usize) {
+    let result = run_transformer(input, "tuple_fn").await;
+
+    result.unwrap_err().assert_contains(
+        format!(
+            "Invalid tuple length for type \"(core::felt252, core::integer::u8, data_transformer_contract::Enum)\": expected 3 elements, got {found}"
+        )
+        .as_str(),
+    );
+}
+
 #[tokio::test]
 async fn test_happy_case_tuple_function_with_nested_struct_cairo_expression_input() {
     let result = run_transformer(


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3807

## Introduced changes

Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
