### PR TITLE
Show expected struct constructor arguments in data transformer errors 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
+- Cairo-like calldata errors now list the names and types of missing function arguments.
 
 ## [0.63.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 - Invalid Cairo-like calldata now reports missing and unexpected positional arguments, alongside the provided arguments and expected argument names and types.
 - Error message for a struct constructor invocation whose fields do not match the ABI now lists the expected fields (with their types) along with the provided fields.
+- Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--json` flag is now global, and can be passed to any subcommand.
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 - Invalid Cairo-like calldata now reports missing and unexpected positional arguments, alongside the provided arguments and expected argument names and types.
-- Error message for a struct constructor invocation whose fields do not match the ABI now lists the expected fields (with their types) along with the provided fields.
+- Invalid struct constructor arguments now report missing and unexpected fields, alongside the provided fields and expected field types.
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 - Invalid Cairo-like calldata now reports missing and unexpected positional arguments, alongside the provided arguments and expected argument names and types.
 - Error message for a struct constructor invocation whose fields do not match the ABI now lists the expected fields (with their types) along with the provided fields.
-- Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
 
 #### Fixed
 
 - Invalid tuple lengths in Cairo-like calldata now produce a data transformer error instead of failing during contract execution.
-- Cairo-like calldata errors now list the names and types of missing function arguments.
 
 ## [0.63.0] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--json` flag is now global, and can be passed to any subcommand.
 - `sncast verify --verifier walnut` has been replaced by `sncast verify --verifier starkloupe`, following Walnut's migration to Starkloupe ([app.starkloupe.co](https://app.starkloupe.co))
 - Invalid Cairo-like calldata now reports missing and unexpected positional arguments, alongside the provided arguments and expected argument names and types.
+- Error message for a struct constructor invocation whose fields do not match the ABI now lists the expected fields (with their types) along with the provided fields.
 
 #### Fixed
 

--- a/crates/data-transformer/src/shared/formatting.rs
+++ b/crates/data-transformer/src/shared/formatting.rs
@@ -6,12 +6,14 @@ const MAX_INLINE_ARGUMENTS_WIDTH: usize = 100;
 #[derive(Clone, Copy)]
 pub enum ArgumentListKind {
     Positional,
+    Named,
 }
 
 impl ArgumentListKind {
     const fn delimiters(self) -> (char, char) {
         match self {
             Self::Positional => ('(', ')'),
+            Self::Named => ('{', '}'),
         }
     }
 }
@@ -58,7 +60,14 @@ fn format_argument_list(label: &str, arguments: &[String], list_kind: ArgumentLi
     }
 
     let inline_arguments = arguments.iter().join(", ");
