### PR TITLE
Change walnut to starkloupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - `--json` flag is now global, and can be passed to any subcommand.
+- `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 
 ## [0.63.0] - 2026-08-05
 

--- a/crates/sncast/src/starknet_commands/verify/mod.rs
+++ b/crates/sncast/src/starknet_commands/verify/mod.rs
@@ -17,14 +17,14 @@ use std::fmt;
 use url::Url;
 
 pub mod explorer;
+pub mod starkloupe;
 pub mod voyager;
-pub mod walnut;
 
 use explorer::ContractIdentifier;
 use explorer::VerificationInterface;
 use foundry_ui::components::warning::WarningMessage;
+use starkloupe::StarkloupeVerificationInterface;
 use voyager::Voyager;
-use walnut::WalnutVerificationInterface;
 
 #[derive(Args)]
 #[command(about = "Verify a contract through a block explorer")]
@@ -36,8 +36,8 @@ pub struct Verify {
     #[arg(short, long)]
     pub contract_name: String,
 
-    /// Block explorer to use for the verification
-    #[arg(short, long, value_enum)]
+    /// Block explorer to use for the verification [possible values: starkloupe, voyager]
+    #[arg(short, long, value_parser = parse_verifier)]
     pub verifier: Verifier,
 
     /// The network on which block explorer will do the verification
@@ -89,17 +89,27 @@ impl ContractIdentifierArgs {
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum Verifier {
-    Walnut,
+    Starkloupe,
     Voyager,
 }
 
 impl fmt::Display for Verifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Verifier::Walnut => write!(f, "walnut"),
+            Verifier::Starkloupe => write!(f, "starkloupe"),
             Verifier::Voyager => write!(f, "voyager"),
         }
     }
+}
+
+fn parse_verifier(value: &str) -> Result<Verifier, String> {
+    if value.eq_ignore_ascii_case("walnut") {
+        return Err(
+            "Walnut has been migrated to Starkloupe; use `--verifier starkloupe` instead. See https://app.starkloupe.co for more information."
+                .to_string(),
+        );
+    }
+    <Verifier as ValueEnum>::from_str(value, true)
 }
 
 async fn resolve_verification_network(
@@ -229,17 +239,17 @@ pub async fn verify(
         ui,
     )?;
 
-    // Handle test_files warning for Walnut
-    if matches!(verifier, Verifier::Walnut) && test_files {
+    // Handle test_files warning for Starkloupe
+    if matches!(verifier, Verifier::Starkloupe) && test_files {
         ui.print_warning(WarningMessage::new(
-            "The `--test-files` option is ignored for Walnut verifier",
+            "The `--test-files` option is ignored for Starkloupe verifier",
         ));
     }
 
     // Create verifier instance, gather files, and perform verification
     match verifier {
-        Verifier::Walnut => {
-            let walnut = WalnutVerificationInterface::new(
+        Verifier::Starkloupe => {
+            let starkloupe = StarkloupeVerificationInterface::new(
                 network,
                 workspace_dir.to_path_buf(),
                 &provider,
@@ -247,7 +257,7 @@ pub async fn verify(
             )?;
 
             // Gather and format files for display
-            let files = walnut.gather_files()?;
+            let files = starkloupe.gather_files()?;
             let files_to_display: Vec<String> =
                 files.iter().map(|(path, _)| format!("  {path}")).collect();
 
@@ -255,7 +265,7 @@ pub async fn verify(
             display_files_and_confirm(&verifier, files_to_display, confirm_verification, ui)?;
 
             // Perform verification
-            walnut
+            starkloupe
                 .verify(
                     contract_identifier,
                     resolved_contract_name,

--- a/crates/sncast/src/starknet_commands/verify/starkloupe.rs
+++ b/crates/sncast/src/starknet_commands/verify/starkloupe.rs
@@ -11,12 +11,12 @@ use walkdir::WalkDir;
 
 use super::explorer::{ContractIdentifier, VerificationInterface, VerificationPayload};
 
-pub struct WalnutVerificationInterface {
+pub struct StarkloupeVerificationInterface {
     network: Network,
     workspace_dir: Utf8PathBuf,
 }
 
-impl WalnutVerificationInterface {
+impl StarkloupeVerificationInterface {
     pub fn gather_files(&self) -> Result<Vec<(String, std::path::PathBuf)>> {
         let mut files = Vec::new();
 
@@ -40,14 +40,14 @@ impl WalnutVerificationInterface {
 }
 
 #[async_trait::async_trait]
-impl VerificationInterface<'_> for WalnutVerificationInterface {
+impl VerificationInterface<'_> for StarkloupeVerificationInterface {
     fn new(
         network: Network,
         workspace_dir: Utf8PathBuf,
         _provider: &JsonRpcClient<HttpTransport>,
         _ui: &UI,
     ) -> Result<Self> {
-        Ok(WalnutVerificationInterface {
+        Ok(StarkloupeVerificationInterface {
             network,
             workspace_dir,
         })
@@ -109,8 +109,8 @@ impl VerificationInterface<'_> for WalnutVerificationInterface {
     }
 
     fn gen_explorer_url(&self) -> Result<String> {
-        let api_base_url =
-            env::var("VERIFIER_API_URL").unwrap_or_else(|_| "https://api.walnut.dev".to_string());
+        let api_base_url = env::var("VERIFIER_API_URL")
+            .unwrap_or_else(|_| "https://api.starkloupe.co".to_string());
         let path = match self.network {
             Network::Mainnet => "/v1/sn_main/verify",
             Network::Sepolia => "/v1/sn_sepolia/verify",

--- a/crates/sncast/tests/e2e/verify/mod.rs
+++ b/crates/sncast/tests/e2e/verify/mod.rs
@@ -1,2 +1,2 @@
+mod starkloupe;
 mod voyager;
-mod walnut;

--- a/crates/sncast/tests/e2e/verify/starkloupe.rs
+++ b/crates/sncast/tests/e2e/verify/starkloupe.rs
@@ -37,7 +37,7 @@ async fn test_happy_case_contract_address() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -89,7 +89,7 @@ async fn test_happy_case_class_hash() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -145,7 +145,7 @@ async fn test_accepts_full_module_path_contract_name() {
         "--contract-name",
         "duplicate_contract_name::first_contract::HelloStarknet",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--confirm-verification",
@@ -197,7 +197,7 @@ async fn test_failed_verification_contract_address() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -248,7 +248,7 @@ async fn test_failed_verification_class_hash() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -285,7 +285,7 @@ async fn test_verification_abort() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -332,7 +332,7 @@ async fn test_happy_case_lowercase_y() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -370,7 +370,7 @@ async fn test_wrong_contract_name_passed() {
         "--contract-name",
         "nonexistent",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -404,7 +404,7 @@ async fn test_errors_on_ambiguous_contract_name() {
         "--contract-name",
         "HelloStarknet",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -453,7 +453,7 @@ async fn test_happy_case_with_confirm_verification_flag() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--confirm-verification",
@@ -505,7 +505,7 @@ async fn test_happy_case_specify_package() {
         "--contract-name",
         "supercomplexcode",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--package",
@@ -559,7 +559,7 @@ async fn test_worskpaces_package_specified_virtual_fibonacci() {
         "--contract-name",
         "FibonacciContract",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--package",
@@ -599,7 +599,7 @@ async fn test_worskpaces_package_no_contract() {
         "--contract-name",
         "nonexistent",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--package",
@@ -648,7 +648,7 @@ async fn test_test_files_flag_ignored_with_warning() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--test-files",
@@ -665,7 +665,7 @@ async fn test_test_files_flag_ignored_with_warning() {
         output,
         formatdoc!(
             r"
-        [WARNING] The `--test-files` option is ignored for Walnut verifier
+        [WARNING] The `--test-files` option is ignored for Starkloupe verifier
         Success: Verification completed
 
         {}
@@ -704,7 +704,7 @@ async fn test_happy_case_contract_address_with_alias() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--confirm-verification",
@@ -758,7 +758,7 @@ async fn test_happy_case_class_hash_with_alias() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
         "--confirm-verification",
@@ -798,7 +798,7 @@ async fn test_unknown_alias_contract_address() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -835,7 +835,7 @@ async fn test_unknown_alias_class_hash() {
         "--contract-name",
         "Map",
         "--verifier",
-        "walnut",
+        "starkloupe",
         "--network",
         "sepolia",
     ];
@@ -853,6 +853,37 @@ async fn test_unknown_alias_class_hash() {
 
             Caused by:
                 Alias `unknown` not found in config
+        "},
+    );
+}
+
+#[tokio::test]
+async fn test_walnut_verifier_value_is_rejected() {
+    let contract_path = copy_directory_to_tempdir(CONTRACTS_DIR.to_string() + "/map");
+
+    let args = vec![
+        "--accounts-file",
+        ACCOUNT_FILE_PATH,
+        "verify",
+        "--contract-address",
+        MAP_CONTRACT_ADDRESS_SEPOLIA,
+        "--contract-name",
+        "Map",
+        "--verifier",
+        "walnut",
+        "--network",
+        "sepolia",
+    ];
+
+    let output = runner(&args)
+        .current_dir(contract_path.path())
+        .assert()
+        .failure();
+
+    assert_stderr_contains(
+        output,
+        indoc! {r"
+            error: invalid value 'walnut' for '--verifier <VERIFIER>': Walnut has been migrated to Starkloupe; use `--verifier starkloupe` instead. See https://app.starkloupe.co for more information.
         "},
     );
 }

--- a/docs/src/appendix/sncast/verify.md
+++ b/docs/src/appendix/sncast/verify.md
@@ -27,7 +27,7 @@ This argument also accepts a module tree path, for example `hello_sncast::contra
 Required.
 
 The verification provider to use for the verification. Possible values are:
