### PR TITLE
Trigger maat after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,3 +190,30 @@ jobs:
     with:
       plugin_dep_version: ${{ needs.verify-version.outputs.version }}
       prod_registry: true
+
+  trigger-maat-experiment:
+    name: Trigger Maat experiment
+    runs-on: ubuntu-latest
+    needs: [ verify-version, publish-to-registry ]
+    steps:
+      - name: Extract version from tag
+        env:
+          RAW_REF: ${{ github.ref_name }}
+        run: |
+          VERSION=${RAW_REF}
+
+          # Strip 'v' prefix from the version if it exists
+          VERSION=${VERSION#v}
+
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          
+      - name: Trigger Maat experiment
+        env:
+          GH_TOKEN: ${{ secrets.MAAT_EXPERIMENTS_DISPATCH_TOKEN }}
+        run: |
+          gh workflow run experiment.yml \
+            --repo software-mansion/maat \
+            --ref main \
+            -f workspace="release" \
+            -f foundry="$VERSION" \
+            -f notify_team="true"


### PR DESCRIPTION
## Summary

Adds an automated step to the `release.yml` workflow that triggers the `experiment.yml` workflow in `software-mansion/maat` whenever a new Foundry release is published.

The job extracts the clean version string from the tag (`vX.Y.Z` → `X.Y.Z`) and invokes the remote `maat` workflow via the GitHub CLI.

---

> ⚠️ **Prerequisite Setup Required**
>
> This workflow requires cross-repository Actions permissions to trigger `software-mansion/maat`.
>
> 1. **Generate PAT:** Create a Fine-Grained Personal Access Token (or Classic PAT) with access to `software-mansion/maat` [Link](https://github.com/settings/tokens/new).
>    * **Permissions:** 
<img width="1748" height="440" alt="image" src="https://github.com/user-attachments/assets/9dfa37fa-4936-468f-9e9e-6953bba74d71" />

> 2. **Add Secret:** Save the token in repository secrets:
>    * **Secret Name:** `MAAT_EXPERIMENTS_DISPATCH_TOKEN`