-    let inline = format!("  {label}: {opening}{inline_arguments}{closing}");
+    let inline = match list_kind {
+        ArgumentListKind::Positional => {
+            format!("  {label}: {opening}{inline_arguments}{closing}")
+        }
+        ArgumentListKind::Named => {
+            format!("  {label}: {opening} {inline_arguments} {closing}")
+        }
+    };
 
     if !inline.contains('\n') && inline.chars().count() <= MAX_INLINE_ARGUMENTS_WIDTH {
         return inline;

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -4,7 +4,7 @@ use super::data_representation::{
 use super::parsing::parse_argument_list;
 use super::{SupportedCalldataKind, build_representation};
 use crate::shared;
-use crate::shared::formatting::{format_abi_members, format_passed_vs_expected};
+use crate::shared::formatting::{ArgumentListKind, format_abi_members, format_passed_vs_expected};
 use crate::shared::parsing::parse_expression;
 use crate::shared::path::SplitResult;
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -304,15 +304,66 @@ fn get_struct_arguments_with_values<'a>(
 fn format_invalid_struct_args_error(
     expected_type: &str,
     expected_members: &[AbiNamedMember],
-    provided_names: &[String],
+    passed_names: &[&str],
+    diagnostics: &[String],
 ) -> String {
-    let passed = provided_names.join(", ");
+    let expected = format_abi_members(expected_members);
 
     format_passed_vs_expected(
-        format!("Invalid arguments for struct `{expected_type}` constructor:"),
-        format!("{{ {} }}", passed),
-        format!("{{ {} }}", format_abi_members(&expected_members)),
+        format!(
+            "Invalid arguments for struct `{expected_type}` constructor: passed {}, expected {}",
+            passed_names.len(),
+            expected_members.len()
+        ),
+        diagnostics,
+        passed_names,
+        &expected,
+        ArgumentListKind::Named,
     )
+}
+
+fn format_struct_field_diagnostics(
+    expected_members: &[AbiNamedMember],
+    passed_names: &[&str],
+) -> Vec<String> {
+    let passed_set: HashSet<&str> = passed_names.iter().copied().collect();
+    let expected_set: HashSet<&str> = expected_members
+        .iter()
+        .map(|member| member.name.as_str())
+        .collect();
+
+    let missing = expected_members
+        .iter()
+        .map(|member| member.name.as_str())
+        .filter(|name| !passed_set.contains(name))
+        .collect::<Vec<_>>();
+    let unexpected = passed_names
+        .iter()
+        .copied()
+        .filter(|name| !expected_set.contains(name))
+        .unique()
+        .collect::<Vec<_>>();
+
+    [
+        format_field_diagnostic("missing", &missing),
+        format_field_diagnostic("unexpected", &unexpected),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+fn format_field_diagnostic(kind: &str, fields: &[&str]) -> Option<String> {
+    match fields {
+        [] => None,
+        [field] => Some(format!("{kind} field: `{field}`")),
+        fields => Some(format!(
+            "{kind} fields: {}",
+            fields
+                .iter()
+                .format_with(", ", |field, f| f(&format_args!("`{field}`")))
+        )),
+    }
 }
 
 // Structs
@@ -340,23 +391,19 @@ impl SupportedCalldataKind for ExprStructCtorCall<'_> {
         let struct_args_with_values = get_struct_arguments_with_values(&struct_args, db)
             .context("Found invalid expression in struct argument")?;
 
-        let provided_names: Vec<String> = struct_args_with_values
+        let passed_names = struct_args_with_values
             .iter()
-            .map(|(arg_name, _)| arg_name.clone())
-            .collect();
+            .map(|(name, _)| name.as_str())
+            .collect::<Vec<_>>();
+        let diagnostics =
+            format_struct_field_diagnostics(&struct_abi_definition.members, &passed_names);
 
-        let provided_set: HashSet<&str> = provided_names.iter().map(String::as_str).collect();
-        let expected_set: HashSet<&str> = struct_abi_definition
-            .members
-            .iter()
-            .map(|member| member.name.as_str())
-            .collect();
-
-        if provided_set != expected_set {
+        if !diagnostics.is_empty() {
             bail!(format_invalid_struct_args_error(
                 expected_type,
                 &struct_abi_definition.members,
-                &provided_names,
+                &passed_names,
+                &diagnostics,
             ));
         }
 

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -300,6 +300,24 @@ fn get_struct_arguments_with_values<'a>(
         .collect()
 }
 
+fn format_struct_arguments_mismatch(
+    expected_type: &str,
+    expected_members: &[AbiNamedMember],
+    provided_names: &[String],
+) -> String {
+    let expected = expected_members
+        .iter()
+        .map(|member| format!("{}: {}", member.name, member.r#type))
+        .join(", ");
+    let provided = provided_names.join(", ");
+
+    format!(
+        "Constructor arguments for `{expected_type}` do not match the ABI:\n  \
+         expected: {{ {expected} }}\n  \
+         provided: {{ {provided} }}"
+    )
+}
+
 // Structs
 impl SupportedCalldataKind for ExprStructCtorCall<'_> {
     fn transform(
@@ -325,29 +343,32 @@ impl SupportedCalldataKind for ExprStructCtorCall<'_> {
         let struct_args_with_values = get_struct_arguments_with_values(&struct_args, db)
             .context("Found invalid expression in struct argument")?;
 
+        let provided_names: Vec<String> = struct_args_with_values
+            .iter()
+            .map(|(arg_name, _)| arg_name.clone())
+            .collect();
+
+        let provided_set: HashSet<&str> = provided_names.iter().map(String::as_str).collect();
+        let expected_set: HashSet<&str> = struct_abi_definition
+            .members
+            .iter()
+            .map(|member| member.name.as_str())
+            .collect();
+
+        if provided_set != expected_set {
+            bail!(format_struct_arguments_mismatch(
+                expected_type,
+                &struct_abi_definition.members,
+                &provided_names,
+            ));
+        }
+
         if struct_args_with_values.len() != struct_abi_definition.members.len() {
             bail!(
                 r#"Invalid number of struct arguments in struct "{}", expected {} arguments, found {}"#,
                 struct_path_joined,
                 struct_abi_definition.members.len(),
                 struct_args.len()
-            )
-        }
-
-        // validate if all arguments' names have corresponding names in abi
-        if struct_args_with_values
-            .iter()
-            .map(|(arg_name, _)| arg_name.clone())
-            .collect::<HashSet<String>>()
-            != struct_abi_definition
-                .members
-                .iter()
-                .map(|x| x.name.clone())
-                .collect::<HashSet<String>>()
-        {
-            // TODO add message which arguments are invalid (Issue #2549)
-            bail!(
-                r"Arguments in constructor invocation for struct {expected_type} do not match struct arguments in ABI",
             )
         }
 

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -305,16 +305,16 @@ fn format_struct_arguments_mismatch(
     expected_members: &[AbiNamedMember],
     provided_names: &[String],
 ) -> String {
+    let passed = provided_names.join(", ");
     let expected = expected_members
         .iter()
         .map(|member| format!("{}: {}", member.name, member.r#type))
         .join(", ");
-    let provided = provided_names.join(", ");
 
     format!(
-        "Constructor arguments for `{expected_type}` do not match the ABI:\n  \
-         expected: {{ {expected} }}\n  \
-         provided: {{ {provided} }}"
+        "Constructor arguments for `{expected_type}` are incorrect:\n  \
+         passed: {{ {passed} }}\n  \
+         expected: {{ {expected} }}",
     )
 }
 

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -4,6 +4,7 @@ use super::data_representation::{
 use super::parsing::parse_argument_list;
 use super::{SupportedCalldataKind, build_representation};
 use crate::shared;
+use crate::shared::formatting::{format_abi_members, format_passed_vs_expected};
 use crate::shared::parsing::parse_expression;
 use crate::shared::path::SplitResult;
 use anyhow::{Context, Result, anyhow, bail, ensure};
@@ -300,21 +301,17 @@ fn get_struct_arguments_with_values<'a>(
         .collect()
 }
 
-fn format_struct_arguments_mismatch(
+fn format_invalid_struct_args_error(
     expected_type: &str,
     expected_members: &[AbiNamedMember],
     provided_names: &[String],
 ) -> String {
     let passed = provided_names.join(", ");
-    let expected = expected_members
-        .iter()
-        .map(|member| format!("{}: {}", member.name, member.r#type))
-        .join(", ");
 
-    format!(
-        "Constructor arguments for `{expected_type}` are incorrect:\n  \
-         passed: {{ {passed} }}\n  \
-         expected: {{ {expected} }}",
+    format_passed_vs_expected(
+        format!("Invalid arguments for struct {expected_type} constructor:"),
+        format!("{{ {} }}", passed),
+        format!("{{ {} }}", format_abi_members(&expected_members)),
     )
 }
 
@@ -356,7 +353,7 @@ impl SupportedCalldataKind for ExprStructCtorCall<'_> {
             .collect();
 
         if provided_set != expected_set {
-            bail!(format_struct_arguments_mismatch(
+            bail!(format_invalid_struct_args_error(
                 expected_type,
                 &struct_abi_definition.members,
                 &provided_names,

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -309,7 +309,7 @@ fn format_invalid_struct_args_error(
     let passed = provided_names.join(", ");
 
     format_passed_vs_expected(
-        format!("Invalid arguments for struct {expected_type} constructor:"),
+        format!("Invalid arguments for struct `{expected_type}` constructor:"),
         format!("{{ {} }}", passed),
         format!("{{ {} }}", format_abi_members(&expected_members)),
     )

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -307,16 +307,21 @@ fn format_invalid_struct_args_error(
     passed_names: &[&str],
     diagnostics: &[String],
 ) -> String {
+    let headline = format!(
+        "Invalid arguments for struct `{expected_type}` constructor: passed {}, expected {}",
+        passed_names.len(),
+        expected_members.len()
+    );
+    let passed = passed_names
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect::<Vec<_>>();
     let expected = format_abi_members(expected_members);
 
     format_passed_vs_expected(
-        format!(
-            "Invalid arguments for struct `{expected_type}` constructor: passed {}, expected {}",
-            passed_names.len(),
-            expected_members.len()
-        ),
+        &headline,
         diagnostics,
-        passed_names,
+        &passed,
         &expected,
         ArgumentListKind::Named,
     )

--- a/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
+++ b/crates/data-transformer/src/transformer/sierra_abi/complex_types.rs
@@ -14,7 +14,7 @@ use cairo_lang_syntax::node::ast::{
     OptionStructArgExpr, StructArg,
 };
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
-use itertools::Itertools;
+use itertools::{Itertools, chain};
 use starknet_rust::core::types::contract::{AbiEntry, AbiEnum, AbiNamedMember, AbiStruct};
 use std::collections::HashSet;
 
@@ -344,12 +344,10 @@ fn format_struct_field_diagnostics(
         .unique()
         .collect::<Vec<_>>();
 
-    [
-        format_field_diagnostic("missing", &missing),
-        format_field_diagnostic("unexpected", &unexpected),
-    ]
-    .into_iter()
-    .flatten()
+    chain!(
+        format_field_diagnostic("missing", &missing).into_iter(),
+        format_field_diagnostic("unexpected", &unexpected).into_iter(),
+    )
     .collect()
 }
 

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -395,7 +395,9 @@ async fn test_struct_function_missing_field() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor: passed 1, expected 2
+          missing field: `b`
+
           passed: { a }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
@@ -403,13 +405,32 @@ async fn test_struct_function_missing_field() {
 #[tokio::test]
 async fn test_struct_function_unexpected_field() {
     let result = run_transformer(
+        "NestedStructWithField { a: SimpleStruct { a: 0x24 }, b: 96, other: 1 }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor: passed 3, expected 2
+          unexpected field: `other`
+
+          passed: { a, b, other }
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
+}
+
+#[tokio::test]
+async fn test_struct_function_renamed_field() {
+    let result = run_transformer(
         "NestedStructWithField { some_other_field: SimpleStruct { a: 0x24 }, b: 96 }",
         "nested_struct_fn",
     )
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor: passed 2, expected 2
+          missing field: `a`
+          unexpected field: `some_other_field`
+
           passed: { some_other_field, b }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
@@ -423,7 +444,10 @@ async fn test_struct_function_renamed_and_missing_fields() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor: passed 1, expected 2
+          missing fields: `a`, `b`
+          unexpected field: `some_other_field`
+
           passed: { some_other_field }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
@@ -450,7 +474,10 @@ async fn test_struct_function_nested_struct_field_mismatch() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Invalid arguments for struct `data_transformer_contract::SimpleStruct` constructor:
+        Invalid arguments for struct `data_transformer_contract::SimpleStruct` constructor: passed 1, expected 1
+          missing field: `a`
+          unexpected field: `wrong_field`
+
           passed: { wrong_field }
           expected: { a: core::felt252 }"});
 }

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -395,7 +395,7 @@ async fn test_struct_function_missing_field() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
           passed: { a }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
@@ -409,7 +409,7 @@ async fn test_struct_function_unexpected_field() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
           passed: { some_other_field, b }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
@@ -423,7 +423,7 @@ async fn test_struct_function_renamed_and_missing_fields() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+        Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor:
           passed: { some_other_field }
           expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -155,53 +155,6 @@ async fn test_unexpected_argument_for_no_args_function() {
           expected: ()"});
 }
 
-#[test_case(
-    "",
-    indoc! {r"
-        Invalid number of arguments: passed 0, expected 2
-        Expected remaining positional arguments:
-        - [1] a: core::integer::i32
-        - [2] b: core::integer::i8
-    "};
-    "all arguments missing"
-)]
-#[test_case(
-    "1_i32",
-    indoc! {r"
-        Invalid number of arguments: passed 1, expected 2
-        Expected remaining positional arguments:
-        - [2] b: core::integer::i8
-    "};
-    "one argument missing"
-)]
-#[tokio::test]
-async fn test_missing_arguments(input: &str, expected_error: &str) {
-    let result = run_transformer(input, "multiple_signed_fn").await;
-
-    result
-        .unwrap_err()
-        .assert_contains(expected_error.trim_end());
-}
-
-#[tokio::test]
-async fn test_multiple_remaining_arguments_with_complex_types() {
-    let result = run_transformer("array![]", "complex_fn").await;
-
-    result.unwrap_err().assert_contains(
-        indoc! {r"
-            Invalid number of arguments: passed 1, expected 7
-            Expected remaining positional arguments:
-            - [2] one: core::integer::u8
-            - [3] two: core::integer::i16
-            - [4] three: core::byte_array::ByteArray
-            - [5] four: (core::felt252, core::integer::u32)
-            - [6] five: core::bool
-            - [7] six: core::integer::u256
-        "}
-        .trim_end(),
-    );
-}
-
 #[tokio::test]
 async fn test_happy_case_simple_cairo_expressions_input() {
     let result = run_transformer("100", "simple_fn").await.unwrap();
@@ -442,9 +395,9 @@ async fn test_struct_function_missing_field() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
-          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
-          provided: { a }"});
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+          passed: { a }
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
 
 #[tokio::test]
@@ -456,9 +409,9 @@ async fn test_struct_function_unexpected_field() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
-          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
-          provided: { some_other_field, b }"});
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+          passed: { some_other_field, b }
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
 
 #[tokio::test]
@@ -470,9 +423,9 @@ async fn test_struct_function_renamed_and_missing_fields() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
-          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
-          provided: { some_other_field }"});
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` are incorrect:
+          passed: { some_other_field }
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }"});
 }
 
 #[tokio::test]
@@ -497,9 +450,9 @@ async fn test_struct_function_nested_struct_field_mismatch() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::SimpleStruct` do not match the ABI:
-          expected: { a: core::felt252 }
-          provided: { wrong_field }"});
+        Constructor arguments for `data_transformer_contract::SimpleStruct` are incorrect:
+          passed: { wrong_field }
+          expected: { a: core::felt252 }"});
 }
 
 #[tokio::test]

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -387,6 +387,75 @@ async fn test_happy_case_nested_struct_function_cairo_expression_input() {
 }
 
 #[tokio::test]
+async fn test_struct_function_missing_field() {
+    let result = run_transformer(
+        "NestedStructWithField { a: SimpleStruct { a: 0x24 } }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
+          provided: { a }"});
+}
+
+#[tokio::test]
+async fn test_struct_function_unexpected_field() {
+    let result = run_transformer(
+        "NestedStructWithField { some_other_field: SimpleStruct { a: 0x24 }, b: 96 }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
+          provided: { some_other_field, b }"});
+}
+
+#[tokio::test]
+async fn test_struct_function_renamed_and_missing_fields() {
+    let result = run_transformer(
+        "NestedStructWithField { some_other_field: SimpleStruct { a: 0x24 } }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Constructor arguments for `data_transformer_contract::NestedStructWithField` do not match the ABI:
+          expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
+          provided: { some_other_field }"});
+}
+
+#[tokio::test]
+async fn test_struct_function_duplicated_field() {
+    let result = run_transformer(
+        "NestedStructWithField { a: SimpleStruct { a: 0x24 }, b: 96, a: SimpleStruct { a: 0x25 } }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(
+        r#"Invalid number of struct arguments in struct "NestedStructWithField", expected 2 arguments, found 3"#,
+    );
+}
+
+#[tokio::test]
+async fn test_struct_function_nested_struct_field_mismatch() {
+    let result = run_transformer(
+        "NestedStructWithField { a: SimpleStruct { wrong_field: 0x24 }, b: 96 }",
+        "nested_struct_fn",
+    )
+    .await;
+
+    result.unwrap_err().assert_contains(indoc! {r"
+        Constructor arguments for `data_transformer_contract::SimpleStruct` do not match the ABI:
+          expected: { a: core::felt252 }
+          provided: { wrong_field }"});
+}
+
+#[tokio::test]
 async fn test_happy_case_span_function_cairo_expression_input() {
     let result = run_transformer("array![1, 2, 3].span()", "span_fn")
         .await

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -155,6 +155,53 @@ async fn test_unexpected_argument_for_no_args_function() {
           expected: ()"});
 }
 
+#[test_case(
+    "",
+    indoc! {r#"
+        Invalid number of arguments: passed 0, expected 2
+        Expected remaining positional arguments:
+        - [1] a: core::integer::i32
+        - [2] b: core::integer::i8
+    "#};
+    "all arguments missing"
+)]
+#[test_case(
+    "1_i32",
+    indoc! {r#"
+        Invalid number of arguments: passed 1, expected 2
+        Expected remaining positional arguments:
+        - [2] b: core::integer::i8
+    "#};
+    "one argument missing"
+)]
+#[tokio::test]
+async fn test_missing_arguments(input: &str, expected_error: &str) {
+    let result = run_transformer(input, "multiple_signed_fn").await;
+
+    result
+        .unwrap_err()
+        .assert_contains(expected_error.trim_end());
+}
+
+#[tokio::test]
+async fn test_multiple_remaining_arguments_with_complex_types() {
+    let result = run_transformer("array![]", "complex_fn").await;
+
+    result.unwrap_err().assert_contains(
+        indoc! {r#"
+            Invalid number of arguments: passed 1, expected 7
+            Expected remaining positional arguments:
+            - [2] one: core::integer::u8
+            - [3] two: core::integer::i16
+            - [4] three: core::byte_array::ByteArray
+            - [5] four: (core::felt252, core::integer::u32)
+            - [6] five: core::bool
+            - [7] six: core::integer::u256
+        "#}
+        .trim_end(),
+    );
+}
+
 #[tokio::test]
 async fn test_happy_case_simple_cairo_expressions_input() {
     let result = run_transformer("100", "simple_fn").await.unwrap();

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -450,7 +450,7 @@ async fn test_struct_function_nested_struct_field_mismatch() {
     .await;
 
     result.unwrap_err().assert_contains(indoc! {r"
-        Constructor arguments for `data_transformer_contract::SimpleStruct` are incorrect:
+        Invalid arguments for struct `data_transformer_contract::SimpleStruct` constructor:
           passed: { wrong_field }
           expected: { a: core::felt252 }"});
 }

--- a/crates/data-transformer/tests/integration/transformer.rs
+++ b/crates/data-transformer/tests/integration/transformer.rs
@@ -157,21 +157,21 @@ async fn test_unexpected_argument_for_no_args_function() {
 
 #[test_case(
     "",
-    indoc! {r#"
+    indoc! {r"
         Invalid number of arguments: passed 0, expected 2
         Expected remaining positional arguments:
         - [1] a: core::integer::i32
         - [2] b: core::integer::i8
-    "#};
+    "};
     "all arguments missing"
 )]
 #[test_case(
     "1_i32",
-    indoc! {r#"
+    indoc! {r"
         Invalid number of arguments: passed 1, expected 2
         Expected remaining positional arguments:
         - [2] b: core::integer::i8
-    "#};
+    "};
     "one argument missing"
 )]
 #[tokio::test]
@@ -188,7 +188,7 @@ async fn test_multiple_remaining_arguments_with_complex_types() {
     let result = run_transformer("array![]", "complex_fn").await;
 
     result.unwrap_err().assert_contains(
-        indoc! {r#"
+        indoc! {r"
             Invalid number of arguments: passed 1, expected 7
             Expected remaining positional arguments:
             - [2] one: core::integer::u8
@@ -197,7 +197,7 @@ async fn test_multiple_remaining_arguments_with_complex_types() {
             - [5] four: (core::felt252, core::integer::u32)
             - [6] five: core::bool
             - [7] six: core::integer::u256
-        "#}
+        "}
         .trim_end(),
     );
 }


### PR DESCRIPTION
<!-- Reference any GitHub issues resolved by this PR -->

Closes #2549

## Introduced changes

This PR improves errors for missing or unexpected fields in Cairo struct constructors.

### Before

```text
Arguments in constructor invocation for struct data_transformer_contract::NestedStructWithField do not match struct arguments in ABI
```

### After

```text
Invalid arguments for struct `data_transformer_contract::NestedStructWithField` constructor: passed 1, expected 2
  missing field: `b`

  passed: { a }
  expected: { a: data_transformer_contract::SimpleStruct, b: core::felt252 }
```

## Checklist

<!-- Make sure all of these are complete -->

- [x] Linked relevant issue
- [x] Updated relevant documentation
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