-* `walnut`
+* `starkloupe`
 * `voyager`
 
 ## `--network, -n <NETWORK>`

--- a/docs/src/starknet/verify.md
+++ b/docs/src/starknet/verify.md
@@ -13,9 +13,9 @@ For detailed CLI description, see [verify command reference](../appendix/sncast/
 
 ## Verification Providers
 
-### Walnut
+### Starkloupe
 
-Walnut is a tool for step-by-step debugging of Starknet transactions. You can learn more about Walnut here [walnut.dev](https://walnut.dev). Note that Walnut requires you to specify the Starknet version in your `Scarb.toml` config file.
+Starkloupe (formerly Walnut) is a tool for step-by-step debugging of Starknet transactions. You can learn more about Starkloupe here [app.starkloupe.co](https://app.starkloupe.co). Note that Starkloupe requires you to specify the Starknet version in your `Scarb.toml` config file.
 
 ### Voyager
 
@@ -25,7 +25,7 @@ Walnut is a tool for step-by-step debugging of Starknet transactions. You can le
 
 First, ensure that you have created a `Scarb.toml` file for your contract (it should be present in the project directory or one of its parent directories). Make sure the contract has already been deployed on the network.
 
-### Using Walnut
+### Using Starkloupe
 
 <!-- TODO(#4225) -->
 <!-- { "ignored": true, "ignored_output": true, "replace_network": false } -->
@@ -34,7 +34,7 @@ $ sncast \
     verify \
     --class-hash 0x031966c9fe618bcee61d267750b9d46e3d71469e571e331f35f0ca26efe306dc \
     --contract-name SimpleBalance \
-    --verifier walnut \
+    --verifier starkloupe \
     --network sepolia
 ```
 
@@ -43,7 +43,7 @@ $ sncast \
 
 ```shell
 
-    You are about to submit the entire workspace code to the third-party verifier at walnut.
+    You are about to submit the entire workspace code to the third-party verifier at starkloupe.
 
     Important: Make sure your project does not include sensitive information like private keys.
 


### PR DESCRIPTION
## Introduced changes

- change `walnut` arg in `sncast verify` to `starkloupe` since https://app.walnut.dev migration to https://app.starkloupe.co. Changed the verification endpoint URL as well

## Checklist

- [ ] Linked relevant issue
- [x] Updated relevant documentation
- [ ] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
