### PR TITLE
Notify in scheduled workflow only on first run

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -227,7 +227,7 @@ jobs:
 
   notify_if_failed:
     runs-on: ubuntu-latest
-    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
+    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule' && github.run_attempt == '1'
     needs: [ create-nightly-release, test-forge-unit-and-integration, test-forge-e2e, test-cast , build-plugin-binaries, build-binaries, publish-plugin, publish-std, test-binary ]
     steps:
       - name: Notify that the workflow has failed


### PR DESCRIPTION
- This change allows re-running failed jobs without sending Slack message if it fails