### PR TITLE
Show expected function arguments in data transformer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
+- Cairo-like calldata errors now list the names and types of missing function arguments.
 
 ## [0.63.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--json` flag is now global, and can be passed to any subcommand.
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
+- Invalid Cairo-like calldata now reports missing and unexpected positional arguments, alongside the provided arguments and expected argument names and types.
 
 #### Fixed
 
 - Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
-- Cairo-like calldata errors now list the names and types of missing function arguments.
 
 ## [0.63.0] - 2026-08-05
 

--- a/crates/data-transformer/src/shared/formatting.rs
+++ b/crates/data-transformer/src/shared/formatting.rs
@@ -1,0 +1,21 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+use starknet_rust::core::types::contract::AbiNamedMember;
+
+/// Formats ABI members as a name: type list, e.g. a: `core::felt252`, b: `core::integer::u32`.                                             
+pub fn format_abi_members(members: &[AbiNamedMember]) -> String {
+    members
+        .iter()
+        .map(|member| format!("{}: {}", member.name, member.r#type))
+        .join(", ")
+}
+
+/// Appends an indented passed: / expected: comparison to an error headline.                                                            
+pub fn format_passed_vs_expected(
+    headline: impl Display,
+    passed: impl Display,
+    expected: impl Display,
+) -> String {
+    format!("{headline}\n  passed: {passed}\n  expected: {expected}")
+}

--- a/crates/data-transformer/src/shared/formatting.rs
+++ b/crates/data-transformer/src/shared/formatting.rs
@@ -3,19 +3,135 @@ use std::fmt::Display;
 use itertools::Itertools;
 use starknet_rust::core::types::contract::AbiNamedMember;
 
-/// Formats ABI members as a name: type list, e.g. a: `core::felt252`, b: `core::integer::u32`.                                             
-pub fn format_abi_members(members: &[AbiNamedMember]) -> String {
+const MAX_INLINE_ARGUMENTS_WIDTH: usize = 100;
+
+#[derive(Clone, Copy)]
+pub enum ArgumentListKind {
+    Positional,
+}
+
+impl ArgumentListKind {
+    const fn delimiters(self) -> (char, char) {
+        match self {
+            Self::Positional => ('(', ')'),
+        }
+    }
+}
+
+/// Formats ABI members as individual `name: type` entries.
+pub fn format_abi_members(members: &[AbiNamedMember]) -> Vec<String> {
     members
         .iter()
         .map(|member| format!("{}: {}", member.name, member.r#type))
-        .join(", ")
+        .collect()
 }
 
-/// Appends an indented passed: / expected: comparison to an error headline.                                                            
-pub fn format_passed_vs_expected(
+/// Formats an argument error with optional diagnostics and a shared passed/expected layout.
+pub fn format_passed_vs_expected<P, E, D>(
     headline: impl Display,
-    passed: impl Display,
-    expected: impl Display,
+    diagnostics: &[D],
+    passed: &[P],
+    expected: &[E],
+    list_kind: ArgumentListKind,
+) -> String
+where
+    P: AsRef<str>,
+    E: AsRef<str>,
+    D: AsRef<str>,
+{
+    let mut output = headline.to_string();
+
+    for diagnostic in diagnostics {
+        output.push_str("\n  ");
+        output.push_str(diagnostic.as_ref());
+    }
+
+    if !diagnostics.is_empty() {
+        output.push('\n');
+    }
+
+    output.push('\n');
+    output.push_str(&format_argument_list("passed", passed, list_kind));
+    output.push('\n');
+    output.push_str(&format_argument_list("expected", expected, list_kind));
+    output
+}
+
+fn format_argument_list<T: AsRef<str>>(
+    label: &str,
+    arguments: &[T],
+    list_kind: ArgumentListKind,
 ) -> String {
-    format!("{headline}\n  passed: {passed}\n  expected: {expected}")
+    let (opening, closing) = list_kind.delimiters();
+
+    if arguments.is_empty() {
+        return format!("  {label}: {opening}{closing}");
+    }
+
+    let inline_arguments = arguments.iter().map(AsRef::as_ref).join(", ");
+    let inline = format!("  {label}: {opening}{inline_arguments}{closing}");
+
+    if !inline.contains('\n') && inline.chars().count() <= MAX_INLINE_ARGUMENTS_WIDTH {
+        return inline;
+    }
+
+    let multiline_arguments = arguments
+        .iter()
+        .map(AsRef::as_ref)
+        .map(|argument| argument.replace('\n', "\n    "))
+        .join(",\n    ");
+
+    format!("  {label}: {opening}\n    {multiline_arguments}\n  {closing}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ArgumentListKind, format_passed_vs_expected};
+
+    #[test]
+    fn formats_empty_argument_lists_inline() {
+        let arguments: [&str; 0] = [];
+
+        assert_eq!(
+            format_passed_vs_expected(
+                "Invalid arguments",
+                &[] as &[&str],
+                &arguments,
+                &arguments,
+                ArgumentListKind::Positional,
+            ),
+            "Invalid arguments\n  passed: ()\n  expected: ()"
+        );
+    }
+
+    #[test]
+    fn formats_short_argument_lists_inline() {
+        assert_eq!(
+            format_passed_vs_expected(
+                "Invalid arguments",
+                &["unexpected argument at position 3"],
+                &["1", "2", "3"],
+                &["a: felt252", "b: felt252"],
+                ArgumentListKind::Positional,
+            ),
+            "Invalid arguments\n  unexpected argument at position 3\n\n  passed: (1, 2, 3)\n  expected: (a: felt252, b: felt252)"
+        );
+    }
+
+    #[test]
+    fn formats_long_argument_lists_on_separate_lines() {
+        assert_eq!(
+            format_passed_vs_expected(
+                "Invalid arguments",
+                &[] as &[&str],
+                &["foo", "bar"],
+                &[
+                    "first: core::array::Array::<core::array::Array::<core::felt252>>",
+                    "second: core::array::Array::<core::array::Array::<core::felt252>>",
+                ],
+                ArgumentListKind::Positional,
+            ),
+            "Invalid arguments\n  passed: (foo, bar)\n  expected: (\n    first: core::array::Array::<core::array::Array::<core::felt252>>,\n    second: core::array::Array::<core::array::Array::<core::felt252>>\n  )"
+        );
+    }
 }

--- a/crates/data-transformer/src/shared/formatting.rs
+++ b/crates/data-transformer/src/shared/formatting.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use itertools::Itertools;
 use starknet_rust::core::types::contract::AbiNamedMember;
 
@@ -27,23 +25,18 @@ pub fn format_abi_members(members: &[AbiNamedMember]) -> Vec<String> {
 }
 
 /// Formats an argument error with optional diagnostics and a shared passed/expected layout.
-pub fn format_passed_vs_expected<P, E, D>(
-    headline: impl Display,
-    diagnostics: &[D],
-    passed: &[P],
-    expected: &[E],
+pub fn format_passed_vs_expected(
+    headline: &str,
+    diagnostics: &[String],
+    passed: &[String],
+    expected: &[String],
     list_kind: ArgumentListKind,
-) -> String
-where
-    P: AsRef<str>,
-    E: AsRef<str>,
-    D: AsRef<str>,
-{
-    let mut output = headline.to_string();
+) -> String {
+    let mut output = headline.to_owned();
 
     for diagnostic in diagnostics {
         output.push_str("\n  ");
-        output.push_str(diagnostic.as_ref());
+        output.push_str(diagnostic);
     }
 
     if !diagnostics.is_empty() {
@@ -57,18 +50,14 @@ where
     output
 }
 
-fn format_argument_list<T: AsRef<str>>(
-    label: &str,
-    arguments: &[T],
-    list_kind: ArgumentListKind,
-) -> String {
+fn format_argument_list(label: &str, arguments: &[String], list_kind: ArgumentListKind) -> String {
     let (opening, closing) = list_kind.delimiters();
 
     if arguments.is_empty() {
         return format!("  {label}: {opening}{closing}");
     }
 
-    let inline_arguments = arguments.iter().map(AsRef::as_ref).join(", ");
+    let inline_arguments = arguments.iter().join(", ");
     let inline = format!("  {label}: {opening}{inline_arguments}{closing}");
 
     if !inline.contains('\n') && inline.chars().count() <= MAX_INLINE_ARGUMENTS_WIDTH {
@@ -77,61 +66,8 @@ fn format_argument_list<T: AsRef<str>>(
 
     let multiline_arguments = arguments
         .iter()
-        .map(AsRef::as_ref)
         .map(|argument| argument.replace('\n', "\n    "))
         .join(",\n    ");
 
     format!("  {label}: {opening}\n    {multiline_arguments}\n  {closing}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{ArgumentListKind, format_passed_vs_expected};
-
-    #[test]
-    fn formats_empty_argument_lists_inline() {
-        let arguments: [&str; 0] = [];
-
-        assert_eq!(
-            format_passed_vs_expected(
-                "Invalid arguments",
-                &[] as &[&str],
-                &arguments,
-                &arguments,
-                ArgumentListKind::Positional,
-            ),
-            "Invalid arguments\n  passed: ()\n  expected: ()"
-        );
-    }
-
-    #[test]
-    fn formats_short_argument_lists_inline() {
-        assert_eq!(
-            format_passed_vs_expected(
-                "Invalid arguments",
-                &["unexpected argument at position 3"],
-                &["1", "2", "3"],
-                &["a: felt252", "b: felt252"],
-                ArgumentListKind::Positional,
-            ),
-            "Invalid arguments\n  unexpected argument at position 3\n\n  passed: (1, 2, 3)\n  expected: (a: felt252, b: felt252)"
-        );
-    }
-
-    #[test]
-    fn formats_long_argument_lists_on_separate_lines() {
-        assert_eq!(
-            format_passed_vs_expected(
-                "Invalid arguments",
-                &[] as &[&str],
-                &["foo", "bar"],
-                &[
-                    "first: core::array::Array::<core::array::Array::<core::felt252>>",
-                    "second: core::array::Array::<core::array::Array::<core::felt252>>",
-                ],
-                ArgumentListKind::Positional,
-            ),
-            "Invalid arguments\n  passed: (foo, bar)\n  expected: (\n    first: core::array::Array::<core::array::Array::<core::felt252>>,\n    second: core::array::Array::<core::array::Array::<core::felt252>>\n  )"
-        );
-    }
 }

--- a/crates/data-transformer/src/shared/mod.rs
+++ b/crates/data-transformer/src/shared/mod.rs
@@ -1,3 +1,4 @@
 pub mod extraction;
+pub mod formatting;
 pub mod parsing;
 pub mod path;

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -90,7 +90,7 @@ fn format_invalid_args_error(
 
     format_passed_vs_expected(
         format!(
-            "Invalid number of arguments for {}: passed {n_arguments}, expected {n_inputs}",
+            "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}",
             function.name
         ),
         format!("({passed})"),

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -1,12 +1,11 @@
 mod sierra_abi;
 
-use std::cmp::Ordering;
-
 use crate::shared::extraction::extract_function_from_selector;
 use crate::shared::parsing::parse_expression;
 use crate::transformer::sierra_abi::build_representation;
 use anyhow::{Context, Result, bail};
 use cairo_lang_parser::utils::SimpleParserDatabase;
+use cairo_lang_syntax::node::TypedSyntaxNode;
 use cairo_lang_syntax::node::ast::Expr;
 use conversions::serde::serialize::SerializeToFeltVec;
 use itertools::Itertools;
@@ -51,40 +50,54 @@ fn process(
     let n_inputs = function.inputs.len();
     let n_arguments = calldata.len();
 
-    match n_arguments.cmp(&n_inputs) {
-        Ordering::Less => {
-            let missing_arguments = function.inputs[n_arguments..]
-                .iter()
-                .enumerate()
-                .map(|(i, parameter)| {
-                    format!(
-                        "- [{}] {}: {}",
-                        i + n_arguments + 1,
-                        parameter.name,
-                        parameter.r#type
-                    )
-                })
-                .join("\n");
-
-            bail!(
-                "Invalid number of arguments: passed {n_arguments}, expected {n_inputs}\nExpected remaining positional arguments:\n{missing_arguments}"
-            );
-        }
-        Ordering::Greater => {
-            bail!("Invalid number of arguments: passed {n_arguments}, expected {n_inputs}");
-        }
-        Ordering::Equal => {}
+    if n_arguments != n_inputs {
+        bail!(format_invalid_args_number_error(
+            &calldata,
+            function,
+            n_arguments,
+            db
+        ));
     }
+
     function
         .inputs
         .iter()
-        .zip(calldata)
+        .zip(&calldata)
         .map(|(parameter, expr)| {
-            let representation = build_representation(expr, &parameter.r#type, abi, db)?;
+            let representation = build_representation(expr.clone(), &parameter.r#type, abi, db)?;
             Ok(representation.serialize_to_vec())
         })
         .flatten_ok()
         .collect::<Result<_>>()
+}
+
+fn format_invalid_args_number_error(
+    calldata: &[Expr],
+    function: &AbiFunction,
+    n_arguments: usize,
+    db: &SimpleParserDatabase,
+) -> String {
+    let n_inputs = function.inputs.len();
+    let expected = function
+        .inputs
+        .iter()
+        .map(|parameter| format!("{}: {}", parameter.name, parameter.r#type))
+        .join(", ");
+    let provided = calldata
+        .iter()
+        .map(|expr| {
+            expr.as_syntax_node()
+                .get_text_without_trivia(db)
+                .to_string(db)
+        })
+        .join(", ");
+
+    format!(
+        "Invalid number of arguments for `{}`: expected {n_inputs}, provided {n_arguments}\n  \
+         expected: ({expected})\n  \
+         provided: ({provided})",
+        function.name,
+    )
 }
 
 fn convert_to_tuple(calldata: &str) -> String {

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -1,8 +1,8 @@
 mod sierra_abi;
 
-use crate::shared::formatting::format_passed_vs_expected;
+use crate::shared::extraction::extract_function_from_selector;
+use crate::shared::formatting::{ArgumentListKind, format_abi_members, format_passed_vs_expected};
 use crate::shared::parsing::parse_expression;
-use crate::shared::{extraction::extract_function_from_selector, formatting::format_abi_members};
 use crate::transformer::sierra_abi::build_representation;
 use anyhow::{Context, Result, bail};
 use cairo_lang_parser::utils::SimpleParserDatabase;
@@ -86,16 +86,45 @@ fn format_invalid_args_error(
                 .get_text_without_trivia(db)
                 .to_string(db)
         })
-        .join(", ");
+        .collect::<Vec<_>>();
+    let expected = format_abi_members(&function.inputs);
+    let diagnostics = format_positional_argument_diagnostics(function, n_arguments);
 
     format_passed_vs_expected(
         format!(
-            "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}:",
+            "Invalid arguments for function `{}`: passed {n_arguments}, expected {n_inputs}",
             function.name
         ),
-        format!("({passed})"),
-        format!("({})", format_abi_members(&function.inputs)),
+        &diagnostics,
+        &passed,
+        &expected,
+        ArgumentListKind::Positional,
     )
+}
+
+fn format_positional_argument_diagnostics(
+    function: &AbiFunction,
+    n_arguments: usize,
+) -> Vec<String> {
+    if n_arguments < function.inputs.len() {
+        function
+            .inputs
+            .iter()
+            .enumerate()
+            .skip(n_arguments)
+            .map(|(position, argument)| {
+                format!(
+                    "missing argument `{}` at position {}",
+                    argument.name,
+                    position + 1
+                )
+            })
+            .collect()
+    } else {
+        (function.inputs.len()..n_arguments)
+            .map(|position| format!("unexpected argument at position {}", position + 1))
+            .collect()
+    }
 }
 
 fn convert_to_tuple(calldata: &str) -> String {

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -52,7 +52,7 @@ fn process(
 
     if n_arguments != n_inputs {
         bail!(format_invalid_args_number_error(
-            &calldata,
+            calldata,
             function,
             n_arguments,
             db

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -26,7 +26,7 @@ pub fn transform(calldata: &str, abi: &[AbiEntry], function_selector: &Felt) -> 
     let input = convert_to_tuple(calldata);
     let calldata = split_expressions(&input, &db)?;
 
-    process(&calldata, &function, abi, &db).context("Error while processing Cairo-like calldata")
+    process(calldata, &function, abi, &db).context("Error while processing Cairo-like calldata")
 }
 
 fn split_expressions<'a>(input: &'a str, db: &'a SimpleParserDatabase) -> Result<Vec<Expr<'a>>> {
@@ -43,7 +43,7 @@ fn split_expressions<'a>(input: &'a str, db: &'a SimpleParserDatabase) -> Result
 }
 
 fn process(
-    calldata: &[Expr],
+    calldata: Vec<Expr>,
     function: &AbiFunction,
     abi: &[AbiEntry],
     db: &SimpleParserDatabase,
@@ -53,7 +53,7 @@ fn process(
 
     if n_arguments != n_inputs {
         bail!(format_invalid_args_error(
-            calldata,
+            &calldata,
             function,
             n_arguments,
             db
@@ -65,7 +65,7 @@ fn process(
         .iter()
         .zip(calldata)
         .map(|(parameter, expr)| {
-            let representation = build_representation(expr.clone(), &parameter.r#type, abi, db)?;
+            let representation = build_representation(expr, &parameter.r#type, abi, db)?;
             Ok(representation.serialize_to_vec())
         })
         .flatten_ok()
@@ -89,12 +89,13 @@ fn format_invalid_args_error(
         .collect::<Vec<_>>();
     let expected = format_abi_members(&function.inputs);
     let diagnostics = format_positional_argument_diagnostics(function, n_arguments);
+    let headline = format!(
+        "Invalid arguments for function `{}`: passed {n_arguments}, expected {n_inputs}",
+        function.name
+    );
 
     format_passed_vs_expected(
-        format!(
-            "Invalid arguments for function `{}`: passed {n_arguments}, expected {n_inputs}",
-            function.name
-        ),
+        &headline,
         &diagnostics,
         &passed,
         &expected,

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -52,7 +52,7 @@ fn process(
     let n_arguments = calldata.len();
 
     if n_arguments != n_inputs {
-        bail!(format_invalid_args_number_error(
+        bail!(format_invalid_args_error(
             calldata,
             function,
             n_arguments,
@@ -72,7 +72,7 @@ fn process(
         .collect::<Result<_>>()
 }
 
-fn format_invalid_args_number_error(
+fn format_invalid_args_error(
     calldata: &[Expr],
     function: &AbiFunction,
     n_arguments: usize,

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -83,7 +83,7 @@ fn format_invalid_args_number_error(
         .iter()
         .map(|parameter| format!("{}: {}", parameter.name, parameter.r#type))
         .join(", ");
-    let provided = calldata
+    let passed = calldata
         .iter()
         .map(|expr| {
             expr.as_syntax_node()
@@ -93,9 +93,9 @@ fn format_invalid_args_number_error(
         .join(", ");
 
     format!(
-        "Invalid number of arguments for `{}`: expected {n_inputs}, provided {n_arguments}\n  \
-         expected: ({expected})\n  \
-         provided: ({provided})",
+        "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}\n  \
+         passed: ({passed})\n  \
+         expected: ({expected})",
         function.name,
     )
 }

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -90,7 +90,7 @@ fn format_invalid_args_error(
 
     format_passed_vs_expected(
         format!(
-            "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}",
+            "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}:",
             function.name
         ),
         format!("({passed})"),

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -25,7 +25,7 @@ pub fn transform(calldata: &str, abi: &[AbiEntry], function_selector: &Felt) -> 
     let input = convert_to_tuple(calldata);
     let calldata = split_expressions(&input, &db)?;
 
-    process(calldata, &function, abi, &db).context("Error while processing Cairo-like calldata")
+    process(&calldata, &function, abi, &db).context("Error while processing Cairo-like calldata")
 }
 
 fn split_expressions<'a>(input: &'a str, db: &'a SimpleParserDatabase) -> Result<Vec<Expr<'a>>> {
@@ -42,7 +42,7 @@ fn split_expressions<'a>(input: &'a str, db: &'a SimpleParserDatabase) -> Result
 }
 
 fn process(
-    calldata: Vec<Expr>,
+    calldata: &[Expr],
     function: &AbiFunction,
     abi: &[AbiEntry],
     db: &SimpleParserDatabase,
@@ -62,7 +62,7 @@ fn process(
     function
         .inputs
         .iter()
-        .zip(&calldata)
+        .zip(calldata)
         .map(|(parameter, expr)| {
             let representation = build_representation(expr.clone(), &parameter.r#type, abi, db)?;
             Ok(representation.serialize_to_vec())

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -1,9 +1,11 @@
 mod sierra_abi;
 
+use std::cmp::Ordering;
+
 use crate::shared::extraction::extract_function_from_selector;
 use crate::shared::parsing::parse_expression;
 use crate::transformer::sierra_abi::build_representation;
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, bail};
 use cairo_lang_parser::utils::SimpleParserDatabase;
 use cairo_lang_syntax::node::ast::Expr;
 use conversions::serde::serialize::SerializeToFeltVec;
@@ -49,11 +51,30 @@ fn process(
     let n_inputs = function.inputs.len();
     let n_arguments = calldata.len();
 
-    ensure!(
-        n_inputs == n_arguments,
-        "Invalid number of arguments: passed {n_arguments}, expected {n_inputs}",
-    );
+    match n_arguments.cmp(&n_inputs) {
+        Ordering::Less => {
+            let missing_arguments = function.inputs[n_arguments..]
+                .iter()
+                .enumerate()
+                .map(|(i, parameter)| {
+                    format!(
+                        "- [{}] {}: {}",
+                        i + n_arguments + 1,
+                        parameter.name,
+                        parameter.r#type
+                    )
+                })
+                .join("\n");
 
+            bail!(
+                "Invalid number of arguments: passed {n_arguments}, expected {n_inputs}\nExpected remaining positional arguments:\n{missing_arguments}"
+            );
+        }
+        Ordering::Greater => {
+            bail!("Invalid number of arguments: passed {n_arguments}, expected {n_inputs}");
+        }
+        Ordering::Equal => {}
+    }
     function
         .inputs
         .iter()

--- a/crates/data-transformer/src/transformer/mod.rs
+++ b/crates/data-transformer/src/transformer/mod.rs
@@ -1,7 +1,8 @@
 mod sierra_abi;
 
-use crate::shared::extraction::extract_function_from_selector;
+use crate::shared::formatting::format_passed_vs_expected;
 use crate::shared::parsing::parse_expression;
+use crate::shared::{extraction::extract_function_from_selector, formatting::format_abi_members};
 use crate::transformer::sierra_abi::build_representation;
 use anyhow::{Context, Result, bail};
 use cairo_lang_parser::utils::SimpleParserDatabase;
@@ -78,11 +79,6 @@ fn format_invalid_args_number_error(
     db: &SimpleParserDatabase,
 ) -> String {
     let n_inputs = function.inputs.len();
-    let expected = function
-        .inputs
-        .iter()
-        .map(|parameter| format!("{}: {}", parameter.name, parameter.r#type))
-        .join(", ");
     let passed = calldata
         .iter()
         .map(|expr| {
@@ -92,11 +88,13 @@ fn format_invalid_args_number_error(
         })
         .join(", ");
 
-    format!(
-        "Invalid number of arguments for `{}`: passed {n_arguments}, expected {n_inputs}\n  \
-         passed: ({passed})\n  \
-         expected: ({expected})",
-        function.name,
+    format_passed_vs_expected(
+        format!(
+            "Invalid number of arguments for {}: passed {n_arguments}, expected {n_inputs}",
+            function.name
+        ),
+        format!("({passed})"),
+        format!("({})", format_abi_members(&function.inputs)),
     )
 }
 

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -82,7 +82,7 @@ async fn test_invalid_argument_number() {
     let result = run_transformer("0x123, 'some_obsolete_argument', 10", "simple_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `simple_fn`: passed 3, expected 1
+        Invalid number of arguments for `simple_fn`: passed 3, expected 1:
           passed: (0x123, 'some_obsolete_argument', 10)
           expected: (a: core::felt252)"});
 }
@@ -90,7 +90,7 @@ async fn test_invalid_argument_number() {
 #[test_case(
     "",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: passed 0, expected 2
+        Invalid number of arguments for `multiple_signed_fn`: passed 0, expected 2:
           passed: ()
           expected: (a: core::integer::i32, b: core::integer::i8)"};
     "all arguments missing"
@@ -98,7 +98,7 @@ async fn test_invalid_argument_number() {
 #[test_case(
     "1_i32",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: passed 1, expected 2
+        Invalid number of arguments for `multiple_signed_fn`: passed 1, expected 2:
           passed: (1_i32)
           expected: (a: core::integer::i32, b: core::integer::i8)"
         };
@@ -116,7 +116,7 @@ async fn test_argument_number_mismatch_with_complex_types() {
     let result = run_transformer("array![]", "complex_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `complex_fn`: passed 1, expected 7
+        Invalid number of arguments for `complex_fn`: passed 1, expected 7:
           passed: (array![])
           expected: (arr: core::array::Array::<core::array::Array::<core::felt252>>, one: core::integer::u8, two: core::integer::i16, three: core::byte_array::ByteArray, four: (core::felt252, core::integer::u32), five: core::bool, six: core::integer::u256)"});
 }

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -86,6 +86,53 @@ async fn test_invalid_argument_number() {
         .assert_contains("Invalid number of arguments: passed 3, expected 1");
 }
 
+#[test_case(
+    "",
+    indoc! {r#"
+        Invalid number of arguments: passed 0, expected 2
+        Expected remaining positional arguments:
+        - [1] a: core::integer::i32
+        - [2] b: core::integer::i8
+    "#};
+    "all arguments missing"
+)]
+#[test_case(
+    "1_i32",
+    indoc! {r#"
+        Invalid number of arguments: passed 1, expected 2
+        Expected remaining positional arguments:
+        - [2] b: core::integer::i8
+    "#};
+    "one argument missing"
+)]
+#[tokio::test]
+async fn test_missing_arguments(input: &str, expected_error: &str) {
+    let result = run_transformer(input, "multiple_signed_fn").await;
+
+    result
+        .unwrap_err()
+        .assert_contains(expected_error.trim_end());
+}
+
+#[tokio::test]
+async fn test_multiple_remaining_arguments_with_complex_types() {
+    let result = run_transformer("array![]", "complex_fn").await;
+
+    result.unwrap_err().assert_contains(
+        indoc! {r#"
+            Invalid number of arguments: passed 1, expected 7
+            Expected remaining positional arguments:
+            - [2] one: core::integer::u8
+            - [3] two: core::integer::i16
+            - [4] three: core::byte_array::ByteArray
+            - [5] four: (core::felt252, core::integer::u32)
+            - [6] five: core::bool
+            - [7] six: core::integer::u256
+        "#}
+        .trim_end(),
+    );
+}
+
 #[tokio::test]
 async fn test_happy_case_simple_cairo_expressions_input() {
     let result = run_transformer("100", "simple_fn").await.unwrap();

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -81,56 +81,43 @@ async fn test_invalid_cairo_expression() {
 async fn test_invalid_argument_number() {
     let result = run_transformer("0x123, 'some_obsolete_argument', 10", "simple_fn").await;
 
-    result
-        .unwrap_err()
-        .assert_contains("Invalid number of arguments: passed 3, expected 1");
+    result.unwrap_err().assert_contains(indoc! {r"
+        Invalid number of arguments for `simple_fn`: expected 1, provided 3
+          expected: (a: core::felt252)
+          provided: (0x123, 'some_obsolete_argument', 10)"});
 }
 
 #[test_case(
     "",
-    indoc! {r#"
-        Invalid number of arguments: passed 0, expected 2
-        Expected remaining positional arguments:
-        - [1] a: core::integer::i32
-        - [2] b: core::integer::i8
-    "#};
+    indoc! {r"
+        Invalid number of arguments for `multiple_signed_fn`: expected 2, provided 0
+          expected: (a: core::integer::i32, b: core::integer::i8)
+          provided: ()"};
     "all arguments missing"
 )]
 #[test_case(
     "1_i32",
-    indoc! {r#"
-        Invalid number of arguments: passed 1, expected 2
-        Expected remaining positional arguments:
-        - [2] b: core::integer::i8
-    "#};
+    indoc! {r"
+        Invalid number of arguments for `multiple_signed_fn`: expected 2, provided 1
+          expected: (a: core::integer::i32, b: core::integer::i8)
+          provided: (1_i32)"};
     "one argument missing"
 )]
 #[tokio::test]
 async fn test_missing_arguments(input: &str, expected_error: &str) {
     let result = run_transformer(input, "multiple_signed_fn").await;
 
-    result
-        .unwrap_err()
-        .assert_contains(expected_error.trim_end());
+    result.unwrap_err().assert_contains(expected_error);
 }
 
 #[tokio::test]
-async fn test_multiple_remaining_arguments_with_complex_types() {
+async fn test_argument_number_mismatch_with_complex_types() {
     let result = run_transformer("array![]", "complex_fn").await;
 
-    result.unwrap_err().assert_contains(
-        indoc! {r#"
-            Invalid number of arguments: passed 1, expected 7
-            Expected remaining positional arguments:
-            - [2] one: core::integer::u8
-            - [3] two: core::integer::i16
-            - [4] three: core::byte_array::ByteArray
-            - [5] four: (core::felt252, core::integer::u32)
-            - [6] five: core::bool
-            - [7] six: core::integer::u256
-        "#}
-        .trim_end(),
-    );
+    result.unwrap_err().assert_contains(indoc! {r"
+        Invalid number of arguments for `complex_fn`: expected 7, provided 1
+          expected: (arr: core::array::Array::<core::array::Array::<core::felt252>>, one: core::integer::u8, two: core::integer::i16, three: core::byte_array::ByteArray, four: (core::felt252, core::integer::u32), five: core::bool, six: core::integer::u256)
+          provided: (array![])"});
 }
 
 #[tokio::test]

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -82,7 +82,10 @@ async fn test_invalid_argument_number() {
     let result = run_transformer("0x123, 'some_obsolete_argument', 10", "simple_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `simple_fn`: passed 3, expected 1:
+        Invalid arguments for function `simple_fn`: passed 3, expected 1
+          unexpected argument at position 2
+          unexpected argument at position 3
+
           passed: (0x123, 'some_obsolete_argument', 10)
           expected: (a: core::felt252)"});
 }
@@ -90,7 +93,10 @@ async fn test_invalid_argument_number() {
 #[test_case(
     "",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: passed 0, expected 2:
+        Invalid arguments for function `multiple_signed_fn`: passed 0, expected 2
+          missing argument `a` at position 1
+          missing argument `b` at position 2
+
           passed: ()
           expected: (a: core::integer::i32, b: core::integer::i8)"};
     "all arguments missing"
@@ -98,10 +104,11 @@ async fn test_invalid_argument_number() {
 #[test_case(
     "1_i32",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: passed 1, expected 2:
+        Invalid arguments for function `multiple_signed_fn`: passed 1, expected 2
+          missing argument `b` at position 2
+
           passed: (1_i32)
-          expected: (a: core::integer::i32, b: core::integer::i8)"
-        };
+          expected: (a: core::integer::i32, b: core::integer::i8)"};
     "one argument missing"
 )]
 #[tokio::test]
@@ -116,9 +123,36 @@ async fn test_argument_number_mismatch_with_complex_types() {
     let result = run_transformer("array![]", "complex_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `complex_fn`: passed 1, expected 7:
+        Invalid arguments for function `complex_fn`: passed 1, expected 7
+          missing argument `one` at position 2
+          missing argument `two` at position 3
+          missing argument `three` at position 4
+          missing argument `four` at position 5
+          missing argument `five` at position 6
+          missing argument `six` at position 7
+
           passed: (array![])
-          expected: (arr: core::array::Array::<core::array::Array::<core::felt252>>, one: core::integer::u8, two: core::integer::i16, three: core::byte_array::ByteArray, four: (core::felt252, core::integer::u32), five: core::bool, six: core::integer::u256)"});
+          expected: (
+            arr: core::array::Array::<core::array::Array::<core::felt252>>,
+            one: core::integer::u8,
+            two: core::integer::i16,
+            three: core::byte_array::ByteArray,
+            four: (core::felt252, core::integer::u32),
+            five: core::bool,
+            six: core::integer::u256
+          )"});
+}
+
+#[tokio::test]
+async fn test_unexpected_argument_for_no_args_function() {
+    let result = run_transformer("1", "no_args_fn").await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Invalid arguments for function `no_args_fn`: passed 1, expected 0
+          unexpected argument at position 1
+
+          passed: (1)
+          expected: ()"});
 }
 
 #[tokio::test]

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -82,25 +82,26 @@ async fn test_invalid_argument_number() {
     let result = run_transformer("0x123, 'some_obsolete_argument', 10", "simple_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `simple_fn`: expected 1, provided 3
-          expected: (a: core::felt252)
-          provided: (0x123, 'some_obsolete_argument', 10)"});
+        Invalid number of arguments for `simple_fn`: passed 3, expected 1
+          passed: (0x123, 'some_obsolete_argument', 10)
+          expected: (a: core::felt252)"});
 }
 
 #[test_case(
     "",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: expected 2, provided 0
-          expected: (a: core::integer::i32, b: core::integer::i8)
-          provided: ()"};
+        Invalid number of arguments for `multiple_signed_fn`: passed 0, expected 2
+          passed: ()
+          expected: (a: core::integer::i32, b: core::integer::i8)"};
     "all arguments missing"
 )]
 #[test_case(
     "1_i32",
     indoc! {r"
-        Invalid number of arguments for `multiple_signed_fn`: expected 2, provided 1
-          expected: (a: core::integer::i32, b: core::integer::i8)
-          provided: (1_i32)"};
+        Invalid number of arguments for `multiple_signed_fn`: passed 1, expected 2
+          passed: (1_i32)
+          expected: (a: core::integer::i32, b: core::integer::i8)"
+        };
     "one argument missing"
 )]
 #[tokio::test]
@@ -115,9 +116,9 @@ async fn test_argument_number_mismatch_with_complex_types() {
     let result = run_transformer("array![]", "complex_fn").await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid number of arguments for `complex_fn`: expected 7, provided 1
-          expected: (arr: core::array::Array::<core::array::Array::<core::felt252>>, one: core::integer::u8, two: core::integer::i16, three: core::byte_array::ByteArray, four: (core::felt252, core::integer::u32), five: core::bool, six: core::integer::u256)
-          provided: (array![])"});
+        Invalid number of arguments for `complex_fn`: passed 1, expected 7
+          passed: (array![])
+          expected: (arr: core::array::Array::<core::array::Array::<core::felt252>>, one: core::integer::u8, two: core::integer::i16, three: core::byte_array::ByteArray, four: (core::felt252, core::integer::u32), five: core::bool, six: core::integer::u256)"});
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #3806

## Introduced changes

This PR improves errors for missing or unexpected positional Cairo-like calldata arguments.

### Before

```text
Invalid number of arguments for `multiple_signed_fn`: passed 1, expected 2:
  passed: (1_i32)
  expected: (a: core::integer::i32, b: core::integer::i8)
```

### After

```text
Invalid arguments for function `multiple_signed_fn`: passed 1, expected 2
  missing argument `b` at position 2

  passed: (1_i32)
  expected: (a: core::integer::i32, b: core::integer::i8)
```

Long argument lists are rendered across multiple lines for readability.

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [ ] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
